### PR TITLE
feat(api): invalid API input returns field errors instead of a 500

### DIFF
--- a/backend/Api/Controllers/Authenticate/AuthenticateRequest.cs
+++ b/backend/Api/Controllers/Authenticate/AuthenticateRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Database.Models;
 
 namespace NzbWebDAV.Api.Controllers.Authenticate;
@@ -11,14 +12,16 @@ public class AuthenticateRequest
 
     public AuthenticateRequest(HttpContext context)
     {
-        Username = context.Request.Form["username"].FirstOrDefault()?.ToLowerInvariant() ??
-            throw new BadHttpRequestException("Username is required");
-
-        Password = context.Request.Form["password"].FirstOrDefault() ??
-            throw new BadHttpRequestException("Password is required");
-
-        Type = !Enum.TryParse<Account.AccountType>(context.Request.Form["type"], ignoreCase: true, out var parsedType)
-            ? throw new BadHttpRequestException("Invalid account type")
-            : parsedType;
+        var errors = new ValidationErrors();
+        Username = context.Request.Form["username"].FirstOrDefault()?.ToLowerInvariant() ?? "";
+        Password = context.Request.Form["password"].FirstOrDefault() ?? "";
+        if (string.IsNullOrEmpty(Username))
+            errors.Add("username", "Username is required");
+        if (context.Request.Form["password"].FirstOrDefault() is null)
+            errors.Add("password", "Password is required");
+        if (!Enum.TryParse<Account.AccountType>(context.Request.Form["type"], ignoreCase: true, out var parsedType))
+            errors.Add("type", "Invalid account type");
+        errors.ThrowIfAny();
+        Type = parsedType;
     }
 }

--- a/backend/Api/Controllers/BaseApiController.cs
+++ b/backend/Api/Controllers/BaseApiController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Auth;
 using NzbWebDAV.Config;
 using Serilog;
@@ -26,6 +27,15 @@ public abstract class BaseApiController : ControllerBase
             }
 
             return await HandleRequest().ConfigureAwait(false);
+        }
+        catch (ApiValidationException e)
+        {
+            HttpContext.Items[ApiValidationException.HttpContextItemKey] = e;
+            return BadRequest(new BaseApiResponse()
+            {
+                Status = false,
+                Error = e.Message
+            });
         }
         catch (Exception e) when (e is BadHttpRequestException or ArgumentException)
         {

--- a/backend/Api/Controllers/CreateAccount/CreateAccountRequest.cs
+++ b/backend/Api/Controllers/CreateAccount/CreateAccountRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Database.Models;
 
 namespace NzbWebDAV.Api.Controllers.CreateAccount;
@@ -11,14 +12,16 @@ public class CreateAccountRequest
 
     public CreateAccountRequest(HttpContext context)
     {
-        Username = context.Request.Form["username"].FirstOrDefault()?.ToLowerInvariant() ??
-            throw new BadHttpRequestException("Username is required");
-
-        Password = context.Request.Form["password"].FirstOrDefault() ??
-            throw new BadHttpRequestException("Password is required");
-
-        Type = !Enum.TryParse<Account.AccountType>(context.Request.Form["type"], ignoreCase: true, out var parsedType)
-            ? throw new BadHttpRequestException("Invalid account type")
-            : parsedType;
+        var errors = new ValidationErrors();
+        Username = context.Request.Form["username"].FirstOrDefault()?.ToLowerInvariant() ?? "";
+        Password = context.Request.Form["password"].FirstOrDefault() ?? "";
+        if (string.IsNullOrEmpty(Username))
+            errors.Add("username", "Username is required");
+        if (context.Request.Form["password"].FirstOrDefault() is null)
+            errors.Add("password", "Password is required");
+        if (!Enum.TryParse<Account.AccountType>(context.Request.Form["type"], ignoreCase: true, out var parsedType))
+            errors.Add("type", "Invalid account type");
+        errors.ThrowIfAny();
+        Type = parsedType;
     }
 }

--- a/backend/Api/Controllers/GetArrHealth/GetArrHealthRequest.cs
+++ b/backend/Api/Controllers/GetArrHealth/GetArrHealthRequest.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Extensions;
 
 namespace NzbWebDAV.Api.Controllers.GetArrHealth;
@@ -13,21 +14,29 @@ public class GetArrHealthRequest
         CancellationToken = context.RequestAborted;
         var w = context.GetQueryParam("window");
         if (w is not null)
-        {
             Window = ParseWindow(w);
-        }
     }
 
-    internal static ArrHealthWindow ParseWindow(string window) =>
-        window.ToLowerInvariant() switch
+    internal static ArrHealthWindow ParseWindow(string window)
+    {
+        return window.ToLowerInvariant() switch
         {
             "1h" => ArrHealthWindow.Last1Hour,
             "24h" => ArrHealthWindow.Last24Hours,
             "7d" => ArrHealthWindow.Last7Days,
             "30d" => ArrHealthWindow.Last30Days,
             "all" => ArrHealthWindow.AllTime,
-            _ => throw new BadHttpRequestException("Invalid window parameter (use 1h, 24h, 7d, 30d, or all)"),
+            _ => ThrowInvalidWindow(),
         };
+
+        static ArrHealthWindow ThrowInvalidWindow()
+        {
+            var errors = new ValidationErrors();
+            errors.Add("window", "Invalid window parameter (use 1h, 24h, 7d, 30d, or all)");
+            errors.ThrowIfAny();
+            return default;
+        }
+    }
 
     public enum ArrHealthWindow
     {

--- a/backend/Api/Controllers/GetHealthCheckHistory/GetHealthCheckHistoryRequest.cs
+++ b/backend/Api/Controllers/GetHealthCheckHistory/GetHealthCheckHistoryRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Extensions;
 
@@ -14,6 +15,7 @@ public class GetHealthCheckHistoryRequest
 
     public GetHealthCheckHistoryRequest(HttpContext context)
     {
+        var errors = new ValidationErrors();
         var pageParam = context.GetQueryParam("page");
         var pageSizeParam = context.GetQueryParam("pageSize");
         var repairStatusParam = context.GetQueryParam("repairStatus");
@@ -23,15 +25,17 @@ public class GetHealthCheckHistoryRequest
         if (pageParam is not null)
         {
             if (!int.TryParse(pageParam, out var page) || page < 1)
-                throw new BadHttpRequestException("Invalid page parameter");
-            Page = page;
+                errors.Add("page", "Invalid page parameter");
+            else
+                Page = page;
         }
 
         if (pageSizeParam is not null)
         {
             if (!int.TryParse(pageSizeParam, out var pageSize) || pageSize is < 1 or > 250)
-                throw new BadHttpRequestException("Invalid pageSize parameter");
-            PageSize = pageSize;
+                errors.Add("pageSize", "Invalid pageSize parameter");
+            else
+                PageSize = pageSize;
         }
 
         if (repairStatusParam is not null)
@@ -57,8 +61,10 @@ public class GetHealthCheckHistoryRequest
                         repairStatuses.Add(HealthCheckResult.RepairAction.ActionNeeded);
                         break;
                     default:
-                        throw new BadHttpRequestException(
+                        errors.Add(
+                            "repairStatus",
                             "Invalid repairStatus parameter (use none, repaired, deleted, or action-needed)");
+                        break;
                 }
             }
             // An empty or comma-only repairStatus value (e.g. "?repairStatus=") means "no filter"
@@ -71,17 +77,22 @@ public class GetHealthCheckHistoryRequest
             var results = new HashSet<HealthCheckResult.HealthResult>();
             foreach (var result in resultParam.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
             {
-                results.Add(result.ToLowerInvariant() switch
+                var parsed = result.ToLowerInvariant() switch
                 {
                     "healthy" => HealthCheckResult.HealthResult.Healthy,
                     "unhealthy" => HealthCheckResult.HealthResult.Unhealthy,
                     "degraded" => HealthCheckResult.HealthResult.Degraded,
-                    _ => throw new BadHttpRequestException(
-                        "Invalid result parameter (use healthy, unhealthy, or degraded)")
-                });
+                    _ => (HealthCheckResult.HealthResult?)null,
+                };
+                if (parsed is null)
+                    errors.Add("result", "Invalid result parameter (use healthy, unhealthy, or degraded)");
+                else
+                    results.Add(parsed.Value);
             }
             // Same convention as repairStatus: an empty or comma-only value means "no filter".
             Results = results.Count > 0 ? results : null;
         }
+
+        errors.ThrowIfAny();
     }
 }

--- a/backend/Api/Controllers/GetHealthCheckQueue/GetHealthCheckQueueRequest.cs
+++ b/backend/Api/Controllers/GetHealthCheckQueue/GetHealthCheckQueueRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Extensions;
 
 namespace NzbWebDAV.Api.Controllers.GetHealthCheckQueue;
@@ -12,12 +13,14 @@ public class GetHealthCheckQueueRequest
     {
         var pageSizeParam = context.GetQueryParam("pageSize");
         CancellationToken = context.RequestAborted;
+        var errors = new ValidationErrors();
 
         if (pageSizeParam is not null)
         {
-            var isValidStartParam = int.TryParse(pageSizeParam, out int pageSize);
-            if (!isValidStartParam) throw new BadHttpRequestException("Invalid pageSize parameter");
-            PageSize = pageSize;
+            if (errors.TryParseInt("pageSize", pageSizeParam, "Invalid pageSize parameter", out var pageSize))
+                PageSize = pageSize;
         }
+
+        errors.ThrowIfAny();
     }
 }

--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsRequest.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsRequest.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Extensions;
 
 namespace NzbWebDAV.Api.Controllers.GetOverviewStats;
@@ -12,6 +13,7 @@ public class GetOverviewStatsRequest
     public GetOverviewStatsRequest(HttpContext context)
     {
         CancellationToken = context.RequestAborted;
+        var errors = new ValidationErrors();
         var w = context.GetQueryParam("window");
         if (w is not null)
         {
@@ -22,11 +24,22 @@ public class GetOverviewStatsRequest
                 "7d" => OverviewWindow.Last7Days,
                 "30d" => OverviewWindow.Last30Days,
                 "all" => OverviewWindow.AllTime,
-                _ => throw new BadHttpRequestException("Invalid window parameter (use 1h, 24h, 7d, 30d, or all)")
+                _ => OverviewWindow.Last24Hours,
             };
+            if (w.ToLowerInvariant() is not ("1h" or "24h" or "7d" or "30d" or "all"))
+                errors.Add("window", "Invalid window parameter (use 1h, 24h, 7d, 30d, or all)");
         }
 
-        Sections = ParseSections(context.GetQueryParam("sections"));
+        try
+        {
+            Sections = ParseSections(context.GetQueryParam("sections"));
+        }
+        catch (BadHttpRequestException ex)
+        {
+            errors.Add("sections", ex.Message);
+        }
+
+        errors.ThrowIfAny();
     }
 
     private static OverviewSections ParseSections(string? raw)

--- a/backend/Api/Controllers/SearchIndexers/SearchIndexersRequest.cs
+++ b/backend/Api/Controllers/SearchIndexers/SearchIndexersRequest.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Extensions;
 
 namespace NzbWebDAV.Api.Controllers.SearchIndexers;
@@ -10,8 +11,11 @@ public class SearchIndexersRequest
 
     public SearchIndexersRequest(HttpContext context)
     {
-        Query = context.GetRequestParam("q")
-                ?? throw new BadHttpRequestException("Query `q` is required");
+        var errors = new ValidationErrors();
+        Query = context.GetRequestParam("q") ?? "";
+        if (string.IsNullOrEmpty(Query))
+            errors.Add("q", "Query `q` is required");
+        errors.ThrowIfAny();
 
         Limit = int.TryParse(context.GetRequestParam("limit"), out var n) && n is > 0 and <= 500
             ? n

--- a/backend/Api/Controllers/TestArrConnection/TestArrConnectionRequest.cs
+++ b/backend/Api/Controllers/TestArrConnection/TestArrConnectionRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Config;
 
 namespace NzbWebDAV.Api.Controllers.TestArrConnection;
@@ -10,11 +11,14 @@ public class TestArrConnectionRequest
 
     public TestArrConnectionRequest(HttpContext context, ConfigManager configManager)
     {
-        Host = context.Request.Form["host"].FirstOrDefault()
-               ?? throw new BadHttpRequestException("Arr host is required");
-
-        var submittedApiKey = context.Request.Form["apiKey"].FirstOrDefault()
-               ?? throw new BadHttpRequestException("Arr apiKey is required");
-        ApiKey = ArrApiKeyResolver.Resolve(submittedApiKey, configManager);
+        var errors = new ValidationErrors();
+        Host = context.Request.Form["host"].FirstOrDefault() ?? "";
+        var submittedApiKey = context.Request.Form["apiKey"].FirstOrDefault();
+        if (string.IsNullOrEmpty(Host))
+            errors.Add("host", "Arr host is required");
+        if (submittedApiKey is null)
+            errors.Add("apiKey", "Arr apiKey is required");
+        errors.ThrowIfAny();
+        ApiKey = ArrApiKeyResolver.Resolve(submittedApiKey!, configManager);
     }
 }

--- a/backend/Api/Controllers/TestIndexerConnection/TestIndexerConnectionRequest.cs
+++ b/backend/Api/Controllers/TestIndexerConnection/TestIndexerConnectionRequest.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Config;
 
 namespace NzbWebDAV.Api.Controllers.TestIndexerConnection;
@@ -14,12 +15,15 @@ public class TestIndexerConnectionRequest
 
     public TestIndexerConnectionRequest(HttpContext context, ConfigManager configManager)
     {
-        Url = context.Request.Form["url"].FirstOrDefault()
-              ?? throw new BadHttpRequestException("Indexer url is required");
-
-        var submittedApiKey = context.Request.Form["apiKey"].FirstOrDefault()
-                              ?? throw new BadHttpRequestException("Indexer apiKey is required");
-        ApiKey = IndexerApiKeyResolver.Resolve(submittedApiKey, configManager);
+        var errors = new ValidationErrors();
+        Url = context.Request.Form["url"].FirstOrDefault() ?? "";
+        var submittedApiKey = context.Request.Form["apiKey"].FirstOrDefault();
+        if (string.IsNullOrEmpty(Url))
+            errors.Add("url", "Indexer url is required");
+        if (submittedApiKey is null)
+            errors.Add("apiKey", "Indexer apiKey is required");
+        errors.ThrowIfAny();
+        ApiKey = IndexerApiKeyResolver.Resolve(submittedApiKey!, configManager);
 
         UserAgent = context.Request.Form["userAgent"].FirstOrDefault();
         ProxyUrl = context.Request.Form["proxyUrl"].FirstOrDefault();

--- a/backend/Api/Controllers/TestProwlarrConnection/TestProwlarrConnectionRequest.cs
+++ b/backend/Api/Controllers/TestProwlarrConnection/TestProwlarrConnectionRequest.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Config;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Utils;
@@ -12,29 +13,36 @@ public sealed class TestProwlarrConnectionRequest
 
     public TestProwlarrConnectionRequest(HttpContext context, ConfigManager configManager)
     {
+        var errors = new ValidationErrors();
         Url = StringUtil.EmptyToNull(context.GetRequestParam("url"))
               ?? configManager.GetProwlarrUrl()
-              ?? throw new BadHttpRequestException("Prowlarr URL is required.");
+              ?? "";
+        if (string.IsNullOrEmpty(Url))
+            errors.Add("url", "Prowlarr URL is required.");
 
         var submittedApiKey = StringUtil.EmptyToNull(context.GetRequestParam("apiKey"));
+        string? apiKey = null;
         if (submittedApiKey is null)
         {
-            ApiKey = configManager.GetProwlarrApiKey()
-                     ?? throw new BadHttpRequestException("Prowlarr API key is required.");
-            return;
+            apiKey = configManager.GetProwlarrApiKey();
+            if (apiKey is null)
+                errors.Add("apiKey", "Prowlarr API key is required.");
         }
-
-        if (!ConfigSecretMasker.IsMaskToken(submittedApiKey))
+        else if (!ConfigSecretMasker.IsMaskToken(submittedApiKey))
         {
-            ApiKey = submittedApiKey;
-            return;
+            apiKey = submittedApiKey;
+        }
+        else
+        {
+            var masker = new ConfigSecretMasker(
+                EnvironmentUtil.GetRequiredVariable("FRONTEND_BACKEND_API_KEY"));
+            apiKey = masker.ResolveForUpdate(
+                ConfigKeys.ProwlarrApiKey,
+                submittedApiKey,
+                configManager.GetEffectiveConfigValue(ConfigKeys.ProwlarrApiKey));
         }
 
-        var masker = new ConfigSecretMasker(
-            EnvironmentUtil.GetRequiredVariable("FRONTEND_BACKEND_API_KEY"));
-        ApiKey = masker.ResolveForUpdate(
-            ConfigKeys.ProwlarrApiKey,
-            submittedApiKey,
-            configManager.GetEffectiveConfigValue(ConfigKeys.ProwlarrApiKey));
+        errors.ThrowIfAny();
+        ApiKey = apiKey!;
     }
 }

--- a/backend/Api/Controllers/TestRcloneConnection/TestRcloneConnectionRequest.cs
+++ b/backend/Api/Controllers/TestRcloneConnection/TestRcloneConnectionRequest.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Config;
 
 namespace NzbWebDAV.Api.Controllers.TestRcloneConnection;
@@ -11,8 +12,11 @@ public class TestRcloneConnectionRequest
 
     public TestRcloneConnectionRequest(HttpContext context, ConfigManager configManager)
     {
-        Host = context.Request.Form["host"].FirstOrDefault()
-               ?? throw new BadHttpRequestException("Rclone host is required");
+        var errors = new ValidationErrors();
+        Host = context.Request.Form["host"].FirstOrDefault() ?? "";
+        if (string.IsNullOrEmpty(Host))
+            errors.Add("host", "Rclone host is required");
+        errors.ThrowIfAny();
 
         User = context.Request.Form["user"].FirstOrDefault();
         Pass = RclonePassResolver.Resolve(context.Request.Form["pass"].FirstOrDefault(), configManager);

--- a/backend/Api/Controllers/TestUsenetConnection/TestUsenetConnectionRequest.cs
+++ b/backend/Api/Controllers/TestUsenetConnection/TestUsenetConnectionRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Config;
 using NzbWebDAV.Models;
 
@@ -15,29 +16,35 @@ public class TestUsenetConnectionRequest
 
     public TestUsenetConnectionRequest(HttpContext context, ConfigManager configManager)
     {
-        Host = context.Request.Form["host"].FirstOrDefault()
-               ?? throw new BadHttpRequestException("Usenet host is required");
+        var errors = new ValidationErrors();
+        Host = context.Request.Form["host"].FirstOrDefault() ?? "";
+        User = context.Request.Form["user"].FirstOrDefault() ?? "";
+        var submittedPass = context.Request.Form["pass"].FirstOrDefault();
+        var port = context.Request.Form["port"].FirstOrDefault();
+        var useSsl = context.Request.Form["use-ssl"].FirstOrDefault();
 
-        User = context.Request.Form["user"].FirstOrDefault()
-               ?? throw new BadHttpRequestException("Usenet user is required");
+        if (string.IsNullOrEmpty(Host))
+            errors.Add("host", "Usenet host is required");
+        if (string.IsNullOrEmpty(User))
+            errors.Add("user", "Usenet user is required");
+        if (submittedPass is null)
+            errors.Add("pass", "Usenet pass is required");
+        if (port is null)
+            errors.Add("port", "Usenet port is required");
+        else if (!int.TryParse(port, out var portValue))
+            errors.Add("port", "Invalid usenet port");
+        else
+            Port = portValue;
 
-        var submittedPass = context.Request.Form["pass"].FirstOrDefault()
-               ?? throw new BadHttpRequestException("Usenet pass is required");
-        Pass = UsenetPassResolver.Resolve(submittedPass, configManager);
+        if (useSsl is null)
+            errors.Add("use-ssl", "Usenet use-ssl is required");
+        else if (!bool.TryParse(useSsl, out var useSslValue))
+            errors.Add("use-ssl", "Invalid use-ssl value");
+        else
+            UseSsl = useSslValue;
 
-        var port = context.Request.Form["port"].FirstOrDefault()
-                   ?? throw new BadHttpRequestException("Usenet port is required");
-
-        var useSsl = context.Request.Form["use-ssl"].FirstOrDefault()
-                     ?? throw new BadHttpRequestException("Usenet use-ssl is required");
-
-        Port = !int.TryParse(port, out int portValue)
-            ? throw new BadHttpRequestException("Invalid usenet port")
-            : portValue;
-
-        UseSsl = !bool.TryParse(useSsl, out bool useSslValue)
-            ? throw new BadHttpRequestException("Invalid use-ssl value")
-            : useSslValue;
+        errors.ThrowIfAny();
+        Pass = UsenetPassResolver.Resolve(submittedPass!, configManager);
 
         var skipTlsVerification = context.Request.Form["skip-tls-verification"].FirstOrDefault();
         SkipTlsVerification = bool.TryParse(skipTlsVerification, out var skipTlsVerificationValue)

--- a/backend/Api/Controllers/UpdateConfig/UpdateConfigRequest.cs
+++ b/backend/Api/Controllers/UpdateConfig/UpdateConfigRequest.cs
@@ -1,20 +1,67 @@
 ﻿using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Database.Models;
 
 namespace NzbWebDAV.Api.Controllers.UpdateConfig;
 
 public class UpdateConfigRequest
 {
+    public const int MaxConfigNameLength = 256;
+    public const int MaxConfigValueLength = 1_000_000;
+
     public List<ConfigItem> ConfigItems { get; init; }
 
     public UpdateConfigRequest(HttpContext context)
     {
-        ConfigItems = context.Request.Form
-            .Select(x => new ConfigItem()
+        var errors = new ValidationErrors();
+        if (!context.Request.HasFormContentType)
+        {
+            errors.Add("config", "Config updates must be submitted as form fields.");
+            errors.ThrowIfAny();
+        }
+
+        var items = new List<ConfigItem>();
+        foreach (var pair in context.Request.Form)
+        {
+            if (string.IsNullOrWhiteSpace(pair.Key))
             {
-                ConfigName = x.Key,
-                ConfigValue = x.Value.FirstOrDefault() ?? ""
-            })
-            .ToList();
+                errors.Add("config", "Config names must be non-empty strings.");
+                continue;
+            }
+
+            if (pair.Key.Length > MaxConfigNameLength)
+            {
+                errors.Add(pair.Key, "Config name exceeds the maximum length.");
+                continue;
+            }
+
+            if (pair.Value.Count > 1)
+            {
+                errors.Add(pair.Key, "Config values must be a single string.");
+                continue;
+            }
+
+            var value = pair.Value.FirstOrDefault();
+            if (value is null)
+            {
+                errors.Add(pair.Key, "Config values must be strings.");
+                continue;
+            }
+
+            if (value.Length > MaxConfigValueLength)
+            {
+                errors.Add(pair.Key, "Config value exceeds the maximum length.");
+                continue;
+            }
+
+            items.Add(new ConfigItem
+            {
+                ConfigName = pair.Key,
+                ConfigValue = value
+            });
+        }
+
+        errors.ThrowIfAny();
+        ConfigItems = items;
     }
 }

--- a/backend/Api/Controllers/UsenetMigration/UsenetMigrationBaseController.cs
+++ b/backend/Api/Controllers/UsenetMigration/UsenetMigrationBaseController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Auth;
 using NzbWebDAV.Config;
 using NzbWebDAV.Extensions;
@@ -30,6 +31,11 @@ public abstract class UsenetMigrationBaseController : ControllerBase
             var migrationStore = HttpContext.RequestServices.GetRequiredService<UsenetMigrationStore>();
             await migrationStore.EnsureDatabaseAsync(HttpContext.RequestAborted).ConfigureAwait(false);
             return await handler().ConfigureAwait(false);
+        }
+        catch (ApiValidationException e)
+        {
+            HttpContext.Items[ApiValidationException.HttpContextItemKey] = e;
+            return BadRequest(new BaseApiResponse { Status = false, Error = e.Message });
         }
         catch (Exception e) when (e is BadHttpRequestException or ArgumentException)
         {

--- a/backend/Api/Errors/ApiErrorContractFilter.cs
+++ b/backend/Api/Errors/ApiErrorContractFilter.cs
@@ -24,7 +24,7 @@ public sealed class ApiErrorContractFilter : IAsyncResultFilter
             && ApiRequestClassifier.IsAdminApi(httpContext))
         {
             var status = objectResult.StatusCode ?? StatusCodes.Status400BadRequest;
-            var problem = ApiProblemDetailsFactory.FromStatus(httpContext, status, admin.Error);
+            var problem = CreateProblem(httpContext, status, admin.Error);
             context.Result = new ProblemJsonResult(
                 problem.Status ?? status,
                 ApiProblemDetailsFactory.ToWritablePayload(problem));
@@ -36,7 +36,17 @@ public sealed class ApiErrorContractFilter : IAsyncResultFilter
         {
             var status = objectResult.StatusCode ?? StatusCodes.Status400BadRequest;
             sab.Problem ??= ApiProblemDetailsFactory.ToWritablePayload(
-                ApiProblemDetailsFactory.FromStatus(httpContext, status, sab.Error));
+                CreateProblem(httpContext, status, sab.Error));
         }
+    }
+
+    private static ProblemDetails CreateProblem(HttpContext httpContext, int status, string? detail)
+    {
+        if (httpContext.Items[ApiValidationException.HttpContextItemKey] is ApiValidationException validation)
+        {
+            return ApiProblemDetailsFactory.Validation(httpContext, validation.Errors, validation.Message);
+        }
+
+        return ApiProblemDetailsFactory.FromStatus(httpContext, status, detail);
     }
 }

--- a/backend/Api/Errors/ApiValidationException.cs
+++ b/backend/Api/Errors/ApiValidationException.cs
@@ -2,6 +2,8 @@ namespace NzbWebDAV.Api.Errors;
 
 public sealed class ApiValidationException : Exception
 {
+    public const string HttpContextItemKey = "NzbWebDAV.ApiValidationException";
+
     public ApiValidationException(IReadOnlyDictionary<string, string[]> errors, string? message = null)
         : base(message ?? "One or more validation errors occurred.")
     {

--- a/backend/Api/Errors/NzbInputLimits.cs
+++ b/backend/Api/Errors/NzbInputLimits.cs
@@ -1,0 +1,18 @@
+namespace NzbWebDAV.Api.Errors;
+
+/// <summary>
+/// Bounded NZB ingest limits. Defaults are high enough for legitimate large
+/// releases (selected above current accepted fixtures) and are enforced before
+/// a queue item is inserted.
+/// </summary>
+public sealed class NzbInputLimits
+{
+    public static NzbInputLimits Default { get; } = new();
+
+    public int MaxXmlBytes { get; init; } = 64 * 1024 * 1024;
+    public int MaxFiles { get; init; } = 10_000;
+    public int MaxTotalSegments { get; init; } = 500_000;
+    public int MaxSegmentsPerFile { get; init; } = 100_000;
+    public int MaxNameLength { get; init; } = 255;
+    public int MaxMessageIdLength { get; init; } = 248;
+}

--- a/backend/Api/Errors/ValidationErrors.cs
+++ b/backend/Api/Errors/ValidationErrors.cs
@@ -1,0 +1,53 @@
+namespace NzbWebDAV.Api.Errors;
+
+/// <summary>
+/// Collects field-level input errors and throws <see cref="ApiValidationException"/>
+/// once, before queue, database, filesystem, or provider work.
+/// InfiniDysk uses this manual collector (not FluentValidation / DataAnnotations)
+/// so SAB quirks and existing typed request parsers stay in control.
+/// </summary>
+public sealed class ValidationErrors
+{
+    private readonly Dictionary<string, List<string>> _errors = new(StringComparer.Ordinal);
+
+    public bool HasErrors => _errors.Count > 0;
+
+    public void Add(string field, string message)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(field);
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+        if (!_errors.TryGetValue(field, out var list))
+        {
+            list = [];
+            _errors[field] = list;
+        }
+
+        list.Add(message);
+    }
+
+    public IReadOnlyDictionary<string, string[]> ToDictionary() =>
+        _errors.ToDictionary(
+            static pair => pair.Key,
+            static pair => pair.Value.ToArray(),
+            StringComparer.Ordinal);
+
+    public void ThrowIfAny()
+    {
+        if (_errors.Count == 0)
+            return;
+
+        var summary = _errors.SelectMany(static pair => pair.Value).First();
+        throw new ApiValidationException(ToDictionary(), summary);
+    }
+
+    public bool TryParseInt(string field, string? raw, string invalidMessage, out int value)
+    {
+        value = default;
+        if (raw is null)
+            return false;
+        if (int.TryParse(raw, out value))
+            return true;
+        Add(field, invalidMessage);
+        return false;
+    }
+}

--- a/backend/Api/SabControllers/AddFile/AddFileController.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileController.cs
@@ -1,12 +1,13 @@
-﻿using System.Xml;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Api.SabControllers.GetQueue;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Models.Nzb;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Utils;
 using NzbWebDAV.Websocket;
@@ -22,12 +23,6 @@ public class AddFileController(
     WebsocketManager websocketManager
 ) : SabApiController.BaseController(httpContext, configManager)
 {
-    private static readonly XmlReaderSettings XmlSettings = new()
-    {
-        Async = true,
-        DtdProcessing = DtdProcessing.Ignore
-    };
-
     /// <summary>
     /// Creates a short-lived context for conflict removal without flushing
     /// pending Added entities on the request-scoped context. Tests can override
@@ -125,17 +120,8 @@ public class AddFileController(
 
             // compute the total segment bytes
             await using var nzbFileStream = BlobStore.ReadBlob(id)!;
-            long totalSegmentBytes;
-            try
-            {
-                totalSegmentBytes = ComputeTotalSegmentBytes(nzbFileStream);
-            }
-            catch (XmlException exception) when (prepared.IsGzip)
-            {
-                throw new BadHttpRequestException(
-                    "The uploaded gzip file does not contain a valid NZB document.",
-                    exception);
-            }
+            var totalSegmentBytes = NzbInputValidator.ValidateAndSumSegmentBytes(
+                nzbFileStream, NzbInputLimits.Default);
 
             // Keep enqueues after any manually moved item in their priority band.
             // CreatedAt remains the immutable enqueue timestamp; SortOrder owns
@@ -390,22 +376,5 @@ public class AddFileController(
         {
             throw new ArgumentException("The NZB backup category must be a single directory name.", nameof(category));
         }
-    }
-
-    private static long ComputeTotalSegmentBytes(Stream stream)
-    {
-        long totalBytes = 0;
-        using var reader = XmlReader.Create(stream, XmlSettings);
-        while (reader.Read())
-        {
-            if (reader.NodeType != XmlNodeType.Element || reader.LocalName != "segment") continue;
-            var bytesAttr = reader.GetAttribute("bytes");
-            if (bytesAttr != null && long.TryParse(bytesAttr, out var bytes))
-            {
-                totalBytes += bytes;
-            }
-        }
-
-        return totalBytes;
     }
 }

--- a/backend/Api/SabControllers/AddFile/AddFileRequest.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Extensions;
@@ -33,29 +34,39 @@ public class AddFileRequest()
     public string? ContentGroupKey { get; init; }
     public CancellationToken CancellationToken { get; init; }
 
-    public static async Task<AddFileRequest> New(HttpContext context, ConfigManager configManager)
+    public static Task<AddFileRequest> New(HttpContext context, ConfigManager configManager)
     {
+        var errors = new ValidationErrors();
         var file =
-            context.Request.Form.Files["nzbFile"] ??
-            context.Request.Form.Files["name"] ??
-            throw new BadHttpRequestException("Invalid nzbFile/name param");
+            context.Request.HasFormContentType
+                ? context.Request.Form.Files["nzbFile"] ?? context.Request.Form.Files["name"]
+                : null;
+        if (file is null)
+            errors.Add("nzbFile", "Invalid nzbFile/name param");
 
-        // Prefer the nzbname query/form param (set by some SAB clients); fall back to the
-        // form file's filename. Without this, file.FileName can be null/empty and downstream
-        // Regex.Match throws a 500. Adopted from elfhosted/rebased-v3.
-        var fileName = ResolveFileName(context.GetRequestParam("nzbname"), file.FileName);
+        var fileName = TryResolveFileName(
+            context.GetRequestParam("nzbname"),
+            file?.FileName,
+            errors);
 
-        return new AddFileRequest()
+        if (!TryMapPriorityOption(context.GetRequestParam("priority"), out var priority))
+            errors.Add("priority", "Invalid priority");
+        if (!TryMapPostProcessingOption(context.GetRequestParam("pp"), out var postProcessing))
+            errors.Add("pp", "Invalid pp param");
+
+        errors.ThrowIfAny();
+
+        return Task.FromResult(new AddFileRequest()
         {
-            FileName = fileName,
-            ContentType = file.ContentType,
+            FileName = fileName!,
+            ContentType = file!.ContentType,
             NzbFileStream = file.OpenReadStream(),
             Category = SabCategoryResolver.GetCategory(context, configManager)
                        ?? configManager.GetManualUploadCategory(),
-            Priority = MapPriorityOption(context.GetRequestParam("priority")),
-            PostProcessing = MapPostProcessingOption(context.GetRequestParam("pp")),
+            Priority = priority,
+            PostProcessing = postProcessing,
             CancellationToken = context.RequestAborted
-        };
+        });
     }
 
     /// <summary>
@@ -63,17 +74,54 @@ public class AddFileRequest()
     /// </summary>
     internal static string ResolveFileName(string? nzbName, string? formFileName)
     {
+        var errors = new ValidationErrors();
+        var fileName = TryResolveFileName(nzbName, formFileName, errors);
+        errors.ThrowIfAny();
+        return fileName!;
+    }
+
+    internal static string? TryResolveFileName(string? nzbName, string? formFileName, ValidationErrors errors)
+    {
         var fileName = !string.IsNullOrWhiteSpace(nzbName) ? nzbName : formFileName;
-
         if (string.IsNullOrWhiteSpace(fileName))
-            throw new BadHttpRequestException("NZB filename could not be determined.");
+        {
+            errors.Add("nzbname", "NZB filename could not be determined.");
+            return null;
+        }
 
-        return NzbStreamUtil.NormalizeFileName(fileName);
+        var normalized = NzbStreamUtil.NormalizeFileName(fileName);
+        if (normalized.Contains('/', StringComparison.Ordinal)
+            || normalized.Contains('\\', StringComparison.Ordinal)
+            || normalized.Contains('\0', StringComparison.Ordinal)
+            || normalized is "." or ".."
+            || Path.IsPathRooted(normalized))
+        {
+            errors.Add("nzbname", "NZB filename must be a single path segment.");
+            return null;
+        }
+
+        if (normalized.Length > NzbInputLimits.Default.MaxNameLength)
+        {
+            errors.Add("nzbname", "NZB filename exceeds the maximum name length.");
+            return null;
+        }
+
+        return normalized;
     }
 
     internal static QueueItem.PriorityOption MapPriorityOption(string? priority)
     {
-        return priority switch
+        if (TryMapPriorityOption(priority, out var option))
+            return option;
+        var errors = new ValidationErrors();
+        errors.Add("priority", "Invalid priority");
+        errors.ThrowIfAny();
+        return default;
+    }
+
+    internal static bool TryMapPriorityOption(string? priority, out QueueItem.PriorityOption option)
+    {
+        option = priority switch
         {
             "-100" => QueueItem.PriorityOption.Normal,
             "-3" => QueueItem.PriorityOption.Duplicate,
@@ -83,13 +131,24 @@ public class AddFileRequest()
             "1" => QueueItem.PriorityOption.High,
             "2" => QueueItem.PriorityOption.Force,
             null => QueueItem.PriorityOption.Normal,
-            _ => throw new BadHttpRequestException("Invalid priority")
+            _ => (QueueItem.PriorityOption)int.MinValue,
         };
+        return option != (QueueItem.PriorityOption)int.MinValue;
     }
 
     protected static QueueItem.PostProcessingOption MapPostProcessingOption(string? postProcessing)
     {
-        return postProcessing switch
+        if (TryMapPostProcessingOption(postProcessing, out var option))
+            return option;
+        var errors = new ValidationErrors();
+        errors.Add("pp", "Invalid pp param");
+        errors.ThrowIfAny();
+        return default;
+    }
+
+    internal static bool TryMapPostProcessingOption(string? postProcessing, out QueueItem.PostProcessingOption option)
+    {
+        option = postProcessing switch
         {
             "-1" => QueueItem.PostProcessingOption.None,
             "0" => QueueItem.PostProcessingOption.None,
@@ -97,7 +156,8 @@ public class AddFileRequest()
             "2" => QueueItem.PostProcessingOption.RepairUnpack,
             "3" => QueueItem.PostProcessingOption.RepairUnpackDelete,
             null => QueueItem.PostProcessingOption.None,
-            _ => throw new BadHttpRequestException("Invalid pp param")
+            _ => (QueueItem.PostProcessingOption)int.MinValue,
         };
+        return option != (QueueItem.PostProcessingOption)int.MinValue;
     }
 }

--- a/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Api.SabControllers.AddFile;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
@@ -21,7 +22,22 @@ public class AddUrlRequest() : AddFileRequest
 
     public static async Task<AddUrlRequest> New(HttpContext context, ConfigManager configManager, IndexerHitTracker hitTracker)
     {
+        var errors = new ValidationErrors();
         var nzbUrl = context.GetRequestParam("name");
+        if (string.IsNullOrWhiteSpace(nzbUrl))
+            errors.Add("name", "The nzb url is required.");
+        else if (!Uri.TryCreate(nzbUrl, UriKind.Absolute, out var requestUri)
+                 || (requestUri.Scheme != Uri.UriSchemeHttp && requestUri.Scheme != Uri.UriSchemeHttps))
+        {
+            errors.Add("name", "The nzb url must be an absolute HTTP or HTTPS URL.");
+        }
+
+        if (!AddFileRequest.TryMapPriorityOption(context.GetRequestParam("priority"), out _))
+            errors.Add("priority", "Invalid priority");
+        if (!AddFileRequest.TryMapPostProcessingOption(context.GetRequestParam("pp"), out _))
+            errors.Add("pp", "Invalid pp param");
+        errors.ThrowIfAny();
+
         var nzbName = context.GetRequestParam("nzbname");
         var indexerConfig = configManager.GetIndexerConfig();
         var matchedIndexer = MatchIndexerByHost(nzbUrl, indexerConfig);

--- a/backend/Api/SabControllers/GetHistory/GetHistoryRequest.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Extensions;
@@ -22,6 +23,7 @@ public class GetHistoryRequest
 
     public GetHistoryRequest(HttpContext context, ConfigManager configManager)
     {
+        var errors = new ValidationErrors();
         var startParam = context.GetRequestParam("start");
         var limitParam = context.GetRequestParam("limit");
         var pageSizeParam = context.GetRequestParam("pageSize");
@@ -39,9 +41,8 @@ public class GetHistoryRequest
 
         if (startParam is not null)
         {
-            var isValidStartParam = int.TryParse(startParam, out int start);
-            if (!isValidStartParam) throw new BadHttpRequestException("Invalid start parameter");
-            Start = Math.Max(0, start);
+            if (errors.TryParseInt("start", startParam, "Invalid start parameter", out var start))
+                Start = Math.Max(0, start);
         }
 
         // The official Sabnzbd api uses the `limit` param to specify the number of history items
@@ -55,9 +56,8 @@ public class GetHistoryRequest
         // (see GetHistoryMaxPageSize) so responses stay bounded.
         if (limitParam is not null && !configManager.IsIgnoreSabHistoryLimitEnabled())
         {
-            var isValidLimit = int.TryParse(limitParam, out var limit);
-            if (!isValidLimit) throw new BadHttpRequestException("Invalid limit parameter");
-            Limit = limit > 0 ? limit : int.MaxValue;
+            if (errors.TryParseInt("limit", limitParam, "Invalid limit parameter", out var limit))
+                Limit = limit > 0 ? limit : int.MaxValue;
         }
 
         // Even though we may want to ignore the `limit` param from the Arrs, NzbDAV frontend
@@ -66,9 +66,8 @@ public class GetHistoryRequest
         // the Sabnzbd api, and is intended to be used only by the NzbDAV frontend.
         if (pageSizeParam is not null)
         {
-            var isValidPageSize = int.TryParse(pageSizeParam, out var pageSize);
-            if (!isValidPageSize) throw new BadHttpRequestException("Invalid pageSize parameter");
-            Limit = pageSize > 0 ? pageSize : int.MaxValue;
+            if (errors.TryParseInt("pageSize", pageSizeParam, "Invalid pageSize parameter", out var pageSize))
+                Limit = pageSize > 0 ? pageSize : int.MaxValue;
         }
 
         // Server-side ceiling: keep ignore-limit semantics for Arrs but never materialize
@@ -101,11 +100,13 @@ public class GetHistoryRequest
                     bad += $", ... ({badTokens.Count - maxBadTokensShown} more)";
                 }
 
-                throw new BadHttpRequestException($"Invalid nzo_ids parameter: {bad}");
+                errors.Add("nzo_ids", $"Invalid nzo_ids parameter: {bad}");
             }
 
             NzoIds = nzoIds;
         }
+
+        errors.ThrowIfAny();
     }
 
     private static bool IsEnabled(string? value) =>

--- a/backend/Api/SabControllers/GetQueue/GetQueueRequest.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Config;
 using NzbWebDAV.Extensions;
 
@@ -18,6 +19,7 @@ public class GetQueueRequest
 
     public GetQueueRequest(HttpContext context, ConfigManager configManager)
     {
+        var errors = new ValidationErrors();
         var startParam = context.GetRequestParam("start");
         var limitParam = context.GetRequestParam("limit");
         Category = SabCategoryResolver.GetCategory(context, configManager);
@@ -29,17 +31,17 @@ public class GetQueueRequest
 
         if (startParam is not null)
         {
-            var isValidStartParam = int.TryParse(startParam, out int start);
-            if (!isValidStartParam) throw new BadHttpRequestException("Invalid start parameter");
-            Start = Math.Max(0, start);
+            if (errors.TryParseInt("start", startParam, "Invalid start parameter", out var start))
+                Start = Math.Max(0, start);
         }
 
         if (limitParam is not null)
         {
-            var isValidLimit = int.TryParse(limitParam, out int limit);
-            if (!isValidLimit) throw new BadHttpRequestException("Invalid limit parameter");
-            Limit = limit > 0 ? limit : int.MaxValue;
+            if (errors.TryParseInt("limit", limitParam, "Invalid limit parameter", out var limit))
+                Limit = limit > 0 ? limit : int.MaxValue;
         }
+
+        errors.ThrowIfAny();
     }
 
     private static string? NormalizeStatus(string? value) => value?.Trim().ToLowerInvariant() switch

--- a/backend/Api/SabControllers/MoveInQueue/MoveInQueueRequest.cs
+++ b/backend/Api/SabControllers/MoveInQueue/MoveInQueueRequest.cs
@@ -1,6 +1,5 @@
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Utils;
 
@@ -16,13 +15,16 @@ public class MoveInQueueRequest
     {
         var cancellationToken = SigtermUtil.GetCancellationToken();
         var queryIds = ParseNzoIds(httpContext);
-        var bodyIds = await NzoIdsFromRequestBody(httpContext, cancellationToken).ConfigureAwait(false);
-        var position = httpContext.GetRequestParam("value2");
+        var bodyIds = await SabJsonNzoIds.ReadAsync(httpContext, cancellationToken).ConfigureAwait(false);
+        var errors = new ValidationErrors();
+        var moveToTop = TryIsMoveToTop(httpContext.GetRequestParam("value2"), errors);
+
+        errors.ThrowIfAny();
 
         return new MoveInQueueRequest
         {
             NzoIds = queryIds.Concat(bodyIds).Distinct().ToList(),
-            MoveToTop = IsMoveToTop(position),
+            MoveToTop = moveToTop,
             CancellationToken = cancellationToken
         };
     }
@@ -33,6 +35,14 @@ public class MoveInQueueRequest
     /// </summary>
     internal static bool IsMoveToTop(string? position)
     {
+        var errors = new ValidationErrors();
+        var result = TryIsMoveToTop(position, errors);
+        errors.ThrowIfAny();
+        return result;
+    }
+
+    private static bool TryIsMoveToTop(string? position, ValidationErrors errors)
+    {
         if (string.IsNullOrWhiteSpace(position))
             return true;
 
@@ -42,8 +52,8 @@ public class MoveInQueueRequest
         if (int.TryParse(position, out var index) && index == 0)
             return true;
 
-        throw new BadHttpRequestException(
-            "Only move-to-top is supported (value2=0 or value2=top).");
+        errors.Add("value2", "Only move-to-top is supported (value2=0 or value2=top).");
+        return false;
     }
 
     private static List<Guid> ParseNzoIds(HttpContext httpContext)
@@ -59,26 +69,5 @@ public class MoveInQueueRequest
         }
 
         return ids;
-    }
-
-    private static async Task<List<Guid>> NzoIdsFromRequestBody(HttpContext httpContext, CancellationToken ct)
-    {
-        try
-        {
-            await using var stream = httpContext.Request.Body;
-            var deserialized = await JsonSerializer.DeserializeAsync<RequestBody>(stream, cancellationToken: ct)
-                .ConfigureAwait(false);
-            return deserialized?.NzoIds ?? [];
-        }
-        catch
-        {
-            return [];
-        }
-    }
-
-    private class RequestBody
-    {
-        [JsonPropertyName("nzo_ids")]
-        public List<Guid> NzoIds { get; set; } = [];
     }
 }

--- a/backend/Api/SabControllers/RemoveFromHistory/RemoveFromHistoryRequest.cs
+++ b/backend/Api/SabControllers/RemoveFromHistory/RemoveFromHistoryRequest.cs
@@ -1,6 +1,5 @@
-﻿using System.Text.Json;
-using System.Text.Json.Serialization;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.SabControllers;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Utils;
 
@@ -19,7 +18,7 @@ public class RemoveFromHistoryRequest
     {
         var cancellationToken = SigtermUtil.GetCancellationToken();
         var query = SabDeleteValueParser.Parse(httpContext, allowFailed: true);
-        var bodyIds = await NzoIdsFromRequestBody(httpContext, cancellationToken).ConfigureAwait(false);
+        var bodyIds = await SabJsonNzoIds.ReadAsync(httpContext, cancellationToken).ConfigureAwait(false);
         return new RemoveFromHistoryRequest()
         {
             NzoIds = query.NzoIds.Concat(bodyIds).Distinct().ToList(),
@@ -32,25 +31,5 @@ public class RemoveFromHistoryRequest
             DeleteCompletedFiles = httpContext.GetRequestParam("del_completed_files") == "1",
             CancellationToken = cancellationToken
         };
-    }
-
-    private static async Task<List<Guid>> NzoIdsFromRequestBody(HttpContext httpContext, CancellationToken ct)
-    {
-        try
-        {
-            await using var stream = httpContext.Request.Body;
-            var deserialized = await JsonSerializer.DeserializeAsync<RequestBody>(stream, cancellationToken: ct).ConfigureAwait(false);
-            return deserialized?.NzoIds ?? [];
-        }
-        catch
-        {
-            return [];
-        }
-    }
-
-    private class RequestBody
-    {
-        [JsonPropertyName("nzo_ids")]
-        public List<Guid> NzoIds { get; set; } = [];
     }
 }

--- a/backend/Api/SabControllers/RetryHistory/RetryHistoryRequest.cs
+++ b/backend/Api/SabControllers/RetryHistory/RetryHistoryRequest.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Api.SabControllers;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Utils;
@@ -15,7 +16,11 @@ public class RetryHistoryRequest
         var parsed = await SabNzoIdsParser.ParseAsync(httpContext, SigtermUtil.GetCancellationToken())
             .ConfigureAwait(false);
         if (parsed.NzoIds.Count == 0)
-            throw new BadHttpRequestException("Missing or invalid value (nzo_id).");
+        {
+            var errors = new ValidationErrors();
+            errors.Add("value", "Missing or invalid value (nzo_id).");
+            errors.ThrowIfAny();
+        }
 
         return new RetryHistoryRequest
         {

--- a/backend/Api/SabControllers/SabApiController.cs
+++ b/backend/Api/SabControllers/SabApiController.cs
@@ -21,6 +21,7 @@ using NzbWebDAV.Api.SabControllers.SetQueuePriority;
 using NzbWebDAV.Api.SabControllers.RetryHistory;
 using NzbWebDAV.Api.SabControllers.SpeedLimit;
 using NzbWebDAV.Api.SabControllers.SwitchQueue;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Auth;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
@@ -51,6 +52,15 @@ public class SabApiController(
         {
             var controller = GetController();
             return await controller.HandleRequest().ConfigureAwait(false);
+        }
+        catch (ApiValidationException e)
+        {
+            HttpContext.Items[ApiValidationException.HttpContextItemKey] = e;
+            return BadRequest(new SabBaseResponse()
+            {
+                Status = false,
+                Error = e.Message
+            });
         }
         catch (BadHttpRequestException e)
         {

--- a/backend/Api/SabControllers/SabJsonNzoIds.cs
+++ b/backend/Api/SabControllers/SabJsonNzoIds.cs
@@ -1,0 +1,46 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
+
+namespace NzbWebDAV.Api.SabControllers;
+
+internal static class SabJsonNzoIds
+{
+    public static async Task<List<Guid>> ReadAsync(HttpContext context, CancellationToken cancellationToken)
+    {
+        if (!IsJsonContent(context))
+            return [];
+
+        if (context.Request.ContentLength == 0)
+            return [];
+
+        try
+        {
+            var deserialized = await JsonSerializer.DeserializeAsync<RequestBody>(
+                    context.Request.Body, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+            return deserialized?.NzoIds ?? [];
+        }
+        catch (JsonException)
+        {
+            var errors = new ValidationErrors();
+            errors.Add("body", "Request body is not valid JSON.");
+            errors.ThrowIfAny();
+            return [];
+        }
+    }
+
+    private static bool IsJsonContent(HttpContext context)
+    {
+        var contentType = context.Request.ContentType;
+        return contentType is not null
+               && contentType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class RequestBody
+    {
+        [JsonPropertyName("nzo_ids")]
+        public List<Guid> NzoIds { get; set; } = [];
+    }
+}

--- a/backend/Api/SabControllers/SabNzoIdsParser.cs
+++ b/backend/Api/SabControllers/SabNzoIdsParser.cs
@@ -1,5 +1,3 @@
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
 using NzbWebDAV.Extensions;
 
@@ -27,28 +25,7 @@ internal static class SabNzoIdsParser
     internal static async Task<Result> ParseAsync(HttpContext context, CancellationToken ct)
     {
         var queryIds = ParseQuery(context);
-        var bodyIds = await ParseBodyAsync(context, ct).ConfigureAwait(false);
+        var bodyIds = await SabJsonNzoIds.ReadAsync(context, ct).ConfigureAwait(false);
         return new Result(queryIds.Concat(bodyIds).Distinct().ToList());
-    }
-
-    private static async Task<List<Guid>> ParseBodyAsync(HttpContext context, CancellationToken ct)
-    {
-        try
-        {
-            var deserialized = await JsonSerializer.DeserializeAsync<RequestBody>(
-                    context.Request.Body, cancellationToken: ct)
-                .ConfigureAwait(false);
-            return deserialized?.NzoIds ?? [];
-        }
-        catch (JsonException)
-        {
-            return [];
-        }
-    }
-
-    private class RequestBody
-    {
-        [JsonPropertyName("nzo_ids")]
-        public List<Guid> NzoIds { get; set; } = [];
     }
 }

--- a/backend/Api/SabControllers/SetQueueCategory/SetQueueCategoryRequest.cs
+++ b/backend/Api/SabControllers/SetQueueCategory/SetQueueCategoryRequest.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Api.SabControllers;
 using NzbWebDAV.Config;
 using NzbWebDAV.Extensions;
@@ -18,17 +19,17 @@ public class SetQueueCategoryRequest
             .ConfigureAwait(false);
         var category = httpContext.GetRequestParam("cat")
                        ?? httpContext.GetRequestParam("category");
+        var errors = new ValidationErrors();
         if (string.IsNullOrWhiteSpace(category))
-            throw new BadHttpRequestException("Missing cat/category param.");
-
-        var allowed = configManager.GetApiCategories();
-        if (!allowed.Contains(category, StringComparer.OrdinalIgnoreCase))
-            throw new BadHttpRequestException("Invalid category.");
+            errors.Add("cat", "Missing cat/category param.");
+        else if (!configManager.GetApiCategories().Contains(category, StringComparer.OrdinalIgnoreCase))
+            errors.Add("cat", "Invalid category.");
+        errors.ThrowIfAny();
 
         return new SetQueueCategoryRequest
         {
             NzoIds = parsed.NzoIds,
-            Category = category,
+            Category = category!,
             CancellationToken = SigtermUtil.GetCancellationToken(),
         };
     }

--- a/backend/Api/SabControllers/SpeedLimit/SpeedLimitRequest.cs
+++ b/backend/Api/SabControllers/SpeedLimit/SpeedLimitRequest.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Extensions;
 
 namespace NzbWebDAV.Api.SabControllers.SpeedLimit;
@@ -20,8 +21,13 @@ public class SpeedLimitRequest
         if (string.IsNullOrWhiteSpace(raw))
             return new SpeedLimitRequest { LimitKbps = 0 };
 
-        if (!int.TryParse(raw, out var limitKbps) || limitKbps < 0)
-            throw new BadHttpRequestException("Invalid speed limit value.");
+        var errors = new ValidationErrors();
+        if (!errors.TryParseInt("value", raw, "Invalid speed limit value.", out var limitKbps) || limitKbps < 0)
+        {
+            if (limitKbps < 0)
+                errors.Add("value", "Invalid speed limit value.");
+            errors.ThrowIfAny();
+        }
 
         return new SpeedLimitRequest { LimitKbps = limitKbps };
     }

--- a/backend/Api/SabControllers/SwitchQueue/SwitchQueueRequest.cs
+++ b/backend/Api/SabControllers/SwitchQueue/SwitchQueueRequest.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Extensions;
 
 namespace NzbWebDAV.Api.SabControllers.SwitchQueue;
@@ -11,15 +12,19 @@ public sealed class SwitchQueueRequest
 
     public static SwitchQueueRequest New(HttpContext context)
     {
+        var errors = new ValidationErrors();
         var value = context.GetRequestParam("value");
         var value2 = context.GetRequestParam("value2");
-        if (!Guid.TryParse(value, out var sourceId) || string.IsNullOrWhiteSpace(value2))
-            throw new BadHttpRequestException("Switch expects two parameters.");
+        if (!Guid.TryParse(value, out var sourceId))
+            errors.Add("value", "Switch expects a queue item id.");
+        if (string.IsNullOrWhiteSpace(value2))
+            errors.Add("value2", "Switch expects two parameters.");
+        errors.ThrowIfAny();
 
         return new SwitchQueueRequest
         {
             SourceId = sourceId,
-            Target = value2,
+            Target = value2!,
             CancellationToken = context.RequestAborted,
         };
     }

--- a/backend/Models/Nzb/NzbInputValidator.cs
+++ b/backend/Models/Nzb/NzbInputValidator.cs
@@ -1,0 +1,209 @@
+using System.Xml;
+using NzbWebDAV.Api.Errors;
+
+namespace NzbWebDAV.Models.Nzb;
+
+public static class NzbInputValidator
+{
+    private static readonly XmlReaderSettings XmlSettings = new()
+    {
+        DtdProcessing = DtdProcessing.Ignore,
+        IgnoreComments = true,
+        IgnoreProcessingInstructions = true,
+        IgnoreWhitespace = true,
+        CloseInput = false,
+    };
+
+    /// <summary>
+    /// Walks NZB XML incrementally, enforces <paramref name="limits"/>, and
+    /// returns the sum of valid segment byte counts. Does not echo message IDs
+    /// or raw XML in error text.
+    /// </summary>
+    public static long ValidateAndSumSegmentBytes(Stream stream, NzbInputLimits limits)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(limits);
+
+        if (stream.CanSeek)
+        {
+            var remaining = stream.Length - stream.Position;
+            if (remaining > limits.MaxXmlBytes)
+            {
+                Throw("nzb", "The NZB document exceeds the maximum allowed size.");
+            }
+        }
+
+        var errors = new ValidationErrors();
+        long totalBytes = 0;
+        var fileCount = 0;
+        var totalSegments = 0;
+        using var counting = new CountingStream(stream, limits.MaxXmlBytes, () =>
+        {
+            errors.Add("nzb", "The NZB document exceeds the maximum allowed size.");
+            errors.ThrowIfAny();
+        });
+        using var reader = XmlReader.Create(counting, XmlSettings);
+
+        try
+        {
+            while (reader.Read())
+            {
+                if (reader.NodeType != XmlNodeType.Element)
+                    continue;
+
+                if (reader.LocalName == "file")
+                {
+                    fileCount++;
+                    if (fileCount > limits.MaxFiles)
+                    {
+                        errors.Add("nzb", "The NZB document contains too many files.");
+                        errors.ThrowIfAny();
+                    }
+
+                    var subject = reader.GetAttribute("subject") ?? string.Empty;
+                    if (subject.Length > limits.MaxNameLength)
+                        errors.Add("nzb", "An NZB file subject exceeds the maximum name length.");
+
+                    totalBytes += ReadFileSegments(
+                        reader, limits, errors, ref totalSegments);
+                }
+            }
+        }
+        catch (XmlException)
+        {
+            errors.Add("nzb", "The NZB document is not valid XML.");
+            errors.ThrowIfAny();
+        }
+
+        errors.ThrowIfAny();
+        return totalBytes;
+    }
+
+    private static long ReadFileSegments(
+        XmlReader reader,
+        NzbInputLimits limits,
+        ValidationErrors errors,
+        ref int totalSegments)
+    {
+        long fileBytes = 0;
+        var segmentsInFile = 0;
+        var seenNumbers = new HashSet<int>();
+        if (reader.IsEmptyElement)
+            return 0;
+
+        while (true)
+        {
+            if (reader is { NodeType: XmlNodeType.EndElement, LocalName: "file" })
+                break;
+
+            if (reader is { NodeType: XmlNodeType.Element, LocalName: "segment" })
+            {
+                segmentsInFile++;
+                totalSegments++;
+                if (segmentsInFile > limits.MaxSegmentsPerFile)
+                {
+                    errors.Add("nzb", "An NZB file contains too many segments.");
+                    errors.ThrowIfAny();
+                }
+
+                if (totalSegments > limits.MaxTotalSegments)
+                {
+                    errors.Add("nzb", "The NZB document contains too many segments.");
+                    errors.ThrowIfAny();
+                }
+
+                var bytesAttr = reader.GetAttribute("bytes");
+                if (!long.TryParse(bytesAttr, out var bytes) || bytes < 0)
+                    errors.Add("nzb", "An NZB segment has an invalid byte count.");
+                else
+                    fileBytes += bytes;
+
+                var numberAttr = reader.GetAttribute("number");
+                if (numberAttr is not null)
+                {
+                    if (!int.TryParse(numberAttr, out var number) || number < 1)
+                        errors.Add("nzb", "An NZB segment has an invalid number.");
+                    else if (!seenNumbers.Add(number))
+                        errors.Add("nzb", "An NZB file contains duplicate segment numbers.");
+                }
+
+                var messageId = reader.ReadElementContentAsString().Trim();
+                if (messageId.Length == 0)
+                    errors.Add("nzb", "An NZB segment is missing a message ID.");
+                else if (messageId.Length > limits.MaxMessageIdLength)
+                    errors.Add("nzb", "An NZB segment message ID exceeds the maximum length.");
+
+                continue;
+            }
+
+            if (!reader.Read())
+                break;
+        }
+
+        return fileBytes;
+    }
+
+    private static void Throw(string field, string message)
+    {
+        var errors = new ValidationErrors();
+        errors.Add(field, message);
+        errors.ThrowIfAny();
+    }
+
+    private sealed class CountingStream(Stream inner, int maxBytes, Action onLimit) : Stream
+    {
+        public int BytesRead { get; private set; }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => inner.Position;
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = inner.Read(buffer, offset, count);
+            Add(read);
+            return read;
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            var read = await inner.ReadAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
+            Add(read);
+            return read;
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            var read = inner.Read(buffer);
+            Add(read);
+            return read;
+        }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            var read = await inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            Add(read);
+            return read;
+        }
+
+        private void Add(int read)
+        {
+            if (read <= 0) return;
+            BytesRead += read;
+            if (BytesRead > maxBytes)
+                onLimit();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/frontend/app/clients/backend-client.server.test.ts
+++ b/frontend/app/clients/backend-client.server.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import {
   backendClient,
   BackendApiError,
+  BackendContractError,
   BackendUnavailableError,
   parseBackendFailure,
+  parseBackendSuccess,
 } from "./backend-client.server";
 
 const fetchMock = vi.fn<typeof fetch>();
@@ -233,6 +236,24 @@ describe("BackendClient", () => {
 
     await expect(backendClient.getQueue(1)).rejects.toThrow(
       "Failed to get queue: bad request",
+    );
+  });
+
+  it("rejects malformed success bodies without echoing the payload", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("[1, 2, 3]", {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+
+    const error = await backendClient.isOnboarding().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(error).toBeInstanceOf(BackendContractError);
+    expect(String(error)).toContain("backend response did not match the expected contract");
+    expect(String(error)).not.toContain("[1, 2, 3]");
+    expect(() => parseBackendSuccess("Failed", [1, 2, 3], z.looseObject({}))).toThrow(
+      BackendContractError,
     );
   });
 

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import {
     toStreamTracingStatus,
     type StreamTracingStatus,
@@ -62,6 +63,30 @@ export class BackendApiError extends Error {
         super(message, options);
         this.name = "BackendApiError";
     }
+}
+
+/** Thrown when a 2xx backend body does not match the expected runtime schema. */
+export class BackendContractError extends Error {
+    public constructor(message: string, options?: ErrorOptions) {
+        super(message, options);
+        this.name = "BackendContractError";
+    }
+}
+
+const backendObject: z.ZodType<Record<string, unknown>> = z.looseObject({});
+
+export function parseBackendSuccess<T>(
+    errorPrefix: string,
+    json: unknown,
+    schema: z.ZodType<T>,
+): T {
+    const result = schema.safeParse(json);
+    if (!result.success) {
+        throw new BackendContractError(
+            `${errorPrefix}: backend response did not match the expected contract`,
+        );
+    }
+    return result.data;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -198,7 +223,12 @@ function form(...entries: [string, string | Blob, string?][]): FormData {
  * shared api key, and converts a non-2xx response into an Error whose message is
  * prefixed with `errorPrefix` and suffixed with the backend's reported error.
  */
-async function call<T = unknown>(path: string, errorPrefix: string, init?: RequestInit): Promise<T> {
+async function call<T = Record<string, unknown>>(
+    path: string,
+    errorPrefix: string,
+    init?: RequestInit,
+    schema: z.ZodType<T> = backendObject as z.ZodType<T>,
+): Promise<T> {
     let response: Response;
     try {
         response = await fetch(process.env["BACKEND_URL"] + path, {
@@ -236,9 +266,8 @@ async function call<T = unknown>(path: string, errorPrefix: string, init?: Reque
         );
     }
 
-    // The type parameter is the caller's declared contract for the backend
-    // response shape; the assertion is centralized here.
-    return (await response.json()) as T;
+    const json: unknown = await response.json();
+    return parseBackendSuccess(errorPrefix, json, schema);
 }
 
 class BackendClient {

--- a/frontend/app/routes/settings.update/route.test.ts
+++ b/frontend/app/routes/settings.update/route.test.ts
@@ -51,7 +51,16 @@ describe("settings.update route action", () => {
 
     await expect(
       action({ request } as Parameters<typeof action>[0]),
-    ).rejects.toBeInstanceOf(SyntaxError);
+    ).rejects.toThrow("Config payload is not valid JSON.");
+    expect(updateConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-string config values without updating the backend", async () => {
+    const request = configRequest(JSON.stringify({ "repair.enable": true }));
+
+    await expect(
+      action({ request } as Parameters<typeof action>[0]),
+    ).rejects.toThrow("string keys to string values");
     expect(updateConfigMock).not.toHaveBeenCalled();
   });
 

--- a/frontend/app/routes/settings.update/route.tsx
+++ b/frontend/app/routes/settings.update/route.tsx
@@ -1,22 +1,37 @@
 import type { Route } from "./+types/route";
+import { z } from "zod";
 import { backendClient, type ConfigItem } from "~/clients/backend-client.server";
 
+const configFormSchema = z.object({
+    config: z.string().min(1),
+});
+
+const configMapSchema = z.record(z.string().min(1), z.string());
+
 export async function action({ request }: Route.ActionArgs) {
-    // get the ConfigItems to update
     const formData = await request.formData();
-    const configJson = formData.get("config");
-    if (typeof configJson !== "string") throw new Error("config required");
-    // settings.update posts a JSON object mapping config names to string values (backend contract)
-    const config = JSON.parse(configJson) as Record<string, string>;
-    const configItems: ConfigItem[] = [];
-    for (const [key, value] of Object.entries<string>(config)) {
-        configItems.push({
-            configName: key,
-            configValue: value
-        })
+    const form = configFormSchema.safeParse({ config: formData.get("config") });
+    if (!form.success) {
+        throw new Error("config required");
     }
 
-    // update the config items
+    let parsedJson: unknown;
+    try {
+        parsedJson = JSON.parse(form.data.config) as unknown;
+    } catch {
+        throw new Error("Config payload is not valid JSON.");
+    }
+
+    const config = configMapSchema.safeParse(parsedJson);
+    if (!config.success) {
+        throw new Error("Config values must be a map of string keys to string values.");
+    }
+
+    const configItems: ConfigItem[] = Object.entries(config.data).map(([configName, configValue]) => ({
+        configName,
+        configValue,
+    }));
+
     await backendClient.updateConfig(configItems);
-    return { config: config }
+    return { config: config.data };
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,7 +27,8 @@
         "react-router": "~8.3.0",
         "remix-auth": "^4.2.0",
         "remix-auth-form": "^3.0.0",
-        "ws": "^8.21.3"
+        "ws": "^8.21.3",
+        "zod": "4.4.3"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -6794,7 +6795,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,8 @@
     "react-router": "~8.3.0",
     "remix-auth": "^4.2.0",
     "remix-auth-form": "^3.0.0",
-    "ws": "^8.21.3"
+    "ws": "^8.21.3",
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/tests/NzbWebDAV.Tests/Api/AddFileRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AddFileRequestTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Api.SabControllers.AddFile;
 
 namespace NzbWebDAV.Tests.Api;
@@ -36,10 +37,10 @@ public class AddFileRequestTests
     [Fact]
     public void ResolveFileName_ThrowsWhenNeitherNameIsUsable()
     {
-        var ex = Assert.Throws<BadHttpRequestException>(() => AddFileRequest.ResolveFileName(null, null));
+        var ex = Assert.Throws<ApiValidationException>(() => AddFileRequest.ResolveFileName(null, null));
         Assert.Contains("filename", ex.Message, StringComparison.OrdinalIgnoreCase);
 
-        ex = Assert.Throws<BadHttpRequestException>(() => AddFileRequest.ResolveFileName("  ", ""));
+        ex = Assert.Throws<ApiValidationException>(() => AddFileRequest.ResolveFileName("  ", ""));
         Assert.Contains("filename", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 

--- a/tests/NzbWebDAV.Tests/Api/ApiValidationHttpTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/ApiValidationHttpTests.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Controllers.UpdateConfig;
+using NzbWebDAV.Api.Errors;
+using NzbWebDAV.Tests.TestUtils;
+
+namespace NzbWebDAV.Tests.Api;
+
+[Collection(nameof(HttpIntegrationCollection))]
+public sealed class ApiValidationHttpTests
+{
+    [Fact]
+    public async Task AdminHealthHistory_InvalidQuery_ReturnsValidationProblem()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        using var client = factory.CreateAuthenticatedClient();
+        using var response = await client.GetAsync("/api/get-health-check-history?page=0");
+        using var json = await AdminProblemAssertions.AssertProblemAsync(
+            response, HttpStatusCode.BadRequest, "page");
+        Assert.Equal(
+            "https://www.infinidysk.com/problems/validation",
+            json.RootElement.GetProperty("type").GetString());
+        Assert.True(json.RootElement.TryGetProperty("errors", out var errors));
+        Assert.True(errors.TryGetProperty("page", out var pageErrors));
+        Assert.NotEmpty(pageErrors.EnumerateArray());
+    }
+
+    [Fact]
+    public async Task SabHistory_MalformedNzoIds_NestsValidationProblem()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        using var client = factory.CreateAuthenticatedClient();
+        using var response = await client.GetAsync("/api?mode=history&output=json&nzo_ids=not-a-guid");
+        using var json = await SabContractAssertions.AssertFailureAsync(
+            response, HttpStatusCode.BadRequest, "Invalid nzo_ids");
+        var problem = json.RootElement.GetProperty("problem");
+        Assert.Equal(
+            "https://www.infinidysk.com/problems/validation",
+            problem.GetProperty("type").GetString());
+        Assert.True(problem.GetProperty("errors").TryGetProperty("nzo_ids", out _));
+    }
+
+    [Fact]
+    public async Task SabMove_MalformedJsonBody_ReturnsValidationError()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        using var client = factory.CreateAuthenticatedClient();
+        using var content = new StringContent("{", Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync(
+            $"/api?mode=queue&name=move&value={Guid.NewGuid()}&value2=0",
+            content);
+        using var json = await SabContractAssertions.AssertFailureAsync(
+            response, HttpStatusCode.BadRequest, "JSON");
+        Assert.True(json.RootElement.GetProperty("problem").GetProperty("errors").TryGetProperty("body", out _));
+    }
+
+    [Fact]
+    public void UpdateConfigRequest_RejectsArrayAndOversizedNames()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.ContentType = "application/x-www-form-urlencoded";
+        context.Request.Form = new FormCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+        {
+            ["dup"] = new(["one", "two"]),
+            [new string('k', UpdateConfigRequest.MaxConfigNameLength + 1)] = "value",
+        });
+
+        var ex = Assert.Throws<ApiValidationException>(() => new UpdateConfigRequest(context));
+        Assert.True(ex.Errors.ContainsKey("dup"));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Api/GetHistoryRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetHistoryRequestTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Api.SabControllers.GetHistory;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
@@ -111,7 +112,7 @@ public class GetHistoryRequestTests
         var context = new DefaultHttpContext();
         context.Request.QueryString = new QueryString("?limit=abc");
 
-        var ex = Assert.Throws<BadHttpRequestException>(() => new GetHistoryRequest(context, config));
+        var ex = Assert.Throws<ApiValidationException>(() => new GetHistoryRequest(context, config));
         Assert.Equal("Invalid limit parameter", ex.Message);
     }
 
@@ -122,7 +123,7 @@ public class GetHistoryRequestTests
         var context = new DefaultHttpContext();
         context.Request.QueryString = new QueryString("?pageSize=abc");
 
-        var ex = Assert.Throws<BadHttpRequestException>(() => new GetHistoryRequest(context, config));
+        var ex = Assert.Throws<ApiValidationException>(() => new GetHistoryRequest(context, config));
         Assert.Equal("Invalid pageSize parameter", ex.Message);
     }
 
@@ -149,7 +150,7 @@ public class GetHistoryRequestTests
         var context = new DefaultHttpContext();
         context.Request.QueryString = new QueryString("?nzo_ids=not-a-guid");
 
-        var ex = Assert.Throws<BadHttpRequestException>(() => new GetHistoryRequest(context, config));
+        var ex = Assert.Throws<ApiValidationException>(() => new GetHistoryRequest(context, config));
         Assert.Contains("not-a-guid", ex.Message);
     }
 
@@ -161,7 +162,7 @@ public class GetHistoryRequestTests
         var context = new DefaultHttpContext();
         context.Request.QueryString = new QueryString($"?nzo_ids={validId},bad-one,also-bad");
 
-        var ex = Assert.Throws<BadHttpRequestException>(() => new GetHistoryRequest(context, config));
+        var ex = Assert.Throws<ApiValidationException>(() => new GetHistoryRequest(context, config));
         Assert.Contains("bad-one", ex.Message);
         Assert.Contains("also-bad", ex.Message);
         Assert.DoesNotContain(validId.ToString(), ex.Message);

--- a/tests/NzbWebDAV.Tests/Api/GetOverviewStatsRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetOverviewStatsRequestTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using NzbWebDAV.Api.Controllers.GetOverviewStats;
+using NzbWebDAV.Api.Errors;
 
 namespace NzbWebDAV.Tests.Api;
 
@@ -31,7 +32,7 @@ public class GetOverviewStatsRequestTests
         var context = new DefaultHttpContext();
         context.Request.QueryString = new QueryString("?sections=window,nope");
 
-        Assert.Throws<BadHttpRequestException>(() => new GetOverviewStatsRequest(context));
+        Assert.Throws<ApiValidationException>(() => new GetOverviewStatsRequest(context));
     }
 
     [Theory]

--- a/tests/NzbWebDAV.Tests/Api/GetQueueRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetQueueRequestTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Api.SabControllers.GetQueue;
 using NzbWebDAV.Config;
 
@@ -50,7 +51,7 @@ public class GetQueueRequestTests
         var context = new DefaultHttpContext();
         context.Request.QueryString = new QueryString("?limit=abc");
 
-        var ex = Assert.Throws<BadHttpRequestException>(() => new GetQueueRequest(context, new ConfigManager()));
+        var ex = Assert.Throws<ApiValidationException>(() => new GetQueueRequest(context, new ConfigManager()));
         Assert.Equal("Invalid limit parameter", ex.Message);
     }
 

--- a/tests/NzbWebDAV.Tests/Api/MoveInQueueRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/MoveInQueueRequestTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Api.SabControllers.MoveInQueue;
 
 namespace NzbWebDAV.Tests.Api;
@@ -22,7 +23,7 @@ public class MoveInQueueRequestTests
     [InlineData("-1")]
     public void IsMoveToTop_RejectsOtherPositions(string position)
     {
-        Assert.Throws<BadHttpRequestException>(() => MoveInQueueRequest.IsMoveToTop(position));
+        Assert.Throws<ApiValidationException>(() => MoveInQueueRequest.IsMoveToTop(position));
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Api/NzbInputValidatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/NzbInputValidatorTests.cs
@@ -1,0 +1,95 @@
+using System.Text;
+using NzbWebDAV.Api.Errors;
+using NzbWebDAV.Models.Nzb;
+
+namespace NzbWebDAV.Tests.Api;
+
+public class NzbInputValidatorTests
+{
+    [Fact]
+    public void AcceptsDocumentAtSegmentLimit()
+    {
+        var xml = BuildNzb(fileCount: 1, segmentsPerFile: 2);
+        using var stream = Bytes(xml);
+        var limits = new NzbInputLimits { MaxFiles = 1, MaxSegmentsPerFile = 2, MaxTotalSegments = 2 };
+
+        var bytes = NzbInputValidator.ValidateAndSumSegmentBytes(stream, limits);
+
+        Assert.Equal(30, bytes);
+    }
+
+    [Fact]
+    public void RejectsOneFilePastLimit()
+    {
+        var xml = BuildNzb(fileCount: 2, segmentsPerFile: 1);
+        using var stream = Bytes(xml);
+        var limits = new NzbInputLimits { MaxFiles = 1, MaxSegmentsPerFile = 10, MaxTotalSegments = 10 };
+
+        var ex = Assert.Throws<ApiValidationException>(
+            () => NzbInputValidator.ValidateAndSumSegmentBytes(stream, limits));
+        Assert.Contains("too many files", ex.Errors["nzb"][0], StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void RejectsOneSegmentPastPerFileLimit()
+    {
+        var xml = BuildNzb(fileCount: 1, segmentsPerFile: 2);
+        using var stream = Bytes(xml);
+        var limits = new NzbInputLimits { MaxFiles = 5, MaxSegmentsPerFile = 1, MaxTotalSegments = 10 };
+
+        var ex = Assert.Throws<ApiValidationException>(
+            () => NzbInputValidator.ValidateAndSumSegmentBytes(stream, limits));
+        Assert.Contains("too many segments", ex.Errors["nzb"][0], StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void RejectsInvalidByteCountAndDuplicateNumbers()
+    {
+        const string xml = """
+            <nzb><file subject="file"><segments>
+              <segment bytes="nope" number="1">id-one@example</segment>
+              <segment bytes="10" number="1">id-two@example</segment>
+            </segments></file></nzb>
+            """;
+        using var stream = Bytes(xml);
+
+        var ex = Assert.Throws<ApiValidationException>(
+            () => NzbInputValidator.ValidateAndSumSegmentBytes(stream, NzbInputLimits.Default));
+        Assert.Contains(ex.Errors["nzb"], message => message.Contains("byte count", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(ex.Errors["nzb"], message => message.Contains("duplicate", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void RejectsOversizedXmlWithoutEchoingContents()
+    {
+        var payload = "<nzb>" + new string('a', 64) + "</nzb>";
+        using var stream = Bytes(payload);
+        var limits = new NzbInputLimits { MaxXmlBytes = 16 };
+
+        var ex = Assert.Throws<ApiValidationException>(
+            () => NzbInputValidator.ValidateAndSumSegmentBytes(stream, limits));
+        Assert.Contains("size", ex.Errors["nzb"][0], StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("aaaa", ex.Message, StringComparison.Ordinal);
+    }
+
+    private static string BuildNzb(int fileCount, int segmentsPerFile)
+    {
+        var builder = new StringBuilder("<nzb>");
+        for (var file = 1; file <= fileCount; file++)
+        {
+            builder.Append($"<file subject=\"file-{file}\"><segments>");
+            for (var segment = 1; segment <= segmentsPerFile; segment++)
+            {
+                builder.Append(
+                    $"<segment bytes=\"15\" number=\"{segment}\">id-{file}-{segment}@example</segment>");
+            }
+
+            builder.Append("</segments></file>");
+        }
+
+        builder.Append("</nzb>");
+        return builder.ToString();
+    }
+
+    private static MemoryStream Bytes(string xml) => new(Encoding.UTF8.GetBytes(xml));
+}

--- a/tests/NzbWebDAV.Tests/Api/RetryHistoryControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/RetryHistoryControllerTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Api.SabControllers.RetryHistory;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
@@ -159,7 +160,7 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
         context.Request.QueryString = new QueryString("?value=not-a-guid");
         context.Request.Body = Stream.Null;
 
-        var ex = await Assert.ThrowsAsync<BadHttpRequestException>(() => RetryHistoryRequest.New(context));
+        var ex = await Assert.ThrowsAsync<ApiValidationException>(() => RetryHistoryRequest.New(context));
         Assert.Equal("Missing or invalid value (nzo_id).", ex.Message);
     }
 
@@ -169,7 +170,7 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
         var context = new DefaultHttpContext();
         context.Request.Body = Stream.Null;
 
-        var ex = await Assert.ThrowsAsync<BadHttpRequestException>(() => RetryHistoryRequest.New(context));
+        var ex = await Assert.ThrowsAsync<ApiValidationException>(() => RetryHistoryRequest.New(context));
         Assert.Equal("Missing or invalid value (nzo_id).", ex.Message);
     }
 

--- a/tests/NzbWebDAV.Tests/Api/SabHttpContractTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabHttpContractTests.cs
@@ -137,6 +137,6 @@ public sealed class SabHttpContractTests
             "/api?mode=addfile&output=json",
             serverErrorBody);
         await SabContractAssertions.AssertFailureAsync(
-            serverError, HttpStatusCode.InternalServerError, "internal server error");
+            serverError, HttpStatusCode.BadRequest, "nzbFile");
     }
 }

--- a/tests/NzbWebDAV.Tests/Api/SabPauseResumeTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabPauseResumeTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Api.SabControllers;
 using NzbWebDAV.Api.SabControllers.GetQueue;
 using NzbWebDAV.Api.SabControllers.Pause;
@@ -202,7 +203,7 @@ public sealed class SabPauseResumeTests : IAsyncLifetime
         var context = new DefaultHttpContext();
         context.Request.QueryString = new QueryString("?value=-5");
 
-        Assert.Throws<BadHttpRequestException>(() => SpeedLimitRequest.New(context));
+        Assert.Throws<ApiValidationException>(() => SpeedLimitRequest.New(context));
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Api/SwitchQueueRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SwitchQueueRequestTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Api.SabControllers.SwitchQueue;
 
 namespace NzbWebDAV.Tests.Api;
@@ -28,6 +29,6 @@ public class SwitchQueueRequestTests
         var context = new DefaultHttpContext();
         context.Request.QueryString = new QueryString(query);
 
-        Assert.Throws<BadHttpRequestException>(() => SwitchQueueRequest.New(context));
+        Assert.Throws<ApiValidationException>(() => SwitchQueueRequest.New(context));
     }
 }


### PR DESCRIPTION
## Summary
- SAB and admin request parsers now collect field errors in a shared `ValidationErrors` helper and throw `ApiValidationException` before queue, database, filesystem, or provider work. HTTP failures use the #858 contract: admin `application/problem+json` with per-field `errors`, SAB `status: false` plus a nested `problem`.
- NZB upload and URL ingest share one `NzbInputLimits` walker (files, segments, byte counts, duplicate numbers, message-ID length, XML size) and reject oversized or malformed documents without echoing raw NZB contents.
- The frontend settings update action and `backend-client` success path use pinned Zod so non-string config maps and non-object success bodies fail closed without dumping the payload.

Depends on #1067.

Fixes #851

## Out of scope (follow-up on #851)
- WebSocket envelope guards and reconnect backoff.
- Newznab / Arr / NNTP response-shape validation at the provider boundary.
- Per-route Zod schemas once #856 generates admin types.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (3424 passed, 10 skipped)
- [x] `npx vitest run app/clients/backend-client.server.test.ts app/routes/settings.update/route.test.ts` (27 passed)
- [x] `npx tsc -b`
- [x] Admin `?page=0` on health history is `application/problem+json` with `errors.page`
- [x] SAB `mode=history&nzo_ids=not-a-guid` keeps boolean `status: false` and nests `problem.errors.nzo_ids`
- [x] NZB validator accepts limit and rejects limit+1 without echoing XML
- [ ] Confirm Sonarr still posts `mode=addfile` successfully and that a missing `nzbFile` shows a field error in the admin UI