### PR TITLE
fix(api): HTTP clients time out and the process shuts down within 5 seconds

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -110,6 +110,12 @@ dotnet_diagnostic.CA1725.severity = none
 # was introduced keep their ConfigureAwait(false) for consistency.
 dotnet_diagnostic.CA2007.severity = none
 
+# Cancellation and disposal conventions (#849). These stay errors even if the
+# blanket TreatWarningsAsErrors gate is ever narrowed. Tests relax both in
+# tests/.editorconfig; SharpCompress opts out via <NoWarn>.
+dotnet_diagnostic.CA2016.severity = error
+dotnet_diagnostic.CA1001.severity = error
+
 # --- Misc noise -------------------------------------------------------------
 
 # Justification: ASP.NET Core apps gain nothing from making every public type

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,6 +234,12 @@ When a rule fires, resolve it in this order:
 
 Rules that must **never** be disabled rule-wide: the security rules (CA53xx) —
 use per-site justification suppressions so each instance stays auditable.
+`CA2016` (forward CancellationToken) and `CA1001` (types that own disposables
+implement IDisposable) are listed explicitly in `Directory.Build.props`
+`<WarningsAsErrors>` so they stay errors even if the blanket gate is narrowed.
+
+Hosted services must honor `stoppingToken`. The generic host `ShutdownTimeout`
+is 5 seconds (see `backend/Program.cs`).
 
 Notes:
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,6 +26,8 @@
     <!-- Every warning in first-party code fails the build. Suppression policy:
          CONTRIBUTING.md "Static analysis policy". -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Explicit so CA2016/CA1001 stay errors if the blanket gate is ever narrowed (#849). -->
+    <WarningsAsErrors>$(WarningsAsErrors);CA2016;CA1001</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/backend/Api/Controllers/DeleteWebdavItem/DeleteWebdavItemController.cs
+++ b/backend/Api/Controllers/DeleteWebdavItem/DeleteWebdavItemController.cs
@@ -95,7 +95,7 @@ public class DeleteWebdavItemController(
                     string.Join(",", prunedHistoryIds));
             }
 
-            _ = DavDatabaseContext.RcloneVfsForget(auditItems);
+            _ = DavDatabaseContext.RcloneVfsForget(auditItems, ct);
             return Ok(new BaseApiResponse { Status = true });
         }
         catch

--- a/backend/Api/Controllers/TestArrConnection/TestArrConnectionController.cs
+++ b/backend/Api/Controllers/TestArrConnection/TestArrConnectionController.cs
@@ -10,12 +10,12 @@ namespace NzbWebDAV.Api.Controllers.TestArrConnection;
 [Route("api/test-arr-connection")]
 public class TestArrConnectionController(ConfigManager configManager) : BaseApiController
 {
-    private static async Task<TestArrConnectionResponse> TestArrConnection(TestArrConnectionRequest request)
+    private async Task<TestArrConnectionResponse> TestArrConnection(TestArrConnectionRequest request)
     {
         try
         {
             var client = new ArrClient(request.Host, request.ApiKey);
-            var apiInfo = await client.GetApiInfo().ConfigureAwait(false);
+            var apiInfo = await client.GetApiInfo(HttpContext.RequestAborted).ConfigureAwait(false);
             if (apiInfo.Current?.Length > 0)
             {
                 return new TestArrConnectionResponse

--- a/backend/Api/Controllers/TestRcloneConnection/TestRcloneConnectionController.cs
+++ b/backend/Api/Controllers/TestRcloneConnection/TestRcloneConnectionController.cs
@@ -8,12 +8,12 @@ namespace NzbWebDAV.Api.Controllers.TestRcloneConnection;
 [Route("api/test-rclone-connection")]
 public class TestRcloneConnectionController(ConfigManager configManager) : BaseApiController
 {
-    private static async Task<TestRcloneConnectionResponse> TestRcloneConnection(TestRcloneConnectionRequest request)
+    private async Task<TestRcloneConnectionResponse> TestRcloneConnection(TestRcloneConnectionRequest request)
     {
         try
         {
             var result = await RcloneClient
-                .TestConnection(request.Host, request.User, request.Pass)
+                .TestConnection(request.Host, request.User, request.Pass, HttpContext.RequestAborted)
                 .ConfigureAwait(false);
 
             return new TestRcloneConnectionResponse

--- a/backend/Api/SabControllers/AddFile/AddFileController.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileController.cs
@@ -201,7 +201,7 @@ public class AddFileController(
                     ex);
             }
 
-            _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"]);
+            _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"], request.CancellationToken);
         }
         catch
         {
@@ -252,7 +252,7 @@ public class AddFileController(
 
         await queueManager.RemoveQueueItemsAsync([existingId.Value], dbClient, ct).ConfigureAwait(false);
         _ = websocketManager.SendMessage(WebsocketTopic.QueueItemRemoved, existingId.Value.ToString());
-        _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"]);
+        _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"], ct);
     }
 
     private async Task RemoveConflictingQueueItemViaFreshContextAsync(
@@ -279,7 +279,7 @@ public class AddFileController(
 
         await queueManager.RemoveQueueItemsAsync([conflictingId.Value], freshClient, ct).ConfigureAwait(false);
         _ = websocketManager.SendMessage(WebsocketTopic.QueueItemRemoved, conflictingId.Value.ToString());
-        _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"]);
+        _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"], ct);
     }
 
     internal static bool IsCategoryFileNameUniqueViolation(DbUpdateException ex)

--- a/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
@@ -226,7 +226,10 @@ public class AddUrlRequest() : AddFileRequest
 #pragma warning restore CA5359
             };
         }
-        return new HttpClient(handler);
+        return new HttpClient(handler)
+        {
+            Timeout = FetchTimeout,
+        };
     }
 
     private static async Task EnsurePublicHostAsync(

--- a/backend/Api/SabControllers/RemoveFromQueue/RemoveFromQueueController.cs
+++ b/backend/Api/SabControllers/RemoveFromQueue/RemoveFromQueueController.cs
@@ -28,7 +28,7 @@ public class RemoveFromQueueController(
                 .ConfigureAwait(false);
         }
         _ = websocketManager.SendMessage(WebsocketTopic.QueueItemRemoved, string.Join(",", ids));
-        _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"]);
+        _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"], request.CancellationToken);
         return new RemoveFromQueueResponse() { Status = true };
     }
 

--- a/backend/Clients/RadarrSonarr/ArrClient.cs
+++ b/backend/Clients/RadarrSonarr/ArrClient.cs
@@ -9,7 +9,8 @@ namespace NzbWebDAV.Clients.RadarrSonarr;
 
 public class ArrClient(string host, string apiKey)
 {
-    protected static readonly HttpClient HttpClient = new();
+    internal static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(30);
+    protected static readonly HttpClient HttpClient = new() { Timeout = RequestTimeout };
     protected virtual HttpClient Client => HttpClient;
 
     public string Host { get; } = host;
@@ -28,10 +29,7 @@ public class ArrClient(string host, string apiKey)
         CancellationToken ct = default) =>
         throw new InvalidOperationException();
 
-    public virtual Task<List<ArrRootFolder>> GetRootFolders() =>
-        GetRootFolders(CancellationToken.None);
-
-    public virtual Task<List<ArrRootFolder>> GetRootFolders(CancellationToken ct) =>
+    public virtual Task<List<ArrRootFolder>> GetRootFolders(CancellationToken ct = default) =>
         Get<List<ArrRootFolder>>($"/rootfolder", ct);
 
     public Task<List<ArrDownloadClient>> GetDownloadClientsAsync(CancellationToken ct = default) =>
@@ -49,15 +47,21 @@ public class ArrClient(string host, string apiKey)
     public virtual Task<ArrHistory> GetImportHistoryAsync(int page, int pageSize, CancellationToken ct = default) =>
         Get<ArrHistory>($"/history?eventType=3&page={page}&pageSize={pageSize}&sortKey=date&sortDirection=descending", ct);
 
-    public async Task<int> GetQueueCountAsync() =>
-        (await Get<ArrQueue<ArrQueueRecord>>($"/queue?pageSize=1").ConfigureAwait(false)).TotalRecords;
+    public async Task<int> GetQueueCountAsync(CancellationToken ct = default) =>
+        (await Get<ArrQueue<ArrQueueRecord>>($"/queue?pageSize=1", ct).ConfigureAwait(false)).TotalRecords;
 
-    public Task<HttpStatusCode> DeleteQueueRecord(int id, DeleteQueueRecordRequest request) =>
-        Delete($"/queue/{id}", request.GetQueryParams());
+    public Task<HttpStatusCode> DeleteQueueRecord(
+        int id,
+        DeleteQueueRecordRequest request,
+        CancellationToken ct = default) =>
+        Delete($"/queue/{id}", request.GetQueryParams(), ct);
 
-    public Task<HttpStatusCode> DeleteQueueRecord(int id, ArrConfig.QueueAction request) =>
+    public Task<HttpStatusCode> DeleteQueueRecord(
+        int id,
+        ArrConfig.QueueAction request,
+        CancellationToken ct = default) =>
         request is not ArrConfig.QueueAction.DoNothing
-            ? Delete($"/queue/{id}", new DeleteQueueRecordRequest(request).GetQueryParams())
+            ? Delete($"/queue/{id}", new DeleteQueueRecordRequest(request).GetQueryParams(), ct)
             : Task.FromResult(HttpStatusCode.OK);
 
     public Task<ArrCommand> CommandAsync(object command, CancellationToken ct = default) =>
@@ -170,9 +174,9 @@ public class ArrClient(string host, string apiKey)
         return resource;
     }
 
-    private Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+    private async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
     {
         request.Headers.Add("X-Api-Key", ApiKey);
-        return Client.SendAsync(request, ct);
+        return await Client.SendAsync(request, ct).ConfigureAwait(false);
     }
 }

--- a/backend/Clients/Rclone/RcloneClient.cs
+++ b/backend/Clients/Rclone/RcloneClient.cs
@@ -16,7 +16,8 @@ namespace NzbWebDAV.Clients.Rclone;
 /// </summary>
 public static class RcloneClient
 {
-    private static readonly HttpClient HttpClient = new();
+    internal static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(30);
+    private static readonly HttpClient HttpClient = CreateHttpClient();
     private static ForgetErrorEntry? _lastForgetError;
 
     internal static HttpMessageHandler? TestHandler { get; set; }
@@ -42,6 +43,8 @@ public static class RcloneClient
     private static string? Pass { get; set; }
     public static bool IsRemoteControlEnabled { get; private set; }
 
+    private static HttpClient CreateHttpClient() => new() { Timeout = RequestTimeout };
+
     public static void Initialize(ConfigManager configManager)
     {
         Host = configManager.GetRcloneHost();
@@ -66,7 +69,10 @@ public static class RcloneClient
     /// <param name="paths">The paths to refresh</param>
     /// <param name="recursive">Whether to refresh recursively</param>
     /// <param name="fs">Optional VFS name if multiple VFS instances exist</param>
-    public static async Task<RcloneResponse> RefreshVfsPaths(IEnumerable<string> paths, bool recursive = false)
+    public static async Task<RcloneResponse> RefreshVfsPaths(
+        IEnumerable<string> paths,
+        bool recursive = false,
+        CancellationToken cancellationToken = default)
     {
         var pathList = paths.ToList();
         if (pathList.Count == 0)
@@ -85,7 +91,7 @@ public static class RcloneClient
             request["recursive"] = true;
 
         Log.Debug("Rclone vfs/refresh: {0}", paths.ToIndentedJson());
-        return await Post<RcloneResponse>("vfs/refresh", request).ConfigureAwait(false);
+        return await Post<RcloneResponse>("vfs/refresh", request, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -93,7 +99,9 @@ public static class RcloneClient
     /// </summary>
     /// <param name="paths">The paths to forget</param>
     /// <param name="fs">Optional VFS name if multiple VFS instances exist</param>
-    public static async Task<VfsForgetResponse> ForgetVfsPaths(IEnumerable<string> paths)
+    public static async Task<VfsForgetResponse> ForgetVfsPaths(
+        IEnumerable<string> paths,
+        CancellationToken cancellationToken = default)
     {
         var pathList = paths.ToList();
         if (pathList.Count == 0)
@@ -116,7 +124,7 @@ public static class RcloneClient
 
         for (var attempt = 1; attempt <= maxAttempts; attempt++)
         {
-            lastResponse = await Post<VfsForgetResponse>("vfs/forget", request).ConfigureAwait(false);
+            lastResponse = await Post<VfsForgetResponse>("vfs/forget", request, cancellationToken).ConfigureAwait(false);
 
             if (lastResponse.Success)
             {
@@ -131,7 +139,7 @@ public static class RcloneClient
             }
 
             if (attempt < maxAttempts)
-                await Task.Delay(GetBackoff(attempt)).ConfigureAwait(false);
+                await Task.Delay(GetBackoff(attempt), cancellationToken).ConfigureAwait(false);
         }
 
         var reason = lastResponse?.Error ?? "Unknown error";
@@ -155,37 +163,43 @@ public static class RcloneClient
     /// Get VFS statistics including cache information.
     /// </summary>
     /// <param name="fs">Optional VFS name if multiple VFS instances exist</param>
-    public static async Task<VfsStatsResponse> GetVfsStats(string? fs = null)
+    public static async Task<VfsStatsResponse> GetVfsStats(
+        string? fs = null,
+        CancellationToken cancellationToken = default)
     {
         var request = fs != null ? new { fs } : null;
-        return await Post<VfsStatsResponse>("vfs/stats", request).ConfigureAwait(false);
+        return await Post<VfsStatsResponse>("vfs/stats", request, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
     /// Get rclone version information.
     /// </summary>
-    public static async Task<CoreVersionResponse> GetVersion()
+    public static async Task<CoreVersionResponse> GetVersion(CancellationToken cancellationToken = default)
     {
-        return await Post<CoreVersionResponse>("core/version", null).ConfigureAwait(false);
+        return await Post<CoreVersionResponse>("core/version", null, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
     /// Test connectivity - a no-operation call.
     /// </summary>
-    public static async Task<RcloneResponse> NoOp()
+    public static async Task<RcloneResponse> NoOp(CancellationToken cancellationToken = default)
     {
-        return await Post<RcloneResponse>("rc/noop", null).ConfigureAwait(false);
+        return await Post<RcloneResponse>("rc/noop", null, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
     /// Check if the rclone RC server is reachable and authenticated.
     /// </summary>
-    public static async Task<bool> IsAvailable()
+    public static async Task<bool> IsAvailable(CancellationToken cancellationToken = default)
     {
         try
         {
-            await NoOp().ConfigureAwait(false);
+            await NoOp(cancellationToken).ConfigureAwait(false);
             return true;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch
         {
@@ -196,9 +210,14 @@ public static class RcloneClient
     /// <summary>
     /// Test connectivity to a rclone RC server with the given credentials.
     /// </summary>
-    public static async Task<RcloneResponse> TestConnection(string host, string? user, string? pass)
+    public static async Task<RcloneResponse> TestConnection(
+        string host,
+        string? user,
+        string? pass,
+        CancellationToken cancellationToken = default)
     {
-        var result = await Post<CoreVersionResponse>(host, user, pass, "core/version", null).ConfigureAwait(false);
+        var result = await Post<CoreVersionResponse>(host, user, pass, "core/version", null, cancellationToken)
+            .ConfigureAwait(false);
         if (result.Success && string.IsNullOrEmpty(result.Version))
             return new RcloneResponse { Success = false, Error = "Connected but received empty version" };
         return result;
@@ -210,7 +229,8 @@ public static class RcloneClient
         string? user,
         string? pass,
         string endpoint,
-        object? body
+        object? body,
+        CancellationToken cancellationToken
     ) where T : RcloneResponse, new()
     {
         var url = $"{host}/{endpoint}";
@@ -230,8 +250,8 @@ public static class RcloneClient
 
         try
         {
-            using var response = await SendRequest(request).ConfigureAwait(false);
-            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            using var response = await SendRequest(request, cancellationToken).ConfigureAwait(false);
+            var content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -263,6 +283,10 @@ public static class RcloneClient
             result.Success = true;
             return result;
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (HttpRequestException ex)
         {
             Log.Warning("Rclone RC request to {Endpoint} failed. Reason: {Reason}", endpoint, ex.Message);
@@ -278,18 +302,24 @@ public static class RcloneClient
         }
     }
 
-    private static Task<T> Post<T>(string endpoint, object? body) where T : RcloneResponse, new()
-        => Post<T>(Host!, User, Pass, endpoint, body);
+    private static Task<T> Post<T>(string endpoint, object? body, CancellationToken cancellationToken)
+        where T : RcloneResponse, new()
+        => Post<T>(Host!, User, Pass, endpoint, body, cancellationToken);
 
-    private static async Task<HttpResponseMessage> SendRequest(HttpRequestMessage request)
+    private static async Task<HttpResponseMessage> SendRequest(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
     {
         if (TestHandler != null)
         {
-            using var client = new HttpClient(TestHandler, disposeHandler: false);
-            return await client.SendAsync(request).ConfigureAwait(false);
+            using var client = new HttpClient(TestHandler, disposeHandler: false)
+            {
+                Timeout = RequestTimeout,
+            };
+            return await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
-        return await HttpClient.SendAsync(request).ConfigureAwait(false);
+        return await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
 
     private static void AddAuthHeader(HttpRequestMessage request, string? user, string? pass)

--- a/backend/Clients/Usenet/ArticleMissNegativeCache.cs
+++ b/backend/Clients/Usenet/ArticleMissNegativeCache.cs
@@ -269,47 +269,47 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
         {
             while (await reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
             {
-            var marks = new Dictionary<string, long>(StringComparer.Ordinal);
-            var clearPending = false;
-            TaskCompletionSource? barrier = null;
-            var itemsRead = 0;
-            while (itemsRead < MaxPersistenceBatchSize && reader.TryRead(out var item))
-            {
-                itemsRead++;
-                switch (item)
+                var marks = new Dictionary<string, long>(StringComparer.Ordinal);
+                var clearPending = false;
+                TaskCompletionSource? barrier = null;
+                var itemsRead = 0;
+                while (itemsRead < MaxPersistenceBatchSize && reader.TryRead(out var item))
                 {
-                    case ClearItem:
-                        // Marks queued before the clear must not survive it.
-                        marks.Clear();
-                        clearPending = true;
-                        break;
-                    case MarkItem mark:
-                        marks[mark.Key] = mark.ConfirmedAtUnix;
-                        break;
-                    case BarrierItem b:
-                        barrier = b.Completion;
-                        break;
+                    itemsRead++;
+                    switch (item)
+                    {
+                        case ClearItem:
+                            // Marks queued before the clear must not survive it.
+                            marks.Clear();
+                            clearPending = true;
+                            break;
+                        case MarkItem mark:
+                            marks[mark.Key] = mark.ConfirmedAtUnix;
+                            break;
+                        case BarrierItem b:
+                            barrier = b.Completion;
+                            break;
+                    }
+                    if (barrier is not null) break;
                 }
-                if (barrier is not null) break;
-            }
 
-            try
-            {
-                if (clearPending || marks.Count > 0)
-                    await ApplyBatchAsync(clearPending, marks, cancellationToken).ConfigureAwait(false);
-                barrier?.TrySetResult();
+                try
+                {
+                    if (clearPending || marks.Count > 0)
+                        await ApplyBatchAsync(clearPending, marks, cancellationToken).ConfigureAwait(false);
+                    barrier?.TrySetResult();
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    barrier?.TrySetCanceled(cancellationToken);
+                    throw;
+                }
+                catch (Exception e) when (e is not OutOfMemoryException)
+                {
+                    Log.Debug(e, "Unable to persist definitive article misses; retaining memory-only entries.");
+                    barrier?.TrySetException(e);
+                }
             }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                barrier?.TrySetCanceled(cancellationToken);
-                throw;
-            }
-            catch (Exception e) when (e is not OutOfMemoryException)
-            {
-                Log.Debug(e, "Unable to persist definitive article misses; retaining memory-only entries.");
-                barrier?.TrySetException(e);
-            }
-        }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/backend/Clients/Usenet/ArticleMissNegativeCache.cs
+++ b/backend/Clients/Usenet/ArticleMissNegativeCache.cs
@@ -49,6 +49,7 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
     private readonly Func<DavDatabaseContext>? _contextFactory;
     private readonly ConcurrentDictionary<string, DateTimeOffset> _missingAt = new(StringComparer.Ordinal);
     private readonly Channel<PersistenceWorkItem>? _persistenceQueue;
+    private CancellationTokenSource? _persistenceLoopCts;
     private Task _persistenceLoop = Task.CompletedTask;
     private volatile bool _persistenceLoopStarted;
     private long _hits;
@@ -166,7 +167,11 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
         }
 
         // The loop outlives startup; it stops when StopAsync/Dispose completes the queue.
-        _persistenceLoop = Task.Run(RunPersistenceLoopAsync, CancellationToken.None);
+        // The loop token is cancelled only if the host ShutdownTimeout elapses mid-drain.
+        _persistenceLoopCts?.Dispose();
+        _persistenceLoopCts = new CancellationTokenSource();
+        var loopToken = _persistenceLoopCts.Token;
+        _persistenceLoop = Task.Run(() => RunPersistenceLoopAsync(loopToken), CancellationToken.None);
         _persistenceLoopStarted = true;
     }
 
@@ -180,11 +185,19 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
         }
         catch (OperationCanceledException)
         {
+            if (_persistenceLoopCts is not null)
+                await _persistenceLoopCts.CancelAsync().ConfigureAwait(false);
             Log.Warning("Timed out draining the article-miss persistence queue; recent definitive misses may be lost.");
         }
     }
 
-    public void Dispose() => _persistenceQueue?.Writer.TryComplete();
+    public void Dispose()
+    {
+        _persistenceQueue?.Writer.TryComplete();
+        _persistenceLoopCts?.Cancel();
+        _persistenceLoopCts?.Dispose();
+        _persistenceLoopCts = null;
+    }
 
     /// <summary>Test helper: mark an entry as if it were recorded at <paramref name="at"/>.</summary>
     internal void MarkMissingAtForTests(string key, DateTimeOffset at)
@@ -249,11 +262,13 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
         });
     }
 
-    private async Task RunPersistenceLoopAsync()
+    private async Task RunPersistenceLoopAsync(CancellationToken cancellationToken)
     {
         var reader = _persistenceQueue!.Reader;
-        while (await reader.WaitToReadAsync().ConfigureAwait(false))
+        try
         {
+            while (await reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+            {
             var marks = new Dictionary<string, long>(StringComparer.Ordinal);
             var clearPending = false;
             TaskCompletionSource? barrier = null;
@@ -281,8 +296,13 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
             try
             {
                 if (clearPending || marks.Count > 0)
-                    await ApplyBatchAsync(clearPending, marks).ConfigureAwait(false);
+                    await ApplyBatchAsync(clearPending, marks, cancellationToken).ConfigureAwait(false);
                 barrier?.TrySetResult();
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                barrier?.TrySetCanceled(cancellationToken);
+                throw;
             }
             catch (Exception e) when (e is not OutOfMemoryException)
             {
@@ -290,20 +310,28 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
                 barrier?.TrySetException(e);
             }
         }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Host is stopping; remaining marks stay memory-only.
+        }
     }
 
-    private async Task ApplyBatchAsync(bool clearPending, Dictionary<string, long> marks)
+    private async Task ApplyBatchAsync(
+        bool clearPending,
+        Dictionary<string, long> marks,
+        CancellationToken cancellationToken)
     {
         await using var context = _contextFactory!();
         if (clearPending)
-            await context.ArticleMissCacheEntries.ExecuteDeleteAsync().ConfigureAwait(false);
+            await context.ArticleMissCacheEntries.ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
 
         if (marks.Count > 0)
         {
             var keys = marks.Keys.ToList();
             var existing = await context.ArticleMissCacheEntries
                 .Where(x => keys.Contains(x.CacheKey))
-                .ToDictionaryAsync(x => x.CacheKey)
+                .ToDictionaryAsync(x => x.CacheKey, cancellationToken)
                 .ConfigureAwait(false);
             foreach (var (key, confirmedAtUnix) in marks)
             {
@@ -316,13 +344,13 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
                         ConfirmedAtUnix = confirmedAtUnix,
                     });
             }
-            await context.SaveChangesAsync().ConfigureAwait(false);
+            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
 
         var cutoffUnix = (DateTimeOffset.UtcNow - _configManager.GetArticleMissCacheTtl())
             .ToUnixTimeMilliseconds();
         await TrimPersistedAsync(
-            context, cutoffUnix, _configManager.GetArticleMissCacheMaxEntries(), CancellationToken.None)
+            context, cutoffUnix, _configManager.GetArticleMissCacheMaxEntries(), cancellationToken)
             .ConfigureAwait(false);
     }
 

--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -931,24 +931,36 @@ public class DavDatabaseContext : DbContext
             .ToList();
     }
 
-    public static Task RcloneVfsForget(
+    public static async Task RcloneVfsForget(
         List<DavItem> addedOrRemovedDavItems,
         CancellationToken cancellationToken = default)
     {
-        if (!RcloneClient.IsRemoteControlEnabled) return Task.CompletedTask;
-        if (RcloneClient.Host == null) return Task.CompletedTask;
-        if (addedOrRemovedDavItems.Count == 0) return Task.CompletedTask;
+        if (!RcloneClient.IsRemoteControlEnabled) return;
+        if (RcloneClient.Host == null) return;
+        if (addedOrRemovedDavItems.Count == 0) return;
         var vfsForgetPaths = GetRcloneVfsForgetDirectories(addedOrRemovedDavItems);
-        if (vfsForgetPaths.Count == 0) return Task.CompletedTask;
-        return RcloneClient.ForgetVfsPaths(vfsForgetPaths, cancellationToken);
+        if (vfsForgetPaths.Count == 0) return;
+        await ForgetVfsPathsQuietly(vfsForgetPaths, cancellationToken).ConfigureAwait(false);
     }
 
-    public static Task RcloneVfsForget(List<string> paths, CancellationToken cancellationToken = default)
+    public static async Task RcloneVfsForget(List<string> paths, CancellationToken cancellationToken = default)
     {
-        if (!RcloneClient.IsRemoteControlEnabled) return Task.CompletedTask;
-        if (RcloneClient.Host == null) return Task.CompletedTask;
-        if (paths.Count == 0) return Task.CompletedTask;
-        return RcloneClient.ForgetVfsPaths(paths, cancellationToken);
+        if (!RcloneClient.IsRemoteControlEnabled) return;
+        if (RcloneClient.Host == null) return;
+        if (paths.Count == 0) return;
+        await ForgetVfsPathsQuietly(paths, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task ForgetVfsPathsQuietly(List<string> paths, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await RcloneClient.ForgetVfsPaths(paths, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Call sites are fire-and-forget; do not surface cancellation as UnobservedTaskException.
+        }
     }
 
     public void ClearChangeTracker()

--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -875,7 +875,7 @@ public class DavDatabaseContext : DbContext
             // save db changes
             var addedOrRemovedDavItems = GetAddedOrRemovedDavItems();
             var result = await base.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-            _ = RcloneVfsForget(addedOrRemovedDavItems);
+            _ = RcloneVfsForget(addedOrRemovedDavItems, cancellationToken);
 
             // clear pending blob writes
             ClearBlobs();
@@ -931,22 +931,24 @@ public class DavDatabaseContext : DbContext
             .ToList();
     }
 
-    public static Task RcloneVfsForget(List<DavItem> addedOrRemovedDavItems)
+    public static Task RcloneVfsForget(
+        List<DavItem> addedOrRemovedDavItems,
+        CancellationToken cancellationToken = default)
     {
         if (!RcloneClient.IsRemoteControlEnabled) return Task.CompletedTask;
         if (RcloneClient.Host == null) return Task.CompletedTask;
         if (addedOrRemovedDavItems.Count == 0) return Task.CompletedTask;
         var vfsForgetPaths = GetRcloneVfsForgetDirectories(addedOrRemovedDavItems);
         if (vfsForgetPaths.Count == 0) return Task.CompletedTask;
-        return RcloneClient.ForgetVfsPaths(vfsForgetPaths);
+        return RcloneClient.ForgetVfsPaths(vfsForgetPaths, cancellationToken);
     }
 
-    public static Task RcloneVfsForget(List<string> paths)
+    public static Task RcloneVfsForget(List<string> paths, CancellationToken cancellationToken = default)
     {
         if (!RcloneClient.IsRemoteControlEnabled) return Task.CompletedTask;
         if (RcloneClient.Host == null) return Task.CompletedTask;
         if (paths.Count == 0) return Task.CompletedTask;
-        return RcloneClient.ForgetVfsPaths(paths);
+        return RcloneClient.ForgetVfsPaths(paths, cancellationToken);
     }
 
     public void ClearChangeTracker()

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -230,6 +230,8 @@ public partial class Program
             var maxRequestBodySize = EnvironmentUtil.GetLongVariable("MAX_REQUEST_BODY_SIZE") ?? 100 * 1024 * 1024;
             builder.WebHost.ConfigureKestrel(options => options.Limits.MaxRequestBodySize = maxRequestBodySize);
             builder.Host.UseSerilog();
+            builder.Services.Configure<HostOptions>(options =>
+                options.ShutdownTimeout = TimeSpan.FromSeconds(5));
             builder.Services.AddControllers();
             builder.Services.AddHttpContextAccessor();
             if (apiDocsEnabled)

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -827,7 +827,7 @@ public class QueueItemProcessor(
         {
             _ = websocketManager.SendMessage(WebsocketTopic.QueueItemRemoved, queueItem.Id.ToString());
             _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemAdded, historySlot!.ToJson());
-            _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"]);
+            _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"], ct);
             _ = RefreshMonitoredDownloads();
             if (error is null)
             {
@@ -947,10 +947,10 @@ public class QueueItemProcessor(
     {
         try
         {
-            var downloadClients = await arrClient.GetDownloadClientsAsync().ConfigureAwait(false);
+            var downloadClients = await arrClient.GetDownloadClientsAsync(ct).ConfigureAwait(false);
             if (downloadClients.All(x => x.Category != queueItem.Category)) return;
-            var queueCount = await arrClient.GetQueueCountAsync().ConfigureAwait(false);
-            if (queueCount < 300) await arrClient.RefreshMonitoredDownloads().ConfigureAwait(false);
+            var queueCount = await arrClient.GetQueueCountAsync(ct).ConfigureAwait(false);
+            if (queueCount < 300) await arrClient.RefreshMonitoredDownloads(ct).ConfigureAwait(false);
         }
         catch (Exception e) when (e is HttpRequestException or TaskCanceledException or InvalidOperationException)
         {

--- a/backend/Services/ArrMonitoringService.cs
+++ b/backend/Services/ArrMonitoringService.cs
@@ -108,7 +108,7 @@ public class ArrMonitoringService : BackgroundService
             .Max();
 
         if (action is ArrConfig.QueueAction.DoNothing) return null;
-        await client.DeleteQueueRecord(item.Id, action).ConfigureAwait(false);
+        await client.DeleteQueueRecord(item.Id, action, ct).ConfigureAwait(false);
         Log.Debug(
             "Resolved stuck queue record {QueueRecordId} ({QueueItemTitle}) from {Host} with action {Action}",
             item.Id, item.Title, client.Host, action);

--- a/backend/Services/DavCleanupService.cs
+++ b/backend/Services/DavCleanupService.cs
@@ -76,7 +76,7 @@ public class DavCleanupService : BackgroundService
                 .Where(x => x.ParentId == cleanupItemIdPg)
                 .ExecuteDeleteAsync(cancellationToken)
                 .ConfigureAwait(false);
-            _ = DavDatabaseContext.RcloneVfsForget(deletedItemsPg);
+            _ = DavDatabaseContext.RcloneVfsForget(deletedItemsPg, cancellationToken);
 
             await dbContext.DavCleanupItems
                 .Where(x => x.Id == cleanupItemIdPg)
@@ -129,7 +129,7 @@ public class DavCleanupService : BackgroundService
             CreateParentIdParameters(cleanupItemId),
             cancellationToken).ConfigureAwait(false);
 
-        _ = DavDatabaseContext.RcloneVfsForget(deletedItems);
+        _ = DavDatabaseContext.RcloneVfsForget(deletedItems, cancellationToken);
 
         // Delete by the exact text selected above. A concurrent or repeated delete
         // affects zero rows without raising an optimistic-concurrency exception.

--- a/backend/Services/HistoryCleanupService.cs
+++ b/backend/Services/HistoryCleanupService.cs
@@ -56,7 +56,7 @@ public class HistoryCleanupService : BackgroundService
                         .ExecuteDeleteAsync(stoppingToken).ConfigureAwait(false);
 
                     // Trigger rclone vfs/forget for deleted items
-                    _ = DavDatabaseContext.RcloneVfsForget(deletedItems);
+                    _ = DavDatabaseContext.RcloneVfsForget(deletedItems, stoppingToken);
                 }
                 else
                 {

--- a/backend/Services/WardenBackupService.cs
+++ b/backend/Services/WardenBackupService.cs
@@ -150,7 +150,7 @@ public partial class WardenBackupService : BackgroundService
             if (resp.StatusCode == HttpStatusCode.NotFound)
                 throw new BadHttpRequestException("No backup file was found in the repo.");
             if (!resp.IsSuccessStatusCode)
-                throw new BadHttpRequestException($"GitHub returned {(int)resp.StatusCode}: {await GithubMessage(resp).ConfigureAwait(false)}");
+                throw new BadHttpRequestException($"GitHub returned {(int)resp.StatusCode}: {await GithubMessage(resp, ct).ConfigureAwait(false)}");
 
             await using var raw = await resp.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
             using var buffer = await BufferAsync(raw, ct).ConfigureAwait(false);
@@ -178,7 +178,7 @@ public partial class WardenBackupService : BackgroundService
         using var resp = await Http.SendAsync(req, ct).ConfigureAwait(false);
         if (resp.StatusCode == HttpStatusCode.NotFound) return null;
         if (!resp.IsSuccessStatusCode)
-            throw new GithubException($"{(int)resp.StatusCode} {await GithubMessage(resp).ConfigureAwait(false)}");
+            throw new GithubException($"{(int)resp.StatusCode} {await GithubMessage(resp, ct).ConfigureAwait(false)}");
         using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false));
         return doc.RootElement.TryGetProperty("sha", out var sha) ? sha.GetString() : null;
     }
@@ -200,7 +200,7 @@ public partial class WardenBackupService : BackgroundService
         if (resp.StatusCode is HttpStatusCode.Conflict or HttpStatusCode.UnprocessableEntity && sha is not null)
             return new PutResult { StaleConflict = true };
         if (!resp.IsSuccessStatusCode)
-            throw new GithubException($"{(int)resp.StatusCode} {await GithubMessage(resp).ConfigureAwait(false)}");
+            throw new GithubException($"{(int)resp.StatusCode} {await GithubMessage(resp, ct).ConfigureAwait(false)}");
 
         using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false));
         var newSha = doc.RootElement.TryGetProperty("content", out var c) && c.TryGetProperty("sha", out var sh)
@@ -219,11 +219,11 @@ public partial class WardenBackupService : BackgroundService
         return req;
     }
 
-    private static async Task<string> GithubMessage(HttpResponseMessage resp)
+    private static async Task<string> GithubMessage(HttpResponseMessage resp, CancellationToken ct)
     {
         try
         {
-            var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
             using var doc = JsonDocument.Parse(body);
             if (doc.RootElement.TryGetProperty("message", out var m) && m.GetString() is { } msg)
             {

--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -480,7 +480,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
                 Id = Guid.Parse(x.Id),
                 Type = (DavItem.ItemType)x.Type,
                 Path = x.Path
-            }).ToList());
+            }).ToList(), CancellationToken);
 
             // Track removed paths
             _allRemovedPaths.AddRange(itemsToDelete.Select(x => x.Path));
@@ -500,7 +500,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
             dbContext,
             createdBefore,
             removedSoFar => UpdatePhase($"Removing empty directories...\nRemoved {removedSoFar}..."),
-            dirs => DavDatabaseContext.RcloneVfsForget(dirs),
+            dirs => DavDatabaseContext.RcloneVfsForget(dirs, CancellationToken),
             CancellationToken).ConfigureAwait(false);
     }
 

--- a/backend/Tasks/RenameWindowsInvalidDavPathsTask.cs
+++ b/backend/Tasks/RenameWindowsInvalidDavPathsTask.cs
@@ -180,7 +180,7 @@ public class RenameWindowsInvalidDavPathsTask(
         }
 
         await dbContext.SaveChangesAsync(CancellationToken).ConfigureAwait(false);
-        _ = DavDatabaseContext.RcloneVfsForget(forgetItems);
+        _ = DavDatabaseContext.RcloneVfsForget(forgetItems, CancellationToken);
         Report($"Applying renames...\nRenamed {plan.Renames.Count}...");
     }
 

--- a/libs/RapidYencSharp/.editorconfig
+++ b/libs/RapidYencSharp/.editorconfig
@@ -73,3 +73,7 @@ dotnet_diagnostic.CA3003.severity = none
 # default-search-order loading, which the resolver preempts. The assembly-level
 # DefaultDllImportSearchPaths attribute stays as defense-in-depth.
 dotnet_diagnostic.CA5393.severity = none
+# Cancellation and disposal conventions (#849). Mirror the root .editorconfig
+# explicit errors — this file is root = true and does not inherit them.
+dotnet_diagnostic.CA2016.severity = error
+dotnet_diagnostic.CA1001.severity = error

--- a/libs/UsenetSharp/.editorconfig
+++ b/libs/UsenetSharp/.editorconfig
@@ -83,3 +83,7 @@ dotnet_diagnostic.CA1508.severity = none
 dotnet_diagnostic.CA1852.severity = none
 dotnet_diagnostic.CA2100.severity = none
 dotnet_diagnostic.CA3003.severity = none
+# Cancellation and disposal conventions (#849). Mirror the root .editorconfig
+# explicit errors — this file is root = true and does not inherit them.
+dotnet_diagnostic.CA2016.severity = error
+dotnet_diagnostic.CA1001.severity = error

--- a/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
@@ -317,6 +317,24 @@ public class RadarrSonarrClientTests
             await client.RemoveAndBlocklist(filePath, downloadId));
     }
 
+    [Fact]
+    public async Task GetQueueCountAsync_HonorsCancellationToken()
+    {
+        using var httpClient = new HttpClient(new HangUntilCancelledHandler());
+        var client = new TestArrClient(httpClient);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => client.GetQueueCountAsync(cts.Token));
+    }
+
+    [Fact]
+    public void SharedHttpClient_HasExplicitTimeout()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(30), ArrClient.RequestTimeout);
+    }
+
     private static HttpResponseMessage JsonResponse(string json) =>
         new(HttpStatusCode.OK)
         {
@@ -367,6 +385,19 @@ public class RadarrSonarrClientTests
         protected override HttpClient Client => _client;
     }
 
+    private sealed class TestArrClient : ArrClient
+    {
+        private readonly HttpClient _client;
+
+        public TestArrClient(HttpClient client)
+            : base("http://arr.test", "test-key")
+        {
+            _client = client;
+        }
+
+        protected override HttpClient Client => _client;
+    }
+
     private sealed class ResponseQueueHandler(
         Dictionary<string, Queue<HttpResponseMessage>> responses) : HttpMessageHandler
     {
@@ -379,6 +410,17 @@ public class RadarrSonarrClientTests
                 throw new InvalidOperationException($"Unexpected request: {key}");
 
             return Task.FromResult(response);
+        }
+    }
+
+    private sealed class HangUntilCancelledHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            throw new InvalidOperationException("Expected cancellation before a response.");
         }
     }
 }

--- a/tests/NzbWebDAV.Tests/Clients/RcloneClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RcloneClientTests.cs
@@ -94,6 +94,23 @@ public class RcloneClientTests : IDisposable
         Assert.Empty(result.Forgotten ?? []);
     }
 
+    [Fact]
+    public async Task TestConnection_PropagatesCancellation()
+    {
+        RcloneClient.TestHandler = new HangUntilCancelledHandler();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => RcloneClient.TestConnection("http://rclone.test", null, null, cts.Token));
+    }
+
+    [Fact]
+    public void SharedHttpClient_HasExplicitTimeout()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(30), RcloneClient.RequestTimeout);
+    }
+
     public void Dispose()
     {
         RcloneClient.TestHandler = null;
@@ -135,6 +152,17 @@ public class RcloneClientTests : IDisposable
                 throw new InvalidOperationException($"Unexpected request: {key}");
 
             return Task.FromResult(response);
+        }
+    }
+
+    private sealed class HangUntilCancelledHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            throw new InvalidOperationException("Expected cancellation before a response.");
         }
     }
 }

--- a/tests/NzbWebDAV.Tests/Hosting/HostShutdownConventionTests.cs
+++ b/tests/NzbWebDAV.Tests/Hosting/HostShutdownConventionTests.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using NzbWebDAV.Tests.TestUtils;
+
+namespace NzbWebDAV.Tests.Hosting;
+
+[Collection(nameof(HttpIntegrationCollection))]
+public sealed class HostShutdownConventionTests(NzbDavWebApplicationFactory factory)
+{
+    [Fact]
+    public void HostShutdownTimeout_IsFiveSeconds()
+    {
+        var options = factory.Services.GetRequiredService<IOptions<HostOptions>>();
+        Assert.Equal(TimeSpan.FromSeconds(5), options.Value.ShutdownTimeout);
+    }
+}


### PR DESCRIPTION
## Summary
- Pin `CA2016` (forward `CancellationToken`) and `CA1001` (owning types implement `IDisposable`) as explicit errors in `Directory.Build.props` and first-party `.editorconfig` files so they stay errors even if the blanket warnings-as-errors gate is narrowed.
- Give Arr and rclone HTTP clients a 30s timeout and thread `CancellationToken` through their public I/O methods; set AddUrl's `HttpClient.Timeout` to the existing 60s fetch budget; cancel in-flight article-miss persistence only if host shutdown times out.
- Set generic-host `ShutdownTimeout` to 5 seconds so hosted services must honor `stoppingToken` instead of blocking SIGTERM for the 30s default.

Fixes #849

## Audit report (#849)

### Analyzers
- First-party code already built with `TreatWarningsAsErrors=true` and `AnalysisLevel=latest-All`. This PR names `CA2016` and `CA1001` in `<WarningsAsErrors>` and sets `dotnet_diagnostic.*.severity = error` in the root, UsenetSharp, and RapidYencSharp editorconfigs.
- Tests still disable both rules in `tests/.editorconfig`. Vendored SharpCompress remains on `<NoWarn>`.
- Existing justified `#pragma warning disable CA2016` / `CA1001` sites are unchanged (classification must not bind the ambient token; `LazyRarResolver` process-lifetime `SemaphoreSlim`).
- No new suppressions.

### Async I/O without a `CancellationToken` parameter
**Remediated here:** `ArrClient.GetQueueCountAsync` / `DeleteQueueRecord` / `GetRootFolders`; all public `RcloneClient` HTTP methods and `DavDatabaseContext.RcloneVfsForget`; Warden GitHub error-body reads; Arr/rclone connection-test controllers; article-miss persistence loop EF calls.

**Already respecting cancellation without a method parameter (left as-is):**
- Admin controllers that forward `HttpContext.RequestAborted` to EF/HTTP.
- SAB controllers that stash `RequestAborted` on the request DTO (`AddUrlRequest.New`, etc.).
- `IAsyncDisposable.DisposeAsync` and NNTP/stream pipeline helpers that use an operation or field token.
- `#317` sync-over-async `Stream.Read` bridges (out of scope).

**Not given a token on purpose:** `DisposeAsync` methods; test-only helpers.

### Method-scope `IDisposable` / `IAsyncDisposable` without `using`
`CA2000` is already an error. Remaining sites are ownership-transfer `#pragma` comments (response streams, static `HttpClient` handlers, queue worker CTS). No new leaks found in first-party HTTP/client code.

### HTTP timeout policy
| Client | Policy |
| --- | --- |
| `ArrClient` | `HttpClient.Timeout = 30s` (was the 100s default) |
| `RcloneClient` | `HttpClient.Timeout = 30s` (was the 100s default) |
| AddUrl NZB fetch | `HttpClient.Timeout = FetchTimeout` (60s; already had a per-request CTS) |
| Warden GitHub | already 90–100s |
| `ProxyHttpClientPool` | `Timeout.InfiniteTimeSpan` by design; callers pass a token |

### `ConfigureAwait(false)`
Kept `CA2007` disabled for the ASP.NET app (`await using` + no `SynchronizationContext`; see CONTRIBUTING). `libs/` still enable it. `backend/Clients` and `backend/Streams` already configure awaited expressions; re-enabling `CA2007` there would fail on `await using`.

### Hosted shutdown
`HostOptions.ShutdownTimeout = 5s`. Hosted `BackgroundService` loops already pass `stoppingToken` into `Task.Delay` and I/O. Article-miss persistence completes the channel first so a graceful stop can drain; the loop token is cancelled only if that 5s budget elapses.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (3415 passed)
- [x] Arr `GetQueueCountAsync` honors a cancelled token; rclone `TestConnection` propagates cancellation
- [x] Hosted `IOptions<HostOptions>.ShutdownTimeout` is 5 seconds via the HTTP test factory
- [ ] Confirm a running container returns from SIGTERM in about 5 seconds when a hosted loop is in `Task.Delay`