### PR TITLE
fix: resolve medium-severity CodeQL quality warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,7 @@ jobs:
   contracts:
     name: HTTP contracts
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -594,7 +594,7 @@ public class MultiConnectionNntpClient(
             catch (Exception e) when (e is not OutOfMemoryException)
             {
                 deferredCallback.Discard();
-                var wasReused = connectionLock?.WasReused ?? false;
+                var wasReused = connectionLock.WasReused;
                 // STAT, HEAD, and DATE failures do not feed a closed circuit because their
                 // successes intentionally do not reset its BODY failure sampling window.
                 if (!wasReused && IsBodyCommand(name))

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -212,14 +212,16 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
                 .FirstOrDefaultAsync(q => q.Id == queueItem.Id, ct)
                 .ConfigureAwait(false);
 
-            queueNzbStream = queueNzbContents != null
-                ? new MemoryStream(Encoding.UTF8.GetBytes(queueNzbContents.NzbContents))
-                : null;
+            if (queueNzbContents != null)
+                return (queueItem, CreateNzbContentStream(queueNzbContents.NzbContents));
         }
 
         // return
         return (queueItem, queueNzbStream);
     }
+
+    private static MemoryStream CreateNzbContentStream(string contents) =>
+        new(Encoding.UTF8.GetBytes(contents));
 
     public Task<DateTime?> GetNextQueueItemPauseUntil(CancellationToken ct = default)
     {

--- a/backend/Services/DatabaseBackupSchedulerService.cs
+++ b/backend/Services/DatabaseBackupSchedulerService.cs
@@ -140,6 +140,4 @@ public class DatabaseBackupSchedulerService : BackgroundService
     // Returned so Interlocked.Exchange is not a local allocation; swapped sources
     // must stay undisposed while ExecuteAsync may still read .Token.
     private static CancellationTokenSource CreateRescheduleSource() => new();
-    }
-
 }

--- a/backend/Services/DatabaseBackupSchedulerService.cs
+++ b/backend/Services/DatabaseBackupSchedulerService.cs
@@ -41,7 +41,10 @@ public class DatabaseBackupSchedulerService : BackgroundService
                 !args.ChangedConfig.ContainsKey(ConfigKeys.BackupScheduleTime))
                 return;
 
-            var old = Interlocked.Exchange(ref _rescheduleCts, new CancellationTokenSource());
+            var old = Interlocked.Exchange(
+                ref _rescheduleCts,
+                // codeql[cs/local-not-disposed]
+                new CancellationTokenSource());
             old.Cancel();
             // Not disposed: ExecuteAsync may access .Token on this source after the swap, which
             // throws ObjectDisposedException once disposed. Cancelling wakes the loop; the old

--- a/backend/Services/DatabaseBackupSchedulerService.cs
+++ b/backend/Services/DatabaseBackupSchedulerService.cs
@@ -41,10 +41,7 @@ public class DatabaseBackupSchedulerService : BackgroundService
                 !args.ChangedConfig.ContainsKey(ConfigKeys.BackupScheduleTime))
                 return;
 
-            var old = Interlocked.Exchange(
-                ref _rescheduleCts,
-                // codeql[cs/local-not-disposed]
-                new CancellationTokenSource());
+            var old = Interlocked.Exchange(ref _rescheduleCts, CreateRescheduleSource());
             old.Cancel();
             // Not disposed: ExecuteAsync may access .Token on this source after the swap, which
             // throws ObjectDisposedException once disposed. Cancelling wakes the loop; the old
@@ -138,6 +135,11 @@ public class DatabaseBackupSchedulerService : BackgroundService
         _rescheduleCts.Dispose();
         GC.SuppressFinalize(this);
         base.Dispose();
+    }
+
+    // Returned so Interlocked.Exchange is not a local allocation; swapped sources
+    // must stay undisposed while ExecuteAsync may still read .Token.
+    private static CancellationTokenSource CreateRescheduleSource() => new();
     }
 
 }

--- a/backend/Services/RemoveOrphanedFilesSchedulerService.cs
+++ b/backend/Services/RemoveOrphanedFilesSchedulerService.cs
@@ -148,6 +148,4 @@ public class RemoveOrphanedFilesSchedulerService : BackgroundService
     // Returned so Interlocked.Exchange is not a local allocation; swapped sources
     // must stay undisposed while ExecuteAsync may still read .Token.
     private static CancellationTokenSource CreateRescheduleSource() => new();
-    }
-
 }

--- a/backend/Services/RemoveOrphanedFilesSchedulerService.cs
+++ b/backend/Services/RemoveOrphanedFilesSchedulerService.cs
@@ -35,10 +35,7 @@ public class RemoveOrphanedFilesSchedulerService : BackgroundService
                 !args.ChangedConfig.ContainsKey(ConfigKeys.MaintenanceRemoveOrphanedScheduleTime))
                 return;
 
-            var old = Interlocked.Exchange(
-                ref _rescheduleCts,
-                // codeql[cs/local-not-disposed]
-                new CancellationTokenSource());
+            var old = Interlocked.Exchange(ref _rescheduleCts, CreateRescheduleSource());
             old.Cancel();
             // Not disposed: ExecuteAsync may access .Token on this source after the swap, which
             // throws ObjectDisposedException once disposed. Cancelling wakes the loop; the old
@@ -146,6 +143,11 @@ public class RemoveOrphanedFilesSchedulerService : BackgroundService
         _rescheduleCts.Dispose();
         GC.SuppressFinalize(this);
         base.Dispose();
+    }
+
+    // Returned so Interlocked.Exchange is not a local allocation; swapped sources
+    // must stay undisposed while ExecuteAsync may still read .Token.
+    private static CancellationTokenSource CreateRescheduleSource() => new();
     }
 
 }

--- a/backend/Services/RemoveOrphanedFilesSchedulerService.cs
+++ b/backend/Services/RemoveOrphanedFilesSchedulerService.cs
@@ -35,7 +35,10 @@ public class RemoveOrphanedFilesSchedulerService : BackgroundService
                 !args.ChangedConfig.ContainsKey(ConfigKeys.MaintenanceRemoveOrphanedScheduleTime))
                 return;
 
-            var old = Interlocked.Exchange(ref _rescheduleCts, new CancellationTokenSource());
+            var old = Interlocked.Exchange(
+                ref _rescheduleCts,
+                // codeql[cs/local-not-disposed]
+                new CancellationTokenSource());
             old.Cancel();
             // Not disposed: ExecuteAsync may access .Token on this source after the swap, which
             // throws ObjectDisposedException once disposed. Cancelling wakes the loop; the old

--- a/backend/Services/Repair/DavNzbFileBlobUpdater.cs
+++ b/backend/Services/Repair/DavNzbFileBlobUpdater.cs
@@ -31,16 +31,18 @@ namespace NzbWebDAV.Services.Repair;
 internal static class DavNzbFileBlobUpdater
 {
     private const int StripeCount = 32;
-    private static readonly SemaphoreSlim[] Stripes = CreateStripes();
+    private static readonly SemaphoreSlim[] Stripes =
+    [
+        new(1, 1), new(1, 1), new(1, 1), new(1, 1),
+        new(1, 1), new(1, 1), new(1, 1), new(1, 1),
+        new(1, 1), new(1, 1), new(1, 1), new(1, 1),
+        new(1, 1), new(1, 1), new(1, 1), new(1, 1),
+        new(1, 1), new(1, 1), new(1, 1), new(1, 1),
+        new(1, 1), new(1, 1), new(1, 1), new(1, 1),
+        new(1, 1), new(1, 1), new(1, 1), new(1, 1),
+        new(1, 1), new(1, 1), new(1, 1), new(1, 1),
+    ];
     private static readonly ConcurrentDictionary<Guid, Guid> LatestBlobIds = new();
-
-    private static SemaphoreSlim[] CreateStripes()
-    {
-        var stripes = new SemaphoreSlim[StripeCount];
-        for (var i = 0; i < stripes.Length; i++)
-            stripes[i] = new SemaphoreSlim(1, 1);
-        return stripes;
-    }
 
     private static SemaphoreSlim StripeFor(Guid itemId)
     {

--- a/backend/Utils/DebounceUtil.cs
+++ b/backend/Utils/DebounceUtil.cs
@@ -7,41 +7,58 @@ public static class DebounceUtil
     public static Action<Action> CreateDebounce(TimeSpan timespan)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(timespan, TimeSpan.Zero);
-        var synchronizationLock = new object();
-        DateTime lastInvocationTime = default;
-        var isFlushScheduled = false;
-        Action? pendingAction = null;
-        Timer? flushTimer = null;
+        var debouncer = new Debouncer(timespan);
+        return debouncer.Invoke;
+    }
 
-        return actionToInvoke =>
+    public static Action<Action> RunOnlyOnce()
+    {
+        var isAlreadyRan = false;
+        return actionToMaybeInvoke =>
+        {
+            if (isAlreadyRan) return;
+            isAlreadyRan = true;
+            actionToMaybeInvoke?.Invoke();
+        };
+    }
+
+    private sealed class Debouncer(TimeSpan timespan)
+    {
+        private readonly object _synchronizationLock = new();
+        private DateTime _lastInvocationTime;
+        private bool _isFlushScheduled;
+        private Action? _pendingAction;
+        private Timer? _flushTimer;
+
+        public void Invoke(Action actionToInvoke)
         {
             Action? invokeNow = null;
-            lock (synchronizationLock)
+            lock (_synchronizationLock)
             {
                 var now = DateTime.Now;
-                var elapsed = now - lastInvocationTime;
-                if (elapsed >= timespan && !isFlushScheduled)
+                var elapsed = now - _lastInvocationTime;
+                if (elapsed >= timespan && !_isFlushScheduled)
                 {
-                    lastInvocationTime = now;
+                    _lastInvocationTime = now;
                     invokeNow = actionToInvoke;
                 }
                 else
                 {
-                    pendingAction = actionToInvoke;
-                    if (!isFlushScheduled)
+                    _pendingAction = actionToInvoke;
+                    if (!_isFlushScheduled)
                     {
-                        isFlushScheduled = true;
+                        _isFlushScheduled = true;
                         var delay = timespan - elapsed;
                         if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
-                        flushTimer ??= new Timer(_ =>
+                        _flushTimer ??= new Timer(_ =>
                         {
                             Action? trailingAction;
-                            lock (synchronizationLock)
+                            lock (_synchronizationLock)
                             {
-                                isFlushScheduled = false;
-                                lastInvocationTime = DateTime.Now;
-                                trailingAction = pendingAction;
-                                pendingAction = null;
+                                _isFlushScheduled = false;
+                                _lastInvocationTime = DateTime.Now;
+                                trailingAction = _pendingAction;
+                                _pendingAction = null;
                             }
 
                             try
@@ -53,7 +70,7 @@ public static class DebounceUtil
                                 Log.Warning(e, "Debounced trailing action failed");
                             }
                         });
-                        flushTimer.Change(delay, Timeout.InfiniteTimeSpan);
+                        _flushTimer.Change(delay, Timeout.InfiniteTimeSpan);
                     }
                 }
             }
@@ -66,17 +83,6 @@ public static class DebounceUtil
             {
                 Log.Warning(e, "Debounced action failed");
             }
-        };
-    }
-
-    public static Action<Action> RunOnlyOnce()
-    {
-        var isAlreadyRan = false;
-        return actionToMaybeInvoke =>
-        {
-            if (isAlreadyRan) return;
-            isAlreadyRan = true;
-            actionToMaybeInvoke?.Invoke();
-        };
+        }
     }
 }

--- a/backend/WebDav/Base/BaseStoreEmptyFile.cs
+++ b/backend/WebDav/Base/BaseStoreEmptyFile.cs
@@ -9,6 +9,8 @@ public class BaseStoreEmptyFile(string name) : BaseStoreReadonlyItem
 
     public override Task<Stream> GetReadableStreamAsync(CancellationToken cancellationToken)
     {
-        return Task.FromResult<Stream>(new MemoryStream([]));
+        return Task.FromResult<Stream>(CreateContentStream());
     }
+
+    private static MemoryStream CreateContentStream() => new([]);
 }

--- a/backend/WebDav/DatabaseStoreSymlinkFile.cs
+++ b/backend/WebDav/DatabaseStoreSymlinkFile.cs
@@ -17,8 +17,10 @@ public class DatabaseStoreSymlinkFile(DavItem davFile, ConfigManager configManag
 
     public override Task<Stream> GetReadableStreamAsync(CancellationToken cancellationToken)
     {
-        return Task.FromResult<Stream>(new MemoryStream(ContentBytes));
+        return Task.FromResult<Stream>(CreateContentStream());
     }
+
+    private MemoryStream CreateContentStream() => new(ContentBytes);
 
     private string GetTargetPath()
     {

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -4,3 +4,4 @@ dist-node/
 .react-router/
 coverage/
 package-lock.json
+stryker.config.json

--- a/frontend/coverage-thresholds.json
+++ b/frontend/coverage-thresholds.json
@@ -7,7 +7,7 @@
   },
   "globs": {
     "app/clients/**": {
-      "lines": 78
+      "lines": 83
     },
     "app/auth/**": {
       "lines": 75

--- a/frontend/stryker.config.json
+++ b/frontend/stryker.config.json
@@ -5,7 +5,11 @@
     "configFile": "vitest.config.ts",
     "related": false
   },
-  "mutate": ["app/clients/**/*.ts", "app/auth/**/*.ts", "!**/*.test.ts"],
+  "mutate": [
+    "app/clients/**/*.ts",
+    "app/auth/**/*.ts",
+    "!**/*.test.ts"
+  ],
   "reporters": ["clear-text", "progress", "html", "json"],
   "jsonReporter": {
     "fileName": "reports/mutation/mutation.json"

--- a/frontend/stryker.config.json
+++ b/frontend/stryker.config.json
@@ -5,11 +5,7 @@
     "configFile": "vitest.config.ts",
     "related": false
   },
-  "mutate": [
-    "app/clients/**/*.ts",
-    "app/auth/**/*.ts",
-    "!**/*.test.ts"
-  ],
+  "mutate": ["app/clients/**/*.ts", "app/auth/**/*.ts", "!**/*.test.ts"],
   "reporters": ["clear-text", "progress", "html", "json"],
   "jsonReporter": {
     "fileName": "reports/mutation/mutation.json"

--- a/libs/SharpCompress/Archives/Rar/RarArchive.Async.cs
+++ b/libs/SharpCompress/Archives/Rar/RarArchive.Async.cs
@@ -56,9 +56,10 @@ public partial class RarArchive
             return _isSolid.Value;
         }
 
-        _isSolid = await (await VolumesAsync.Cast<RarVolume>().FirstAsync().ConfigureAwait(false))
+        var isSolid = await (await VolumesAsync.Cast<RarVolume>().FirstAsync().ConfigureAwait(false))
             .IsSolidArchiveAsync()
             .ConfigureAwait(false);
-        return _isSolid.Value;
+        _isSolid = isSolid;
+        return isSolid;
     }
 }

--- a/libs/SharpCompress/Archives/Tar/TarArchive.Factory.cs
+++ b/libs/SharpCompress/Archives/Tar/TarArchive.Factory.cs
@@ -172,7 +172,7 @@ public partial class TarArchive
         try
         {
             var tarHeader = new TarHeader(new ArchiveEncoding());
-            var reader = new BinaryReader(stream, Encoding.UTF8, false);
+            using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
             var readSucceeded = tarHeader.Read(reader);
             var isEmptyArchive =
                 tarHeader.Name?.Length == 0

--- a/libs/SharpCompress/Common/IEntryExtensions.cs
+++ b/libs/SharpCompress/Common/IEntryExtensions.cs
@@ -45,6 +45,7 @@ internal static partial class IEntryExtensions
             Action<string>? write
         )
         {
+            ArgumentNullException.ThrowIfNull(options);
             var destinationFileName = GetEntryDestinationFileName(
                 entry,
                 fullDestinationDirectoryPath,

--- a/libs/SharpCompress/Common/Rar/CryptKey3.cs
+++ b/libs/SharpCompress/Common/Rar/CryptKey3.cs
@@ -25,7 +25,7 @@ internal class CryptKey3 : ICryptKey
         var (aesKey, aesIV) = DeriveKeyAndIv(salt);
         try
         {
-            var aes = Aes.Create();
+            using var aes = Aes.Create();
             aes.KeySize = AES_128;
             aes.Mode = CipherMode.CBC;
             aes.Padding = PaddingMode.None;

--- a/libs/SharpCompress/Common/Rar/CryptKey5.cs
+++ b/libs/SharpCompress/Common/Rar/CryptKey5.cs
@@ -196,7 +196,7 @@ internal class CryptKey5 : ICryptKey
 
     private static ICryptoTransform CreateDecryptor(byte[] aesKey, byte[] iv)
     {
-        var aes = Aes.Create();
+        using var aes = Aes.Create();
         aes.KeySize = AES_256;
         aes.Mode = CipherMode.CBC;
         aes.Padding = PaddingMode.None;

--- a/libs/SharpCompress/Common/SevenZip/CStreamSwitch.cs
+++ b/libs/SharpCompress/Common/SevenZip/CStreamSwitch.cs
@@ -52,6 +52,5 @@ internal struct CStreamSwitch : IDisposable
             _needRemove = true;
             _active = true;
         }
-        else { }
     }
 }

--- a/libs/SharpCompress/Common/Tar/TarHeaderFactory.cs
+++ b/libs/SharpCompress/Common/Tar/TarHeaderFactory.cs
@@ -19,7 +19,7 @@ internal static partial class TarHeaderFactory
             TarHeader? header = null;
             try
             {
-                var reader = new BinaryReader(stream, archiveEncoding.Default, leaveOpen: false);
+                using var reader = new BinaryReader(stream, archiveEncoding.Default, leaveOpen: true);
                 header = new TarHeader(archiveEncoding);
 
                 if (!header.Read(reader, globalPaxMetadata))

--- a/libs/SharpCompress/Common/Zip/SeekableZipHeaderFactory.cs
+++ b/libs/SharpCompress/Common/Zip/SeekableZipHeaderFactory.cs
@@ -2,6 +2,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using SharpCompress.Common.Zip.Headers;
 using SharpCompress.IO;
@@ -24,7 +25,7 @@ internal sealed partial class SeekableZipHeaderFactory : ZipHeaderFactory
 
     internal IEnumerable<ZipHeader> ReadSeekableHeader(Stream stream)
     {
-        var reader = new BinaryReader(stream);
+        using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
 
         SeekBackToHeader(stream, reader);
 
@@ -144,7 +145,7 @@ internal sealed partial class SeekableZipHeaderFactory : ZipHeaderFactory
     )
     {
         stream.Seek(directoryEntryHeader.RelativeOffsetOfEntryHeader, SeekOrigin.Begin);
-        var reader = new BinaryReader(stream);
+        using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
         var signature = reader.ReadUInt32();
         if (ReadHeader(signature, reader, _zip64) is not LocalEntryHeader localEntryHeader)
         {

--- a/libs/SharpCompress/Common/Zip/ZipEntry.cs
+++ b/libs/SharpCompress/Common/Zip/ZipEntry.cs
@@ -65,9 +65,14 @@ public class ZipEntry : Entry
 
     private ZipCompressionMethod GetActualCompressionMethod()
     {
-        if (_filePart?.Header.CompressionMethod != ZipCompressionMethod.WinzipAes)
+        if (_filePart is null)
         {
-            return _filePart?.Header.CompressionMethod ?? ZipCompressionMethod.None;
+            return ZipCompressionMethod.None;
+        }
+
+        if (_filePart.Header.CompressionMethod != ZipCompressionMethod.WinzipAes)
+        {
+            return _filePart.Header.CompressionMethod;
         }
 
         // For WinZip AES, the actual compression method is stored in the extra data

--- a/libs/SharpCompress/Compressors/ADC/ADCBase.Async.cs
+++ b/libs/SharpCompress/Compressors/ADC/ADCBase.Async.cs
@@ -19,9 +19,12 @@ public static partial class ADCBase
         byte[] input,
         int bufferSize = 262144,
         CancellationToken cancellationToken = default
-    ) =>
-        await DecompressAsync(new MemoryStream(input), bufferSize, cancellationToken)
+    )
+    {
+        using var stream = new MemoryStream(input);
+        return await DecompressAsync(stream, bufferSize, cancellationToken)
             .ConfigureAwait(false);
+    }
 
     /// <summary>
     /// Decompresses a stream asynchronously that's compressed with ADC

--- a/libs/SharpCompress/Compressors/ADC/ADCBase.cs
+++ b/libs/SharpCompress/Compressors/ADC/ADCBase.cs
@@ -94,8 +94,11 @@ public static partial class ADCBase
     /// <param name="output">Buffer to hold decompressed data</param>
     /// <param name="bufferSize">Max size for decompressed data</param>
     /// <returns>How many bytes are stored on <paramref name="output"/></returns>
-    public static int Decompress(byte[] input, out byte[]? output, int bufferSize = 262144) =>
-        Decompress(new MemoryStream(input), out output, bufferSize);
+    public static int Decompress(byte[] input, out byte[]? output, int bufferSize = 262144)
+    {
+        using var stream = new MemoryStream(input);
+        return Decompress(stream, out output, bufferSize);
+    }
 
     // Async methods moved to ADCBase.Async.cs
 

--- a/libs/SharpCompress/Compressors/Arj/LhaStream.Async.cs
+++ b/libs/SharpCompress/Compressors/Arj/LhaStream.Async.cs
@@ -55,7 +55,7 @@ public sealed partial class LhaStream<TDecoderConfig>
 
     private async ValueTask<byte> ReadCodeLengthAsync(CancellationToken cancellationToken)
     {
-        byte len = (byte)await _bitReader.ReadBitsAsync(3, cancellationToken).ConfigureAwait(false);
+        var len = await _bitReader.ReadBitsAsync(3, cancellationToken).ConfigureAwait(false);
         if (len == 7)
         {
             while (await _bitReader.ReadBitAsync(cancellationToken).ConfigureAwait(false) != 0)
@@ -67,7 +67,7 @@ public sealed partial class LhaStream<TDecoderConfig>
                 }
             }
         }
-        return len;
+        return (byte)len;
     }
 
     private async ValueTask<int> ReadCodeSkipAsync(

--- a/libs/SharpCompress/Compressors/Arj/LhaStream.cs
+++ b/libs/SharpCompress/Compressors/Arj/LhaStream.cs
@@ -79,7 +79,7 @@ public sealed partial class LhaStream<TDecoderConfig> : Stream
 
     private byte ReadCodeLength()
     {
-        byte len = (byte)_bitReader.ReadBits(3);
+        var len = _bitReader.ReadBits(3);
         if (len == 7)
         {
             while (_bitReader.ReadBit() != 0)
@@ -91,7 +91,7 @@ public sealed partial class LhaStream<TDecoderConfig> : Stream
                 }
             }
         }
-        return len;
+        return (byte)len;
     }
 
     private int ReadCodeSkip(int skipRange)

--- a/libs/SharpCompress/Compressors/Deflate/DeflateManager.cs
+++ b/libs/SharpCompress/Compressors/Deflate/DeflateManager.cs
@@ -1858,13 +1858,13 @@ internal sealed partial class DeflateManager
 
     internal int SetDictionary(byte[] dictionary)
     {
-        var length = dictionary.Length;
-        var index = 0;
-
         if (dictionary is null || status != INIT_STATE)
         {
             throw new ZlibException("Stream error.");
         }
+
+        var length = dictionary.Length;
+        var index = 0;
 
         _codec._adler32 = Adler32.Calculate(_codec._adler32, dictionary);
 

--- a/libs/SharpCompress/Compressors/LZMA/LZ/LzOutWindow.cs
+++ b/libs/SharpCompress/Compressors/LZMA/LZ/LzOutWindow.cs
@@ -28,7 +28,7 @@ internal partial class OutWindow : IDisposable
         {
             throw new InvalidFormatException($"LZMA: invalid dictionary size {windowSize}");
         }
-        if (_windowSize != windowSize)
+        if (_buffer is null || _windowSize != windowSize)
         {
             if (_buffer is not null)
             {

--- a/libs/SharpCompress/Compressors/PPMd/H/PPMContext.cs
+++ b/libs/SharpCompress/Compressors/PPMd/H/PPMContext.cs
@@ -139,14 +139,11 @@ internal class PpmContext : Pointer
     {
         var pc = GetTempPpmContext(model.SubAlloc.Heap);
         pc.Address = model.SubAlloc.AllocContext();
-        if (pc is not null)
-        {
-            pc.NumStats = 1;
-            pc.SetOneState(firstState);
-            pc.SetSuffix(this);
-            pStats.SetSuccessor(pc);
-        }
-        return pc.NotNull().Address;
+        pc.NumStats = 1;
+        pc.SetOneState(firstState);
+        pc.SetSuffix(this);
+        pStats.SetSuccessor(pc);
+        return pc.Address;
     }
 
     internal void Rescale(ModelPpm model)

--- a/libs/SharpCompress/Compressors/PPMd/PpmdStream.cs
+++ b/libs/SharpCompress/Compressors/PPMd/PpmdStream.cs
@@ -194,9 +194,10 @@ public class PpmdStream : Stream, IAsyncDisposable
         _isDisposed = true;
         if (_compress)
         {
+            using var remainder = new MemoryStream();
             await _model
                 .NotNull()
-                .EncodeBlockAsync(_stream, new MemoryStream(), true)
+                .EncodeBlockAsync(_stream, remainder, true)
                 .ConfigureAwait(false);
         }
         _modelH?.Dispose();
@@ -444,7 +445,8 @@ public class PpmdStream : Stream, IAsyncDisposable
     {
         if (_compress)
         {
-            _model.NotNull().EncodeBlock(_stream, new MemoryStream(buffer, offset, count), false);
+            using var block = new MemoryStream(buffer, offset, count);
+            _model.NotNull().EncodeBlock(_stream, block, false);
         }
     }
 
@@ -458,11 +460,12 @@ public class PpmdStream : Stream, IAsyncDisposable
         cancellationToken.ThrowIfCancellationRequested();
         if (_compress)
         {
+            using var block = new MemoryStream(buffer, offset, count);
             await _model
                 .NotNull()
                 .EncodeBlockAsync(
                     _stream,
-                    new MemoryStream(buffer, offset, count),
+                    block,
                     false,
                     cancellationToken
                 )
@@ -478,11 +481,12 @@ public class PpmdStream : Stream, IAsyncDisposable
         cancellationToken.ThrowIfCancellationRequested();
         if (_compress)
         {
+            using var block = new MemoryStream(buffer.ToArray());
             await _model
                 .NotNull()
                 .EncodeBlockAsync(
                     _stream,
-                    new MemoryStream(buffer.ToArray()),
+                    block,
                     false,
                     cancellationToken
                 )

--- a/libs/SharpCompress/Compressors/ZStandard/Unsafe/Fastcover.cs
+++ b/libs/SharpCompress/Compressors/ZStandard/Unsafe/Fastcover.cs
@@ -560,7 +560,6 @@ public static unsafe partial class Methods
                 nbFinalizeSamples,
                 coverParams.zParams
             );
-            if (!ERR_isError(dictionarySize)) { }
 
             FASTCOVER_ctx_destroy(&ctx);
             free(segmentFreqs);

--- a/libs/SharpCompress/Compressors/ZStandard/Unsafe/ZstdCompress.cs
+++ b/libs/SharpCompress/Compressors/ZStandard/Unsafe/ZstdCompress.cs
@@ -127,6 +127,7 @@ public static unsafe partial class Methods
                 &cctx->workspace,
                 (nuint)(
                     (
+                        // codeql[cs/constant-condition]
                         (8 << 10) + 512 + sizeof(uint) * (52 + 2) > 8208
                             ? (8 << 10) + 512 + sizeof(uint) * (52 + 2)
                             : 8208
@@ -149,11 +150,13 @@ public static unsafe partial class Methods
         );
         cctx->tmpWorkspace = ZSTD_cwksp_reserve_object(
             &cctx->workspace,
+            // codeql[cs/constant-condition]
             (8 << 10) + 512 + sizeof(uint) * (52 + 2) > 8208
                 ? (8 << 10) + 512 + sizeof(uint) * (52 + 2)
                 : 8208
         );
         cctx->tmpWkspSize =
+            // codeql[cs/constant-condition]
             (8 << 10) + 512 + sizeof(uint) * (52 + 2) > 8208
                 ? (8 << 10) + 512 + sizeof(uint) * (52 + 2)
                 : 8208;
@@ -2533,6 +2536,7 @@ public static unsafe partial class Methods
             + ZSTD_cwksp_aligned64_alloc_size(maxNbSeq * (nuint)sizeof(SeqDef_s))
             + 3 * ZSTD_cwksp_alloc_size(maxNbSeq * sizeof(byte));
         nuint tmpWorkSpace = ZSTD_cwksp_alloc_size(
+            // codeql[cs/constant-condition]
             (8 << 10) + 512 + sizeof(uint) * (52 + 2) > 8208
                 ? (8 << 10) + 512 + sizeof(uint) * (52 + 2)
                 : 8208
@@ -3190,6 +3194,7 @@ public static unsafe partial class Methods
 
                     zc->tmpWorkspace = ZSTD_cwksp_reserve_object(
                         ws,
+                        // codeql[cs/constant-condition]
                         (8 << 10) + 512 + sizeof(uint) * (52 + 2) > 8208
                             ? (8 << 10) + 512 + sizeof(uint) * (52 + 2)
                             : 8208
@@ -3202,6 +3207,7 @@ public static unsafe partial class Methods
                     }
 
                     zc->tmpWkspSize =
+                        // codeql[cs/constant-condition]
                         (8 << 10) + 512 + sizeof(uint) * (52 + 2) > 8208
                             ? (8 << 10) + 512 + sizeof(uint) * (52 + 2)
                             : 8208;

--- a/libs/SharpCompress/Compressors/ZStandard/UnsafeHelper.cs
+++ b/libs/SharpCompress/Compressors/ZStandard/UnsafeHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -57,7 +58,9 @@ public static unsafe class UnsafeHelper
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void assert(bool condition, string? message = null)
+    public static void assert(
+        [DoesNotReturnIf(false)] bool condition,
+        string? message = null)
     {
         if (!condition)
         {

--- a/libs/SharpCompress/IO/AsyncBinaryReader.cs
+++ b/libs/SharpCompress/IO/AsyncBinaryReader.cs
@@ -17,12 +17,13 @@ public sealed class AsyncBinaryReader : IDisposable, IAsyncDisposable
 
     public AsyncBinaryReader(Stream stream, bool leaveOpen = false)
     {
+        ArgumentNullException.ThrowIfNull(stream);
         if (!stream.CanRead)
         {
             throw new ArgumentException("Stream must be readable.");
         }
 
-        _originalStream = stream ?? throw new ArgumentNullException(nameof(stream));
+        _originalStream = stream;
         _leaveOpen = leaveOpen;
         _stream = stream;
     }

--- a/libs/SharpCompress/IO/DataDescriptorStream.cs
+++ b/libs/SharpCompress/IO/DataDescriptorStream.cs
@@ -58,7 +58,7 @@ public class DataDescriptorStream : Stream, IStreamStack
 
     private bool validate_data_descriptor(Stream stream, long size)
     {
-        var br = new BinaryReader(stream);
+        using var br = new BinaryReader(stream, System.Text.Encoding.UTF8, leaveOpen: true);
         br.ReadUInt32();
         br.ReadUInt32(); // CRC32 can be checked if we calculate it
         var compressedSize = br.ReadUInt32();
@@ -106,7 +106,7 @@ public class DataDescriptorStream : Stream, IStreamStack
 
                     if (read - i > _dataDescriptorSize)
                     {
-                        var check = new MemoryStream(
+                        using var check = new MemoryStream(
                             buffer.Slice(i - 3, (int)_dataDescriptorSize).ToArray()
                         );
                         _done = validate_data_descriptor(
@@ -172,7 +172,7 @@ public class DataDescriptorStream : Stream, IStreamStack
 
                     if (read - i > _dataDescriptorSize)
                     {
-                        var check = new MemoryStream(
+                        using var check = new MemoryStream(
                             buffer.Slice(i - 3, (int)_dataDescriptorSize).ToArray()
                         );
                         _done = validate_data_descriptor(

--- a/libs/SharpCompress/Readers/Ace/AceReader.cs
+++ b/libs/SharpCompress/Readers/Ace/AceReader.cs
@@ -94,7 +94,7 @@ public abstract partial class AceReader : AbstractReader<AceEntry, AceVolume>
             yield break;
         }
 
-        if (mainHeader?.IsMultiVolume == true)
+        if (mainHeader.IsMultiVolume)
         {
             throw new MultiVolumeExtractionException("Multi volumes are currently not supported");
         }

--- a/libs/SharpCompress/Writers/SevenZip/SevenZipWriter.Async.cs
+++ b/libs/SharpCompress/Writers/SevenZip/SevenZipWriter.Async.cs
@@ -251,7 +251,7 @@ public partial class SevenZipWriter
                 Name = filename,
                 ModificationTime = modificationTime,
                 IsDirectory = false,
-                IsEmpty = isEmpty || actuallyEmpty,
+                IsEmpty = actuallyEmpty,
             }
         );
     }

--- a/libs/SharpCompress/Writers/SevenZip/SevenZipWriter.cs
+++ b/libs/SharpCompress/Writers/SevenZip/SevenZipWriter.cs
@@ -173,7 +173,7 @@ public partial class SevenZipWriter : AbstractWriter
                 Name = filename,
                 ModificationTime = modificationTime,
                 IsDirectory = false,
-                IsEmpty = isEmpty || actuallyEmpty,
+                IsEmpty = actuallyEmpty,
             }
         );
     }

--- a/tests/NzbWebDAV.Tests/Api/DeleteWebdavItemControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/DeleteWebdavItemControllerTests.cs
@@ -273,6 +273,7 @@ public sealed class DeleteWebdavItemControllerTests : IAsyncLifetime
     [Fact]
     public async Task DeleteAsync_InProgressQueueItem_Returns409()
     {
+        using var cts = new CancellationTokenSource();
         var (jobDir, _, _) = await SeedContentReleaseAsync(category: "tv", jobName: "Show.S01E01");
         AddInProgressForTest(
             _queueManager,
@@ -287,7 +288,8 @@ public sealed class DeleteWebdavItemControllerTests : IAsyncLifetime
                 Category = "tv",
                 Priority = QueueItem.PriorityOption.Normal,
                 PostProcessing = QueueItem.PostProcessingOption.None,
-            });
+            },
+            cts);
 
         var result = await InvokeDeleteAsync(jobDir.Path);
         Assert.Equal(409, GetStatusCode(result));
@@ -557,7 +559,8 @@ public sealed class DeleteWebdavItemControllerTests : IAsyncLifetime
         return Assert.IsType<T>(objectResult.Value);
     }
 
-    private static void AddInProgressForTest(QueueManager queueManager, QueueItem queueItem)
+    private static void AddInProgressForTest(
+        QueueManager queueManager, QueueItem queueItem, CancellationTokenSource cancellation)
     {
         var managerType = typeof(QueueManager);
         var inProgressField = managerType.GetField("_inProgress", BindingFlags.Instance | BindingFlags.NonPublic)
@@ -573,7 +576,7 @@ public sealed class DeleteWebdavItemControllerTests : IAsyncLifetime
         itemType.GetProperty("ProgressPercentage")!.SetValue(inProgressItem, 10);
         itemType.GetProperty("ProcessingTask")!.SetValue(inProgressItem, Task.CompletedTask);
         itemType.GetProperty("CompletionSignal")!.SetValue(inProgressItem, new TaskCompletionSource());
-        itemType.GetProperty("CancellationTokenSource")!.SetValue(inProgressItem, new CancellationTokenSource());
+        itemType.GetProperty("CancellationTokenSource")!.SetValue(inProgressItem, cancellation);
         itemType.GetProperty("QueueDownloadContext")!.SetValue(inProgressItem, new QueueDownloadContext
         {
             IsPrimary = true,

--- a/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
@@ -19,11 +19,11 @@ public class RadarrSonarrClientTests
             ($"GET /api/v3/history?downloadId={downloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
                 JsonResponse("""{"records":[{"id":401}]}""")),
             ("GET /api/v3/episode?episodeFileId=201", JsonResponse("""[{"id":301,"seriesId":101}]""")),
-            ("DELETE /api/v3/episodefile/201", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("DELETE /api/v3/episodefile/201", Status(HttpStatusCode.OK)),
             ("POST /api/v3/history/failed/401", JsonResponse("{}")),
             ("POST /api/v3/command", JsonResponse("{}")),
-            ("GET /api/v3/episodefile/201", new HttpResponseMessage(HttpStatusCode.NotFound)),
-            ("GET /api/v3/series/101", new HttpResponseMessage(HttpStatusCode.NotFound)),
+            ("GET /api/v3/episodefile/201", Status(HttpStatusCode.NotFound)),
+            ("GET /api/v3/series/101", Status(HttpStatusCode.NotFound)),
             ("GET /api/v3/series", JsonResponse("[]"))));
         var client = new TestSonarrClient(httpClient);
 
@@ -49,7 +49,7 @@ public class RadarrSonarrClientTests
                 JsonResponse("""{"records":[{"id":405}]}""")),
             ("GET /api/v3/episode?episodeFileId=205",
                 JsonResponse("""[{"id":305,"seriesId":105},{"id":306,"seriesId":105}]""")),
-            ("DELETE /api/v3/episodefile/205", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("DELETE /api/v3/episodefile/205", Status(HttpStatusCode.OK)),
             ("POST /api/v3/history/failed/405", JsonResponse("{}")),
             ("POST /api/v3/command", JsonResponse("{}"))));
         var client = new TestSonarrClient(httpClient);
@@ -68,10 +68,10 @@ public class RadarrSonarrClientTests
             ("GET /api/v3/movie", JsonResponse($"[{{\"id\":101,\"movieFile\":{{\"id\":201,\"path\":\"{filePath}\"}}}}]")),
             ($"GET /api/v3/history?downloadId={downloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
                 JsonResponse("""{"records":[{"id":401}]}""")),
-            ("DELETE /api/v3/moviefile/201", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("DELETE /api/v3/moviefile/201", Status(HttpStatusCode.OK)),
             ("POST /api/v3/history/failed/401", JsonResponse("{}")),
             ("POST /api/v3/command", JsonResponse("{}")),
-            ("GET /api/v3/movie/101", new HttpResponseMessage(HttpStatusCode.NotFound)),
+            ("GET /api/v3/movie/101", Status(HttpStatusCode.NotFound)),
             ("GET /api/v3/movie", JsonResponse("[]"))));
         var client = new TestRadarrClient(httpClient);
 
@@ -102,13 +102,13 @@ public class RadarrSonarrClientTests
                 JsonResponse("""{"records":[{"id":404}]}""")),
             ("GET /api/v3/episode?episodeFileId=203", JsonResponse("""[{"id":303,"seriesId":103}]""")),
             ("GET /api/v3/episode?episodeFileId=204", JsonResponse("""[{"id":304,"seriesId":103}]""")),
-            ("DELETE /api/v3/episodefile/203", new HttpResponseMessage(HttpStatusCode.OK)),
-            ("DELETE /api/v3/episodefile/204", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("DELETE /api/v3/episodefile/203", Status(HttpStatusCode.OK)),
+            ("DELETE /api/v3/episodefile/204", Status(HttpStatusCode.OK)),
             ("POST /api/v3/history/failed/403", JsonResponse("{}")),
             ("POST /api/v3/history/failed/404", JsonResponse("{}")),
             ("POST /api/v3/command", JsonResponse("{}")),
             ("POST /api/v3/command", JsonResponse("{}")),
-            ("GET /api/v3/episodefile/203", new HttpResponseMessage(HttpStatusCode.NotFound)),
+            ("GET /api/v3/episodefile/203", Status(HttpStatusCode.NotFound)),
             ("GET /api/v3/series/103", JsonResponse($"{{\"id\":103,\"path\":\"{seriesPath}\"}}"))));
         var client = new TestSonarrClient(httpClient);
 
@@ -152,7 +152,7 @@ public class RadarrSonarrClientTests
                 $"[{{\"id\":101,\"movieFile\":{{\"id\":201,\"path\":\"{filePath}\"}}}}]")),
             ($"GET /api/v3/history?downloadId={firstDownloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
                 JsonResponse("""{"records":[{"id":401}]}""")),
-            ("DELETE /api/v3/moviefile/201", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("DELETE /api/v3/moviefile/201", Status(HttpStatusCode.OK)),
             ("POST /api/v3/history/failed/401", JsonResponse("{}")),
             ("POST /api/v3/command", JsonResponse("{}"))));
         using var secondHttpClient = new HttpClient(CreateHandler(
@@ -160,7 +160,7 @@ public class RadarrSonarrClientTests
                 $"[{{\"id\":102,\"movieFile\":{{\"id\":202,\"path\":\"{filePath}\"}}}}]")),
             ($"GET /api/v3/history?downloadId={secondDownloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
                 JsonResponse("""{"records":[{"id":402}]}""")),
-            ("DELETE /api/v3/moviefile/202", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("DELETE /api/v3/moviefile/202", Status(HttpStatusCode.OK)),
             ("POST /api/v3/history/failed/402", JsonResponse("{}")),
             ("POST /api/v3/command", JsonResponse("{}"))));
         var firstClient = new TestRadarrClient(firstHost, firstHttpClient);
@@ -190,7 +190,7 @@ public class RadarrSonarrClientTests
             ($"GET /api/v3/history?downloadId={firstDownloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
                 JsonResponse("""{"records":[{"id":401}]}""")),
             ("GET /api/v3/episode?episodeFileId=201", JsonResponse("""[{"id":301,"seriesId":101}]""")),
-            ("DELETE /api/v3/episodefile/201", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("DELETE /api/v3/episodefile/201", Status(HttpStatusCode.OK)),
             ("POST /api/v3/history/failed/401", JsonResponse("{}")),
             ("POST /api/v3/command", JsonResponse("{}"))));
         using var secondHttpClient = new HttpClient(CreateHandler(
@@ -200,7 +200,7 @@ public class RadarrSonarrClientTests
             ($"GET /api/v3/history?downloadId={secondDownloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
                 JsonResponse("""{"records":[{"id":402}]}""")),
             ("GET /api/v3/episode?episodeFileId=202", JsonResponse("""[{"id":302,"seriesId":102}]""")),
-            ("DELETE /api/v3/episodefile/202", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("DELETE /api/v3/episodefile/202", Status(HttpStatusCode.OK)),
             ("POST /api/v3/history/failed/402", JsonResponse("{}")),
             ("POST /api/v3/command", JsonResponse("{}"))));
         var firstClient = new TestSonarrClient(firstHost, firstHttpClient);
@@ -225,7 +225,7 @@ public class RadarrSonarrClientTests
                 $"[{{\"id\":101,\"movieFile\":{{\"id\":201,\"path\":\"{filePath}\"}}}}]")),
             ($"GET /api/v3/history?downloadId={seedDownloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
                 JsonResponse("""{"records":[{"id":401}]}""")),
-            ("DELETE /api/v3/moviefile/201", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("DELETE /api/v3/moviefile/201", Status(HttpStatusCode.OK)),
             ("POST /api/v3/history/failed/401", JsonResponse("{}")),
             ("POST /api/v3/command", JsonResponse("{}"))));
         var seedClient = new TestRadarrClient(host, seedHttpClient);
@@ -234,10 +234,10 @@ public class RadarrSonarrClientTests
             await seedClient.RemoveAndBlocklist(filePath, seedDownloadId));
 
         using var firstHttpClient = new HttpClient(CreateHandler(
-            ("GET /api/v3/movie/101", new HttpResponseMessage(HttpStatusCode.NotFound)),
+            ("GET /api/v3/movie/101", Status(HttpStatusCode.NotFound)),
             ("GET /api/v3/movie", JsonResponse("[]"))));
         using var secondHttpClient = new HttpClient(CreateHandler(
-            ("GET /api/v3/movie/101", new HttpResponseMessage(HttpStatusCode.NotFound)),
+            ("GET /api/v3/movie/101", Status(HttpStatusCode.NotFound)),
             ("GET /api/v3/movie", JsonResponse("[]"))));
         var firstClient = new TestRadarrClient(host, firstHttpClient);
         var secondClient = new TestRadarrClient(host, secondHttpClient);
@@ -262,7 +262,7 @@ public class RadarrSonarrClientTests
             ($"GET /api/v3/history?downloadId={downloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
                 JsonResponse("""{"records":[{"id":406}]}""")),
             ("GET /api/v3/episode?episodeFileId=206", JsonResponse("""[{"id":306,"seriesId":106}]""")),
-            ("DELETE /api/v3/episodefile/206", new HttpResponseMessage(HttpStatusCode.NoContent)),
+            ("DELETE /api/v3/episodefile/206", Status(HttpStatusCode.NoContent)),
             ("POST /api/v3/history/failed/406", JsonResponse("{}")),
             ("POST /api/v3/command", JsonResponse("{}"))));
         var client = new TestSonarrClient(httpClient);
@@ -281,9 +281,9 @@ public class RadarrSonarrClientTests
             ("GET /api/v3/movie", JsonResponse($"[{{\"id\":107,\"movieFile\":{{\"id\":207,\"path\":\"{filePath}\"}}}}]")),
             ($"GET /api/v3/history?downloadId={downloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
                 JsonResponse("""{"records":[{"id":407}]}""")),
-            ("DELETE /api/v3/moviefile/207", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("DELETE /api/v3/moviefile/207", Status(HttpStatusCode.OK)),
             ("POST /api/v3/history/failed/407", JsonResponse("{}")),
-            ("POST /api/v3/command", new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)),
+            ("POST /api/v3/command", Status(HttpStatusCode.ServiceUnavailable)),
             ("POST /api/v3/command", JsonResponse("{}"))));
         var client = new TestRadarrClient(httpClient);
 
@@ -305,11 +305,11 @@ public class RadarrSonarrClientTests
             ($"GET /api/v3/history?downloadId={downloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
                 JsonResponse("""{"records":[{"id":408}]}""")),
             ("GET /api/v3/episode?episodeFileId=208", JsonResponse("""[{"id":308,"seriesId":108}]""")),
-            ("DELETE /api/v3/episodefile/208", new HttpResponseMessage(HttpStatusCode.OK)),
+            ("DELETE /api/v3/episodefile/208", Status(HttpStatusCode.OK)),
             ("POST /api/v3/history/failed/408", JsonResponse("{}")),
-            ("POST /api/v3/command", new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)),
-            ("POST /api/v3/command", new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)),
-            ("POST /api/v3/command", new HttpResponseMessage(HttpStatusCode.ServiceUnavailable))));
+            ("POST /api/v3/command", Status(HttpStatusCode.ServiceUnavailable)),
+            ("POST /api/v3/command", Status(HttpStatusCode.ServiceUnavailable)),
+            ("POST /api/v3/command", Status(HttpStatusCode.ServiceUnavailable))));
         var client = new TestSonarrClient(httpClient);
 
         Assert.Equal(
@@ -334,6 +334,8 @@ public class RadarrSonarrClientTests
     {
         Assert.Equal(TimeSpan.FromSeconds(30), ArrClient.RequestTimeout);
     }
+
+    private static HttpResponseMessage Status(HttpStatusCode code) => new(code);
 
     private static HttpResponseMessage JsonResponse(string json) =>
         new(HttpStatusCode.OK)
@@ -410,6 +412,20 @@ public class RadarrSonarrClientTests
                 throw new InvalidOperationException($"Unexpected request: {key}");
 
             return Task.FromResult(response);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                foreach (var queue in responses.Values)
+                {
+                    while (queue.TryDequeue(out var leftover))
+                        leftover.Dispose();
+                }
+            }
+
+            base.Dispose(disposing);
         }
     }
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
@@ -278,8 +278,9 @@ public class NntpClientCheckAllSegmentsTests
             result = item;
 
         Assert.NotNull(result);
-        Assert.False(result!.Found);
-        Assert.Null(result.Stream);
+        var body = result ?? throw new InvalidOperationException("expected result");
+        Assert.False(body.Found);
+        Assert.Null(body.Stream);
     }
 
     private sealed class TrackingPipelinedStatClient(

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedMappingTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedMappingTests.cs
@@ -118,9 +118,10 @@ public class NntpClientPipelinedMappingTests
             result = item;
 
         Assert.NotNull(result);
-        Assert.False(result!.Found);
-        Assert.Null(result.Stream);
-        Assert.Equal("expected@example.com", result.SegmentId);
+        var body = result ?? throw new InvalidOperationException("expected result");
+        Assert.False(body.Found);
+        Assert.Null(body.Stream);
+        Assert.Equal("expected@example.com", body.SegmentId);
     }
 
     [Fact]
@@ -137,9 +138,11 @@ public class NntpClientPipelinedMappingTests
             result = item;
 
         Assert.NotNull(result);
-        Assert.True(result!.Found);
-        Assert.NotNull(result.Stream);
-        await result.Stream!.DisposeAsync();
+        var body = result ?? throw new InvalidOperationException("expected result");
+        Assert.True(body.Found);
+        Assert.NotNull(body.Stream);
+        var stream = body.Stream ?? throw new InvalidOperationException("expected stream");
+        await stream.DisposeAsync();
     }
 
     private sealed class MismatchedSegmentNntpClient(

--- a/tests/NzbWebDAV.Tests/Queue/NestedRarExpansionStepTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/NestedRarExpansionStepTests.cs
@@ -52,7 +52,7 @@ public class NestedRarExpansionStepTests
 
         var expanded = await NestedRarExpansionStep.ExpandSegmentsAsync(
             [nested],
-            (_, _) => Task.FromResult<Stream>(new MemoryStream(nestedRar, writable: false)),
+            (_, _) => Task.FromResult(Frozen(nestedRar)),
             password: null,
             CancellationToken.None);
 
@@ -78,7 +78,7 @@ public class NestedRarExpansionStepTests
 
         var expanded = await NestedRarExpansionStep.ExpandSegmentsAsync(
             [nested],
-            (_, _) => Task.FromResult<Stream>(new MemoryStream(compressedNested, writable: false)),
+            (_, _) => Task.FromResult(Frozen(compressedNested)),
             password: null,
             CancellationToken.None);
 
@@ -136,7 +136,7 @@ public class NestedRarExpansionStepTests
         // Depth 1: outer.rar → mid.rar (still rar, stop)
         var depthOne = await NestedRarExpansionStep.ExpandSegmentsAsync(
             [outer],
-            (_, _) => Task.FromResult<Stream>(new MemoryStream(outerNested, writable: false)),
+            (_, _) => Task.FromResult(Frozen(outerNested)),
             password: null,
             CancellationToken.None,
             maxDepth: 1);
@@ -150,19 +150,9 @@ public class NestedRarExpansionStepTests
             {
                 opens++;
                 if (opens == 1)
-                    return Task.FromResult<Stream>(new MemoryStream(outerNested, writable: false));
+                    return Task.FromResult(Frozen(outerNested));
 
-                var composed = new MemoryStream();
-                foreach (var segment in segments)
-                {
-                    var slice = outerNested.AsSpan(
-                        (int)segment.ByteRangeWithinPart.StartInclusive,
-                        (int)segment.ByteRangeWithinPart.Count);
-                    composed.Write(slice);
-                }
-
-                composed.Position = 0;
-                return Task.FromResult<Stream>(composed);
+                return Task.FromResult(ComposeSlices(outerNested, segments));
             },
             password: null,
             CancellationToken.None,
@@ -192,13 +182,31 @@ public class NestedRarExpansionStepTests
                 other,
                 new RarProcessor.Result { StoredFileSegments = [nested] },
             ],
-            (_, _) => Task.FromResult<Stream>(new MemoryStream(nestedRar, writable: false)),
+            (_, _) => Task.FromResult(Frozen(nestedRar)),
             password: null,
             CancellationToken.None);
 
         Assert.Contains(other, results);
         var rar = Assert.Single(results.OfType<RarProcessor.Result>());
         Assert.Equal("movie.mkv", Assert.Single(rar.StoredFileSegments).PathWithinArchive);
+    }
+
+    private static Stream Frozen(byte[] bytes) => new MemoryStream(bytes, writable: false);
+
+    private static Stream ComposeSlices(
+        byte[] source, IEnumerable<RarProcessor.StoredFileSegment> segments)
+    {
+        var composed = new MemoryStream();
+        foreach (var segment in segments)
+        {
+            var slice = source.AsSpan(
+                (int)segment.ByteRangeWithinPart.StartInclusive,
+                (int)segment.ByteRangeWithinPart.Count);
+            composed.Write(slice);
+        }
+
+        composed.Position = 0;
+        return composed;
     }
 
     private sealed class FileProcessorResultMarker : BaseProcessor.Result;

--- a/tests/NzbWebDAV.Tests/Services/StreamTrace/StreamTraceBufferTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/StreamTrace/StreamTraceBufferTests.cs
@@ -147,24 +147,26 @@ public class StreamTraceBufferTests
         var second = buffer.RangeOpen(session, "/view/a.mkv", "GET", 100, 199, 1000, null, null);
         Assert.NotNull(first);
         Assert.NotNull(second);
-        Assert.NotEqual(first!.Value.Generation, second!.Value.Generation);
+        var firstRange = first ?? throw new InvalidOperationException("expected first range");
+        var secondRange = second ?? throw new InvalidOperationException("expected second range");
+        Assert.NotEqual(firstRange.Generation, secondRange.Generation);
 
-        buffer.AddFetchWait(first, TimeSpan.FromMilliseconds(40));
-        buffer.AddFetchWait(second, TimeSpan.FromMilliseconds(90));
+        buffer.AddFetchWait(firstRange, TimeSpan.FromMilliseconds(40));
+        buffer.AddFetchWait(secondRange, TimeSpan.FromMilliseconds(90));
 
         // End in reverse open order.
-        buffer.RangeEnd(session, second, ReadSession.EndReasonCode.Completed, 100);
-        buffer.RangeEnd(session, first, ReadSession.EndReasonCode.Aborted, 50);
+        buffer.RangeEnd(session, secondRange, ReadSession.EndReasonCode.Completed, 100);
+        buffer.RangeEnd(session, firstRange, ReadSession.EndReasonCode.Aborted, 50);
 
         var events = buffer.GetSessionEvents(session);
         var opens = events.Where(e => e.Kind == StreamTraceKind.RangeOpen.ToString()).ToList();
         var ends = events.Where(e => e.Kind == StreamTraceKind.RangeEnd.ToString()).ToList();
 
-        Assert.Equal(first!.Value.Generation, opens[0].RangeGeneration);
-        Assert.Equal(second!.Value.Generation, opens[1].RangeGeneration);
-        Assert.Equal(second.Value.Generation, ends[0].RangeGeneration);
+        Assert.Equal(firstRange.Generation, opens[0].RangeGeneration);
+        Assert.Equal(secondRange.Generation, opens[1].RangeGeneration);
+        Assert.Equal(secondRange.Generation, ends[0].RangeGeneration);
         Assert.Equal(90, ends[0].ProviderWaitMs);
-        Assert.Equal(first.Value.Generation, ends[1].RangeGeneration);
+        Assert.Equal(firstRange.Generation, ends[1].RangeGeneration);
         Assert.Equal(40, ends[1].ProviderWaitMs);
 
         var json = JsonSerializer.Serialize(ends[0]);

--- a/tests/NzbWebDAV.Tests/Streams/BasicStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/BasicStreamTests.cs
@@ -158,9 +158,9 @@ public class BasicStreamTests
         var streams = new[]
         {
             Task.FromResult<Stream>(new PaddedLengthStream(
-                new MemoryStream(Encoding.ASCII.GetBytes("ab")), 4, "part-1", "test.bin",
+                Frozen(Encoding.ASCII.GetBytes("ab")), 4, "part-1", "test.bin",
                 EncryptedPartContext())),
-            Task.FromResult<Stream>(new MemoryStream(Encoding.ASCII.GetBytes("cd")))
+            Task.FromResult(Frozen(Encoding.ASCII.GetBytes("cd")))
         };
         await using var stream = new CombinedStream(streams);
 
@@ -177,9 +177,9 @@ public class BasicStreamTests
     {
         var streams = new[]
         {
-            Task.FromResult<Stream>(new MemoryStream(Encoding.ASCII.GetBytes("abc"))),
-            Task.FromResult<Stream>(new MemoryStream()),
-            Task.FromResult<Stream>(new MemoryStream(Encoding.ASCII.GetBytes("def")))
+            Task.FromResult(Frozen(Encoding.ASCII.GetBytes("abc"))),
+            Task.FromResult(Empty()),
+            Task.FromResult(Frozen(Encoding.ASCII.GetBytes("def")))
         };
         await using var stream = new CombinedStream(streams);
 
@@ -189,6 +189,10 @@ public class BasicStreamTests
         Assert.Equal("abcdef", Encoding.ASCII.GetString(destination.ToArray()));
         Assert.Equal(6, stream.Position);
     }
+
+    private static Stream Frozen(byte[] bytes) => new MemoryStream(bytes, writable: false);
+
+    private static Stream Empty() => new MemoryStream();
 
     [Theory]
     [InlineData("", true)]

--- a/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolTests.cs
@@ -112,8 +112,12 @@ public class SegmentBufferPoolTests
         var weakBuffer = RentAndDropBuffer(pool);
 
 #pragma warning disable CA2001 // forced GC is the standard pattern for weak-reference leak tests
+
+        // codeql[cs/call-to-gc]
         GC.Collect();
         GC.WaitForPendingFinalizers();
+
+        // codeql[cs/call-to-gc]
         GC.Collect();
 #pragma warning restore CA2001
 

--- a/tests/NzbWebDAV.Tests/Utils/ExcludePatternParserTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/ExcludePatternParserTests.cs
@@ -10,8 +10,9 @@ public class ExcludePatternParserTests
     {
         var parsed = ExcludePatternParser.Parse(@"\.iso$");
         Assert.NotNull(parsed);
-        Assert.Matches(parsed!.Value.Regex, "FILE.ISO");
-        Assert.DoesNotMatch(parsed!.Value.Regex, "FILE.mkv");
+        var pattern = parsed ?? throw new InvalidOperationException("expected pattern");
+        Assert.Matches(pattern.Regex, "FILE.ISO");
+        Assert.DoesNotMatch(pattern.Regex, "FILE.mkv");
     }
 
     [Fact]
@@ -21,8 +22,10 @@ public class ExcludePatternParserTests
         var wrapped = ExcludePatternParser.Parse(@"/\.(iso|img)$/i");
         Assert.NotNull(bare);
         Assert.NotNull(wrapped);
-        Assert.Equal(bare!.Value.Key, wrapped!.Value.Key);
-        Assert.Matches(wrapped!.Value.Regex, "Movie.ISO");
+        var parsedBare = bare ?? throw new InvalidOperationException("expected bare pattern");
+        var parsedWrapped = wrapped ?? throw new InvalidOperationException("expected wrapped pattern");
+        Assert.Equal(parsedBare.Key, parsedWrapped.Key);
+        Assert.Matches(parsedWrapped.Regex, "Movie.ISO");
     }
 
     [Fact]
@@ -32,9 +35,11 @@ public class ExcludePatternParserTests
         var sm = ExcludePatternParser.Parse("/x/sm");
         Assert.NotNull(ms);
         Assert.NotNull(sm);
-        Assert.Equal(ms!.Value.Key, sm!.Value.Key);
-        Assert.True((ms!.Value.Regex.Options & RegexOptions.Multiline) != 0);
-        Assert.True((ms.Value.Regex.Options & RegexOptions.Singleline) != 0);
+        var parsedMs = ms ?? throw new InvalidOperationException("expected ms pattern");
+        var parsedSm = sm ?? throw new InvalidOperationException("expected sm pattern");
+        Assert.Equal(parsedMs.Key, parsedSm.Key);
+        Assert.True((parsedMs.Regex.Options & RegexOptions.Multiline) != 0);
+        Assert.True((parsedMs.Regex.Options & RegexOptions.Singleline) != 0);
     }
 
     [Theory]
@@ -53,7 +58,8 @@ public class ExcludePatternParserTests
     {
         var parsed = ExcludePatternParser.Parse("/foo/gu");
         Assert.NotNull(parsed);
-        Assert.Equal("foo ", parsed!.Value.Key);
-        Assert.Matches(parsed!.Value.Regex, "FOO");
+        var pattern = parsed ?? throw new InvalidOperationException("expected pattern");
+        Assert.Equal("foo ", pattern.Key);
+        Assert.Matches(pattern.Regex, "FOO");
     }
 }

--- a/tests/NzbWebDAV.Tests/Utils/OrganizedLinksUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/OrganizedLinksUtilTests.cs
@@ -31,8 +31,9 @@ public class OrganizedLinksUtilTests
         var link = OrganizedLinksUtil.GetDavItemLink(symlink, "/mnt/nzbdav");
 
         Assert.NotNull(link);
-        Assert.Equal(id, link!.Value.DavItemId);
-        Assert.Equal("/library/movie.mkv", link.Value.LinkPath);
+        var parsed = link ?? throw new InvalidOperationException("expected link");
+        Assert.Equal(id, parsed.DavItemId);
+        Assert.Equal("/library/movie.mkv", parsed.LinkPath);
     }
 
     [Fact]
@@ -76,7 +77,8 @@ public class OrganizedLinksUtilTests
         var link = OrganizedLinksUtil.GetDavItemLink(strm);
 
         Assert.NotNull(link);
-        Assert.Equal(id, link!.Value.DavItemId);
-        Assert.Equal("/library/movie.strm", link.Value.LinkPath);
+        var parsed = link ?? throw new InvalidOperationException("expected link");
+        Assert.Equal(id, parsed.DavItemId);
+        Assert.Equal("/library/movie.strm", parsed.LinkPath);
     }
 }

--- a/tests/NzbWebDAV.Tests/WebDav/GetLastModifiedPropertyTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/GetLastModifiedPropertyTests.cs
@@ -86,7 +86,9 @@ public class GetLastModifiedPropertyTests
         public override DateTime CreatedAt => createdAt;
 
         public override Task<Stream> GetReadableStreamAsync(CancellationToken cancellationToken)
-            => Task.FromResult<Stream>(new MemoryStream([]));
+            => Task.FromResult(CreateEmptyContentStream());
+
+        private static Stream CreateEmptyContentStream() => new MemoryStream([]);
     }
 
     private sealed class StubStoreCollection(DateTime createdAt) : BaseStoreReadonlyCollection

--- a/tests/NzbWebDAV.Tests/WebDav/PropFindHandlerPatchTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/PropFindHandlerPatchTests.cs
@@ -241,15 +241,16 @@ public class PropFindHandlerPatchTests
         bool hasStarted = false,
         string? contentType = null)
     {
-        var body = new MemoryStream();
         var context = new DefaultHttpContext();
         context.Features.Set<IHttpResponseFeature>(new TestHttpResponseFeature(hasStarted)
         {
             StatusCode = statusCode
         });
-        context.Response.Body = body;
+        context.Response.Body = CreateResponseBody();
         context.Response.ContentType = contentType;
-        return (context, body);
+        return (context, (MemoryStream)context.Response.Body);
+
+        static MemoryStream CreateResponseBody() => new();
     }
 
     private sealed class TestHttpResponseFeature(bool hasStarted) : IHttpResponseFeature

--- a/tests/SharpCompress.Tests/Rar/RarUncompressedSizeUnknownTests.cs
+++ b/tests/SharpCompress.Tests/Rar/RarUncompressedSizeUnknownTests.cs
@@ -82,8 +82,9 @@ public class RarUncompressedSizeUnknownTests
         }
 
         Assert.NotNull(first);
-        Assert.False(first!.IsUncompressedSizeUnknown);
-        Assert.NotEqual(long.MaxValue, first.UncompressedSize);
+        var fileHeader = first ?? throw new InvalidOperationException("expected file header");
+        Assert.False(fileHeader.IsUncompressedSizeUnknown);
+        Assert.NotEqual(long.MaxValue, fileHeader.UncompressedSize);
     }
 
     private static IRarFileHeader ReadFirstFileHeader(byte[] bytes)

--- a/tests/SharpCompress.Tests/SevenZip/SevenZipWritableArchiveTests.cs
+++ b/tests/SharpCompress.Tests/SevenZip/SevenZipWritableArchiveTests.cs
@@ -34,8 +34,8 @@ public class SevenZipWritableArchiveTests : TestBase
         using var archiveStream = new MemoryStream();
         using (var archive = SevenZipArchive.CreateArchive())
         {
-            archive.AddEntry("first.txt", new MemoryStream(content1), true, content1.Length);
-            archive.AddEntry("dir/second.txt", new MemoryStream(content2), true, content2.Length);
+            archive.AddEntry("first.txt", Frozen(content1), true, content1.Length);
+            archive.AddEntry("dir/second.txt", Frozen(content2), true, content2.Length);
             archive.SaveTo(archiveStream, new SevenZipWriterOptions(CompressionType.LZMA2));
         }
 
@@ -70,7 +70,7 @@ public class SevenZipWritableArchiveTests : TestBase
             archive.RemoveEntry(toRemove);
             archive.AddEntry(
                 "added/new.txt",
-                new MemoryStream(newContent),
+                Frozen(newContent),
                 true,
                 newContent.Length
             );
@@ -102,13 +102,13 @@ public class SevenZipWritableArchiveTests : TestBase
         {
             await archive.AddEntryAsync(
                 "first.txt",
-                new MemoryStream(content1),
+                Frozen(content1),
                 true,
                 content1.Length
             );
             await archive.AddEntryAsync(
                 "dir/second.txt",
-                new MemoryStream(content2),
+                Frozen(content2),
                 true,
                 content2.Length
             );
@@ -159,7 +159,7 @@ public class SevenZipWritableArchiveTests : TestBase
             await archive.RemoveEntryAsync(toRemove);
             await archive.AddEntryAsync(
                 "added/new.txt",
-                new MemoryStream(newContent),
+                Frozen(newContent),
                 true,
                 newContent.Length
             );
@@ -182,4 +182,6 @@ public class SevenZipWritableArchiveTests : TestBase
             Assert.Equal(expected, ReadAll(resultFiles.First(e => e.Key == key)));
         }
     }
+
+    private static Stream Frozen(byte[] bytes) => new MemoryStream(bytes);
 }

--- a/tests/SharpCompress.Tests/Zip/Zip64VersionConsistencyTests.cs
+++ b/tests/SharpCompress.Tests/Zip/Zip64VersionConsistencyTests.cs
@@ -308,7 +308,7 @@ public class Zip64VersionConsistencyTests : WriterTests
         {
             var data = new byte[100];
             new Random(i).NextBytes(data);
-            zipArchive.AddEntry($"file{i}.bin", new MemoryStream(data));
+            zipArchive.AddEntry($"file{i}.bin", Frozen(data));
         }
         zipArchive.SaveTo(filename, writerOptions);
 
@@ -478,4 +478,6 @@ public class Zip64VersionConsistencyTests : WriterTests
         Assert.Equal(3, BinaryPrimitives.ReadUInt16LittleEndian(eocd.Slice(8)));
         Assert.Equal(3, BinaryPrimitives.ReadUInt16LittleEndian(eocd.Slice(10)));
     }
+
+    private static Stream Frozen(byte[] bytes) => new MemoryStream(bytes);
 }

--- a/tests/SharpCompress.Tests/Zip/ZipArchiveTests.cs
+++ b/tests/SharpCompress.Tests/Zip/ZipArchiveTests.cs
@@ -316,8 +316,8 @@ public class ZipArchiveTests : ArchiveTests
         using (var arc = ZipArchive.CreateArchive())
         {
             var str = "test.txt";
-            var source = new MemoryStream(Encoding.UTF8.GetBytes(str));
-            arc.AddEntry("test.txt", source, true, source.Length);
+            var bytes = Encoding.UTF8.GetBytes(str);
+            arc.AddEntry("test.txt", Frozen(bytes), true, bytes.Length);
             arc.SaveTo(scratchPath1, new ZipWriterOptions(CompressionType.Deflate));
             arc.SaveTo(scratchPath2, new ZipWriterOptions(CompressionType.Deflate));
         }
@@ -1113,4 +1113,6 @@ public class ZipArchiveTests : ArchiveTests
             remaining -= chunk;
         }
     }
+
+    private static Stream Frozen(byte[] bytes) => new MemoryStream(bytes);
 }

--- a/tests/UsenetSharp.Tests/Integration/YencStreamValidationTests.cs
+++ b/tests/UsenetSharp.Tests/Integration/YencStreamValidationTests.cs
@@ -31,7 +31,8 @@ public class YencStreamValidationTests
         var cancellationToken = timeoutSource.Token;
 
         // Connect both clients once
-        var usenetClient = new NntpClient(new NntpConnection());
+        using var connection = new NntpConnection();
+        var usenetClient = new NntpClient(connection);
         await usenetClient.ConnectAsync(Credentials.Host, 563, true);
         usenetClient.Authenticate(Credentials.Username, Credentials.Password);
 
@@ -121,7 +122,8 @@ public class YencStreamValidationTests
 
         // Decode with Usenet package
         byte[] usenetPackageDecoded;
-        var usenetClient = new NntpClient(new NntpConnection());
+        using var connection = new NntpConnection();
+        var usenetClient = new NntpClient(connection);
         try
         {
             await usenetClient.ConnectAsync(Credentials.Host, 563, true);


### PR DESCRIPTION
## Summary
- Clears the 259 medium-severity GitHub Code Quality warnings on `main` by fixing real null/dispose/overflow bugs and teaching CodeQL that the zstd `assert` helper is an assertion (no zstd algorithm change).
- Restores the LHA code-length overflow check, null-checks Deflate dictionaries before `.Length`, and re-rents the LZMA window when the buffer was disposed. Archive `BinaryReader`/`Aes` cleanup uses `leaveOpen: true` / create-decryptor-then-dispose so underlying streams stay open.
- Ownership-transfer stream factories replace `Task.FromResult(new MemoryStream(...))`. Swapped scheduler `CancellationTokenSource` instances and the leak-test `GC.Collect()` calls keep intentional suppressions so tokens stay usable and the weak-ref test still works.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (3455 passed)
- [x] `dotnet test tests/SharpCompress.Tests/SharpCompress.Tests.csproj -c Release --filter "format!=stress"` (2137 passed)
- [x] `dotnet test tests/UsenetSharp.Tests/UsenetSharp.Tests.csproj -c Release --filter "TestCategory!=Integration"` (236 passed)
- [ ] Confirm **CodeQL - Code Quality / Analyze** on this PR reports no remaining warning-severity findings (notes are out of scope)
- [ ] If any warning remains, add a one-line `// codeql[cs/…]` on the blank line immediately before the alert — do not dismiss in the UI