### PR TITLE
chore(db): background jobs use the shared database factory

### DIFF
--- a/backend/Database/DavDatabaseContexts.cs
+++ b/backend/Database/DavDatabaseContexts.cs
@@ -1,3 +1,5 @@
+using Microsoft.EntityFrameworkCore;
+
 namespace NzbWebDAV.Database;
 
 /// <summary>
@@ -11,9 +13,15 @@ namespace NzbWebDAV.Database;
 internal static class DavDatabaseContexts
 {
     public static DavDatabaseContext Create(Func<DavDatabaseContext>? factoryOverride)
+        => Create(factoryOverride, dbContextFactory: null);
+
+    public static DavDatabaseContext Create(
+        Func<DavDatabaseContext>? factoryOverride,
+        IDbContextFactory<DavDatabaseContext>? dbContextFactory)
     {
         var overridden = factoryOverride?.Invoke();
         if (overridden is not null) return overridden;
+        if (dbContextFactory is not null) return dbContextFactory.CreateDbContext();
         return new DavDatabaseContext();
     }
 }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -313,7 +313,8 @@ public partial class Program
                     sp.GetRequiredService<UsenetStreamingClient>(),
                     sp.GetRequiredService<ConfigManager>()))
                 .AddSingleton<QueueManager>()
-                .AddSingleton(_ => new NzbResolutionCache(() => new DavDatabaseContext()))
+                .AddSingleton(sp => new NzbResolutionCache(
+                    () => sp.GetRequiredService<IDbContextFactory<DavDatabaseContext>>().CreateDbContext()))
                 .AddSingleton<PreferredOrderStore>()
                 .AddSingleton<NzbFetchCoalescer>()
                 .AddSingleton<PlayResolutionCoalescer>()
@@ -322,7 +323,7 @@ public partial class Program
                 // NNTP client never depends on scoped database services.
                 .AddSingleton(sp => new ArticleMissNegativeCache(
                     sp.GetRequiredService<ConfigManager>(),
-                    () => new DavDatabaseContext()))
+                    () => sp.GetRequiredService<IDbContextFactory<DavDatabaseContext>>().CreateDbContext()))
                 .AddHostedService(sp => sp.GetRequiredService<ArticleMissNegativeCache>())
                 .AddSingleton(sp =>
                 {
@@ -400,7 +401,10 @@ public partial class Program
                 .AddSingleton<ListSourceEnumerator>()
                 .AddSingleton<EpisodeEnumerator>()
                 .AddHostedService<WatchtowerService>()
-                .AddScoped<DavDatabaseContext>()
+                .AddDbContextFactory<DavDatabaseContext>(options =>
+                    DavDatabaseContext.ConfigureOptions(options))
+                .AddScoped(sp =>
+                    sp.GetRequiredService<IDbContextFactory<DavDatabaseContext>>().CreateDbContext())
                 .AddScoped<DavDatabaseClient>()
                 .AddScoped<NzbWebDAV.Services.Benchmark.BenchmarkCorpusProvider>()
                 .AddScoped<NzbWebDAV.Services.Benchmark.UsenetBenchmarkService>()

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -72,7 +72,10 @@ public sealed class QueueManager : IDisposable
     internal Func<CancellationToken, Task<DateTime?>>? GetNextPauseUntilOverride { get; set; }
     internal Func<DavDatabaseContext>? CreateDbContextOverride { get; set; }
 
-    private DavDatabaseContext CreateDbContext() => DavDatabaseContexts.Create(CreateDbContextOverride);
+    private readonly IDbContextFactory<DavDatabaseContext>? _dbContextFactory;
+
+    private DavDatabaseContext CreateDbContext() =>
+        DavDatabaseContexts.Create(CreateDbContextOverride, _dbContextFactory);
 
     public QueueManager(
         UsenetStreamingClient usenetClient,
@@ -81,10 +84,11 @@ public sealed class QueueManager : IDisposable
         ProviderUsageTracker providerUsageTracker,
         WatchdogLog watchdogLog,
         QueueItemSourceTracker sourceTracker,
-        BenchmarkGate benchmarkGate
+        BenchmarkGate benchmarkGate,
+        IDbContextFactory<DavDatabaseContext> dbContextFactory
     ) : this(
         usenetClient, configManager, websocketManager, providerUsageTracker,
-        watchdogLog, sourceTracker, benchmarkGate, startLoop: false)
+        watchdogLog, sourceTracker, benchmarkGate, startLoop: false, dbContextFactory)
     {
     }
 
@@ -96,7 +100,8 @@ public sealed class QueueManager : IDisposable
         WatchdogLog watchdogLog,
         QueueItemSourceTracker sourceTracker,
         BenchmarkGate benchmarkGate,
-        bool startLoop
+        bool startLoop,
+        IDbContextFactory<DavDatabaseContext>? dbContextFactory = null
     )
     {
         _usenetClient = usenetClient;
@@ -106,6 +111,7 @@ public sealed class QueueManager : IDisposable
         _watchdogLog = watchdogLog;
         _sourceTracker = sourceTracker;
         _benchmarkGate = benchmarkGate;
+        _dbContextFactory = dbContextFactory;
         _cancellationTokenSource = CancellationTokenSource
             .CreateLinkedTokenSource(SigtermUtil.GetCancellationToken());
         if (startLoop)

--- a/backend/Services/ArrHealthService.cs
+++ b/backend/Services/ArrHealthService.cs
@@ -40,13 +40,18 @@ public sealed class ArrHealthService : BackgroundService
     internal TimeSpan PollInterval { get; set; } = TimeSpan.FromSeconds(60);
     internal Func<string, ArrConfig.ConnectionDetails, ArrClient> ClientFactory { get; set; } = CreateClient;
     internal Func<MetricsDbContext> MetricsContextFactory { get; set; } = static () => new MetricsDbContext();
-    internal Func<DavDatabaseContext> DavContextFactory { get; set; } = static () => new DavDatabaseContext();
+    internal Func<DavDatabaseContext> DavContextFactory { get; set; }
     internal int CycleAttempts => _cycleAttempts;
     private int _cycleAttempts;
 
-    public ArrHealthService(ConfigManager configManager)
+    public ArrHealthService(
+        ConfigManager configManager,
+        IDbContextFactory<DavDatabaseContext>? dbContextFactory = null)
     {
         _configManager = configManager;
+        DavContextFactory = dbContextFactory is null
+            ? static () => new DavDatabaseContext()
+            : dbContextFactory.CreateDbContext;
         _configManager.OnConfigChanged += OnConfigChanged;
     }
 

--- a/backend/Services/BlobCleanupService.cs
+++ b/backend/Services/BlobCleanupService.cs
@@ -11,7 +11,7 @@ namespace NzbWebDAV.Services;
 /// Background service that processes the blob cleanup queue.
 /// A payload blob is only deleted once no DavItem still references it.
 /// </summary>
-public class BlobCleanupService : BackgroundService
+public class BlobCleanupService(IDbContextFactory<DavDatabaseContext> dbContextFactory) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -19,7 +19,7 @@ public class BlobCleanupService : BackgroundService
         {
             try
             {
-                await using var dbContext = new DavDatabaseContext();
+                await using var dbContext = dbContextFactory.CreateDbContext();
 
                 var processed = await ProcessNextCleanupItemAsync(dbContext, stoppingToken).ConfigureAwait(false);
 

--- a/backend/Services/DavCleanupService.cs
+++ b/backend/Services/DavCleanupService.cs
@@ -7,7 +7,7 @@ using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Services;
 
-public class DavCleanupService : BackgroundService
+public class DavCleanupService(IDbContextFactory<DavDatabaseContext> dbContextFactory) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -15,7 +15,7 @@ public class DavCleanupService : BackgroundService
         {
             try
             {
-                await using var dbContext = new DavDatabaseContext();
+                await using var dbContext = dbContextFactory.CreateDbContext();
 
                 // If no items in queue, wait 10 seconds before checking again
                 if (!await ProcessNextItemAsync(dbContext, stoppingToken).ConfigureAwait(false))

--- a/backend/Services/HealthCheckRetentionService.cs
+++ b/backend/Services/HealthCheckRetentionService.cs
@@ -12,7 +12,9 @@ namespace NzbWebDAV.Services;
 /// HealthCheckStats stay consistent via existing AFTER DELETE triggers.
 /// Inspired by elfhosted/nzbdav database maintenance (PR #199 retention idea).
 /// </summary>
-public class HealthCheckRetentionService(ConfigManager configManager) : BackgroundService
+public class HealthCheckRetentionService(
+    ConfigManager configManager,
+    IDbContextFactory<DavDatabaseContext> dbContextFactory) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -54,7 +56,7 @@ public class HealthCheckRetentionService(ConfigManager configManager) : Backgrou
             var retentionDays = configManager.GetHealthResultRetentionDays();
             if (retentionDays <= 0) return;
 
-            await using var dbContext = new DavDatabaseContext();
+            await using var dbContext = dbContextFactory.CreateDbContext();
             var deleted = await SweepAsync(dbContext, retentionDays, stoppingToken).ConfigureAwait(false);
             if (deleted > 0)
             {

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -70,6 +70,7 @@ public class HealthCheckService : BackgroundService
     private readonly QueueManager _queueManager;
     private readonly Par2RepairService _par2RepairService;
     private readonly RepairPatchStore _repairPatchStore;
+    private readonly IDbContextFactory<DavDatabaseContext>? _dbContextFactory;
 
     private static readonly HashSet<string> _missingSegmentIds = [];
     private static readonly Queue<string> _missingSegmentOrder = [];
@@ -85,7 +86,8 @@ public class HealthCheckService : BackgroundService
         StreamingFailureTracker failureTracker,
         QueueManager queueManager,
         Par2RepairService par2RepairService,
-        RepairPatchStore repairPatchStore
+        RepairPatchStore repairPatchStore,
+        IDbContextFactory<DavDatabaseContext>? dbContextFactory = null
     )
     {
         _configManager = configManager;
@@ -96,6 +98,7 @@ public class HealthCheckService : BackgroundService
         _queueManager = queueManager;
         _par2RepairService = par2RepairService;
         _repairPatchStore = repairPatchStore;
+        _dbContextFactory = dbContextFactory;
 
         _configManager.OnConfigChanged += (_, configEventArgs) =>
         {
@@ -120,7 +123,7 @@ public class HealthCheckService : BackgroundService
             return;
         }
 
-        await ClearNonMediaHealthCheckEntries(stoppingToken).ConfigureAwait(false);
+        await ClearNonMediaHealthCheckEntriesAsync(stoppingToken).ConfigureAwait(false);
 
         while (!stoppingToken.IsCancellationRequested)
         {
@@ -154,7 +157,7 @@ public class HealthCheckService : BackgroundService
                 using var cts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
 
                 // get the davItem to health-check
-                await using var dbContext = new DavDatabaseContext();
+                await using var dbContext = CreateContext();
                 var dbClient = new DavDatabaseClient(dbContext);
                 var currentDateTime = DateTimeOffset.UtcNow;
 
@@ -232,16 +235,19 @@ public class HealthCheckService : BackgroundService
                 x.NextHealthCheck == DateTimeOffset.UnixEpoch);
     }
 
+    private DavDatabaseContext CreateContext() =>
+        _dbContextFactory?.CreateDbContext() ?? new DavDatabaseContext();
+
     /// <summary>
     /// One-shot cleanup: clear <c>NextHealthCheck</c>/<c>LastHealthCheck</c> for non-media files
     /// (images, subtitles, NFOs, etc.) that were queued before the media-type filter was added.
     /// Urgent repairs (<c>UnixEpoch</c> sentinel) are never cleared.
     /// </summary>
-    internal static async Task ClearNonMediaHealthCheckEntries(CancellationToken ct)
+    private async Task ClearNonMediaHealthCheckEntriesAsync(CancellationToken ct)
     {
         try
         {
-            await using var dbContext = new DavDatabaseContext();
+            await using var dbContext = CreateContext();
             await ClearNonMediaHealthCheckEntries(dbContext, ct).ConfigureAwait(false);
         }
         catch (Exception e) when (e is not OperationCanceledException and not OutOfMemoryException)

--- a/backend/Services/HistoryCleanupService.cs
+++ b/backend/Services/HistoryCleanupService.cs
@@ -6,7 +6,7 @@ using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Services;
 
-public class HistoryCleanupService : BackgroundService
+public class HistoryCleanupService(IDbContextFactory<DavDatabaseContext> dbContextFactory) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -14,7 +14,7 @@ public class HistoryCleanupService : BackgroundService
         {
             try
             {
-                await using var dbContext = new DavDatabaseContext();
+                await using var dbContext = dbContextFactory.CreateDbContext();
 
                 // Get the first item from the queue
                 var cleanupItem = await dbContext.HistoryCleanupItems

--- a/backend/Services/HistoryRetentionService.cs
+++ b/backend/Services/HistoryRetentionService.cs
@@ -13,7 +13,9 @@ namespace NzbWebDAV.Services;
 /// clears HistoryItemId links instead of removing DavItems.
 /// Inspired by elfhosted/nzbdav database maintenance (PR #199 retention idea).
 /// </summary>
-public class HistoryRetentionService(ConfigManager configManager) : BackgroundService
+public class HistoryRetentionService(
+    ConfigManager configManager,
+    IDbContextFactory<DavDatabaseContext> dbContextFactory) : BackgroundService
 {
     private const int BatchSize = 100;
 
@@ -79,7 +81,7 @@ public class HistoryRetentionService(ConfigManager configManager) : BackgroundSe
             var retentionDays = configManager.GetHistoryRetentionDays();
             if (retentionDays <= 0) return;
 
-            await using var dbContext = new DavDatabaseContext();
+            await using var dbContext = dbContextFactory.CreateDbContext();
             var dbClient = new DavDatabaseClient(dbContext);
             var removed = await SweepAsync(dbClient, retentionDays, stoppingToken).ConfigureAwait(false);
             if (removed > 0)

--- a/backend/Services/MultipartFileSizeRepairService.cs
+++ b/backend/Services/MultipartFileSizeRepairService.cs
@@ -11,13 +11,13 @@ namespace NzbWebDAV.Services;
 /// One-shot startup repair for multipart DavItems that still advertise
 /// <see cref="long.MaxValue"/> as FileSize (issue #537).
 /// </summary>
-public class MultipartFileSizeRepairService : BackgroundService
+public class MultipartFileSizeRepairService(IDbContextFactory<DavDatabaseContext> dbContextFactory) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         try
         {
-            await using var ctx = new DavDatabaseContext();
+            await using var ctx = dbContextFactory.CreateDbContext();
             await RepairAsync(ctx, stoppingToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)

--- a/backend/Services/NzbBlobCleanupService.cs
+++ b/backend/Services/NzbBlobCleanupService.cs
@@ -12,7 +12,7 @@ namespace NzbWebDAV.Services;
 /// An NZB blob is only deleted once it is no longer referenced by any
 /// QueueItem, HistoryItem, or DavItem.
 /// </summary>
-public class NzbBlobCleanupService : BackgroundService
+public class NzbBlobCleanupService(IDbContextFactory<DavDatabaseContext> dbContextFactory) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -20,7 +20,7 @@ public class NzbBlobCleanupService : BackgroundService
         {
             try
             {
-                await using var dbContext = new DavDatabaseContext();
+                await using var dbContext = dbContextFactory.CreateDbContext();
 
                 var processed = await ProcessNextCleanupItemAsync(dbContext, stoppingToken).ConfigureAwait(false);
 

--- a/backend/Services/ProwlarrSyncService.cs
+++ b/backend/Services/ProwlarrSyncService.cs
@@ -26,13 +26,19 @@ public sealed class ProwlarrSyncService : BackgroundService
     private readonly IndexerConfigWriteLock _writeLock;
     private readonly SemaphoreSlim _syncGate = new(1, 1);
 
-    internal Func<DavDatabaseContext> FreshContextFactory { get; set; } = static () => new DavDatabaseContext();
+    internal Func<DavDatabaseContext> FreshContextFactory { get; set; }
     internal IProwlarrClientFactory ClientFactory { get; set; } = new ProwlarrClientFactory();
 
-    public ProwlarrSyncService(ConfigManager configManager, IndexerConfigWriteLock writeLock)
+    public ProwlarrSyncService(
+        ConfigManager configManager,
+        IndexerConfigWriteLock writeLock,
+        IDbContextFactory<DavDatabaseContext>? dbContextFactory = null)
     {
         _configManager = configManager;
         _writeLock = writeLock;
+        FreshContextFactory = dbContextFactory is null
+            ? static () => new DavDatabaseContext()
+            : dbContextFactory.CreateDbContext;
         _configManager.OnConfigChanged += OnConfigChanged;
     }
 

--- a/backend/Services/RemoveOrphanedFilesSchedulerService.cs
+++ b/backend/Services/RemoveOrphanedFilesSchedulerService.cs
@@ -1,5 +1,7 @@
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Config;
+using NzbWebDAV.Database;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Tasks;
 using NzbWebDAV.Utils;
@@ -15,12 +17,17 @@ public class RemoveOrphanedFilesSchedulerService : BackgroundService
 {
     private readonly ConfigManager _configManager;
     private readonly WebsocketManager _websocketManager;
+    private readonly IDbContextFactory<DavDatabaseContext> _dbContextFactory;
     private CancellationTokenSource _rescheduleCts = new();
 
-    public RemoveOrphanedFilesSchedulerService(ConfigManager configManager, WebsocketManager websocketManager)
+    public RemoveOrphanedFilesSchedulerService(
+        ConfigManager configManager,
+        WebsocketManager websocketManager,
+        IDbContextFactory<DavDatabaseContext> dbContextFactory)
     {
         _configManager = configManager;
         _websocketManager = websocketManager;
+        _dbContextFactory = dbContextFactory;
 
         _configManager.OnConfigChanged += (_, args) =>
         {
@@ -89,7 +96,11 @@ public class RemoveOrphanedFilesSchedulerService : BackgroundService
                 if (DateTime.Now < nextRun) continue;
 
                 Log.Information("RemoveOrphanedFilesScheduler: running scheduled Remove Orphaned Files task");
-                var task = new RemoveUnlinkedFilesTask(_configManager, _websocketManager, isDryRun: false);
+                var task = new RemoveUnlinkedFilesTask(
+                    _configManager,
+                    _websocketManager,
+                    isDryRun: false,
+                    createContext: () => _dbContextFactory.CreateDbContext());
                 var executed = await task.Execute().ConfigureAwait(false);
                 if (!executed)
                 {

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -31,6 +31,7 @@ public class Par2RepairService : BackgroundService
     private readonly ConfigManager _configManager;
     private readonly UsenetStreamingClient _usenetClient;
     private readonly RepairPatchStore _patchStore;
+    private readonly IDbContextFactory<DavDatabaseContext>? _dbContextFactory;
     private readonly Channel<RepairWorkItem> _queue;
     private readonly Channel<ZeroFillEvent> _zeroFillQueue;
     private readonly ConcurrentDictionary<Guid, byte> _queuedOrRunning = new();
@@ -45,11 +46,13 @@ public class Par2RepairService : BackgroundService
     public Par2RepairService(
         ConfigManager configManager,
         UsenetStreamingClient usenetClient,
-        RepairPatchStore patchStore)
+        RepairPatchStore patchStore,
+        IDbContextFactory<DavDatabaseContext>? dbContextFactory = null)
     {
         _configManager = configManager;
         _usenetClient = usenetClient;
         _patchStore = patchStore;
+        _dbContextFactory = dbContextFactory;
         // Wait mode makes non-blocking TryWrite report full queues as false so
         // callers can undo bookkeeping; DropWrite would return true and silently
         // discard the item, leaking _queuedOrRunning/_pendingZeroFillPaths entries.
@@ -66,6 +69,9 @@ public class Par2RepairService : BackgroundService
             SingleWriter = false,
         });
     }
+
+    private DavDatabaseContext CreateContext() =>
+        _dbContextFactory?.CreateDbContext() ?? new DavDatabaseContext();
 
     internal int PendingZeroFillCount => _pendingZeroFillPaths.Count;
 
@@ -182,7 +188,7 @@ public class Par2RepairService : BackgroundService
 
     private async Task ProcessZeroFillEventAsync(ZeroFillEvent evt, CancellationToken ct)
     {
-        await using var dbContext = new DavDatabaseContext();
+        await using var dbContext = CreateContext();
         var dbClient = new DavDatabaseClient(dbContext);
         if (evt.IsCorruption)
         {
@@ -240,7 +246,7 @@ public class Par2RepairService : BackgroundService
 
     private async Task ProcessQueueItemAsync(RepairWorkItem item, CancellationToken ct)
     {
-        await using var dbContext = new DavDatabaseContext();
+        await using var dbContext = CreateContext();
         var dbClient = new DavDatabaseClient(dbContext);
         var davItem = await dbClient.Ctx.Items
             .FirstOrDefaultAsync(x => x.Id == item.DavItemId, ct)
@@ -382,7 +388,7 @@ public class Par2RepairService : BackgroundService
             return RepairExecutionResult.NotFeasible($"Could not parse NZB blob: {e.Message}");
         }
 
-        await using var dbContext = new DavDatabaseContext();
+        await using var dbContext = CreateContext();
         var dbClient = new DavDatabaseClient(dbContext);
         var nzbFile = await dbClient.GetDavNzbFileAsync(davItem, ct).ConfigureAwait(false);
         if (nzbFile?.SegmentIds is not { Length: > 0 } segmentIds)
@@ -741,7 +747,7 @@ public class Par2RepairService : BackgroundService
         return indices.Where(index => (uint)index < (uint)segmentCount).ToHashSet();
     }
 
-    private static async Task PersistDiscoveredDamageAsync(
+    private async Task PersistDiscoveredDamageAsync(
         DavItem davItem,
         DavNzbFile nzbFile,
         SliceSegmentAccessor accessor,
@@ -770,7 +776,7 @@ public class Par2RepairService : BackgroundService
             },
             fallback: nzbFile).ConfigureAwait(false);
 
-        await using var dbContext = new DavDatabaseContext();
+        await using var dbContext = CreateContext();
         var tracked = await dbContext.Items.FirstOrDefaultAsync(x => x.Id == davItem.Id, ct).ConfigureAwait(false);
         if (tracked is not null && davItem.FileBlobId is { } blobId)
         {
@@ -1169,7 +1175,7 @@ public class Par2RepairService : BackgroundService
     {
         if (_queuedOrRunning.ContainsKey(davItemId)) return false;
 
-        await using var dbContext = new DavDatabaseContext();
+        await using var dbContext = CreateContext();
         var now = DateTimeOffset.UtcNow;
         var active = await dbContext.Par2RepairJobs.AsNoTracking()
             .Where(x => x.DavItemId == davItemId)
@@ -1192,7 +1198,7 @@ public class Par2RepairService : BackgroundService
         IReadOnlyList<string>? missingSegmentIds,
         CancellationToken ct)
     {
-        await using var dbContext = new DavDatabaseContext();
+        await using var dbContext = CreateContext();
         var existing = await dbContext.Par2RepairJobs
             .Where(x => x.DavItemId == davItem.Id)
             .OrderByDescending(x => x.CreatedAt)
@@ -1231,9 +1237,9 @@ public class Par2RepairService : BackgroundService
         };
     }
 
-    private static async Task PersistJobAsync(Par2RepairJob job, CancellationToken ct)
+    private async Task PersistJobAsync(Par2RepairJob job, CancellationToken ct)
     {
-        await using var dbContext = new DavDatabaseContext();
+        await using var dbContext = CreateContext();
         var tracked = await dbContext.Par2RepairJobs
             .FirstOrDefaultAsync(x => x.Id == job.Id, ct)
             .ConfigureAwait(false);
@@ -1289,7 +1295,7 @@ public class Par2RepairService : BackgroundService
     {
         try
         {
-            using var dbContext = new DavDatabaseContext();
+            using var dbContext = CreateContext();
             return dbContext.Par2RepairJobs
                 .OrderByDescending(j => j.CreatedAt)
                 .Take(10)

--- a/backend/Services/SearchExcludeSyncService.cs
+++ b/backend/Services/SearchExcludeSyncService.cs
@@ -34,11 +34,15 @@ public sealed class SearchExcludeSyncService : BackgroundService
     private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(15) };
 
     private readonly ConfigManager _configManager;
+    private readonly IDbContextFactory<DavDatabaseContext>? _dbContextFactory;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
-    public SearchExcludeSyncService(ConfigManager configManager)
+    public SearchExcludeSyncService(
+        ConfigManager configManager,
+        IDbContextFactory<DavDatabaseContext>? dbContextFactory = null)
     {
         _configManager = configManager;
+        _dbContextFactory = dbContextFactory;
         _configManager.OnConfigChanged += OnConfigChanged;
     }
 
@@ -262,7 +266,7 @@ public sealed class SearchExcludeSyncService : BackgroundService
     {
         var json = JsonSerializer.Serialize(cache);
 
-        await using var dbContext = new DavDatabaseContext();
+        await using var dbContext = _dbContextFactory?.CreateDbContext() ?? new DavDatabaseContext();
         var existing = await dbContext.ConfigItems
             .FirstOrDefaultAsync(x => x.ConfigName == CacheKey, ct).ConfigureAwait(false);
         if (existing is null)

--- a/backend/Services/SqliteMaintenanceService.cs
+++ b/backend/Services/SqliteMaintenanceService.cs
@@ -12,7 +12,7 @@ namespace NzbWebDAV.Services;
 /// not stay ballooned after bulk imports. First sweep ~2 minutes after startup,
 /// then every 6 hours.
 /// </summary>
-public class SqliteMaintenanceService : BackgroundService
+public class SqliteMaintenanceService(IDbContextFactory<DavDatabaseContext> dbContextFactory) : BackgroundService
 {
     private static readonly TimeSpan InitialDelay = TimeSpan.FromMinutes(2);
     private static readonly TimeSpan TickInterval = TimeSpan.FromHours(6);
@@ -43,11 +43,11 @@ public class SqliteMaintenanceService : BackgroundService
         }
     }
 
-    private static async Task SafeSweepAsync()
+    private async Task SafeSweepAsync()
     {
         try
         {
-            await using var db = new DavDatabaseContext();
+            await using var db = dbContextFactory.CreateDbContext();
             await using var metrics = new MetricsDbContext();
             await SweepAsync(db, metrics).ConfigureAwait(false);
         }

--- a/backend/Services/UsenetFileToBlobstoreMigrationService.cs
+++ b/backend/Services/UsenetFileToBlobstoreMigrationService.cs
@@ -12,7 +12,9 @@ namespace NzbWebDAV.Services;
 /// Background service that migrates usenet file data
 /// from the sqlite database to the blob-store.
 /// </summary>
-public class UsenetFileToBlobstoreMigrationService(WebsocketManager websocketManager) : BackgroundService
+public class UsenetFileToBlobstoreMigrationService(
+    WebsocketManager websocketManager,
+    IDbContextFactory<DavDatabaseContext> dbContextFactory) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -31,7 +33,7 @@ public class UsenetFileToBlobstoreMigrationService(WebsocketManager websocketMan
 
     private async Task<int> GetTotalCountLeft(CancellationToken ct)
     {
-        await using var dbContext = new DavDatabaseContext();
+        await using var dbContext = dbContextFactory.CreateDbContext();
         return await dbContext.NzbFiles.CountAsync(ct).ConfigureAwait(false) +
                await dbContext.RarFiles.CountAsync(ct).ConfigureAwait(false) +
                await dbContext.MultipartFiles.CountAsync(ct).ConfigureAwait(false);
@@ -90,7 +92,7 @@ public class UsenetFileToBlobstoreMigrationService(WebsocketManager websocketMan
         {
             try
             {
-                await using var dbContext = new DavDatabaseContext();
+                await using var dbContext = dbContextFactory.CreateDbContext();
                 var fileToMigrate = await getFileToMigrate(dbContext).ConfigureAwait(false);
                 if (fileToMigrate == null) return totalRemaining;
                 var davItem = await GetDavItem(getFileToMigrateId(fileToMigrate), dbContext, ct).ConfigureAwait(false);

--- a/backend/Services/WatchdogLog.cs
+++ b/backend/Services/WatchdogLog.cs
@@ -12,15 +12,18 @@ namespace NzbWebDAV.Services;
 /// hiccup. Cleanup happens both on cascade (queue/history deletion) and via
 /// a time-based background purge.
 /// </summary>
-public class WatchdogLog
+public class WatchdogLog(IDbContextFactory<DavDatabaseContext>? dbContextFactory = null)
 {
+    private DavDatabaseContext CreateContext() =>
+        dbContextFactory?.CreateDbContext() ?? new DavDatabaseContext();
+
     public void Record(WatchdogEntry entry)
     {
         _ = Task.Run(async () =>
         {
             try
             {
-                await using var ctx = new DavDatabaseContext();
+                await using var ctx = CreateContext();
                 ctx.WatchdogEntries.Add(entry);
                 await ctx.SaveChangesAsync().ConfigureAwait(false);
             }
@@ -33,7 +36,7 @@ public class WatchdogLog
 
     public async Task<IReadOnlyList<WatchdogEntry>> GetRecentAsync(int limit, CancellationToken ct = default)
     {
-        await using var ctx = new DavDatabaseContext();
+        await using var ctx = CreateContext();
         return await ctx.WatchdogEntries
             .AsNoTracking()
             .OrderByDescending(x => x.AttemptedAt)

--- a/backend/Services/WatchdogPurgeService.cs
+++ b/backend/Services/WatchdogPurgeService.cs
@@ -11,7 +11,7 @@ namespace NzbWebDAV.Services;
 /// Cascade-cleanup on queue/history removal handles "this content went away";
 /// this handles "this content was never queued / never played and is now stale."
 /// </summary>
-public class WatchdogPurgeService : BackgroundService
+public class WatchdogPurgeService(IDbContextFactory<DavDatabaseContext> dbContextFactory) : BackgroundService
 {
     private static readonly TimeSpan RetentionWindow = TimeSpan.FromDays(30);
     private static readonly TimeSpan PurgeInterval = TimeSpan.FromHours(1);
@@ -22,7 +22,7 @@ public class WatchdogPurgeService : BackgroundService
         {
             try
             {
-                await using var dbContext = new DavDatabaseContext();
+                await using var dbContext = dbContextFactory.CreateDbContext();
 
                 var cutoff = DateTimeOffset.UtcNow - RetentionWindow;
                 var deleted = await dbContext.WatchdogEntries

--- a/backend/Services/Watchtower/WatchtowerService.cs
+++ b/backend/Services/Watchtower/WatchtowerService.cs
@@ -25,7 +25,8 @@ public class WatchtowerService(
     EpisodeEnumerator episodeEnumerator,
     PreferredOrderStore preferredOrderStore,
     NzbFetchCoalescer nzbFetchCoalescer,
-    BenchmarkGate benchmarkGate
+    BenchmarkGate benchmarkGate,
+    IDbContextFactory<DavDatabaseContext> dbContextFactory
 ) : BackgroundService
 {
     private static readonly TimeSpan Tick = TimeSpan.FromSeconds(20);
@@ -183,7 +184,7 @@ public class WatchtowerService(
     {
         if (!configManager.IsWatchtowerVerboseLoggingEnabled()) return;
 
-        await using var ctx = new DavDatabaseContext();
+        await using var ctx = dbContextFactory.CreateDbContext();
         var grouped = await ctx.WantedItems
             .GroupBy(w => w.State)
             .Select(g => new { State = g.Key, Count = g.Count() })
@@ -203,7 +204,7 @@ public class WatchtowerService(
         var now = Now();
         var interval = configManager.GetWatchtowerSyncIntervalSeconds();
 
-        await using var ctx = new DavDatabaseContext();
+        await using var ctx = dbContextFactory.CreateDbContext();
         var sources = await ctx.ListSources
             .Where(s => s.Enabled && s.Kind != ListSource.KindManual)
             .ToListAsync(ct).ConfigureAwait(false);
@@ -384,7 +385,7 @@ public class WatchtowerService(
         var now = Now();
         var interval = configManager.GetWatchtowerSyncIntervalSeconds();
 
-        await using var ctx = new DavDatabaseContext();
+        await using var ctx = dbContextFactory.CreateDbContext();
         var due = await ctx.WantedItems
             .Where(w => w.State == WantedItem.StateExpander
                         && (w.NextCheckAtUnix == null || w.NextCheckAtUnix <= now))
@@ -755,7 +756,7 @@ public class WatchtowerService(
             if (budgetRoom <= 0) return;
 
             var now = Now();
-            await using var ctx = new DavDatabaseContext();
+            await using var ctx = dbContextFactory.CreateDbContext();
 
             var cap = configManager.GetWatchtowerActiveSetCap();
             var activeReady = await ctx.WantedItems.CountAsync(w => w.State == WantedItem.StateReady, ct).ConfigureAwait(false);
@@ -792,7 +793,7 @@ public class WatchtowerService(
                 if (auto && !await searchProfileService.HasResolveHeadroomAsync(profileToken, itemCt).ConfigureAwait(false))
                     return;
 
-                await using var itemCtx = new DavDatabaseContext();
+                await using var itemCtx = dbContextFactory.CreateDbContext();
                 var item = await itemCtx.WantedItems.FirstOrDefaultAsync(w => w.Id == id, itemCt).ConfigureAwait(false);
                 if (item is null) return;
 
@@ -1029,7 +1030,7 @@ public class WatchtowerService(
     private async Task KeepFreshDueItemsAsync(CancellationToken ct)
     {
         var now = Now();
-        await using var ctx = new DavDatabaseContext();
+        await using var ctx = dbContextFactory.CreateDbContext();
         var due = await ctx.WantedItems
             .Where(w => w.State == WantedItem.StateReady
                         && w.NextCheckAtUnix != null && w.NextCheckAtUnix <= now)

--- a/backend/Services/Watchtower/WatchtowerStore.cs
+++ b/backend/Services/Watchtower/WatchtowerStore.cs
@@ -5,13 +5,13 @@ using Serilog;
 
 namespace NzbWebDAV.Services;
 
-public class WatchtowerStore(PreflightCache preflightCache)
+public class WatchtowerStore(PreflightCache preflightCache, IDbContextFactory<DavDatabaseContext> dbContextFactory)
 {
     public async Task TryWarmCacheAsync(string type, string contentId, CancellationToken ct)
     {
         try
         {
-            await using var ctx = new DavDatabaseContext();
+            await using var ctx = dbContextFactory.CreateDbContext();
             if (await TryWarmKeyAsync(ctx, $"{type}:{contentId}", ct).ConfigureAwait(false)) return;
 
             if (type == "series")

--- a/tests/NzbWebDAV.Tests/Database/DavDatabaseContextFactoryTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DavDatabaseContextFactoryTests.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NzbWebDAV.Database;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Database;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class DavDatabaseContextFactoryTests
+{
+    [Fact]
+    public async Task HostedServices_CreateContextsFromRegisteredFactory()
+    {
+        var configRoot = Path.Join(Path.GetTempPath(), $"nzbdav-db-factory-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(configRoot);
+        var previous = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Environment.SetEnvironmentVariable("CONFIG_PATH", configRoot);
+        DavDatabaseContext.ResetOptionsForTests();
+
+        try
+        {
+            var services = new ServiceCollection();
+            services.AddDbContextFactory<DavDatabaseContext>(options =>
+                DavDatabaseContext.ConfigureOptions(options));
+            services.AddScoped(sp =>
+                sp.GetRequiredService<IDbContextFactory<DavDatabaseContext>>().CreateDbContext());
+            services.AddSingleton<BlobCleanupService>();
+
+            await using var provider = services.BuildServiceProvider();
+            var factory = provider.GetRequiredService<IDbContextFactory<DavDatabaseContext>>();
+
+            await using (var ctx = factory.CreateDbContext())
+            {
+                await ctx.Database.MigrateAsync();
+                Assert.False(ctx.Database.IsNpgsql());
+            }
+
+            Assert.NotNull(provider.GetRequiredService<BlobCleanupService>());
+
+            await using (var scope = provider.CreateAsyncScope())
+            {
+                var scoped = scope.ServiceProvider.GetRequiredService<DavDatabaseContext>();
+                Assert.Equal(0, await scoped.Accounts.CountAsync());
+            }
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CONFIG_PATH", previous);
+            DavDatabaseContext.ResetOptionsForTests();
+            try
+            {
+                Directory.Delete(configRoot, recursive: true);
+            }
+            catch
+            {
+                // Best-effort cleanup for transient SQLite file handles.
+            }
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Database/DavDatabaseContextFactoryTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DavDatabaseContextFactoryTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NzbWebDAV.Database;
@@ -47,13 +48,14 @@ public sealed class DavDatabaseContextFactoryTests
         {
             Environment.SetEnvironmentVariable("CONFIG_PATH", previous);
             DavDatabaseContext.ResetOptionsForTests();
+            SqliteConnection.ClearAllPools();
             try
             {
                 Directory.Delete(configRoot, recursive: true);
             }
-            catch
+            catch (IOException)
             {
-                // Best-effort cleanup for transient SQLite file handles.
+                // Transient SQLite file handles after pool clear.
             }
         }
     }


### PR DESCRIPTION
## Summary
- Register `IDbContextFactory<DavDatabaseContext>` with the existing `ConfigureOptions()` path (SQLite pragmas/interceptors or Postgres) and create scoped request contexts from that factory.
- Hosted/background work (cleanup services, health, PAR2 repair, Watchtower, queue manager, orphaned-file scheduler, and related singletons) now calls `CreateDbContext()` instead of `new DavDatabaseContext()`.
- Parameterless `DavDatabaseContext()` remains for Program bootstrap, ConfigManager load, and the design-time factory. Request/API controllers are unchanged.

Fixes #247

## Test plan
- [ ] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [ ] App boots; hosted services resolve and query via the factory
- [ ] `dotnet ef` / `--db-migration` still works (parameterless/design-time ctor)
- [ ] No double-dispose or scoped-from-singleton lifetime errors in logs after a few minutes of idle + a queue item