### PR TITLE
fix(usenet): log a single warning when a Usenet article is missing on every provider

### DIFF
--- a/backend/Clients/Usenet/Contexts/FetchAttributionContext.cs
+++ b/backend/Clients/Usenet/Contexts/FetchAttributionContext.cs
@@ -1,0 +1,39 @@
+namespace NzbWebDAV.Clients.Usenet.Contexts;
+
+/// <summary>
+/// Diagnostic-only file attribution for NNTP fetches. Unlike
+/// <see cref="MultiProviderNntpClient.AttributionContext"/>, a non-null value here
+/// must not change cache, repair-patch, or other fetch behavior.
+/// </summary>
+public sealed class FetchAttributionContext : IDisposable
+{
+    private static readonly AsyncLocal<FetchAttributionContext?> CurrentLocal = new();
+    private readonly FetchAttributionContext? _previous;
+
+    public FetchAttributionContext(string? fileName, string? category = null)
+    {
+        FileName = SanitizeFileName(fileName);
+        Category = string.IsNullOrWhiteSpace(category) ? null : category.Trim();
+        _previous = CurrentLocal.Value;
+        CurrentLocal.Value = this;
+    }
+
+    public string? FileName { get; }
+    public string? Category { get; }
+
+    public static FetchAttributionContext? Current => CurrentLocal.Value;
+
+    public static IDisposable Begin(string? fileName, string? category = null) =>
+        new FetchAttributionContext(fileName, category);
+
+    public void Dispose() => CurrentLocal.Value = _previous;
+
+    private static string? SanitizeFileName(string? fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+            return null;
+
+        var name = Path.GetFileName(fileName.Trim());
+        return string.IsNullOrWhiteSpace(name) ? null : name;
+    }
+}

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -173,6 +173,76 @@ public class MultiProviderNntpClient(
         public void Dispose() => onDispose();
     }
 
+    private sealed class ProviderWalkSummary(int eligibleProviders)
+    {
+        public int EligibleProviders { get; } = eligibleProviders;
+        public int Attempts { get; set; }
+        public int CurrentDefinitiveMisses { get; set; }
+        public int CachedSkips { get; set; }
+        public int StorageGroupSkips { get; set; }
+        public int Timeouts { get; set; }
+        public int TransportFailures { get; set; }
+        public int AuthFailures { get; set; }
+        public int ProtocolFailures { get; set; }
+        public int CorruptionFailures { get; set; }
+        public int UnexpectedResponses { get; set; }
+        public int OtherExceptions { get; set; }
+        public bool Cancelled { get; set; }
+        public bool Retired { get; set; }
+        public bool LastOutcomeWasException { get; set; }
+        private readonly Stopwatch _clock = Stopwatch.StartNew();
+        public TimeSpan Elapsed => _clock.Elapsed;
+
+        public bool IsPureDefinitiveMiss =>
+            EligibleProviders > 0
+            && !Cancelled
+            && !Retired
+            && (CurrentDefinitiveMisses > 0 || CachedSkips > 0)
+            && Timeouts == 0
+            && TransportFailures == 0
+            && AuthFailures == 0
+            && ProtocolFailures == 0
+            && CorruptionFailures == 0
+            && UnexpectedResponses == 0
+            && OtherExceptions == 0
+            && !LastOutcomeWasException;
+
+        public void NoteException(Exception ex)
+        {
+            var status = ClassifyException(ex);
+            switch (status)
+            {
+                case SegmentFetch.FetchStatus.Missing:
+                    CurrentDefinitiveMisses++;
+                    break;
+                case SegmentFetch.FetchStatus.Timeout:
+                    Timeouts++;
+                    LastOutcomeWasException = true;
+                    break;
+                case SegmentFetch.FetchStatus.Network:
+                    TransportFailures++;
+                    LastOutcomeWasException = true;
+                    break;
+                case SegmentFetch.FetchStatus.Auth:
+                    AuthFailures++;
+                    LastOutcomeWasException = true;
+                    break;
+                case SegmentFetch.FetchStatus.Protocol:
+                    ProtocolFailures++;
+                    LastOutcomeWasException = true;
+                    break;
+                case SegmentFetch.FetchStatus.Corrupt:
+                    CorruptionFailures++;
+                    LastOutcomeWasException = true;
+                    break;
+                default:
+                    OtherExceptions++;
+                    LastOutcomeWasException = true;
+                    break;
+            }
+        }
+    }
+
     // Per-call attribution. Caller (e.g. PlaybackFastVerifier) sets a mutable
     // holder on AttributionContext BEFORE invoking; we read it inside the call and
     // mutate Host on a non-"missing" response. AsyncLocal reliably flows the holder
@@ -196,13 +266,13 @@ public class MultiProviderNntpClient(
     public override Task<UsenetStatResponse> StatAsync(SegmentId segmentId, CancellationToken cancellationToken)
     {
         return RunFromPoolWithBackup(
-            x => x.StatAsync(segmentId, cancellationToken), segmentId, cancellationToken);
+            x => x.StatAsync(segmentId, cancellationToken), segmentId, NntpOperation.Stat, cancellationToken);
     }
 
     public override Task<UsenetHeadResponse> HeadAsync(SegmentId segmentId, CancellationToken cancellationToken)
     {
         return RunFromPoolWithBackup(
-            x => x.HeadAsync(segmentId, cancellationToken), segmentId, cancellationToken);
+            x => x.HeadAsync(segmentId, cancellationToken), segmentId, NntpOperation.Head, cancellationToken);
     }
 
     public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync
@@ -212,7 +282,7 @@ public class MultiProviderNntpClient(
     )
     {
         return RunFromPoolWithBackup(
-            x => x.DecodedBodyAsync(segmentId, cancellationToken), segmentId, cancellationToken);
+            x => x.DecodedBodyAsync(segmentId, cancellationToken), segmentId, NntpOperation.Body, cancellationToken);
     }
 
     public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync
@@ -222,12 +292,13 @@ public class MultiProviderNntpClient(
     )
     {
         return RunFromPoolWithBackup(
-            x => x.DecodedArticleAsync(segmentId, cancellationToken), segmentId, cancellationToken);
+            x => x.DecodedArticleAsync(segmentId, cancellationToken), segmentId, NntpOperation.Article, cancellationToken);
     }
 
     public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken)
     {
-        return RunFromPoolWithBackup(x => x.DateAsync(cancellationToken), articleId: null, cancellationToken);
+        return RunFromPoolWithBackup(
+            x => x.DateAsync(cancellationToken), articleId: null, NntpOperation.Date, cancellationToken);
     }
 
     public override async Task<UsenetDecodedBodyResponse> DecodedBodyAsync
@@ -258,6 +329,7 @@ public class MultiProviderNntpClient(
                         fetchScope?.Dispose();
                     }
                 },
+                NntpOperation.Body,
                 cancellationToken).ConfigureAwait(false);
         }
         catch
@@ -406,6 +478,8 @@ public class MultiProviderNntpClient(
         var primaryTraceRange = CurrentStreamTraceRange;
         var primaryStopwatch = Stopwatch.StartNew();
         List<(string Host, SegmentFetch.FetchStatus Reason)>? priorMisses = null;
+        var walk = new ProviderWalkSummary(1 + fallbackProviders.Length);
+        MultiConnectionNntpClient? lastAttemptedProvider = primaryProvider;
         // Fresh per article resolution. When primary re-probe is enabled, do not mark the
         // primary's storage group on the initial batch 430 so that re-probe is not skipped
         // by its own miss. Cross-request negative cache may skip re-probe separately.
@@ -420,11 +494,14 @@ public class MultiProviderNntpClient(
             }
             catch (NntpClientRetiredException)
             {
+                walk.Retired = true;
                 throw;
             }
             catch (Exception e) when (!e.IsCancellationException(cancellationToken) && e is not OutOfMemoryException)
             {
                 primaryStopwatch.Stop();
+                walk.Attempts++;
+                walk.NoteException(e);
                 var reason = ClassifyAndRecordFailure(
                     primaryProvider.MetricsKey, e, primaryStopwatch.ElapsedMilliseconds, 0,
                     primaryTraceRange);
@@ -445,10 +522,21 @@ public class MultiProviderNntpClient(
                 UsenetArticleAvailability.IsDefinitiveMissing(response);
             if (definitiveMiss)
             {
+                walk.Attempts++;
+                walk.CurrentDefinitiveMisses++;
                 primaryStopwatch.Stop();
                 RecordFetch(primaryProvider.MetricsKey, SegmentFetch.FetchStatus.Missing,
                     primaryStopwatch.ElapsedMilliseconds, 0, primaryTraceRange);
                 (priorMisses ??= []).Add((primaryProvider.MetricsKey, SegmentFetch.FetchStatus.Missing));
+            }
+            else if (response is { ResponseType: UsenetResponseType.ArticleRetrievedBodyFollows })
+            {
+                // counted as success below
+            }
+            else if (response != null)
+            {
+                walk.Attempts++;
+                walk.UnexpectedResponses++;
             }
 
             // Re-probe primary once on a definitive miss when enabled (default). Multi-node
@@ -507,6 +595,7 @@ public class MultiProviderNntpClient(
                     var group = NormalizeStorageGroup(provider.StorageGroup);
                     if (group.Length > 0 && missingGroups.Contains(group))
                     {
+                        walk.StorageGroupSkips++;
                         Log.Debug(
                             "Skipping provider `{Host}` on storage group `{Group}` — " +
                             "a sibling provider already reported the article missing.",
@@ -516,6 +605,7 @@ public class MultiProviderNntpClient(
 
                     if (IsCachedMissing(segmentId, provider))
                     {
+                        walk.CachedSkips++;
                         Log.Debug(
                             "Skipping provider `{Host}` for article `{SegmentId}` — " +
                             "cached as missing. Reason: article-miss-cache",
@@ -527,8 +617,10 @@ public class MultiProviderNntpClient(
                     var deferredCallback = new DeferredArticleBodyCallback();
                     var traceRange = CurrentStreamTraceRange;
                     var stopwatch = Stopwatch.StartNew();
+                    lastAttemptedProvider = provider;
                     try
                     {
+                        walk.Attempts++;
                         response = await provider.DecodedBodyAsync(
                             segmentId, deferredCallback.Invoke, cancellationToken).ConfigureAwait(false);
                         stopwatch.Stop();
@@ -561,6 +653,7 @@ public class MultiProviderNntpClient(
                             (priorMisses ??= []).Add((provider.MetricsKey, SegmentFetch.FetchStatus.Missing));
                             if (UsenetArticleAvailability.IsDefinitiveMissing(response))
                             {
+                                walk.CurrentDefinitiveMisses++;
                                 if (group.Length > 0) missingGroups.Add(group);
                                 MarkCachedMissing(segmentId, provider);
                             }
@@ -572,6 +665,7 @@ public class MultiProviderNntpClient(
                     }
                     catch (NntpClientRetiredException)
                     {
+                        walk.Retired = true;
                         // The whole provider set belongs to the retired generation.
                         deferredCallback.Discard();
                         coordinator.CompleteAttempt();
@@ -580,6 +674,7 @@ public class MultiProviderNntpClient(
                     catch (Exception e) when (!e.IsCancellationException(cancellationToken) && e is not OutOfMemoryException)
                     {
                         stopwatch.Stop();
+                        walk.NoteException(e);
                         var reason = ClassifyAndRecordFailure(
                             provider.MetricsKey, e, stopwatch.ElapsedMilliseconds,
                             priorMisses?.Count ?? 0, traceRange);
@@ -608,6 +703,14 @@ public class MultiProviderNntpClient(
                     _batchFallbackStartGate.Release();
             }
 
+            walk.LastOutcomeWasException = lastException is not null
+                && ClassifyException(lastException.SourceException) != SegmentFetch.FetchStatus.Missing;
+            LogProviderWalkOutcome(
+                walk,
+                segmentId,
+                NntpOperation.PipelinedBody,
+                lastAttemptedProvider.Host,
+                lastException?.SourceException);
             lastException?.Throw();
             throw new UsenetArticleNotFoundException(segmentId, response?.ResponseMessage);
         }
@@ -698,6 +801,7 @@ public class MultiProviderNntpClient(
             UsenetResponseType.ArticleRetrievedHeadAndBodyFollow,
             segmentId,
             onConnectionReadyAgain,
+            NntpOperation.Article,
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -706,6 +810,7 @@ public class MultiProviderNntpClient(
         UsenetResponseType successResponseType,
         SegmentId segmentId,
         ArticleBodyCompletionHandler? onConnectionReadyAgain,
+        NntpOperation operation,
         CancellationToken cancellationToken)
         where T : UsenetResponse
     {
@@ -718,12 +823,15 @@ public class MultiProviderNntpClient(
         var missingGroups = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var orderedProviders = SelectOrderedProviders(out var reserved);
         using var releasePending = new ScopeReleaser(() => reserved?.ReleasePending());
+        var walk = new ProviderWalkSummary(orderedProviders.Count);
+        MultiConnectionNntpClient? lastAttemptedProvider = null;
         var attemptIndex = 0;
         foreach (var provider in orderedProviders)
         {
             var group = NormalizeStorageGroup(provider.StorageGroup);
             if (group.Length > 0 && missingGroups.Contains(group))
             {
+                walk.StorageGroupSkips++;
                 Log.Debug(
                     "Skipping provider `{Host}` on storage group `{Group}` — " +
                     "a sibling provider already reported the article missing.",
@@ -733,6 +841,7 @@ public class MultiProviderNntpClient(
 
             if (IsCachedMissing(segmentId, provider))
             {
+                walk.CachedSkips++;
                 Log.Debug(
                     "Skipping provider `{Host}` for article `{SegmentId}` — " +
                     "cached as missing. Reason: article-miss-cache",
@@ -743,9 +852,11 @@ public class MultiProviderNntpClient(
             var deferredCallback = new DeferredArticleBodyCallback();
             var traceRange = CurrentStreamTraceRange;
             var stopwatch = Stopwatch.StartNew();
+            lastAttemptedProvider = provider;
             try
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                walk.Attempts++;
                 var result = await task(provider, deferredCallback.Invoke)
                     .ConfigureAwait(false);
                 stopwatch.Stop();
@@ -764,6 +875,7 @@ public class MultiProviderNntpClient(
                 deferredCallback.Discard();
                 if (UsenetArticleAvailability.IsDefinitiveMissing(result))
                 {
+                    walk.CurrentDefinitiveMisses++;
                     RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing,
                         stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
                     (priorMisses ??= []).Add((provider.MetricsKey, SegmentFetch.FetchStatus.Missing));
@@ -775,6 +887,7 @@ public class MultiProviderNntpClient(
                     continue;
                 }
 
+                walk.UnexpectedResponses++;
                 RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing,
                     stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
                 InvokeCompletionCallback(
@@ -783,6 +896,7 @@ public class MultiProviderNntpClient(
             }
             catch (NntpClientRetiredException)
             {
+                walk.Retired = true;
                 deferredCallback.Discard();
                 InvokeCompletionCallback(
                     onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
@@ -791,17 +905,19 @@ public class MultiProviderNntpClient(
             catch (Exception e) when (!e.IsCancellationException(cancellationToken) && e is not OutOfMemoryException)
             {
                 stopwatch.Stop();
+                walk.NoteException(e);
                 var reason = ClassifyAndRecordFailure(
                     provider.MetricsKey, e, stopwatch.ElapsedMilliseconds, attemptIndex,
                     traceRange);
                 (priorMisses ??= []).Add((provider.MetricsKey, reason));
                 deferredCallback.Discard();
                 lastException = ExceptionDispatchInfo.Capture(e);
-                lastOutcomeWasException = true;
+                lastOutcomeWasException = ClassifyException(e) != SegmentFetch.FetchStatus.Missing;
                 attemptIndex++;
             }
             catch
             {
+                walk.Cancelled = cancellationToken.IsCancellationRequested;
                 deferredCallback.Discard();
                 InvokeCompletionCallback(
                     onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
@@ -811,10 +927,14 @@ public class MultiProviderNntpClient(
 
         // Terminal 430 after skips/exhaustion must fire the completion callback exactly once.
         InvokeCompletionCallback(onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
+        walk.LastOutcomeWasException = lastOutcomeWasException;
+        LogProviderWalkOutcome(
+            walk, segmentId, operation, lastAttemptedProvider?.Host, lastException?.SourceException);
         if (lastOutcomeWasException) lastException!.Throw();
         if (lastNoArticleResult is not null) return lastNoArticleResult;
         if (orderedProviders.Count == 0)
             throw new InvalidOperationException("There are no usenet providers configured.");
+        lastException?.Throw();
         // All providers were skipped (negative cache / storage-group) without a probe.
         throw new UsenetArticleNotFoundException(segmentId.ToString()!);
     }
@@ -823,6 +943,7 @@ public class MultiProviderNntpClient(
     (
         Func<INntpClient, Task<T>> task,
         SegmentId? articleId,
+        NntpOperation operation,
         CancellationToken cancellationToken
     ) where T : UsenetResponse
     {
@@ -836,6 +957,7 @@ public class MultiProviderNntpClient(
         var missingGroups = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var orderedProviders = SelectOrderedProviders(out var reserved);
         using var releasePending = new ScopeReleaser(() => reserved?.ReleasePending());
+        var walk = new ProviderWalkSummary(orderedProviders.Count);
         var attemptIndex = 0;
         foreach (var provider in orderedProviders)
         {
@@ -843,6 +965,7 @@ public class MultiProviderNntpClient(
             var group = NormalizeStorageGroup(provider.StorageGroup);
             if (group.Length > 0 && missingGroups.Contains(group))
             {
+                walk.StorageGroupSkips++;
                 Log.Debug(
                     "Skipping provider `{Host}` on storage group `{Group}` — " +
                     "a sibling provider already reported the article missing.",
@@ -852,6 +975,7 @@ public class MultiProviderNntpClient(
 
             if (articleId is { } segmentId && IsCachedMissing(segmentId, provider))
             {
+                walk.CachedSkips++;
                 Log.Debug(
                     "Skipping provider `{Host}` for article `{SegmentId}` — " +
                     "cached as missing. Reason: article-miss-cache",
@@ -874,6 +998,7 @@ public class MultiProviderNntpClient(
             var stopwatch = Stopwatch.StartNew();
             try
             {
+                walk.Attempts++;
                 var result = await task.Invoke(provider).ConfigureAwait(false);
                 stopwatch.Stop();
 
@@ -882,6 +1007,7 @@ public class MultiProviderNntpClient(
                 // never a connection error.
                 if (UsenetArticleAvailability.IsDefinitiveMissing(result))
                 {
+                    walk.CurrentDefinitiveMisses++;
                     RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing,
                         stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
                     (priorMisses ??= new()).Add((provider.MetricsKey, SegmentFetch.FetchStatus.Missing));
@@ -912,6 +1038,7 @@ public class MultiProviderNntpClient(
                 else if (result is UsenetDecodedBodyResponse or UsenetDecodedArticleResponse)
                 {
                     // BODY/ARTICLE response with an unexpected (non-success, non-430) response type.
+                    walk.UnexpectedResponses++;
                     RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing,
                         stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
                 }
@@ -922,17 +1049,19 @@ public class MultiProviderNntpClient(
             }
             catch (NntpClientRetiredException)
             {
+                walk.Retired = true;
                 throw;
             }
             catch (Exception e) when (!e.IsCancellationException(cancellationToken) && e is not OutOfMemoryException)
             {
                 stopwatch.Stop();
+                walk.NoteException(e);
                 var reason = ClassifyAndRecordFailure(
                     provider.MetricsKey, e, stopwatch.ElapsedMilliseconds, attemptIndex,
                     traceRange);
                 (priorMisses ??= new()).Add((provider.MetricsKey, reason));
                 lastException = ExceptionDispatchInfo.Capture(e);
-                lastOutcomeWasException = true;
+                lastOutcomeWasException = ClassifyException(e) != SegmentFetch.FetchStatus.Missing;
                 attemptIndex++;
             }
         }
@@ -940,14 +1069,15 @@ public class MultiProviderNntpClient(
         // Whichever terminal outcome occurred on the last attempted provider wins,
         // matching the original fallback precedence (a later connection error beats
         // an earlier 430, and a later 430 beats an earlier error).
+        walk.LastOutcomeWasException = lastOutcomeWasException;
+        LogProviderWalkOutcome(
+            walk, articleId, operation, lastAttemptedProvider?.Host, lastException?.SourceException);
         if (lastOutcomeWasException)
-        {
-            LogExhaustedProviders(lastAttemptedProvider?.Host, lastException!.SourceException);
-            lastException.Throw();
-        }
+            lastException!.Throw();
         if (lastNoArticleResult is not null) return lastNoArticleResult;
         if (orderedProviders.Count == 0)
             throw new InvalidOperationException("There are no usenet providers configured.");
+        lastException?.Throw();
         // All providers were skipped (negative cache / storage-group) without a probe.
         if (articleId is { } exhaustedId)
             throw new UsenetArticleNotFoundException(exhaustedId.ToString()!);
@@ -967,6 +1097,46 @@ public class MultiProviderNntpClient(
 
     private static string CacheKey(SegmentId segmentId, MultiConnectionNntpClient provider) =>
         ArticleMissNegativeCache.BuildKey(segmentId.ToString()!, provider.MetricsKey, provider.StorageGroup);
+
+    private static void LogProviderWalkOutcome(
+        ProviderWalkSummary walk,
+        SegmentId? segmentId,
+        NntpOperation operation,
+        string? lastHost,
+        Exception? lastException)
+    {
+        try
+        {
+            if (segmentId is null)
+                return;
+
+            if (walk.IsPureDefinitiveMiss)
+            {
+                Log.Warning(
+                    "Usenet segment was unavailable from all eligible provider sources. " +
+                    "Segment: {SegmentId}; File: {FileName}; Operation: {Operation}; " +
+                    "EligibleProviders: {EligibleProviders}; Attempts: {Attempts}; " +
+                    "CachedSkips: {CachedSkips}; StorageGroupSkips: {StorageGroupSkips}; " +
+                    "DurationMs: {DurationMs}",
+                    segmentId,
+                    FetchAttributionContext.Current?.FileName,
+                    LatencyNames.ToWireName(operation),
+                    walk.EligibleProviders,
+                    walk.Attempts,
+                    walk.CachedSkips,
+                    walk.StorageGroupSkips,
+                    walk.Elapsed.TotalMilliseconds);
+                return;
+            }
+
+            if (walk.LastOutcomeWasException && lastException is not null)
+                LogExhaustedProviders(lastHost, lastException);
+        }
+        catch (Exception e) when (e is not OutOfMemoryException)
+        {
+            // Logging is observational; never change fetch, callback, or fallback ownership.
+        }
+    }
 
     /// <summary>
     /// Logs the terminal failure once all providers have been tried. Known

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -529,10 +529,6 @@ public class MultiProviderNntpClient(
                     primaryStopwatch.ElapsedMilliseconds, 0, primaryTraceRange);
                 (priorMisses ??= []).Add((primaryProvider.MetricsKey, SegmentFetch.FetchStatus.Missing));
             }
-            else if (response is { ResponseType: UsenetResponseType.ArticleRetrievedBodyFollows })
-            {
-                // counted as success below
-            }
             else if (response != null)
             {
                 walk.Attempts++;

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -312,6 +312,7 @@ public class HealthCheckService : BackgroundService
 
         // Attribution for latency histograms — does not change pool admission priority.
         using var maintenanceScope = ct.SetContext(MaintenanceDownloadContext.Instance);
+        using var fetchAttribution = FetchAttributionContext.Begin(davItem.Name);
 
         ContextualCancellationTokenSource? statCts = null;
         try

--- a/backend/Services/PlaybackFastVerifier.cs
+++ b/backend/Services/PlaybackFastVerifier.cs
@@ -47,6 +47,8 @@ public class PlaybackFastVerifier
 
         var attribution = new MultiProviderNntpClient.ResponderAttribution();
         MultiProviderNntpClient.AttributionContext.Value = attribution;
+        using var fetchAttribution = FetchAttributionContext.Begin(
+            nzb.Files.FirstOrDefault()?.GetSubjectFileName());
 
         var timeout = segmentTimeout ?? DefaultSegmentTimeout;
         var tasks = samples.Select(s => CheckSegmentAsync(s, mode, timeout, priority, ct)).ToList();

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -285,6 +285,7 @@ public class Par2RepairService : BackgroundService
             // MaintenanceDownloadContext is attribution-only; it does NOT set AttributionContext,
             // so recovery-volume BODY fetches MAY populate the playback segment cache (harmless).
             using var maintenanceScope = ct.SetContext(MaintenanceDownloadContext.Instance);
+            using var fetchAttribution = FetchAttributionContext.Begin(davItem.Name);
 
             var result = await ExecuteRepairJobAsync(davItem, job, ct).ConfigureAwait(false);
             stopwatch.Stop();

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -403,12 +403,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 if (liveIndexes.Length > 0)
                 {
                     var liveIds = liveIndexes.Select(index => segmentIds[index]).ToArray();
-                    var batch = await _usenetClient.DecodedBodiesAsync(
-                        liveIds, onConnectionReadyAgain: null, cancellationToken).ConfigureAwait(false);
-                    if (batch.Responses.Count != liveIndexes.Length)
-                        throw new InvalidOperationException(
-                            $"Pipelined BODY returned {batch.Responses.Count} responses for {liveIndexes.Length} requests.");
-                    liveResponses = batch.Responses.ToArray();
+                    liveResponses = await FetchAttributedBatchResponsesAsync(liveIds, cancellationToken)
+                        .ConfigureAwait(false);
                 }
 
                 streamTasks = new Task<SegmentDownloadResult>[batchCount];
@@ -517,6 +513,19 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         return false;
     }
 
+    private async Task<Task<UsenetDecodedBodyResponse>[]> FetchAttributedBatchResponsesAsync(
+        SegmentId[] liveIds,
+        CancellationToken cancellationToken)
+    {
+        using var fetchAttribution = FetchAttributionContext.Begin(_fileName);
+        var batch = await _usenetClient.DecodedBodiesAsync(
+            liveIds, onConnectionReadyAgain: null, cancellationToken).ConfigureAwait(false);
+        if (batch.Responses.Count != liveIds.Length)
+            throw new InvalidOperationException(
+                $"Pipelined BODY returned {batch.Responses.Count} responses for {liveIds.Length} requests.");
+        return batch.Responses.ToArray();
+    }
+
     /// <summary>
     /// When <see cref="_readBudget"/> is null, pause the producer once in-flight planned
     /// bytes reach task-window-size × estimated segment size so full-file GETs cannot retain
@@ -576,9 +585,13 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             {
                 try
                 {
-                    var bodyResponse = await _usenetClient
-                        .DecodedBodyAsync(segmentId, cancellationToken)
-                        .ConfigureAwait(false);
+                    UsenetDecodedBodyResponse bodyResponse;
+                    using (FetchAttributionContext.Begin(_fileName))
+                    {
+                        bodyResponse = await _usenetClient
+                            .DecodedBodyAsync(segmentId, cancellationToken)
+                            .ConfigureAwait(false);
+                    }
 
                     await ThrowOnSegmentIdMismatchAsync(segmentId, bodyResponse).ConfigureAwait(false);
 #pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
@@ -921,8 +934,12 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                         lease = await LeaseSegmentBytesAsync(
                             GetPlannedSegmentBytes(segmentIndex), cancellationToken).ConfigureAwait(false);
 
-                    var response = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
-                        .ConfigureAwait(false);
+                    UsenetDecodedBodyResponse response;
+                    using (FetchAttributionContext.Begin(_fileName))
+                    {
+                        response = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
+                            .ConfigureAwait(false);
+                    }
                     await ThrowOnSegmentIdMismatchAsync(segmentId, response).ConfigureAwait(false);
 #pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
                     var stream = await DrainSegmentAsync(
@@ -994,8 +1011,12 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                         lease = await LeaseSegmentBytesAsync(
                             GetPlannedSegmentBytes(segmentIndex), cancellationToken).ConfigureAwait(false);
 
-                    var response = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
-                        .ConfigureAwait(false);
+                    UsenetDecodedBodyResponse response;
+                    using (FetchAttributionContext.Begin(_fileName))
+                    {
+                        response = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
+                            .ConfigureAwait(false);
+                    }
                     await ThrowOnSegmentIdMismatchAsync(segmentId, response).ConfigureAwait(false);
 #pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
                     var stream = await DrainSegmentAsync(
@@ -1055,9 +1076,13 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                         lease = await LeaseSegmentBytesAsync(
                             GetPlannedSegmentBytes(segmentIndex), cancellationToken).ConfigureAwait(false);
 
-                    var bodyResponse = await _usenetClient
-                        .DecodedBodyAsync(fallbackId, cancellationToken)
-                        .ConfigureAwait(false);
+                    UsenetDecodedBodyResponse bodyResponse;
+                    using (FetchAttributionContext.Begin(_fileName))
+                    {
+                        bodyResponse = await _usenetClient
+                            .DecodedBodyAsync(fallbackId, cancellationToken)
+                            .ConfigureAwait(false);
+                    }
                     await ThrowOnSegmentIdMismatchAsync(fallbackId, bodyResponse).ConfigureAwait(false);
                     if (!await SegmentResponseValidator.IsFallbackPartSizeCompatibleAsync(
                             bodyResponse.Stream!, _segmentSizes, segmentIndex, cancellationToken)

--- a/backend/Streams/SharedStreamEntry.cs
+++ b/backend/Streams/SharedStreamEntry.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.WebDav.Base;
 using Serilog;
@@ -257,6 +258,7 @@ internal sealed class SharedStreamEntry : IAsyncDisposable
         {
             var upstream = _upstream
                 ?? throw new InvalidOperationException("Shared stream pump started without an upstream.");
+            using var fetchAttribution = FetchAttributionContext.Begin(System.IO.Path.GetFileName(Path));
             if (Anchor > 0 && upstream.CanSeek)
                 upstream.Seek(Anchor, SeekOrigin.Begin);
 

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -1,11 +1,13 @@
 using System.Buffers;
 using System.Runtime.ExceptionServices;
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Services.Repair;
 using NzbWebDAV.Services.StreamTrace;
 using Serilog;
+using UsenetSharp.Models;
 using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Streams;
@@ -119,7 +121,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
                 Stream? fetched = null;
                 try
                 {
-                    var body = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken).ConfigureAwait(false);
+                    var body = await FetchBodyAsync(segmentId, cancellationToken).ConfigureAwait(false);
                     fetched = body.Stream;
                     await SegmentResponseValidator
                         .ThrowOnSegmentIdMismatchAsync(segmentId, body)
@@ -405,7 +407,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
             Stream? retryStream = null;
             try
             {
-                var body = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
+                var body = await FetchBodyAsync(segmentId, cancellationToken)
                     .ConfigureAwait(false);
                 retryStream = body.Stream;
                 await SegmentResponseValidator
@@ -469,7 +471,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
 
         try
         {
-            var body = await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
+            var body = await FetchBodyAsync(segmentId, cancellationToken)
                 .ConfigureAwait(false);
             await SegmentResponseValidator
                 .ThrowOnSegmentIdMismatchAsync(segmentId, body)
@@ -590,8 +592,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
             Stream? fallbackStream = null;
             try
             {
-                var body = await _usenetClient
-                    .DecodedBodyAsync(fallbackId, cancellationToken)
+                var body = await FetchBodyAsync(fallbackId, cancellationToken)
                     .ConfigureAwait(false);
                 fallbackStream = body.Stream;
                 await SegmentResponseValidator
@@ -631,6 +632,17 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         }
 
         return null;
+    }
+
+    private async Task<UsenetDecodedBodyResponse> FetchBodyAsync(
+        string segmentId,
+        CancellationToken cancellationToken)
+    {
+        using (FetchAttributionContext.Begin(_fileName))
+        {
+            return await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
+                .ConfigureAwait(false);
+        }
     }
 
     private async Task DisposeOpenBodyAsync()

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTerminalMissLoggingTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTerminalMissLoggingTests.cs
@@ -301,10 +301,11 @@ public sealed class MultiProviderNntpClientTerminalMissLoggingTests
             });
             var reader = entry.TryAttach(0, NoFallback, out var reason);
             Assert.True(reader is not null, $"attach missed: {reason}");
-            await using (reader)
+            var attached = reader!;
+            await using (attached)
             {
                 var buffer = new byte[8];
-                _ = await reader.ReadAsync(buffer);
+                _ = await attached.ReadAsync(buffer);
             }
         });
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTerminalMissLoggingTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTerminalMissLoggingTests.cs
@@ -1,0 +1,426 @@
+using System.IO;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.TestUtils;
+using NzbWebDAV.WebDav.Base;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+[Collection(nameof(GlobalLoggerCollection))]
+public sealed class MultiProviderNntpClientTerminalMissLoggingTests
+{
+    private const string MissTemplate =
+        "Usenet segment was unavailable from all eligible provider sources";
+
+    [Fact]
+    public async Task TwoProvidersReturn430_EmitsOneWarning()
+    {
+        const string segmentId = "two-430@terminal-miss";
+        var events = await CaptureLogsAsync(async () =>
+        {
+            using var client = TwoMissingProviders(out _);
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            Assert.Equal(UsenetResponseType.NoArticleWithThatMessageId, response.ResponseType);
+        });
+
+        var warning = Assert.Single(events, e => IsMissWarningFor(e, segmentId));
+        Assert.Equal("body", PropertyText(warning, "Operation"));
+    }
+
+    [Fact]
+    public async Task TwoProvidersThrowNotFound_EmitsOneWarning()
+    {
+        const string segmentId = "two-throw@terminal-miss";
+        var events = await CaptureLogsAsync(async () =>
+        {
+            using var client = TwoThrowingProviders();
+            await Assert.ThrowsAsync<UsenetArticleNotFoundException>(
+                () => client.DecodedBodyAsync(segmentId, CancellationToken.None));
+        });
+
+        Assert.Single(events, e => IsMissWarningFor(e, segmentId));
+    }
+
+    [Fact]
+    public async Task Definitive451_FollowsTheSamePolicy()
+    {
+        const string segmentId = "two-451@terminal-miss";
+        var events = await CaptureLogsAsync(async () =>
+        {
+            using var client = new MultiProviderNntpClient(
+            [
+                MultiProviderNntpClientTests.CreateProvider(
+                    new MultiProviderNntpClientTests.ScriptedNntpClient
+                    {
+                        BatchResponseCode = UsenetArticleAvailability.ArticleUnavailable,
+                        SingularResponseCode = UsenetArticleAvailability.ArticleUnavailable,
+                    },
+                    host: "a.example"),
+                MultiProviderNntpClientTests.CreateProvider(
+                    new MultiProviderNntpClientTests.ScriptedNntpClient
+                    {
+                        BatchResponseCode = UsenetArticleAvailability.ArticleUnavailable,
+                        SingularResponseCode = UsenetArticleAvailability.ArticleUnavailable,
+                    },
+                    host: "b.example"),
+            ]);
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            Assert.Equal(UsenetArticleAvailability.ArticleUnavailable, response.ResponseCode);
+        });
+
+        Assert.Single(events, e => IsMissWarningFor(e, segmentId));
+    }
+
+    [Fact]
+    public async Task CallbackStreamingAllMiss_EmitsOneWarningAndOneCallback()
+    {
+        const string segmentId = "callback-miss@terminal-miss";
+        var callbacks = 0;
+        var events = await CaptureLogsAsync(async () =>
+        {
+            using var client = TwoThrowingProviders();
+            await Assert.ThrowsAsync<UsenetArticleNotFoundException>(() =>
+                client.DecodedBodyAsync(
+                    segmentId,
+                    (_, _) => Interlocked.Increment(ref callbacks),
+                    CancellationToken.None));
+        });
+
+        Assert.Single(events, e => IsMissWarningFor(e, segmentId));
+        Assert.Equal(1, callbacks);
+    }
+
+    [Fact]
+    public async Task BatchTerminalMiss_EmitsOneWarningAndCompletesInOrder()
+    {
+        const string segmentId = "batch-miss@terminal-miss";
+        var events = await CaptureLogsAsync(async () =>
+        {
+            using var client = TwoMissingProviders(out _);
+            var batch = await client.DecodedBodiesAsync(
+                [segmentId],
+                onConnectionReadyAgain: null,
+                CancellationToken.None);
+            await Assert.ThrowsAsync<UsenetArticleNotFoundException>(() => batch.Responses[0]);
+        });
+
+        Assert.Single(events, e => IsMissWarningFor(e, segmentId));
+    }
+
+    [Fact]
+    public async Task PersistentMissCacheSkipsEveryProvider_EmitsOneWarningWithZeroAttempts()
+    {
+        const string segmentId = "cache-skip@terminal-miss";
+        var config = new ConfigManager();
+        var cache = new ArticleMissNegativeCache(config);
+        cache.MarkMissing(ArticleMissNegativeCache.BuildKey(segmentId, "a.example", ""));
+        cache.MarkMissing(ArticleMissNegativeCache.BuildKey(segmentId, "b.example", ""));
+        var first = new MultiProviderNntpClientTests.ScriptedNntpClient
+        {
+            BatchResponseCode = 430,
+            SingularResponseCode = 430,
+        };
+        var second = new MultiProviderNntpClientTests.ScriptedNntpClient
+        {
+            BatchResponseCode = 430,
+            SingularResponseCode = 430,
+        };
+
+        var events = await CaptureLogsAsync(async () =>
+        {
+            using var client = new MultiProviderNntpClient(
+            [
+                MultiProviderNntpClientTests.CreateProvider(first, host: "a.example"),
+                MultiProviderNntpClientTests.CreateProvider(second, host: "b.example"),
+            ], articleMissCache: cache);
+
+            await Assert.ThrowsAsync<UsenetArticleNotFoundException>(
+                () => client.DecodedBodyAsync(segmentId, CancellationToken.None));
+        });
+
+        Assert.Equal(0, first.SingularRequests);
+        Assert.Equal(0, second.SingularRequests);
+        var warning = Assert.Single(events, e => IsMissWarningFor(e, segmentId));
+        Assert.Contains("Attempts: {Attempts}", warning.MessageTemplate.Text, StringComparison.Ordinal);
+        Assert.Equal("0", PropertyText(warning, "Attempts"));
+    }
+
+    [Fact]
+    public async Task StorageGroupSiblingSkip_IsCountedOnTheTerminalWarning()
+    {
+        const string segmentId = "storage-group@terminal-miss";
+        var events = await CaptureLogsAsync(async () =>
+        {
+            using var client = new MultiProviderNntpClient(
+            [
+                MultiProviderNntpClientTests.CreateProvider(
+                    MissingClient(), host: "a.example", storageGroup: "block-1"),
+                MultiProviderNntpClientTests.CreateProvider(
+                    MissingClient(), host: "b.example", storageGroup: "block-1"),
+            ]);
+            await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+        });
+
+        var warning = Assert.Single(events, e => IsMissWarningFor(e, segmentId));
+        Assert.Equal("1", PropertyText(warning, "StorageGroupSkips"));
+        Assert.Equal("1", PropertyText(warning, "Attempts"));
+    }
+
+    [Fact]
+    public async Task MissPlusNetworkError_DoesNotEmitPureMissWarning()
+    {
+        const string segmentId = "mixed-network@terminal-miss";
+        var events = await CaptureLogsAsync(async () =>
+        {
+            using var client = new MultiProviderNntpClient(
+            [
+                MultiProviderNntpClientTests.CreateProvider(MissingClient(), host: "a.example"),
+                MultiProviderNntpClientTests.CreateProvider(
+                    new MultiProviderNntpClientTests.ScriptedNntpClient
+                    {
+                        BatchResponseCode = 222,
+                        SingularResponseCode = 222,
+                        SingularException = _ => new IOException("connection reset"),
+                    },
+                    host: "b.example"),
+            ]);
+            await Assert.ThrowsAsync<IOException>(
+                () => client.DecodedBodyAsync(segmentId, CancellationToken.None));
+        });
+
+        Assert.DoesNotContain(events, e => IsMissWarningFor(e, segmentId));
+        Assert.Contains(events, e =>
+            e.Level == LogEventLevel.Warning
+            && e.MessageTemplate.Text.Contains("All providers exhausted", StringComparison.Ordinal)
+            && e.RenderMessage().Contains("connection reset", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task CancellationAfterAnEarlierMiss_DoesNotEmitTerminalMissWarning()
+    {
+        const string segmentId = "cancel-after-miss@terminal-miss";
+        using var cts = new CancellationTokenSource();
+        var events = await CaptureLogsAsync(async () =>
+        {
+            using var client = new MultiProviderNntpClient(
+            [
+                MultiProviderNntpClientTests.CreateProvider(MissingClient(), host: "a.example"),
+                MultiProviderNntpClientTests.CreateProvider(
+                    new MultiProviderNntpClientTests.ScriptedNntpClient
+                    {
+                        BatchResponseCode = 222,
+                        SingularResponseCode = 222,
+                        SingularException = _ =>
+                        {
+                            cts.Cancel();
+                            throw new OperationCanceledException(cts.Token);
+                        },
+                    },
+                    host: "b.example"),
+            ]);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => client.DecodedBodyAsync(segmentId, cts.Token));
+        });
+
+        Assert.DoesNotContain(events, e => IsMissWarningFor(e, segmentId));
+    }
+
+    [Fact]
+    public async Task NoConfiguredProviders_DoesNotEmitPureMissWarning()
+    {
+        const string segmentId = "no-providers@terminal-miss";
+        var events = await CaptureLogsAsync(async () =>
+        {
+            using var client = new MultiProviderNntpClient([]);
+            var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => client.DecodedBodyAsync(segmentId, CancellationToken.None));
+            Assert.Contains("no usenet providers", thrown.Message, StringComparison.OrdinalIgnoreCase);
+        });
+
+        Assert.DoesNotContain(events, e => IsMissWarningFor(e, segmentId));
+    }
+
+    [Fact]
+    public async Task Unexpected400Response_DoesNotEmitPureMissWarning()
+    {
+        const string segmentId = "unexpected-400@terminal-miss";
+        var events = await CaptureLogsAsync(async () =>
+        {
+            using var client = new MultiProviderNntpClient(
+            [
+                MultiProviderNntpClientTests.CreateProvider(
+                    new MultiProviderNntpClientTests.ScriptedNntpClient
+                    {
+                        BatchResponseCode = 400,
+                        SingularResponseCode = 400,
+                    }),
+            ]);
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            Assert.Equal(400, response.ResponseCode);
+        });
+
+        Assert.DoesNotContain(events, e => IsMissWarningFor(e, segmentId));
+    }
+
+    [Fact]
+    public async Task SharedPumpMiss_IncludesFileAttribution()
+    {
+        const string segmentId = "shared-pump@terminal-miss";
+        var events = await CaptureLogsAsync(async () =>
+        {
+            using var nntp = TwoThrowingProviders();
+            await using var upstream = MultiSegmentStream.Create(
+                new[] { segmentId }.AsMemory(),
+                nntp,
+                articleBufferSize: 0,
+                estimatedSegmentSize: 8,
+                failFastOnFirstSegment: false,
+                usePipelinedBodyRequests: false,
+                CancellationToken.None,
+                fileName: "movie.mkv",
+                exactSegmentSizes: new long[] { 8 });
+            await using var entry = new SharedStreamEntry(
+                "/content/movie.mkv",
+                0,
+                8,
+                64,
+                TimeSpan.FromSeconds(10),
+                CancellationToken.None,
+                chunkSize: 8,
+                leadBytes: 8);
+            entry.BindAndStart(new DetachedStreamLease
+            {
+                Stream = upstream,
+                Ownership = NullAsyncDisposable.Instance,
+            });
+            var reader = entry.TryAttach(0, NoFallback, out var reason);
+            Assert.True(reader is not null, $"attach missed: {reason}");
+            await using (reader)
+            {
+                var buffer = new byte[8];
+                _ = await reader.ReadAsync(buffer);
+            }
+        });
+
+        var warning = Assert.Single(events, e => IsMissWarningFor(e, segmentId));
+        Assert.Equal("movie.mkv", PropertyText(warning, "FileName"));
+    }
+
+    [Fact]
+    public async Task PlaybackZeroFill_DoesNotDuplicateTheTerminalMissWarning()
+    {
+        const string segmentId = "zero-fill@terminal-miss";
+        var events = await CaptureLogsAsync(async () =>
+        {
+            using var nntp = TwoThrowingProviders();
+            await using var stream = MultiSegmentStream.Create(
+                new[] { segmentId }.AsMemory(),
+                nntp,
+                articleBufferSize: 0,
+                estimatedSegmentSize: 8,
+                failFastOnFirstSegment: false,
+                usePipelinedBodyRequests: false,
+                CancellationToken.None,
+                fileName: "movie.mkv",
+                exactSegmentSizes: new long[] { 8 });
+            var buffer = new byte[8];
+            _ = await stream.ReadAsync(buffer);
+        });
+
+        Assert.Single(events, e => IsMissWarningFor(e, segmentId));
+    }
+
+    private static MultiProviderNntpClient TwoMissingProviders(
+        out MultiProviderNntpClientTests.ScriptedNntpClient first)
+    {
+        first = MissingClient();
+        return new MultiProviderNntpClient(
+        [
+            MultiProviderNntpClientTests.CreateProvider(first, host: "a.example"),
+            MultiProviderNntpClientTests.CreateProvider(MissingClient(), host: "b.example"),
+        ]);
+    }
+
+    private static MultiProviderNntpClient TwoThrowingProviders() =>
+        new(
+        [
+            MultiProviderNntpClientTests.CreateProvider(ThrowingMissingClient(), host: "a.example"),
+            MultiProviderNntpClientTests.CreateProvider(ThrowingMissingClient(), host: "b.example"),
+        ]);
+
+    private static MultiProviderNntpClientTests.ScriptedNntpClient MissingClient() => new()
+    {
+        BatchResponseCode = 430,
+        SingularResponseCode = 430,
+    };
+
+    private static MultiProviderNntpClientTests.ScriptedNntpClient ThrowingMissingClient() => new()
+    {
+        BatchResponseCode = 430,
+        SingularResponseCode = 430,
+        SingularException = id => new UsenetArticleNotFoundException(id),
+    };
+
+    private static Task<Stream> NoFallback(long offset, CancellationToken _) =>
+        throw new InvalidOperationException($"Private fallback should not run at offset {offset}.");
+
+    private static string PropertyText(LogEvent logEvent, string name)
+    {
+        if (!logEvent.Properties.TryGetValue(name, out var value))
+            return "";
+        return value is ScalarValue { Value: { } raw }
+            ? raw.ToString() ?? ""
+            : value.ToString();
+    }
+
+    private static bool IsMissWarning(LogEvent logEvent) =>
+        logEvent.Level == LogEventLevel.Warning
+        && logEvent.MessageTemplate.Text.Contains(MissTemplate, StringComparison.Ordinal);
+
+    private static bool IsMissWarningFor(LogEvent logEvent, string segmentId) =>
+        IsMissWarning(logEvent) && PropertyText(logEvent, "SegmentId") == segmentId;
+
+    private static async Task<IReadOnlyList<LogEvent>> CaptureLogsAsync(Func<Task> act)
+    {
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        try
+        {
+            await act().ConfigureAwait(false);
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+
+        return sink.Events;
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events) return _events.ToArray();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events) _events.Add(logEvent);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -1928,7 +1928,7 @@ public class MultiProviderNntpClientTests
         Assert.Equal(SegmentFetch.FetchStatus.Corrupt, status);
     }
 
-    private static MultiConnectionNntpClient CreateProvider(
+    internal static MultiConnectionNntpClient CreateProvider(
         INntpClient connection,
         string host = "test",
         string storageGroup = "",
@@ -1969,7 +1969,7 @@ public class MultiProviderNntpClientTests
         return breaker;
     }
 
-    private sealed class ScriptedNntpClient : NntpClient
+    internal sealed class ScriptedNntpClient : NntpClient
     {
         public required int BatchResponseCode { get; init; }
         public int SingularResponseCode { get; init; } = 222;

--- a/tests/NzbWebDAV.Tests/Utils/StreamingResponseWriteWatchdogTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/StreamingResponseWriteWatchdogTests.cs
@@ -103,9 +103,9 @@ public class StreamingResponseWriteWatchdogTests
         await WaitUntil(() => budget.HasWaiters);
 
         using var readCts = new CancellationTokenSource();
-        using var dest = new DelayedCompletingWriteStream(TimeSpan.FromMilliseconds(40));
+        using var dest = new DelayedCompletingWriteStream(TimeSpan.FromMilliseconds(180));
         var watchdog = new StreamingResponseWriteWatchdog(
-            TimeSpan.FromMilliseconds(50), readCts, budget);
+            TimeSpan.FromMilliseconds(300), readCts, budget);
 
         await watchdog.WriteAsync(dest, new byte[100], CancellationToken.None);
         var ex = await Assert.ThrowsAsync<StreamingWriteTimeoutException>(async () =>


### PR DESCRIPTION
## Summary
- Emits **one structured Warning** when a provider walk ends in a pure definitive miss (430 / 451), including cached skips and same-storage-group siblings, with segment id, file name, operation, attempt counts, and duration.
- Keeps Debug-level per-provider attempts. Mixed errors still use the existing exhausted-provider Warning. Cancellation, no providers, unexpected 400, and provider retirement do not emit the miss Warning.
- Adds diagnostic-only `FetchAttributionContext` (does not reuse `AttributionContext`, so cache/repair behavior is unchanged). Logging is observational: callbacks, batch ordering, and fallback admission are unchanged.

Fixes #900

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~MultiProviderNntpClient"`
- [x] Full `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (one unrelated flaky watchdog timing test retried green)
- [ ] Confirm a playback miss at default log level shows one Warning with file name, not a stack dump
- [ ] Confirm a mixed miss+network failure still logs the exhausted-provider Warning and not the pure-miss template