### PR TITLE
fix(health): PAR2 repair reconstructs files when source articles are corrupt

### DIFF
--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -82,6 +82,15 @@ public class UsenetStreamingClient : WrappingNntpClient
         };
     }
 
+    /// <summary>
+    /// Test hook: wrap a scripted inner client without building provider pools.
+    /// </summary>
+    internal UsenetStreamingClient(INntpClient inner, RepairPatchStore? repairPatchStore = null)
+        : base(inner)
+    {
+        _repairPatchStore = repairPatchStore;
+    }
+
     private static HeaderCachingNntpClient CreateDownloadingNntpClient
     (
         ConfigManager configManager,

--- a/backend/Par2Recovery/Par2TestEncoder.cs
+++ b/backend/Par2Recovery/Par2TestEncoder.cs
@@ -21,22 +21,58 @@ public static class Par2TestEncoder
         string fileName,
         byte[] fileData,
         ulong sliceSize,
-        IReadOnlyList<uint> recoveryExponents)
+        IReadOnlyList<uint> recoveryExponents,
+        byte[]? fileHashOverride = null)
+        => EncodeSet(
+            [(fileName, fileData)],
+            sliceSize,
+            recoveryExponents,
+            fileHashOverride is null
+                ? null
+                : new Dictionary<string, byte[]>(StringComparer.Ordinal) { [fileName] = fileHashOverride });
+
+    public static (byte[] indexBytes, byte[] volumeBytes) EncodeSet(
+        IReadOnlyList<(string FileName, byte[] FileData)> files,
+        ulong sliceSize,
+        IReadOnlyList<uint> recoveryExponents,
+        IReadOnlyDictionary<string, byte[]>? fileHashOverrides = null)
     {
+        ArgumentOutOfRangeException.ThrowIfEqual(files.Count, 0);
+
         var recoverySetId = RandomNumberGenerator.GetBytes(16);
-        var fileId = MD5.HashData(fileData.Length >= 16 ? fileData.AsSpan(0, 16) : fileData);
-        var fileHash = MD5.HashData(fileData);
-        var file16k = MD5.HashData(fileData.AsSpan(0, Math.Min(16 * 1024, fileData.Length)));
-        var slices = BuildSlices(fileData, sliceSize);
-        var ifscBody = BuildIfscBody(fileId, slices);
-
+        var fileIds = new byte[files.Count][];
+        var perFileSlices = new byte[files.Count][][];
         using var index = new MemoryStream();
-        WritePacket(index, FileDesc.PacketType, BuildFileDescBody(fileId, fileHash, file16k, fileData.Length, fileName), recoverySetId);
-        WritePacket(index, MainPacket.PacketType, BuildMainBody(sliceSize, 1, [fileId]), recoverySetId);
-        WritePacket(index, IfscPacket.PacketType, ifscBody, recoverySetId);
 
+        for (var i = 0; i < files.Count; i++)
+        {
+            var (fileName, fileData) = files[i];
+            fileIds[i] = files.Count == 1
+                ? MD5.HashData(fileData.Length >= 16 ? fileData.AsSpan(0, 16) : fileData)
+                : MD5.HashData(
+                    Encoding.UTF8.GetBytes($"{i}:{fileName}")
+                        .Concat(fileData.Length >= 16 ? fileData.AsSpan(0, 16).ToArray() : fileData)
+                        .ToArray());
+            var fileHash = fileHashOverrides is not null
+                           && fileHashOverrides.TryGetValue(fileName, out var overrideHash)
+                ? overrideHash
+                : MD5.HashData(fileData);
+            var file16k = MD5.HashData(fileData.AsSpan(0, Math.Min(16 * 1024, fileData.Length)));
+            perFileSlices[i] = BuildSlices(fileData, sliceSize);
+            WritePacket(
+                index,
+                FileDesc.PacketType,
+                BuildFileDescBody(fileIds[i], fileHash, file16k, fileData.Length, fileName),
+                recoverySetId);
+        }
+
+        WritePacket(index, MainPacket.PacketType, BuildMainBody(sliceSize, (uint)files.Count, fileIds), recoverySetId);
+        for (var i = 0; i < files.Count; i++)
+            WritePacket(index, IfscPacket.PacketType, BuildIfscBody(fileIds[i], perFileSlices[i]), recoverySetId);
+
+        var allSlices = perFileSlices.SelectMany(slices => slices).ToArray();
         var recoveryPayloads = recoveryExponents
-            .Select(exp => (exp, ComputeRecoverySlice(exp, sliceSize, slices)))
+            .Select(exp => (exp, ComputeRecoverySlice(exp, sliceSize, allSlices)))
             .ToList();
 
         using var volume = new MemoryStream();

--- a/backend/Par2Recovery/ReedSolomon/Par2Reconstructor.cs
+++ b/backend/Par2Recovery/ReedSolomon/Par2Reconstructor.cs
@@ -225,7 +225,7 @@ public sealed class Par2Reconstructor
         throw new ArgumentOutOfRangeException(nameof(globalSlice));
     }
 
-    private static bool VerifySliceChecksum(byte[] slice, IfscPacket.SliceChecksum checksum)
+    internal static bool VerifySliceChecksum(byte[] slice, IfscPacket.SliceChecksum checksum)
     {
         var md5 = MD5.HashData(slice);
         if (!md5.AsSpan().SequenceEqual(checksum.Md5)) return false;

--- a/backend/Services/Repair/Par2FileSliceMap.cs
+++ b/backend/Services/Repair/Par2FileSliceMap.cs
@@ -1,0 +1,146 @@
+using NzbWebDAV.Models;
+
+namespace NzbWebDAV.Services.Repair;
+
+/// <summary>
+/// Immutable mapping from a target file's NZB segments onto PAR2 global slice indexes.
+/// Overlap uses half-open byte ranges; zero-length segments contribute no slices.
+/// </summary>
+internal sealed class Par2FileSliceMap
+{
+    public long FileLength { get; }
+    public int GlobalSliceBase { get; }
+    public int SliceSize { get; }
+    public int SliceCount { get; }
+    public IReadOnlyList<LongRange> SegmentRanges { get; }
+
+    private Par2FileSliceMap(
+        long fileLength,
+        int globalSliceBase,
+        int sliceSize,
+        int sliceCount,
+        LongRange[] segmentRanges)
+    {
+        FileLength = fileLength;
+        GlobalSliceBase = globalSliceBase;
+        SliceSize = sliceSize;
+        SliceCount = sliceCount;
+        SegmentRanges = segmentRanges;
+    }
+
+    public static bool TryCreate(
+        long fileLength,
+        int globalSliceBase,
+        int sliceSize,
+        int sliceCount,
+        LongRange[] segmentRanges,
+        out Par2FileSliceMap? map,
+        out string? error)
+    {
+        map = null;
+        error = null;
+
+        if (fileLength < 0)
+        {
+            error = "Target file length is negative.";
+            return false;
+        }
+
+        if (sliceSize <= 0)
+        {
+            error = "PAR2 slice size must be positive.";
+            return false;
+        }
+
+        if (globalSliceBase < 0)
+        {
+            error = "PAR2 global slice base is negative.";
+            return false;
+        }
+
+        if (sliceCount < 0)
+        {
+            error = "PAR2 slice count is negative.";
+            return false;
+        }
+
+        var expectedSlices = fileLength == 0
+            ? 0
+            : (int)((fileLength + sliceSize - 1) / sliceSize);
+        if (sliceCount != expectedSlices)
+        {
+            error = "PAR2 slice count does not match the target file length.";
+            return false;
+        }
+
+        for (var i = 0; i < segmentRanges.Length; i++)
+        {
+            var range = segmentRanges[i];
+            if (range.Count < 0)
+            {
+                error = $"Segment {i} has a negative byte range.";
+                return false;
+            }
+
+            if (range.Count == 0)
+                continue;
+
+            if (range.StartInclusive < 0 || range.EndExclusive > fileLength)
+            {
+                error = $"Segment {i} maps outside the target file.";
+                return false;
+            }
+        }
+
+        map = new Par2FileSliceMap(fileLength, globalSliceBase, sliceSize, sliceCount, segmentRanges);
+        return true;
+    }
+
+    public IEnumerable<int> GlobalSlicesForSegment(int segmentIndex)
+    {
+        var range = SegmentRanges[segmentIndex];
+        if (range.Count == 0)
+            yield break;
+
+        long firstSlice;
+        long lastSlice;
+        try
+        {
+            firstSlice = range.StartInclusive / SliceSize;
+            lastSlice = (range.EndExclusive - 1) / SliceSize;
+        }
+        catch (OverflowException)
+        {
+            yield break;
+        }
+
+        for (var local = firstSlice; local <= lastSlice; local++)
+            yield return checked(GlobalSliceBase + (int)local);
+    }
+
+    public IEnumerable<int> SegmentIndicesForGlobalSlice(int globalSlice)
+    {
+        var local = globalSlice - GlobalSliceBase;
+        if ((uint)local >= (uint)SliceCount)
+            yield break;
+
+        var start = (long)local * SliceSize;
+        var end = Math.Min(start + SliceSize, FileLength);
+        for (var i = 0; i < SegmentRanges.Count; i++)
+        {
+            var range = SegmentRanges[i];
+            if (range.Count == 0)
+                continue;
+            if (range.StartInclusive < end && range.EndExclusive > start)
+                yield return i;
+        }
+    }
+
+    public LongRange SliceFileRange(int globalSlice)
+    {
+        var local = globalSlice - GlobalSliceBase;
+        var start = (long)local * SliceSize;
+        var count = Math.Min(SliceSize, Math.Max(0, FileLength - start));
+        return LongRange.FromStartAndSize(start, count);
+    }
+}

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
 using System.Threading.Channels;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
@@ -395,45 +396,160 @@ public class Par2RepairService : BackgroundService
         if (par2Context == null)
             return RepairExecutionResult.NotFeasible("No matching PAR2 recovery set found in the NZB.");
 
-        var missingSegments = ResolveMissingSegments(job.MissingSegmentIds, segmentIds);
-        if (missingSegments.Count == 0 && job.MissingSegmentIds.Length == 0)
+        var sliceSize = (int)par2Context.Main.SliceSize;
+        var targetKey = Convert.ToHexString(par2Context.Main.FileIds[par2Context.TargetFileIndex]);
+        var targetDesc = par2Context.FileDescsById[targetKey];
+        var targetIfsc = par2Context.IfscsByFileId[targetKey];
+        var fileLength = davItem.FileSize ?? (long)targetDesc.FileLength;
+        var globalSliceBase = GlobalSliceOffset(
+            par2Context.TargetFileIndex, par2Context.Main, par2Context.IfscsByFileId);
+
+        LongRange[] segmentRanges;
+        try
         {
-            missingSegments = segmentIds
-                .Select((id, index) => new MissingSegment(id, index))
-                .ToList();
+            segmentRanges = BuildSegmentRanges(nzbFile, segmentIds.Length, fileLength);
+        }
+        catch (InvalidOperationException e)
+        {
+            return RepairExecutionResult.NotFeasible(e.Message);
         }
 
-        if (missingSegments.Count == 0)
-            return RepairExecutionResult.NotFeasible("No missing segments to repair.");
+        if (!Par2FileSliceMap.TryCreate(
+                fileLength,
+                globalSliceBase,
+                sliceSize,
+                targetIfsc.Slices.Count,
+                segmentRanges,
+                out var sliceMap,
+                out var mapError)
+            || sliceMap is null)
+        {
+            return RepairExecutionResult.NotFeasible(mapError ?? "Could not map segments onto PAR2 slices.");
+        }
 
-        var sliceSize = (int)par2Context.Main.SliceSize;
-        var maxMissingSlices = _configManager.GetPar2MaxMissingSlices();
-        var maxMemoryBytes = _configManager.GetPar2MaxMemoryMb() * 1024L * 1024L;
-        var workingSetBytes = (long)(missingSegments.Count + 2) * sliceSize;
-        if (workingSetBytes > maxMemoryBytes)
-            return RepairExecutionResult.NotFeasible(
-                $"PAR2 working set {workingSetBytes} bytes exceeds memory cap.");
+        var requested = ResolveMissingSegments(job.MissingSegmentIds, segmentIds);
+        var persistedMissing = ValidIndices(nzbFile.MissingSegmentIndices, segmentIds.Length);
+        var persistedCorrupt = ValidIndices(nzbFile.CorruptSegmentIndices, segmentIds.Length);
+        var unavailableSegments = new HashSet<int>();
+        foreach (var item in requested)
+            unavailableSegments.Add(item.Index);
+        unavailableSegments.UnionWith(persistedMissing);
+        unavailableSegments.UnionWith(persistedCorrupt);
 
-        var releaseBytesCap = _configManager.GetPar2MaxReleaseGb() * 1024L * 1024L * 1024L;
-        var releaseBytes = EstimateReleaseBytes(par2Context.Main, par2Context.FileDescsById);
-        if (releaseBytes > releaseBytesCap)
-            return RepairExecutionResult.NotFeasible(
-                $"Recovery set size {releaseBytes} bytes exceeds release cap.");
+        if (unavailableSegments.Count == 0 && job.MissingSegmentIds.Length == 0
+            && persistedMissing.Count == 0 && persistedCorrupt.Count == 0)
+        {
+            unavailableSegments.UnionWith(Enumerable.Range(0, segmentIds.Length));
+        }
 
-        var segmentRanges = BuildSegmentRanges(nzbFile, segmentIds.Length, davItem.FileSize);
-        var missingSliceIndices = MapMissingSegmentsToSlices(
-            missingSegments, segmentRanges, sliceSize, par2Context.TargetFileIndex, par2Context.Main, par2Context.IfscsByFileId);
-        if (missingSliceIndices.Count == 0)
-            return RepairExecutionResult.NotFeasible("Missing segments do not map to PAR2 slices.");
+        if (unavailableSegments.Count == 0)
+            return RepairExecutionResult.NotFeasible("No missing or corrupt segments to repair.");
 
-        if (missingSliceIndices.Count > maxMissingSlices)
-            return RepairExecutionResult.NotFeasible(
-                $"Missing slice count {missingSliceIndices.Count} exceeds cap {maxMissingSlices}.");
+        var unavailableSlices = new HashSet<int>();
+        try
+        {
+            foreach (var index in unavailableSegments)
+            {
+                foreach (var slice in sliceMap.GlobalSlicesForSegment(index))
+                    unavailableSlices.Add(slice);
+            }
+        }
+        catch (OverflowException)
+        {
+            return RepairExecutionResult.NotFeasible("Segment-to-slice mapping overflowed.");
+        }
+
+        if (unavailableSlices.Count == 0)
+            return RepairExecutionResult.NotFeasible("Missing or corrupt segments do not map to PAR2 slices.");
 
         var fetchConcurrency = _configManager.GetPar2FetchConcurrency();
         using var fetchGate = new SemaphoreSlim(fetchConcurrency, fetchConcurrency);
         var bytesRead = 0L;
+        var accessor = new SliceSegmentAccessor(
+            segmentIds,
+            sliceMap,
+            nzbDocument,
+            par2Context,
+            _usenetClient,
+            fetchGate,
+            unavailableSlices,
+            onBytesRead: n => bytesRead += n);
+        foreach (var index in persistedMissing)
+            accessor.NoteMissing(index);
+        foreach (var index in persistedCorrupt)
+            accessor.NoteCorrupt(index);
 
+        try
+        {
+            await DiscoverUnavailableSourcesAsync(
+                    accessor, sliceMap, targetIfsc, unavailableSegments, unavailableSlices, ct)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+
+        var discoveredMissing = accessor.MissingSegmentIndices.Except(persistedMissing).Except(requested.Select(x => x.Index)).Count();
+        var discoveredCorrupt = accessor.CorruptSegmentIndices.Except(persistedCorrupt).Except(requested.Select(x => x.Index)).Count();
+        Log.Information(
+            "PAR2 repair targeting {Path}: requested={Requested} persistedMissing={PersistedMissing} "
+            + "persistedCorrupt={PersistedCorrupt} discoveredMissing={DiscoveredMissing} "
+            + "discoveredCorrupt={DiscoveredCorrupt} slices={Slices}",
+            davItem.Path,
+            requested.Count,
+            persistedMissing.Count,
+            persistedCorrupt.Count,
+            discoveredMissing,
+            discoveredCorrupt,
+            unavailableSlices.Count);
+
+        var maxMissingSlices = _configManager.GetPar2MaxMissingSlices();
+        if (unavailableSlices.Count > maxMissingSlices)
+        {
+            await PersistDiscoveredDamageAsync(davItem, nzbFile, accessor, ct).ConfigureAwait(false);
+            return RepairExecutionResult.NotFeasible(
+                $"Missing slice count {unavailableSlices.Count} exceeds cap {maxMissingSlices}.");
+        }
+
+        var patchTargets = SegmentsOverlappingSlices(sliceMap, unavailableSlices, segmentIds);
+        var stagedPatchBytes = patchTargets.Sum(target => segmentRanges[target.Index].Count);
+        var presentSliceCount = Math.Max(0, sliceMap.SliceCount - unavailableSlices.Count);
+        long workingSetBytes;
+        try
+        {
+            workingSetBytes = EstimateWorkingSetBytes(
+                accessor.CachedBodyBytes,
+                presentSliceCount,
+                unavailableSlices.Count,
+                unavailableSlices.Count,
+                stagedPatchBytes,
+                sliceSize);
+        }
+        catch (OverflowException)
+        {
+            await PersistDiscoveredDamageAsync(davItem, nzbFile, accessor, ct).ConfigureAwait(false);
+            return RepairExecutionResult.NotFeasible("PAR2 working-set estimate overflowed.");
+        }
+
+        var maxMemoryBytes = _configManager.GetPar2MaxMemoryMb() * 1024L * 1024L;
+        if (workingSetBytes > maxMemoryBytes)
+        {
+            await PersistDiscoveredDamageAsync(davItem, nzbFile, accessor, ct).ConfigureAwait(false);
+            return RepairExecutionResult.NotFeasible(
+                $"PAR2 working set {workingSetBytes} bytes exceeds memory cap.");
+        }
+
+        var releaseBytesCap = _configManager.GetPar2MaxReleaseGb() * 1024L * 1024L * 1024L;
+        var releaseBytes = EstimateReleaseBytes(par2Context.Main, par2Context.FileDescsById);
+        if (releaseBytes > releaseBytesCap)
+        {
+            await PersistDiscoveredDamageAsync(davItem, nzbFile, accessor, ct).ConfigureAwait(false);
+            return RepairExecutionResult.NotFeasible(
+                $"Recovery set size {releaseBytes} bytes exceeds release cap.");
+        }
+
+        var missingSliceIndices = unavailableSlices.OrderBy(x => x).ToList();
         var recoverySlices = await CollectRecoverySlicesAsync(
             par2Context.VolumeFiles,
             missingSliceIndices.Count,
@@ -442,16 +558,11 @@ public class Par2RepairService : BackgroundService
             ct,
             onBytesRead: n => bytesRead += n).ConfigureAwait(false);
         if (recoverySlices.Count < missingSliceIndices.Count)
+        {
+            await PersistDiscoveredDamageAsync(davItem, nzbFile, accessor, ct).ConfigureAwait(false);
             return RepairExecutionResult.NotFeasible(
                 $"Need {missingSliceIndices.Count} recovery slices but only collected {recoverySlices.Count}.");
-
-        var accessor = new SliceSegmentAccessor(
-            segmentIds,
-            segmentRanges,
-            contentNzb,
-            _usenetClient,
-            fetchGate,
-            onBytesRead: n => bytesRead += n);
+        }
 
         var reconstructor = new Par2Reconstructor();
         var reconstruction = await reconstructor.ReconstructAsync(
@@ -466,30 +577,37 @@ public class Par2RepairService : BackgroundService
         if (!reconstruction.Success)
         {
             PrometheusMetrics.Current?.RecordPar2ValidationFailure("slice");
+            await PersistDiscoveredDamageAsync(davItem, nzbFile, accessor, ct).ConfigureAwait(false);
             return RepairExecutionResult.Failed(reconstruction.FailureReason ?? "Reconstruction failed.");
         }
 
-        var patchTargets = job.MissingSegmentIds.Length > 0
-            ? missingSegments
-            : accessor.GetMissingSegments();
         if (patchTargets.Count == 0)
-            return RepairExecutionResult.NotFeasible("No missing segments were confirmed during PAR2 repair.");
+        {
+            await PersistDiscoveredDamageAsync(davItem, nzbFile, accessor, ct).ConfigureAwait(false);
+            return RepairExecutionResult.NotFeasible("No missing or corrupt segments were confirmed during PAR2 repair.");
+        }
 
-        var commits = ExtractSegmentPatches(
+        var commits = await ExtractSegmentPatchesAsync(
             patchTargets,
-            segmentRanges,
+            sliceMap,
             reconstruction.ReconstructedSlices,
-            sliceSize,
-            par2Context.TargetFileIndex,
-            par2Context.Main,
-            par2Context.IfscsByFileId,
+            accessor,
             davItem.Name,
-            davItem.FileSize ?? 0,
-            segmentIds.Length);
+            fileLength,
+            segmentIds.Length,
+            ct).ConfigureAwait(false);
 
-        foreach (var patch in commits)
-            _patchStore.CommitPatch(patch.SegmentId, patch.Bytes, patch.Header);
+        if (!TryVerifyWholeFileMd5(targetDesc, sliceMap, reconstruction.ReconstructedSlices, accessor, out var md5Reason))
+        {
+            PrometheusMetrics.Current?.RecordPar2ValidationFailure("file");
+            await PersistDiscoveredDamageAsync(davItem, nzbFile, accessor, ct).ConfigureAwait(false);
+            return RepairExecutionResult.Failed(md5Reason ?? "Whole-file MD5 mismatch.");
+        }
 
+        _patchStore.CommitPatches(
+            commits.Select(patch => (patch.SegmentId, patch.Bytes, patch.Header)).ToList());
+
+        await PersistDiscoveredDamageAsync(davItem, nzbFile, accessor, ct).ConfigureAwait(false);
         PrometheusMetrics.Current?.AddPar2RepairBytesRead(bytesRead);
         PrometheusMetrics.Current?.AddPar2SlicesReconstructed(reconstruction.ReconstructedSlices.Count);
         PrometheusMetrics.Current?.AddPar2SegmentsCommitted(commits.Count);
@@ -497,39 +615,247 @@ public class Par2RepairService : BackgroundService
         return RepairExecutionResult.Succeeded(bytesRead, reconstruction.ReconstructedSlices.Count, commits.Count);
     }
 
-    private static List<SegmentPatch> ExtractSegmentPatches(
-        IReadOnlyList<MissingSegment> missingSegments,
-        LongRange[] segmentRanges,
+    private static async Task DiscoverUnavailableSourcesAsync(
+        SliceSegmentAccessor accessor,
+        Par2FileSliceMap sliceMap,
+        IfscPacket targetIfsc,
+        HashSet<int> unavailableSegments,
+        HashSet<int> unavailableSlices,
+        CancellationToken ct)
+    {
+        var expanded = true;
+        while (expanded)
+        {
+            ct.ThrowIfCancellationRequested();
+            expanded = false;
+            AbsorbAccessorDiscoveries(accessor, sliceMap, unavailableSegments, unavailableSlices, ref expanded);
+
+            for (var local = 0; local < sliceMap.SliceCount; local++)
+            {
+                ct.ThrowIfCancellationRequested();
+                var globalSlice = checked(sliceMap.GlobalSliceBase + local);
+                if (unavailableSlices.Contains(globalSlice))
+                    continue;
+
+                var assembled = await accessor.FetchSliceBytesAsync(globalSlice, sliceMap.SliceSize, ct)
+                    .ConfigureAwait(false);
+                AbsorbAccessorDiscoveries(accessor, sliceMap, unavailableSegments, unavailableSlices, ref expanded);
+                if (assembled is null)
+                {
+                    if (unavailableSlices.Add(globalSlice))
+                        expanded = true;
+                    continue;
+                }
+
+                if (!Par2Reconstructor.VerifySliceChecksum(assembled, targetIfsc.Slices[local]))
+                {
+                    if (unavailableSlices.Add(globalSlice))
+                        expanded = true;
+                }
+            }
+        }
+    }
+
+    private static void AbsorbAccessorDiscoveries(
+        SliceSegmentAccessor accessor,
+        Par2FileSliceMap sliceMap,
+        HashSet<int> unavailableSegments,
+        HashSet<int> unavailableSlices,
+        ref bool expanded)
+    {
+        foreach (var index in accessor.MissingSegmentIndices.Concat(accessor.CorruptSegmentIndices))
+        {
+            if (!unavailableSegments.Add(index))
+                continue;
+            foreach (var slice in sliceMap.GlobalSlicesForSegment(index))
+            {
+                if (unavailableSlices.Add(slice))
+                    expanded = true;
+            }
+        }
+    }
+
+    private static List<MissingSegment> SegmentsOverlappingSlices(
+        Par2FileSliceMap sliceMap,
+        HashSet<int> unavailableSlices,
+        string[] segmentIds)
+    {
+        var targets = new List<MissingSegment>();
+        for (var i = 0; i < segmentIds.Length; i++)
+        {
+            if (sliceMap.GlobalSlicesForSegment(i).Any(unavailableSlices.Contains))
+                targets.Add(new MissingSegment(segmentIds[i], i));
+        }
+
+        return targets;
+    }
+
+    internal static long EstimateWorkingSetBytes(
+        long cachedSourceBodyBytes,
+        int assembledPresentSliceCount,
+        int recoverySliceCount,
+        int reconstructedSliceCount,
+        long stagedPatchBytes,
+        int sliceSize)
+    {
+        checked
+        {
+            var assembled = (long)assembledPresentSliceCount * sliceSize;
+            var recovery = (long)recoverySliceCount * sliceSize;
+            var accumulators = (long)recoverySliceCount * sliceSize;
+            var reconstructed = (long)reconstructedSliceCount * sliceSize;
+            var memoryStreamDup = cachedSourceBodyBytes;
+            return cachedSourceBodyBytes
+                   + assembled
+                   + recovery
+                   + accumulators
+                   + reconstructed
+                   + stagedPatchBytes
+                   + memoryStreamDup;
+        }
+    }
+
+    private static HashSet<int> ValidIndices(int[]? indices, int segmentCount)
+    {
+        if (indices is not { Length: > 0 })
+            return [];
+        return indices.Where(index => (uint)index < (uint)segmentCount).ToHashSet();
+    }
+
+    private static async Task PersistDiscoveredDamageAsync(
+        DavItem davItem,
+        DavNzbFile nzbFile,
+        SliceSegmentAccessor accessor,
+        CancellationToken ct)
+    {
+        var missing = accessor.MissingSegmentIndices.OrderBy(i => i).ToArray();
+        var corrupt = accessor.CorruptSegmentIndices.OrderBy(i => i).ToArray();
+        if (missing.Length == 0 && corrupt.Length == 0)
+            return;
+
+        await DavNzbFileBlobUpdater.MutateAsync(
+            davItem,
+            current =>
+            {
+                if (missing.Length > 0)
+                {
+                    current.MissingSegmentIndices = UnionIndices(current.MissingSegmentIndices, missing);
+                }
+
+                if (corrupt.Length > 0)
+                {
+                    current.CorruptSegmentIndices = UnionIndices(current.CorruptSegmentIndices, corrupt);
+                }
+
+                return current;
+            },
+            fallback: nzbFile).ConfigureAwait(false);
+
+        await using var dbContext = new DavDatabaseContext();
+        var tracked = await dbContext.Items.FirstOrDefaultAsync(x => x.Id == davItem.Id, ct).ConfigureAwait(false);
+        if (tracked is not null && davItem.FileBlobId is { } blobId)
+        {
+            tracked.FileBlobId = blobId;
+            await dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+    }
+
+    private static int[] UnionIndices(int[]? existing, int[] discovered)
+    {
+        return (existing ?? [])
+            .Concat(discovered)
+            .Distinct()
+            .OrderBy(i => i)
+            .ToArray();
+    }
+
+#pragma warning disable CA5351 // PAR 2.0 whole-file hashes use MD5 per spec
+    private static bool TryVerifyWholeFileMd5(
+        FileDesc desc,
+        Par2FileSliceMap sliceMap,
         Dictionary<int, byte[]> reconstructedSlices,
-        int sliceSize,
-        int targetFileIndex,
-        MainPacket main,
-        IReadOnlyDictionary<string, IfscPacket> ifscsByFileId,
+        SliceSegmentAccessor accessor,
+        out string? reason)
+    {
+        reason = null;
+        if (desc.FileHash is not { Length: 16 })
+            return true;
+
+        using var hasher = IncrementalHash.CreateHash(HashAlgorithmName.MD5);
+        long offset = 0;
+        while (offset < sliceMap.FileLength)
+        {
+            var globalSlice = sliceMap.GlobalSliceBase + (int)(offset / sliceMap.SliceSize);
+            var sliceRange = sliceMap.SliceFileRange(globalSlice);
+            byte[] sliceBytes;
+            if (reconstructedSlices.TryGetValue(globalSlice, out var reconstructed))
+            {
+                sliceBytes = reconstructed;
+            }
+            else
+            {
+                var fetched = accessor.TryGetCachedSlice(globalSlice, sliceMap.SliceSize);
+                if (fetched is null)
+                {
+                    reason = $"Whole-file MD5 coverage gap at slice {globalSlice}.";
+                    return false;
+                }
+
+                sliceBytes = fetched;
+            }
+
+            var validLen = (int)Math.Min(sliceRange.Count, sliceMap.FileLength - offset);
+            if (validLen > 0)
+                hasher.AppendData(sliceBytes.AsSpan(0, validLen));
+            offset += validLen;
+        }
+
+        var computed = hasher.GetHashAndReset();
+        if (computed.AsSpan().SequenceEqual(desc.FileHash))
+            return true;
+
+        reason = $"Whole-file MD5 mismatch for {desc.FileName}.";
+        return false;
+    }
+#pragma warning restore CA5351
+
+    private static async Task<List<SegmentPatch>> ExtractSegmentPatchesAsync(
+        IReadOnlyList<MissingSegment> missingSegments,
+        Par2FileSliceMap sliceMap,
+        Dictionary<int, byte[]> reconstructedSlices,
+        SliceSegmentAccessor accessor,
         string fileName,
         long fileSize,
-        int segmentCount)
+        int segmentCount,
+        CancellationToken ct)
     {
-        var globalSliceOffset = GlobalSliceOffset(targetFileIndex, main, ifscsByFileId);
         var patches = new List<SegmentPatch>();
-
         foreach (var missing in missingSegments)
         {
-            var range = segmentRanges[missing.Index];
+            var range = sliceMap.SegmentRanges[missing.Index];
             var bytes = new byte[range.Count];
+            var cached = await accessor.TryGetCachedBodyAsync(missing.Index, ct).ConfigureAwait(false);
+            if (cached is not null)
+            {
+                var copy = (int)Math.Min(cached.Length, bytes.Length);
+                Buffer.BlockCopy(cached, 0, bytes, 0, copy);
+            }
+
             var copied = 0L;
             var fileOffset = range.StartInclusive;
-
             while (copied < range.Count)
             {
-                var localSlice = (int)((fileOffset + copied) / sliceSize);
-                var globalSlice = globalSliceOffset + localSlice;
-                if (!reconstructedSlices.TryGetValue(globalSlice, out var slice))
-                    throw new InvalidOperationException($"Reconstructed slice {globalSlice} missing for segment patch.");
+                var globalSlice = sliceMap.GlobalSliceBase + (int)((fileOffset + copied) / sliceMap.SliceSize);
+                if (reconstructedSlices.TryGetValue(globalSlice, out var slice))
+                {
+                    var offsetInSlice = (int)((fileOffset + copied) % sliceMap.SliceSize);
+                    var toCopy = (int)Math.Min(range.Count - copied, sliceMap.SliceSize - offsetInSlice);
+                    Buffer.BlockCopy(slice, offsetInSlice, bytes, (int)copied, toCopy);
+                    copied += toCopy;
+                    continue;
+                }
 
-                var offsetInSlice = (int)((fileOffset + copied) % sliceSize);
-                var toCopy = (int)Math.Min(range.Count - copied, sliceSize - offsetInSlice);
-                Buffer.BlockCopy(slice, offsetInSlice, bytes, (int)copied, toCopy);
-                copied += toCopy;
+                copied += Math.Min(range.Count - copied, sliceMap.SliceSize - ((fileOffset + copied) % sliceMap.SliceSize));
             }
 
             patches.Add(new SegmentPatch(
@@ -553,7 +879,7 @@ public class Par2RepairService : BackgroundService
     private static int GlobalSliceOffset(
         int targetFileIndex,
         MainPacket main,
-        IReadOnlyDictionary<string, IfscPacket> ifscsByFileId)
+        Dictionary<string, IfscPacket> ifscsByFileId)
     {
         var offset = 0;
         for (var i = 0; i < targetFileIndex; i++)
@@ -563,30 +889,6 @@ public class Par2RepairService : BackgroundService
         }
 
         return offset;
-    }
-
-    private static List<int> MapMissingSegmentsToSlices(
-        IReadOnlyList<MissingSegment> missingSegments,
-        LongRange[] segmentRanges,
-        int sliceSize,
-        int targetFileIndex,
-        MainPacket main,
-        IReadOnlyDictionary<string, IfscPacket> ifscsByFileId)
-    {
-        var globalOffset = GlobalSliceOffset(targetFileIndex, main, ifscsByFileId);
-        var slices = new HashSet<int>();
-        foreach (var missing in missingSegments)
-        {
-            var start = segmentRanges[missing.Index].StartInclusive;
-            var end = segmentRanges[missing.Index].EndExclusive;
-            for (var offset = start; offset < end; offset += sliceSize)
-            {
-                var localSlice = (int)(offset / sliceSize);
-                slices.Add(globalOffset + localSlice);
-            }
-        }
-
-        return slices.OrderBy(x => x).ToList();
     }
 
     private static LongRange[] BuildSegmentRanges(DavNzbFile nzbFile, int segmentCount, long? fileSize)
@@ -1046,68 +1348,127 @@ public class Par2RepairService : BackgroundService
     private sealed class SliceSegmentAccessor
     {
         private readonly string[] _segmentIds;
-        private readonly LongRange[] _ranges;
-        private readonly NzbFile _contentNzb;
+        private readonly Par2FileSliceMap _map;
+        private readonly NzbDocument _nzbDocument;
+        private readonly Par2SetContext _par2;
         private readonly UsenetStreamingClient _client;
         private readonly SemaphoreSlim _fetchGate;
+        private readonly HashSet<int> _targetSlices;
         private readonly Action<long>? _onBytesRead;
         private readonly Dictionary<int, byte[]> _segmentBodies = new();
+        private readonly Dictionary<int, byte[]> _siblingFileBytes = new();
         private readonly HashSet<int> _missingSegmentIndices = new();
+        private readonly HashSet<int> _corruptSegmentIndices = new();
+        private long _cachedBodyBytes;
 
         public SliceSegmentAccessor(
             string[] segmentIds,
-            LongRange[] ranges,
-            NzbFile contentNzb,
+            Par2FileSliceMap map,
+            NzbDocument nzbDocument,
+            Par2SetContext par2,
             UsenetStreamingClient client,
             SemaphoreSlim fetchGate,
+            HashSet<int> targetSlices,
             Action<long>? onBytesRead)
         {
             _segmentIds = segmentIds;
-            _ranges = ranges;
-            _contentNzb = contentNzb;
+            _map = map;
+            _nzbDocument = nzbDocument;
+            _par2 = par2;
             _client = client;
             _fetchGate = fetchGate;
+            _targetSlices = targetSlices;
             _onBytesRead = onBytesRead;
         }
 
+        public IReadOnlyCollection<int> MissingSegmentIndices => _missingSegmentIndices;
+        public IReadOnlyCollection<int> CorruptSegmentIndices => _corruptSegmentIndices;
+        public long CachedBodyBytes => Interlocked.Read(ref _cachedBodyBytes);
+
+        public void NoteMissing(int segmentIndex) => _missingSegmentIndices.Add(segmentIndex);
+
+        public void NoteCorrupt(int segmentIndex) => _corruptSegmentIndices.Add(segmentIndex);
+
         public async Task<byte[]?> FetchSliceBytesAsync(int globalSliceIndex, int sliceSize, CancellationToken ct)
         {
-            var fileOffset = (long)globalSliceIndex * sliceSize;
-            var segmentIndex = FindSegmentIndex(fileOffset);
-            if (segmentIndex < 0) return null;
+            var local = globalSliceIndex - _map.GlobalSliceBase;
+            if ((uint)local >= (uint)_map.SliceCount)
+                return await FetchForeignSliceAsync(globalSliceIndex, sliceSize, ct).ConfigureAwait(false);
 
-            var body = await GetSegmentBodyAsync(segmentIndex, ct).ConfigureAwait(false);
-            if (body == null) return null;
+            if (_targetSlices.Contains(globalSliceIndex))
+                return null;
 
-            var segmentStart = _ranges[segmentIndex].StartInclusive;
-            var offsetInSegment = (int)(fileOffset - segmentStart);
-            if (offsetInSegment < 0 || offsetInSegment + sliceSize > body.Length)
+            var sliceRange = _map.SliceFileRange(globalSliceIndex);
+            var buffer = new byte[sliceSize];
+            var copied = 0;
+            foreach (var segmentIndex in _map.SegmentIndicesForGlobalSlice(globalSliceIndex))
             {
-                var slice = new byte[sliceSize];
-                var available = Math.Min(sliceSize, body.Length - offsetInSegment);
-                if (available > 0)
-                    Buffer.BlockCopy(body, offsetInSegment, slice, 0, available);
-                return slice;
+                var body = await GetSegmentBodyAsync(segmentIndex, ct).ConfigureAwait(false);
+                if (body is null)
+                {
+                    if (sliceRange.EndExclusive < _map.FileLength)
+                        return null;
+                    break;
+                }
+
+                var segmentRange = _map.SegmentRanges[segmentIndex];
+                var intersectStart = Math.Max(sliceRange.StartInclusive, segmentRange.StartInclusive);
+                var intersectEnd = Math.Min(sliceRange.EndExclusive, segmentRange.EndExclusive);
+                if (intersectEnd <= intersectStart)
+                    continue;
+
+                var destOffset = (int)(intersectStart - sliceRange.StartInclusive);
+                var srcOffset = (int)(intersectStart - segmentRange.StartInclusive);
+                var count = (int)(intersectEnd - intersectStart);
+                if (srcOffset < 0 || srcOffset + count > body.Length)
+                    return null;
+                Buffer.BlockCopy(body, srcOffset, buffer, destOffset, count);
+                copied += count;
             }
 
-            var exact = new byte[sliceSize];
-            Buffer.BlockCopy(body, offsetInSegment, exact, 0, sliceSize);
-            return exact;
+            if (copied < sliceRange.Count && sliceRange.EndExclusive < _map.FileLength)
+                return null;
+            return buffer;
         }
 
-        private int FindSegmentIndex(long fileOffset)
+        public byte[]? TryGetCachedSlice(int globalSliceIndex, int sliceSize)
         {
-            for (var i = 0; i < _ranges.Length; i++)
+            if (_targetSlices.Contains(globalSliceIndex))
+                return null;
+
+            var sliceRange = _map.SliceFileRange(globalSliceIndex);
+            var buffer = new byte[sliceSize];
+            var copied = 0;
+            foreach (var segmentIndex in _map.SegmentIndicesForGlobalSlice(globalSliceIndex))
             {
-                if (fileOffset >= _ranges[i].StartInclusive && fileOffset < _ranges[i].EndExclusive)
-                    return i;
+                if (!_segmentBodies.TryGetValue(segmentIndex, out var body))
+                    return null;
+                var segmentRange = _map.SegmentRanges[segmentIndex];
+                var intersectStart = Math.Max(sliceRange.StartInclusive, segmentRange.StartInclusive);
+                var intersectEnd = Math.Min(sliceRange.EndExclusive, segmentRange.EndExclusive);
+                if (intersectEnd <= intersectStart)
+                    continue;
+                var destOffset = (int)(intersectStart - sliceRange.StartInclusive);
+                var srcOffset = (int)(intersectStart - segmentRange.StartInclusive);
+                var count = (int)(intersectEnd - intersectStart);
+                Buffer.BlockCopy(body, srcOffset, buffer, destOffset, count);
+                copied += count;
             }
 
-            return -1;
+            return copied < sliceRange.Count && sliceRange.EndExclusive < _map.FileLength ? null : buffer;
+        }
+
+        public Task<byte[]?> TryGetCachedBodyAsync(int segmentIndex, CancellationToken ct)
+        {
+            _ = ct;
+            return Task.FromResult(
+                _segmentBodies.TryGetValue(segmentIndex, out var body) ? body : null);
         }
 
         private async Task<byte[]?> GetSegmentBodyAsync(int segmentIndex, CancellationToken ct)
         {
+            if (_missingSegmentIndices.Contains(segmentIndex) || _corruptSegmentIndices.Contains(segmentIndex))
+                return null;
             if (_segmentBodies.TryGetValue(segmentIndex, out var cached))
                 return cached;
 
@@ -1116,26 +1477,41 @@ public class Par2RepairService : BackgroundService
             {
                 if (_segmentBodies.TryGetValue(segmentIndex, out cached))
                     return cached;
+                if (_missingSegmentIndices.Contains(segmentIndex) || _corruptSegmentIndices.Contains(segmentIndex))
+                    return null;
 
                 var segmentId = _segmentIds[segmentIndex];
-                UsenetDecodedBodyResponse response;
                 try
                 {
-                    response = await _client.DecodedBodyAsync(segmentId, ct).ConfigureAwait(false);
+                    var response = await _client.DecodedBodyAsync(segmentId, ct).ConfigureAwait(false);
+                    await using var stream = response.Stream!;
+                    await using var ms = new MemoryStream();
+                    await stream.CopyToAsync(ms, ct).ConfigureAwait(false);
+                    var bytes = ms.ToArray();
+                    _onBytesRead?.Invoke(bytes.Length);
+                    _segmentBodies[segmentIndex] = bytes;
+                    Interlocked.Add(ref _cachedBodyBytes, bytes.Length);
+                    return bytes;
                 }
-                catch (UsenetArticleNotFoundException)
+                catch (Exception e) when (e is not OutOfMemoryException)
                 {
-                    _missingSegmentIndices.Add(segmentIndex);
-                    return null;
-                }
+                    if (e.IsCancellationException(ct))
+                        throw;
 
-                await using var stream = response.Stream!;
-                await using var ms = new MemoryStream();
-                await stream.CopyToAsync(ms, ct).ConfigureAwait(false);
-                var bytes = ms.ToArray();
-                _onBytesRead?.Invoke(bytes.Length);
-                _segmentBodies[segmentIndex] = bytes;
-                return bytes;
+                    if (e.TryGetCausingException<UsenetArticleNotFoundException>(out _))
+                    {
+                        _missingSegmentIndices.Add(segmentIndex);
+                        return null;
+                    }
+
+                    if (e.TryGetCausingException<UsenetCorruptArticleException>(out _))
+                    {
+                        _corruptSegmentIndices.Add(segmentIndex);
+                        return null;
+                    }
+
+                    throw;
+                }
             }
             finally
             {
@@ -1143,10 +1519,76 @@ public class Par2RepairService : BackgroundService
             }
         }
 
-        public List<MissingSegment> GetMissingSegments()
-            => _missingSegmentIndices
-                .OrderBy(i => i)
-                .Select(i => new MissingSegment(_segmentIds[i], i))
-                .ToList();
+        private async Task<byte[]?> FetchForeignSliceAsync(int globalSliceIndex, int sliceSize, CancellationToken ct)
+        {
+            var offset = 0;
+            for (var fileIndex = 0; fileIndex < _par2.Main.FileIds.Count; fileIndex++)
+            {
+                var key = Convert.ToHexString(_par2.Main.FileIds[fileIndex]);
+                if (!_par2.IfscsByFileId.TryGetValue(key, out var ifsc))
+                    return null;
+
+                var count = ifsc.Slices.Count;
+                if (globalSliceIndex >= offset + count)
+                {
+                    offset += count;
+                    continue;
+                }
+
+                if (fileIndex == _par2.TargetFileIndex)
+                    return null;
+
+                var fileBytes = await GetSiblingFileBytesAsync(fileIndex, ct).ConfigureAwait(false);
+                if (fileBytes is null)
+                    return null;
+
+                var local = globalSliceIndex - offset;
+                var start = checked(local * sliceSize);
+                var slice = new byte[sliceSize];
+                if (start >= fileBytes.Length)
+                    return slice;
+
+                var copy = Math.Min(sliceSize, fileBytes.Length - start);
+                Buffer.BlockCopy(fileBytes, start, slice, 0, copy);
+                return slice;
+            }
+
+            return null;
+        }
+
+        private async Task<byte[]?> GetSiblingFileBytesAsync(int fileIndex, CancellationToken ct)
+        {
+            if (_siblingFileBytes.TryGetValue(fileIndex, out var cached))
+                return cached;
+
+            var key = Convert.ToHexString(_par2.Main.FileIds[fileIndex]);
+            if (!_par2.FileDescsById.TryGetValue(key, out var desc))
+                return null;
+
+            var nzbFile = FindContentNzbFile(_nzbDocument, desc.FileName);
+            if (nzbFile is null || nzbFile.Segments.Count == 0)
+                return null;
+
+            await _fetchGate.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                if (_siblingFileBytes.TryGetValue(fileIndex, out cached))
+                    return cached;
+
+                var segmentIds = nzbFile.GetSegmentIds();
+                var fileSize = nzbFile.Segments.Sum(segment => segment.Bytes);
+                await using var stream = _client.GetFileStream(segmentIds, fileSize, articleBufferSize: 0);
+                await using var destination = new MemoryStream();
+                await stream.CopyToAsync(destination, ct).ConfigureAwait(false);
+                var bytes = destination.ToArray();
+                _onBytesRead?.Invoke(bytes.Length);
+                _siblingFileBytes[fileIndex] = bytes;
+                return bytes;
+            }
+            finally
+            {
+                _fetchGate.Release();
+            }
+        }
     }
 }

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -641,12 +641,9 @@ public class Par2RepairService : BackgroundService
                 var assembled = await accessor.FetchSliceBytesAsync(globalSlice, sliceMap.SliceSize, ct)
                     .ConfigureAwait(false);
                 AbsorbAccessorDiscoveries(accessor, sliceMap, unavailableSegments, unavailableSlices, ref expanded);
-                if (assembled is null ||
-                    !Par2Reconstructor.VerifySliceChecksum(assembled, targetIfsc.Slices[local]))
-                {
-                    if (unavailableSlices.Add(globalSlice))
-                        expanded = true;
-                }
+                expanded |= (assembled is null ||
+                             !Par2Reconstructor.VerifySliceChecksum(assembled, targetIfsc.Slices[local]))
+                            && unavailableSlices.Add(globalSlice);
             }
         }
     }
@@ -1746,19 +1743,8 @@ public class Par2RepairService : BackgroundService
 
         private void EvictSiblingFile(int fileIndex)
         {
-            List<int>? indices = null;
-            foreach (var key in _siblingSegmentBodies.Keys)
-            {
-                if (key.FileIndex != fileIndex)
-                    continue;
-                indices ??= [];
-                indices.Add(key.SegmentIndex);
-            }
-
-            if (indices is null)
-                return;
-            foreach (var segmentIndex in indices)
-                EvictSiblingSegment(fileIndex, segmentIndex);
+            foreach (var key in _siblingSegmentBodies.Keys.Where(key => key.FileIndex == fileIndex).ToList())
+                EvictSiblingSegment(key.FileIndex, key.SegmentIndex);
         }
 
         private void EvictSiblingSegment(int fileIndex, int segmentIndex)

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -519,7 +519,8 @@ public class Par2RepairService : BackgroundService
         try
         {
             workingSetBytes = EstimateWorkingSetBytes(
-                accessor.CachedBodyBytes,
+                checked(accessor.CachedBodyBytes + EstimateSiblingSegmentPeakBytes(
+                    par2Context, nzbDocument, par2Context.TargetFileIndex)),
                 presentSliceCount,
                 unavailableSlices.Count,
                 unavailableSlices.Count,
@@ -640,14 +641,8 @@ public class Par2RepairService : BackgroundService
                 var assembled = await accessor.FetchSliceBytesAsync(globalSlice, sliceMap.SliceSize, ct)
                     .ConfigureAwait(false);
                 AbsorbAccessorDiscoveries(accessor, sliceMap, unavailableSegments, unavailableSlices, ref expanded);
-                if (assembled is null)
-                {
-                    if (unavailableSlices.Add(globalSlice))
-                        expanded = true;
-                    continue;
-                }
-
-                if (!Par2Reconstructor.VerifySliceChecksum(assembled, targetIfsc.Slices[local]))
+                if (assembled is null ||
+                    !Par2Reconstructor.VerifySliceChecksum(assembled, targetIfsc.Slices[local]))
                 {
                     if (unavailableSlices.Add(globalSlice))
                         expanded = true;
@@ -663,15 +658,12 @@ public class Par2RepairService : BackgroundService
         HashSet<int> unavailableSlices,
         ref bool expanded)
     {
-        foreach (var index in accessor.MissingSegmentIndices.Concat(accessor.CorruptSegmentIndices))
+        foreach (var index in accessor.MissingSegmentIndices
+                     .Concat(accessor.CorruptSegmentIndices)
+                     .Where(unavailableSegments.Add))
         {
-            if (!unavailableSegments.Add(index))
-                continue;
-            foreach (var slice in sliceMap.GlobalSlicesForSegment(index))
-            {
-                if (unavailableSlices.Add(slice))
-                    expanded = true;
-            }
+            foreach (var slice in sliceMap.GlobalSlicesForSegment(index).Where(unavailableSlices.Add))
+                expanded = true;
         }
     }
 
@@ -713,6 +705,35 @@ public class Par2RepairService : BackgroundService
                    + stagedPatchBytes
                    + memoryStreamDup;
         }
+    }
+
+    /// <summary>
+    /// Peak sibling-file cache with sequential slice walks: at most two overlapping
+    /// NZB segments of the largest sibling, not the whole foreign file.
+    /// </summary>
+    private static long EstimateSiblingSegmentPeakBytes(
+        Par2SetContext par2,
+        NzbDocument nzbDocument,
+        int targetFileIndex)
+    {
+        long peak = 0;
+        for (var i = 0; i < par2.Main.FileIds.Count; i++)
+        {
+            if (i == targetFileIndex)
+                continue;
+            var key = Convert.ToHexString(par2.Main.FileIds[i]);
+            if (!par2.FileDescsById.TryGetValue(key, out var desc))
+                continue;
+            var nzbFile = FindContentNzbFile(nzbDocument, desc.FileName);
+            if (nzbFile is null || nzbFile.Segments.Count == 0)
+                continue;
+            var maxSegment = nzbFile.Segments.Max(segment => segment.Bytes);
+            var filePeak = Math.Min((long)desc.FileLength, checked(2 * maxSegment));
+            if (filePeak > peak)
+                peak = filePeak;
+        }
+
+        return peak;
     }
 
     private static HashSet<int> ValidIndices(int[]? indices, int segmentCount)
@@ -1356,7 +1377,9 @@ public class Par2RepairService : BackgroundService
         private readonly HashSet<int> _targetSlices;
         private readonly Action<long>? _onBytesRead;
         private readonly Dictionary<int, byte[]> _segmentBodies = new();
-        private readonly Dictionary<int, byte[]> _siblingFileBytes = new();
+        private readonly Dictionary<int, SiblingLayout> _siblingLayouts = new();
+        private readonly Dictionary<(int FileIndex, int SegmentIndex), byte[]> _siblingSegmentBodies = new();
+        private int _activeSiblingFileIndex = -1;
         private readonly HashSet<int> _missingSegmentIndices = new();
         private readonly HashSet<int> _corruptSegmentIndices = new();
         private long _cachedBodyBytes;
@@ -1519,6 +1542,8 @@ public class Par2RepairService : BackgroundService
             }
         }
 
+        private sealed record SiblingLayout(Par2FileSliceMap Map, string[] SegmentIds);
+
         private async Task<byte[]?> FetchForeignSliceAsync(int globalSliceIndex, int sliceSize, CancellationToken ct)
         {
             var offset = 0;
@@ -1538,57 +1563,208 @@ public class Par2RepairService : BackgroundService
                 if (fileIndex == _par2.TargetFileIndex)
                     return null;
 
-                var fileBytes = await GetSiblingFileBytesAsync(fileIndex, ct).ConfigureAwait(false);
-                if (fileBytes is null)
+                if (!TryGetSiblingLayout(fileIndex, out var layout) || layout is null)
                     return null;
 
-                var local = globalSliceIndex - offset;
-                var start = checked(local * sliceSize);
-                var slice = new byte[sliceSize];
-                if (start >= fileBytes.Length)
-                    return slice;
-
-                var copy = Math.Min(sliceSize, fileBytes.Length - start);
-                Buffer.BlockCopy(fileBytes, start, slice, 0, copy);
-                return slice;
+                return await AssembleSiblingSliceAsync(fileIndex, layout, globalSliceIndex, sliceSize, ct)
+                    .ConfigureAwait(false);
             }
 
             return null;
         }
 
-        private async Task<byte[]?> GetSiblingFileBytesAsync(int fileIndex, CancellationToken ct)
+        private bool TryGetSiblingLayout(int fileIndex, out SiblingLayout? layout)
         {
-            if (_siblingFileBytes.TryGetValue(fileIndex, out var cached))
-                return cached;
+            if (_siblingLayouts.TryGetValue(fileIndex, out layout))
+                return true;
 
+            layout = null;
             var key = Convert.ToHexString(_par2.Main.FileIds[fileIndex]);
-            if (!_par2.FileDescsById.TryGetValue(key, out var desc))
-                return null;
+            if (!_par2.FileDescsById.TryGetValue(key, out var desc)
+                || !_par2.IfscsByFileId.TryGetValue(key, out var ifsc))
+                return false;
 
             var nzbFile = FindContentNzbFile(_nzbDocument, desc.FileName);
             if (nzbFile is null || nzbFile.Segments.Count == 0)
+                return false;
+
+            var fileLength = (long)desc.FileLength;
+            var ranges = nzbFile.GetSegmentByteRanges()
+                         ?? TryInferSiblingSegmentRanges(nzbFile, fileLength);
+            if (ranges is null)
+                return false;
+
+            var globalBase = GlobalSliceOffset(fileIndex, _par2.Main, _par2.IfscsByFileId);
+            if (!Par2FileSliceMap.TryCreate(
+                    fileLength,
+                    globalBase,
+                    (int)_par2.Main.SliceSize,
+                    ifsc.Slices.Count,
+                    ranges,
+                    out var map,
+                    out _)
+                || map is null)
+                return false;
+
+            layout = new SiblingLayout(map, nzbFile.GetSegmentIds());
+            _siblingLayouts[fileIndex] = layout;
+            return true;
+        }
+
+        private static LongRange[]? TryInferSiblingSegmentRanges(NzbFile nzbFile, long fileLength)
+        {
+            var count = nzbFile.Segments.Count;
+            if (count == 0 || fileLength <= 0)
                 return null;
+
+            var ranges = new LongRange[count];
+            long start = 0;
+            for (var i = 0; i < count; i++)
+            {
+                var remaining = fileLength - start;
+                if (remaining <= 0)
+                    return null;
+                var size = i == count - 1 ? remaining : nzbFile.Segments[i].Bytes;
+                if (size <= 0 || size > remaining)
+                    return null;
+                ranges[i] = LongRange.FromStartAndSize(start, size);
+                start += size;
+            }
+
+            return start == fileLength ? ranges : null;
+        }
+
+        private async Task<byte[]?> AssembleSiblingSliceAsync(
+            int fileIndex,
+            SiblingLayout layout,
+            int globalSliceIndex,
+            int sliceSize,
+            CancellationToken ct)
+        {
+            NoteActiveSiblingFile(fileIndex);
+            var sliceRange = layout.Map.SliceFileRange(globalSliceIndex);
+            EvictPassedSiblingSegments(fileIndex, layout, sliceRange.StartInclusive);
+
+            var buffer = new byte[sliceSize];
+            var copied = 0;
+            foreach (var segmentIndex in layout.Map.SegmentIndicesForGlobalSlice(globalSliceIndex))
+            {
+                var body = await GetSiblingSegmentBodyAsync(fileIndex, layout, segmentIndex, ct)
+                    .ConfigureAwait(false);
+                if (body is null)
+                {
+                    if (sliceRange.EndExclusive < layout.Map.FileLength)
+                        return null;
+                    break;
+                }
+
+                var segmentRange = layout.Map.SegmentRanges[segmentIndex];
+                var intersectStart = Math.Max(sliceRange.StartInclusive, segmentRange.StartInclusive);
+                var intersectEnd = Math.Min(sliceRange.EndExclusive, segmentRange.EndExclusive);
+                if (intersectEnd <= intersectStart)
+                    continue;
+
+                var destOffset = (int)(intersectStart - sliceRange.StartInclusive);
+                var srcOffset = (int)(intersectStart - segmentRange.StartInclusive);
+                var count = (int)(intersectEnd - intersectStart);
+                if (srcOffset < 0 || srcOffset + count > body.Length)
+                    return null;
+                Buffer.BlockCopy(body, srcOffset, buffer, destOffset, count);
+                copied += count;
+            }
+
+            if (copied < sliceRange.Count && sliceRange.EndExclusive < layout.Map.FileLength)
+                return null;
+            return buffer;
+        }
+
+        private async Task<byte[]?> GetSiblingSegmentBodyAsync(
+            int fileIndex,
+            SiblingLayout layout,
+            int segmentIndex,
+            CancellationToken ct)
+        {
+            var cacheKey = (fileIndex, segmentIndex);
+            if (_siblingSegmentBodies.TryGetValue(cacheKey, out var cached))
+                return cached;
 
             await _fetchGate.WaitAsync(ct).ConfigureAwait(false);
             try
             {
-                if (_siblingFileBytes.TryGetValue(fileIndex, out cached))
+                if (_siblingSegmentBodies.TryGetValue(cacheKey, out cached))
                     return cached;
 
-                var segmentIds = nzbFile.GetSegmentIds();
-                var fileSize = nzbFile.Segments.Sum(segment => segment.Bytes);
-                await using var stream = _client.GetFileStream(segmentIds, fileSize, articleBufferSize: 0);
-                await using var destination = new MemoryStream();
-                await stream.CopyToAsync(destination, ct).ConfigureAwait(false);
-                var bytes = destination.ToArray();
-                _onBytesRead?.Invoke(bytes.Length);
-                _siblingFileBytes[fileIndex] = bytes;
-                return bytes;
+                var segmentId = layout.SegmentIds[segmentIndex];
+                try
+                {
+                    var response = await _client.DecodedBodyAsync(segmentId, ct).ConfigureAwait(false);
+                    await using var stream = response.Stream!;
+                    await using var ms = new MemoryStream();
+                    await stream.CopyToAsync(ms, ct).ConfigureAwait(false);
+                    var bytes = ms.ToArray();
+                    _onBytesRead?.Invoke(bytes.Length);
+                    _siblingSegmentBodies[cacheKey] = bytes;
+                    Interlocked.Add(ref _cachedBodyBytes, bytes.Length);
+                    return bytes;
+                }
+                catch (Exception e) when (e is not OutOfMemoryException)
+                {
+                    if (e.IsCancellationException(ct))
+                        throw;
+
+                    if (e.TryGetCausingException<UsenetArticleNotFoundException>(out _)
+                        || e.TryGetCausingException<UsenetCorruptArticleException>(out _))
+                        return null;
+
+                    throw;
+                }
             }
             finally
             {
                 _fetchGate.Release();
             }
+        }
+
+        private void NoteActiveSiblingFile(int fileIndex)
+        {
+            if (_activeSiblingFileIndex == fileIndex)
+                return;
+            if (_activeSiblingFileIndex >= 0)
+                EvictSiblingFile(_activeSiblingFileIndex);
+            _activeSiblingFileIndex = fileIndex;
+        }
+
+        private void EvictPassedSiblingSegments(int fileIndex, SiblingLayout layout, long sliceStart)
+        {
+            for (var i = 0; i < layout.Map.SegmentRanges.Count; i++)
+            {
+                if (layout.Map.SegmentRanges[i].EndExclusive > sliceStart)
+                    continue;
+                EvictSiblingSegment(fileIndex, i);
+            }
+        }
+
+        private void EvictSiblingFile(int fileIndex)
+        {
+            List<int>? indices = null;
+            foreach (var key in _siblingSegmentBodies.Keys)
+            {
+                if (key.FileIndex != fileIndex)
+                    continue;
+                indices ??= [];
+                indices.Add(key.SegmentIndex);
+            }
+
+            if (indices is null)
+                return;
+            foreach (var segmentIndex in indices)
+                EvictSiblingSegment(fileIndex, segmentIndex);
+        }
+
+        private void EvictSiblingSegment(int fileIndex, int segmentIndex)
+        {
+            if (_siblingSegmentBodies.Remove((fileIndex, segmentIndex), out var body))
+                Interlocked.Add(ref _cachedBodyBytes, -body.Length);
         }
     }
 }

--- a/backend/Services/Repair/RepairPatchStore.cs
+++ b/backend/Services/Repair/RepairPatchStore.cs
@@ -122,24 +122,49 @@ public sealed class RepairPatchStore
 
     public void CommitPatch(string segmentId, byte[] bytes, UsenetYencHeader header)
     {
-        if (bytes.Length != header.PartSize)
-            throw new ArgumentException("Patch bytes length does not match yEnc header PartSize.");
+        CommitPatches([(segmentId, bytes, header)]);
+    }
 
-        var hash = Hash(segmentId);
-        var blobPath = BlobPath(hash);
-        var tempPath = blobPath + "." + Guid.NewGuid().ToString("N") + ".tmp";
-        Directory.CreateDirectory(Path.GetDirectoryName(blobPath)!);
+    /// <summary>
+    /// Writes every patch to a temp file first, then publishes them together so a
+    /// verification failure before this call cannot leave a partial catalog.
+    /// </summary>
+    public void CommitPatches(IReadOnlyList<(string SegmentId, byte[] Bytes, UsenetYencHeader Header)> patches)
+    {
+        var staged = new List<(string Hash, string TempPath, string HeaderPath, long Size)>(patches.Count);
         try
         {
-            File.WriteAllBytes(tempPath, bytes);
-            File.WriteAllText(blobPath + ".h", JsonSerializer.Serialize(header, HeaderJsonOptions));
-            File.Move(tempPath, blobPath, overwrite: true);
-            OnFinalized(hash, bytes.Length);
+            foreach (var (segmentId, bytes, header) in patches)
+            {
+                if (bytes.Length != header.PartSize)
+                    throw new ArgumentException("Patch bytes length does not match yEnc header PartSize.");
+
+                var hash = Hash(segmentId);
+                var blobPath = BlobPath(hash);
+                Directory.CreateDirectory(Path.GetDirectoryName(blobPath)!);
+                var tempPath = blobPath + "." + Guid.NewGuid().ToString("N") + ".tmp";
+                var headerPath = blobPath + ".h." + Guid.NewGuid().ToString("N") + ".tmp";
+                File.WriteAllBytes(tempPath, bytes);
+                File.WriteAllText(headerPath, JsonSerializer.Serialize(header, HeaderJsonOptions));
+                staged.Add((hash, tempPath, headerPath, bytes.Length));
+            }
+
+            foreach (var (hash, tempPath, headerPath, size) in staged)
+            {
+                var blobPath = BlobPath(hash);
+                File.Move(headerPath, blobPath + ".h", overwrite: true);
+                File.Move(tempPath, blobPath, overwrite: true);
+                OnFinalized(hash, size);
+            }
         }
         catch
         {
-            SafeDelete(tempPath);
-            SafeDelete(blobPath + ".h");
+            foreach (var (_, tempPath, headerPath, _) in staged)
+            {
+                SafeDelete(tempPath);
+                SafeDelete(headerPath);
+            }
+
             throw;
         }
     }

--- a/backend/Services/Repair/RepairPatchStore.cs
+++ b/backend/Services/Repair/RepairPatchStore.cs
@@ -152,8 +152,10 @@ public sealed class RepairPatchStore
             foreach (var (hash, tempPath, headerPath, size) in staged)
             {
                 var blobPath = BlobPath(hash);
-                File.Move(headerPath, blobPath + ".h", overwrite: true);
+                // Publish bytes before the header so readers never observe a header
+                // whose blob is still missing or from a previous generation.
                 File.Move(tempPath, blobPath, overwrite: true);
+                File.Move(headerPath, blobPath + ".h", overwrite: true);
                 OnFinalized(hash, size);
             }
         }

--- a/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
+++ b/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
@@ -24,7 +24,9 @@ internal sealed class FakeNntpClient(
 
     public int BatchRequestCount { get; private set; }
     public int BodyRequestCount { get; private set; }
+    public int CompletionCallbackCount { get; private set; }
     public Dictionary<string, int> BodyRequestCounts { get; } = new(StringComparer.Ordinal);
+    public Dictionary<string, int> CompletionCallbackCounts { get; } = new(StringComparer.Ordinal);
     public Dictionary<string, int> StatRequestCounts { get; } = new(StringComparer.Ordinal);
     public HashSet<string> RequestedSegmentIds { get; } = new(StringComparer.Ordinal);
 
@@ -85,6 +87,7 @@ internal sealed class FakeNntpClient(
         try
         {
             var response = CreateBodyResponse(segmentId);
+            NoteCompletion(segmentKey);
             onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
             return Task.FromResult(response);
         }
@@ -162,6 +165,12 @@ internal sealed class FakeNntpClient(
 
     public override void Dispose()
     {
+    }
+
+    private void NoteCompletion(string segmentKey)
+    {
+        CompletionCallbackCount++;
+        CompletionCallbackCounts[segmentKey] = CompletionCallbackCounts.GetValueOrDefault(segmentKey) + 1;
     }
 
     private UsenetDecodedBodyResponse CreateBodyResponse(SegmentId segmentId) =>

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2FileSliceMapTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2FileSliceMapTests.cs
@@ -1,0 +1,98 @@
+using NzbWebDAV.Models;
+using NzbWebDAV.Services.Repair;
+
+namespace NzbWebDAV.Tests.Services.Repair;
+
+public sealed class Par2FileSliceMapTests
+{
+    [Fact]
+    public void GlobalSlicesForSegment_UsesHalfOpenOverlap()
+    {
+        const int sliceSize = 64;
+        var ranges = new[]
+        {
+            LongRange.FromStartAndSize(0, 40),
+            LongRange.FromStartAndSize(40, 40),
+            LongRange.FromStartAndSize(80, 48),
+        };
+
+        Assert.True(Par2FileSliceMap.TryCreate(
+            fileLength: 128,
+            globalSliceBase: 4,
+            sliceSize,
+            sliceCount: 2,
+            ranges,
+            out var map,
+            out var error));
+        Assert.Null(error);
+        Assert.Equal([4], map!.GlobalSlicesForSegment(0));
+        Assert.Equal([4, 5], map.GlobalSlicesForSegment(1));
+        Assert.Equal([5], map.GlobalSlicesForSegment(2));
+        Assert.Equal([0, 1], map.SegmentIndicesForGlobalSlice(4));
+        Assert.Equal([1, 2], map.SegmentIndicesForGlobalSlice(5));
+    }
+
+    [Fact]
+    public void GlobalSlicesForSegment_SkipsZeroLengthRanges()
+    {
+        var ranges = new[]
+        {
+            LongRange.FromStartAndSize(0, 64),
+            LongRange.FromStartAndSize(64, 0),
+            LongRange.FromStartAndSize(64, 64),
+        };
+
+        Assert.True(Par2FileSliceMap.TryCreate(
+            128, 0, 64, 2, ranges, out var map, out var error));
+        Assert.Null(error);
+        Assert.Empty(map!.GlobalSlicesForSegment(1));
+        Assert.Equal([0], map.SegmentIndicesForGlobalSlice(0));
+        Assert.Equal([2], map.SegmentIndicesForGlobalSlice(1));
+    }
+
+    [Fact]
+    public void TryCreate_RejectsRangeOutsideTheTargetFile()
+    {
+        var ranges = new[] { LongRange.FromStartAndSize(0, 200) };
+        Assert.False(Par2FileSliceMap.TryCreate(
+            100, 0, 64, 2, ranges, out var map, out var error));
+        Assert.Null(map);
+        Assert.Contains("outside the target file", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TryCreate_RejectsSliceCountMismatch()
+    {
+        var ranges = new[] { LongRange.FromStartAndSize(0, 100) };
+        Assert.False(Par2FileSliceMap.TryCreate(
+            100, 0, 64, 1, ranges, out var map, out var error));
+        Assert.Null(map);
+        Assert.Contains("slice count", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void EstimateWorkingSetBytes_IncludesCachedSlicesRecoveryAndPatches()
+    {
+        var bytes = Par2RepairService.EstimateWorkingSetBytes(
+            cachedSourceBodyBytes: 10,
+            assembledPresentSliceCount: 3,
+            recoverySliceCount: 2,
+            reconstructedSliceCount: 2,
+            stagedPatchBytes: 5,
+            sliceSize: 64);
+        Assert.Equal(10 + (3 * 64) + (2 * 64) + (2 * 64) + (2 * 64) + 5 + 10, bytes);
+    }
+
+    [Fact]
+    public void EstimateWorkingSetBytes_OverflowsInsteadOfWrapping()
+    {
+        Assert.Throws<OverflowException>(() =>
+            Par2RepairService.EstimateWorkingSetBytes(
+                cachedSourceBodyBytes: long.MaxValue,
+                assembledPresentSliceCount: 1,
+                recoverySliceCount: 0,
+                reconstructedSliceCount: 0,
+                stagedPatchBytes: 1,
+                sliceSize: 1));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceCorruptSourceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceCorruptSourceTests.cs
@@ -164,6 +164,11 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
         Assert.Equal(
             target.AsSpan(0, SliceSize).ToArray(),
             await ReadPatchAsync(release.Store, release.ContentSegmentIds[0]));
+        var siblingBodies = release.Fake.BodyRequestCounts.Keys
+            .Where(id => id.Contains("extra-", StringComparison.Ordinal))
+            .ToList();
+        Assert.Equal(2, siblingBodies.Count);
+        Assert.All(siblingBodies, id => Assert.Equal(1, release.Fake.BodyRequestCounts[id]));
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceCorruptSourceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceCorruptSourceTests.cs
@@ -1,0 +1,542 @@
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Models;
+using NzbWebDAV.Par2Recovery;
+using NzbWebDAV.Services.Repair;
+using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Tests.Fakes;
+
+namespace NzbWebDAV.Tests.Services.Repair;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
+{
+    private const int SliceSize = 4096;
+
+    private readonly string _configRoot =
+        Path.Join(Path.GetTempPath(), $"nzbdav-par2-corrupt-src-{Guid.NewGuid():N}");
+    private string? _previousConfigPath;
+    private ConfigManager _config = null!;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+        DavDatabaseContext.ResetOptionsForTests();
+        await using (var context = new DavDatabaseContext())
+            await context.Database.MigrateAsync();
+
+        _config = new ConfigManager();
+        _config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "true" },
+            new ConfigItem { ConfigName = ConfigKeys.RepairPar2Enabled, ConfigValue = "true" },
+        ]);
+    }
+
+    public Task DisposeAsync()
+    {
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        DavDatabaseContext.ResetOptionsForTests();
+        try { Directory.Delete(_configRoot, recursive: true); } catch (IOException) { /* best effort */ }
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task OneKnownCorruptTarget_ReconstructsAndCommits_WithoutRefetchingTheTarget()
+    {
+        var fileData = PatternBytes(SliceSize * 3, 0x11);
+        await using var release = await SeedAsync(fileData, EqualSegments(3), recoveryExponents: [0u, 1u],
+            corruptOnRead: [0]);
+
+        var ok = await release.Service.TryPar2RepairAsync(
+            release.Item, [release.ContentSegmentIds[0]], CancellationToken.None);
+
+        Assert.True(ok);
+        Assert.True(release.Store.Contains(release.ContentSegmentIds[0]));
+        Assert.False(release.Fake.BodyRequestCounts.ContainsKey(release.ContentSegmentIds[0]));
+        Assert.Equal(
+            fileData.AsSpan(0, SliceSize).ToArray(),
+            await ReadPatchAsync(release.Store, release.ContentSegmentIds[0]));
+    }
+
+    [Fact]
+    public async Task MissingTargetPlusDiscoveredAdjacentCorrupt_ReconstructsBoth()
+    {
+        var fileData = PatternBytes(SliceSize * 3, 0x22);
+        await using var release = await SeedAsync(fileData, EqualSegments(3), recoveryExponents: [0u, 1u],
+            omitFromProvider: [0], corruptOnRead: [1]);
+
+        var ok = await release.Service.TryPar2RepairAsync(
+            release.Item, [release.ContentSegmentIds[0]], CancellationToken.None);
+
+        Assert.True(ok);
+        Assert.True(release.Store.Contains(release.ContentSegmentIds[0]));
+        Assert.True(release.Store.Contains(release.ContentSegmentIds[1]));
+        Assert.Equal(
+            fileData.AsSpan(0, SliceSize).ToArray(),
+            await ReadPatchAsync(release.Store, release.ContentSegmentIds[0]));
+        Assert.Equal(
+            fileData.AsSpan(SliceSize, SliceSize).ToArray(),
+            await ReadPatchAsync(release.Store, release.ContentSegmentIds[1]));
+
+        var blob = await ReadBlobAsync(release.Item.Id);
+        Assert.Contains(1, blob.CorruptSegmentIndices ?? []);
+    }
+
+    [Fact]
+    public async Task TwoKnownCorruptSegments_RequireTwoRecoverySlices()
+    {
+        var fileData = PatternBytes(SliceSize * 4, 0x33);
+        await using var release = await SeedAsync(fileData, EqualSegments(4), recoveryExponents: [0u, 1u],
+            corruptOnRead: [0, 2]);
+
+        var ok = await release.Service.TryPar2RepairAsync(
+            release.Item,
+            [release.ContentSegmentIds[0], release.ContentSegmentIds[2]],
+            CancellationToken.None);
+
+        Assert.True(ok);
+        Assert.True(release.Store.Contains(release.ContentSegmentIds[0]));
+        Assert.True(release.Store.Contains(release.ContentSegmentIds[2]));
+        Assert.False(release.Store.Contains(release.ContentSegmentIds[1]));
+    }
+
+    [Fact]
+    public async Task MisalignedSegmentAndSliceBoundaries_ReconstructsOverlappingSegments()
+    {
+        var fileData = PatternBytes(SliceSize * 2, 0x44);
+        int[] sizes = [3000, 3000, SliceSize * 2 - 6000];
+        await using var release = await SeedAsync(fileData, sizes, recoveryExponents: [0u, 1u],
+            corruptOnRead: [0]);
+
+        var ok = await release.Service.TryPar2RepairAsync(
+            release.Item, [release.ContentSegmentIds[0]], CancellationToken.None);
+
+        Assert.True(ok);
+        Assert.True(release.Store.Contains(release.ContentSegmentIds[0]));
+        Assert.True(release.Store.Contains(release.ContentSegmentIds[1]));
+        Assert.Equal(Slice(fileData, 0, sizes[0]), await ReadPatchAsync(release.Store, release.ContentSegmentIds[0]));
+        Assert.Equal(Slice(fileData, sizes[0], sizes[1]), await ReadPatchAsync(release.Store, release.ContentSegmentIds[1]));
+    }
+
+    [Fact]
+    public async Task SliceSpanningTwoNzbSegments_AssemblesPresentSliceAndRepairsTheOther()
+    {
+        var fileData = PatternBytes(SliceSize * 2, 0x55);
+        int[] sizes = [2500, 2500, SliceSize * 2 - 5000];
+        await using var release = await SeedAsync(fileData, sizes, recoveryExponents: [0u],
+            corruptOnRead: [2]);
+
+        var ok = await release.Service.TryPar2RepairAsync(
+            release.Item, [release.ContentSegmentIds[2]], CancellationToken.None);
+
+        Assert.True(ok);
+        Assert.True(release.Store.Contains(release.ContentSegmentIds[2]));
+        Assert.Equal(
+            Slice(fileData, sizes[0] + sizes[1], sizes[2]),
+            await ReadPatchAsync(release.Store, release.ContentSegmentIds[2]));
+    }
+
+    [Fact]
+    public async Task TargetIsSecondFileInMultiFilePar2Set_UsesGlobalSliceBase()
+    {
+        var first = PatternBytes(SliceSize * 2, 0x61);
+        var target = PatternBytes(SliceSize * 2, 0x62);
+        await using var release = await SeedAsync(
+            target,
+            EqualSegments(2),
+            recoveryExponents: [0u, 1u],
+            corruptOnRead: [0],
+            extraFiles: [("other.bin", first, EqualSegments(2))]);
+
+        var ok = await release.Service.TryPar2RepairAsync(
+            release.Item, [release.ContentSegmentIds[0]], CancellationToken.None);
+
+        Assert.True(ok);
+        Assert.True(release.Store.Contains(release.ContentSegmentIds[0]));
+        Assert.Equal(
+            target.AsSpan(0, SliceSize).ToArray(),
+            await ReadPatchAsync(release.Store, release.ContentSegmentIds[0]));
+    }
+
+    [Fact]
+    public async Task SourceStreamOpensThenThrowsDuringCopyToAsync_IsTreatedAsCorruptInput()
+    {
+        var fileData = PatternBytes(SliceSize * 3, 0x66);
+        await using var release = await SeedAsync(fileData, EqualSegments(3), recoveryExponents: [0u, 1u],
+            omitFromProvider: [0], corruptOnRead: [1]);
+
+        var ok = await release.Service.TryPar2RepairAsync(
+            release.Item, [release.ContentSegmentIds[0]], CancellationToken.None);
+
+        Assert.True(ok);
+        Assert.Equal(1, release.Fake.BodyRequestCounts[release.ContentSegmentIds[1]]);
+        Assert.Equal(1, release.Fake.CompletionCallbackCounts[release.ContentSegmentIds[1]]);
+        Assert.True(release.Store.Contains(release.ContentSegmentIds[1]));
+    }
+
+    [Fact]
+    public async Task CancellationDuringDiscovery_PropagatesWithoutDamageOrPatch()
+    {
+        var fileData = PatternBytes(SliceSize * 3, 0x77);
+        using var cts = new CancellationTokenSource();
+        await using var release = await SeedAsync(fileData, EqualSegments(3), recoveryExponents: [0u, 1u],
+            corruptOnRead: [0],
+            cancelOnRead: [1],
+            cancel: cts);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            release.Service.TryPar2RepairAsync(release.Item, [release.ContentSegmentIds[0]], cts.Token));
+
+        Assert.False(release.Store.Contains(release.ContentSegmentIds[0]));
+        Assert.False(release.Store.Contains(release.ContentSegmentIds[1]));
+        var blob = await ReadBlobAsync(release.Item.Id);
+        Assert.Null(blob.MissingSegmentIndices);
+        Assert.Null(blob.CorruptSegmentIndices);
+    }
+
+    [Fact]
+    public async Task InsufficientRecoverySlices_IsInfeasibleAndCommitsNothing()
+    {
+        var fileData = PatternBytes(SliceSize * 3, 0x88);
+        await using var release = await SeedAsync(fileData, EqualSegments(3), recoveryExponents: [0u],
+            corruptOnRead: [0, 1]);
+
+        var ok = await release.Service.TryPar2RepairAsync(
+            release.Item,
+            [release.ContentSegmentIds[0], release.ContentSegmentIds[1]],
+            CancellationToken.None);
+
+        Assert.False(ok);
+        Assert.False(release.Store.Contains(release.ContentSegmentIds[0]));
+        Assert.False(release.Store.Contains(release.ContentSegmentIds[1]));
+        var job = await ReadJobAsync(release.Item.Id);
+        Assert.Equal(Par2RepairJob.RepairJobState.Infeasible, job.State);
+        Assert.Contains("recovery slices", job.FailureReason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task TargetCountCap_ExceededBeforeRecoveryAllocation()
+    {
+        var fileData = PatternBytes(SliceSize * 3, 0x99);
+        await using var release = await SeedAsync(fileData, EqualSegments(3), recoveryExponents: [0u, 1u],
+            corruptOnRead: [0, 1], maxMissingSlices: "1");
+
+        var ok = await release.Service.TryPar2RepairAsync(
+            release.Item,
+            [release.ContentSegmentIds[0], release.ContentSegmentIds[1]],
+            CancellationToken.None);
+
+        Assert.False(ok);
+        Assert.False(release.Store.Contains(release.ContentSegmentIds[0]));
+        var job = await ReadJobAsync(release.Item.Id);
+        Assert.Equal(Par2RepairJob.RepairJobState.Infeasible, job.State);
+        Assert.Contains("exceeds cap", job.FailureReason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task WrongWholeFileMd5_RejectsStagedResultAndCommitsNothing()
+    {
+        var fileData = PatternBytes(SliceSize * 2, 0xAA);
+        var wrongHash = new byte[16];
+        Array.Fill(wrongHash, (byte)0xAB);
+        await using var release = await SeedAsync(fileData, EqualSegments(2), recoveryExponents: [0u],
+            corruptOnRead: [0], fileHashOverride: wrongHash);
+
+        var ok = await release.Service.TryPar2RepairAsync(
+            release.Item, [release.ContentSegmentIds[0]], CancellationToken.None);
+
+        Assert.False(ok);
+        Assert.False(release.Store.Contains(release.ContentSegmentIds[0]));
+        var job = await ReadJobAsync(release.Item.Id);
+        Assert.Equal(Par2RepairJob.RepairJobState.Failed, job.State);
+        Assert.Contains("Whole-file MD5", job.FailureReason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SuccessfulBodyOpens_FireCompletionCallbackExactlyOnce()
+    {
+        var fileData = PatternBytes(SliceSize * 3, 0xBB);
+        await using var release = await SeedAsync(fileData, EqualSegments(3), recoveryExponents: [0u],
+            corruptOnRead: [0]);
+
+        var ok = await release.Service.TryPar2RepairAsync(
+            release.Item, [release.ContentSegmentIds[0]], CancellationToken.None);
+
+        Assert.True(ok);
+        Assert.Equal(release.Fake.BodyRequestCount, release.Fake.CompletionCallbackCount);
+        foreach (var (id, count) in release.Fake.BodyRequestCounts)
+            Assert.Equal(count, release.Fake.CompletionCallbackCounts.GetValueOrDefault(id));
+    }
+
+    private async Task<SeededRelease> SeedAsync(
+        byte[] targetData,
+        int[] targetSegmentSizes,
+        uint[] recoveryExponents,
+        int[]? omitFromProvider = null,
+        int[]? corruptOnRead = null,
+        int[]? cancelOnRead = null,
+        CancellationTokenSource? cancel = null,
+        byte[]? fileHashOverride = null,
+        IReadOnlyList<(string FileName, byte[] Data, int[] Sizes)>? extraFiles = null,
+        string? maxMissingSlices = null)
+    {
+        _config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "true" },
+            new ConfigItem { ConfigName = ConfigKeys.RepairPar2Enabled, ConfigValue = "true" },
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.RepairPar2MaxMissingSlices,
+                ConfigValue = maxMissingSlices ?? "8",
+            },
+        ]);
+        omitFromProvider ??= [];
+        corruptOnRead ??= [];
+        cancelOnRead ??= [];
+        extraFiles ??= [];
+
+        var token = Guid.NewGuid().ToString("N")[..8];
+        var targetName = $"target-{token}.bin";
+        var files = extraFiles
+            .Select(file => (file.FileName, file.Data))
+            .Append((targetName, targetData))
+            .ToList();
+        var hashOverrides = fileHashOverride is null
+            ? null
+            : new Dictionary<string, byte[]>(StringComparer.Ordinal) { [targetName] = fileHashOverride };
+        var (indexBytes, volumeBytes) = Par2TestEncoder.EncodeSet(
+            files, SliceSize, recoveryExponents, hashOverrides);
+
+        var payloads = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        var rangesById = new Dictionary<string, LongRange>(StringComparer.Ordinal);
+        var nzbFiles = new List<(string Name, List<(string Id, int Bytes)> Segments)>();
+
+        foreach (var extra in extraFiles)
+        {
+            var (ids, ranges, parts) = Split(extra.Data, extra.Sizes, $"extra-{token}");
+            nzbFiles.Add((extra.FileName, ids.Zip(extra.Sizes, (id, size) => (id, size)).ToList()));
+            AddPayloads(payloads, rangesById, ids, parts, ranges);
+        }
+
+        var (contentIds, contentRanges, contentParts) = Split(targetData, targetSegmentSizes, $"tgt-{token}");
+        nzbFiles.Add((targetName, contentIds.Zip(targetSegmentSizes, (id, size) => (id, size)).ToList()));
+        AddPayloads(payloads, rangesById, contentIds, contentParts, contentRanges);
+
+        var indexId = $"aaa-index-{token}@test";
+        var volumeId = $"zzz-vol-{token}@test";
+        payloads[indexId] = indexBytes;
+        payloads[volumeId] = volumeBytes;
+        rangesById[indexId] = LongRange.FromStartAndSize(0, indexBytes.Length);
+        rangesById[volumeId] = LongRange.FromStartAndSize(0, volumeBytes.Length);
+        nzbFiles.Add(($"{targetName}.par2", [(indexId, indexBytes.Length)]));
+        nzbFiles.Add(($"{targetName}.vol00+{recoveryExponents.Length:00}.par2", [(volumeId, volumeBytes.Length)]));
+
+        var omit = omitFromProvider.Select(i => contentIds[i]).ToHashSet(StringComparer.Ordinal);
+        foreach (var id in omit)
+            payloads.Remove(id);
+
+        var corruptIds = corruptOnRead.Select(i => contentIds[i]).ToHashSet(StringComparer.Ordinal);
+        var cancelIds = cancelOnRead.Select(i => contentIds[i]).ToHashSet(StringComparer.Ordinal);
+
+        var fake = new FakeNntpClient(
+            payloads,
+            useCachedYencStreams: true,
+            segmentRanges: rangesById,
+            decodedStreamFactory: (id, bytes) =>
+            {
+                if (cancelIds.Contains(id))
+                    return new CancelOnReadStream(cancel ?? throw new InvalidOperationException("cancel CTS required"));
+                if (corruptIds.Contains(id))
+                    return new ThrowingReadStream(id);
+                return new MemoryStream(bytes, writable: false);
+            });
+
+        var nzbXml = BuildNzbXml(nzbFiles);
+        var nzbBlobId = Guid.NewGuid();
+        await using (var nzbStream = new MemoryStream(Encoding.UTF8.GetBytes(nzbXml)))
+            await BlobStore.WriteBlob(nzbBlobId, nzbStream);
+
+        var fileBlobId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        await BlobStore.WriteBlob(fileBlobId, new DavNzbFile
+        {
+            Id = itemId,
+            SegmentIds = contentIds,
+            SegmentByteRanges = contentRanges,
+        });
+
+        var item = DavItem.New(
+            itemId,
+            DavItem.ContentFolder,
+            targetName,
+            fileSize: targetData.Length,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            releaseDate: DateTimeOffset.UtcNow.AddDays(-1),
+            lastHealthCheck: null,
+            historyItemId: null,
+            fileBlobId: fileBlobId,
+            nzbBlobId: nzbBlobId);
+
+        await using (var context = new DavDatabaseContext())
+        {
+            context.Items.Add(item);
+            await context.SaveChangesAsync();
+        }
+
+        var patchDir = Path.Join(_configRoot, "patches", token);
+        var store = new RepairPatchStore(patchDir, 32 * 1024 * 1024);
+        await store.CatalogLoadTask;
+        var usenet = new UsenetStreamingClient(fake, store);
+        var service = new Par2RepairService(_config, usenet, store);
+        return new SeededRelease(item, contentIds, fake, store, service, usenet);
+    }
+
+    private static int[] EqualSegments(int count) => Enumerable.Repeat(SliceSize, count).ToArray();
+
+    private static byte[] PatternBytes(int length, byte seed)
+    {
+        var data = new byte[length];
+        for (var i = 0; i < length; i++)
+            data[i] = (byte)(i * 7 + seed);
+        return data;
+    }
+
+    private static byte[] Slice(byte[] data, int start, int count) => data.AsSpan(start, count).ToArray();
+
+    private static (string[] Ids, LongRange[] Ranges, byte[][] Parts) Split(
+        byte[] data, int[] sizes, string prefix)
+    {
+        var ids = new string[sizes.Length];
+        var ranges = new LongRange[sizes.Length];
+        var parts = new byte[sizes.Length][];
+        var offset = 0;
+        for (var i = 0; i < sizes.Length; i++)
+        {
+            ids[i] = $"{prefix}-{i}@test";
+            ranges[i] = LongRange.FromStartAndSize(offset, sizes[i]);
+            parts[i] = data.AsSpan(offset, sizes[i]).ToArray();
+            offset += sizes[i];
+        }
+
+        if (offset != data.Length)
+            throw new ArgumentException("Segment sizes must cover the file.");
+        return (ids, ranges, parts);
+    }
+
+    private static void AddPayloads(
+        Dictionary<string, byte[]> payloads,
+        Dictionary<string, LongRange> rangesById,
+        string[] ids,
+        byte[][] parts,
+        LongRange[] ranges)
+    {
+        for (var i = 0; i < ids.Length; i++)
+        {
+            payloads[ids[i]] = parts[i];
+            rangesById[ids[i]] = ranges[i];
+        }
+    }
+
+    private static string BuildNzbXml(IReadOnlyList<(string Name, List<(string Id, int Bytes)> Segments)> files)
+    {
+        var xml = new StringBuilder();
+        xml.Append("""<?xml version="1.0" encoding="utf-8"?><nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">""");
+        foreach (var (name, segments) in files)
+        {
+            xml.Append("<file subject=\"&quot;").Append(name).Append("&quot; yEnc\">");
+            xml.Append("<segments>");
+            for (var i = 0; i < segments.Count; i++)
+            {
+                xml.Append("<segment bytes=\"").Append(segments[i].Bytes).Append("\" number=\"")
+                    .Append(i + 1).Append("\">").Append(segments[i].Id).Append("</segment>");
+            }
+
+            xml.Append("</segments></file>");
+        }
+
+        xml.Append("</nzb>");
+        return xml.ToString();
+    }
+
+    private static async Task<byte[]> ReadPatchAsync(RepairPatchStore store, string segmentId)
+    {
+        Assert.True(store.TryGet(segmentId, out var response));
+        await using var output = new MemoryStream();
+        await response!.Stream!.CopyToAsync(output);
+        return output.ToArray();
+    }
+
+    private static async Task<DavNzbFile> ReadBlobAsync(Guid itemId)
+    {
+        await using var context = new DavDatabaseContext();
+        var item = await context.Items.AsNoTracking().SingleAsync(x => x.Id == itemId);
+        return (await BlobStore.ReadBlob<DavNzbFile>(item.FileBlobId!.Value))!;
+    }
+
+    private static async Task<Par2RepairJob> ReadJobAsync(Guid itemId)
+    {
+        await using var context = new DavDatabaseContext();
+        return await context.Par2RepairJobs.SingleAsync(x => x.DavItemId == itemId);
+    }
+
+    private sealed class SeededRelease(
+        DavItem item,
+        string[] contentSegmentIds,
+        FakeNntpClient fake,
+        RepairPatchStore store,
+        Par2RepairService service,
+        UsenetStreamingClient usenet) : IAsyncDisposable
+    {
+        public DavItem Item { get; } = item;
+        public string[] ContentSegmentIds { get; } = contentSegmentIds;
+        public FakeNntpClient Fake { get; } = fake;
+        public RepairPatchStore Store { get; } = store;
+        public Par2RepairService Service { get; } = service;
+
+        public ValueTask DisposeAsync()
+        {
+            usenet.Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingReadStream(string segmentId) : MemoryStream(new byte[64])
+    {
+        private UsenetCorruptArticleException CreateException() =>
+            new(segmentId, "provider-a", new InvalidDataException("CRC mismatch"));
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            throw CreateException();
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromException<int>(CreateException());
+    }
+
+    private sealed class CancelOnReadStream(CancellationTokenSource cts) : MemoryStream([1, 2, 3, 4])
+    {
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            cts.Cancel();
+            throw new OperationCanceledException(cts.Token);
+        }
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            cts.Cancel();
+            return ValueTask.FromException<int>(new OperationCanceledException(cts.Token));
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Repair/RepairPatchStoreTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/RepairPatchStoreTests.cs
@@ -34,9 +34,20 @@ public sealed class RepairPatchStoreTests
             Assert.True(store.TryGet(segmentId, out var response));
             response!.Stream!.Dispose();
 
+            var replacement = "patch-data-v2"u8.ToArray();
+            store.CommitPatch(segmentId, replacement, Header(replacement.Length));
+            Assert.True(store.IsRepaired(segmentId, replacement.Length));
+            Assert.True(store.TryGet(segmentId, out var replaced));
+            using (replaced!.Stream)
+            {
+                using var copy = new MemoryStream();
+                replaced.Stream!.CopyTo(copy);
+                Assert.Equal(replacement, copy.ToArray());
+            }
+
             var reloaded = new RepairPatchStore(dir, 1024 * 1024);
             await reloaded.CatalogLoadTask;
-            Assert.True(reloaded.IsRepaired(segmentId, content.Length));
+            Assert.True(reloaded.IsRepaired(segmentId, replacement.Length));
         }
         finally
         {


### PR DESCRIPTION
## Summary
- PAR2 repair now treats `UsenetCorruptArticleException` (including failures during `CopyToAsync`) as unavailable input, expands the Reed-Solomon target set from overlapping slices, and fetches recovery data only after that set stabilizes.
- Reconstruction maps NZB segments onto PAR2 slices with half-open overlap, assembles slices that span segment boundaries, and verifies both IFSC hashes and the PAR2 whole-file MD5 before committing patches in one batch.
- A known-corrupt target is not re-fetched as present input. Newly discovered missing/corrupt indexes are persisted; cancellation during discovery does not record damage or write patches.

Fixes #1051

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~Par2RepairIntegrationTests|FullyQualifiedName~DavNzbFileCorruptionRecordTests|FullyQualifiedName~Par2ReconstructorTests|FullyQualifiedName~Par2FileSliceMapTests|FullyQualifiedName~Par2RepairServiceCorruptSourceTests"`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [ ] Confirm a health-check PAR2 repair of a release with one CRC-failing article commits a patch and playback reads the reconstructed bytes