### PR TITLE
perf(nntp): decode yEnc body data in buffered batches

### DIFF
--- a/backend.Benchmarks/NntpDecodedBodyBenchmarks.cs
+++ b/backend.Benchmarks/NntpDecodedBodyBenchmarks.cs
@@ -1,0 +1,159 @@
+using System.IO.Pipelines;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using RapidYencSharp;
+using UsenetSharp.Clients;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Benchmarks;
+
+/// <summary>
+/// Measures the decoded NNTP BODY path used by playback: <c>NntpLineReader</c>
+/// plus <c>NntpYencBodyDecoder</c> writing into a pipe that a concurrent consumer
+/// drains. This is the controlling path for issue #1023, unlike
+/// <see cref="YencDecodeBenchmarks"/> which only exercises <c>YencStream</c>.
+/// </summary>
+[MemoryDiagnoser]
+[WarmupCount(1)]
+[IterationCount(5)]
+public class NntpDecodedBodyBenchmarks
+{
+    private byte[] _wireBody = null!;
+    private int _expectedLength;
+
+    [Params(4 * 1024 * 1024, 32 * 1024 * 1024)]
+    public int DecodedSize { get; set; }
+
+    [Params(YencCrcValidationMode.Off, YencCrcValidationMode.Require)]
+    public YencCrcValidationMode CrcValidation { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        YencEncoder.EnsureInitialized();
+        YencDecoder.EnsureInitialized();
+        Crc32.EnsureInitialized();
+
+        var payload = new byte[DecodedSize];
+        new Random(1023).NextBytes(payload);
+        var crc32 = Crc32.Compute(payload);
+
+        int? column = 0;
+        var encoded = YencEncoder.EncodeEx(payload, ref column, 128, true);
+        encoded = DotStuff(encoded);
+
+        using var output = new MemoryStream(encoded.Length + 256);
+        WriteAscii(output, $"=ybegin line=128 size={DecodedSize} name=benchmark.bin\r\n");
+        output.Write(encoded);
+        WriteAscii(output, $"\r\n=yend size={DecodedSize} crc32={crc32:x8}\r\n.\r\n");
+
+        _wireBody = output.ToArray();
+        _expectedLength = DecodedSize;
+    }
+
+    [Benchmark]
+    public async Task DecodeBody()
+    {
+        await using var source = new MemoryStream(_wireBody, writable: false);
+        using var reader = new NntpLineReader(source);
+        var pipe = new Pipe(new PipeOptions(
+            pauseWriterThreshold: 1024 * 1024,
+            resumeWriterThreshold: 512 * 1024,
+            minimumSegmentSize: 64 * 1024,
+            useSynchronizationContext: false));
+        await using var decodedStream = new DecodedBodyReadStream(
+            pipe.Reader.AsStream(), static _ => { });
+        var headers = new TaskCompletionSource<UsenetYencHeader?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var operationCts = new CancellationTokenSource();
+        using var timeout = new CoalescedReadTimeout(
+            TimeSpan.FromSeconds(30), TimeProvider.System, operationCts.Token);
+        var options = new UsenetClientOptions { CrcValidation = CrcValidation };
+        var decoder = new NntpYencBodyDecoder(
+            reader, pipe.Writer, headers, decodedStream, options, 64 * 1024);
+
+#pragma warning disable CA2025 // producer is awaited below before timeout/CTS dispose
+        var producer = ProduceAsync(decoder, pipe.Writer, timeout, operationCts.Token);
+#pragma warning restore CA2025
+        long bytesRead;
+        try
+        {
+            bytesRead = await DrainAndCountAsync(decodedStream).ConfigureAwait(false);
+        }
+        catch
+        {
+            await operationCts.CancelAsync().ConfigureAwait(false);
+            throw;
+        }
+        finally
+        {
+            await producer.ConfigureAwait(false);
+        }
+
+        if (bytesRead != _expectedLength)
+        {
+            throw new InvalidOperationException(
+                $"Decoded benchmark length changed: {bytesRead} != {_expectedLength}.");
+        }
+    }
+
+    private static async Task ProduceAsync(
+        NntpYencBodyDecoder decoder,
+        PipeWriter writer,
+        CoalescedReadTimeout timeout,
+        CancellationToken cancellationToken)
+    {
+        Exception? failure = null;
+        try
+        {
+            await decoder.ReadAsync(timeout, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            failure = exception;
+            throw;
+        }
+        finally
+        {
+            await writer.CompleteAsync(failure).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task<long> DrainAndCountAsync(Stream stream)
+    {
+        var buffer = new byte[64 * 1024];
+        long total = 0;
+        while (true)
+        {
+            var read = await stream.ReadAsync(buffer.AsMemory()).ConfigureAwait(false);
+            if (read == 0)
+            {
+                return total;
+            }
+
+            total += read;
+        }
+    }
+
+    private static byte[] DotStuff(ReadOnlySpan<byte> data)
+    {
+        using var stuffed = new MemoryStream(data.Length);
+        var atLineStart = true;
+        foreach (var value in data)
+        {
+            if (atLineStart && value == (byte)'.')
+            {
+                stuffed.WriteByte(value);
+            }
+
+            stuffed.WriteByte(value);
+            atLineStart = value == (byte)'\n';
+        }
+
+        return stuffed.ToArray();
+    }
+
+    private static void WriteAscii(Stream output, string value) =>
+        output.Write(Encoding.ASCII.GetBytes(value));
+}

--- a/backend.Benchmarks/NzbWebDAV.Benchmarks.csproj
+++ b/backend.Benchmarks/NzbWebDAV.Benchmarks.csproj
@@ -3,6 +3,8 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
     <ProjectReference Include="..\backend\NzbWebDAV.csproj" />
+    <ProjectReference Include="..\libs\UsenetSharp\UsenetSharp.csproj" />
+    <ProjectReference Include="..\libs\RapidYencSharp\RapidYencSharp.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/backend.Benchmarks/README.md
+++ b/backend.Benchmarks/README.md
@@ -15,6 +15,30 @@ dotnet run --project backend.Benchmarks -c Release
 Use the same machine and runtime when comparing BenchmarkDotNet results across
 UsenetSharp or streaming changes.
 
+## NNTP decoded BODY (`NntpDecodedBodyBenchmarks`)
+
+This measures the playback decode path in
+`UsenetSharp.Clients.NntpYencBodyDecoder`: `NntpLineReader` buffering, NNTP/yEnc
+framing, rapidyenc, optional CRC, `PipeWriter` backpressure, and a concurrent
+consumer. It does **not** include TLS, providers, archives, or WebDAV.
+
+`YencDecodeBenchmarks.DecodeYencSegment` only exercises `YencStream` and is not
+evidence for decoded BODY changes.
+
+```bash
+dotnet run --project backend.Benchmarks/NzbWebDAV.Benchmarks.csproj -c Release -- \
+  --filter "*NntpDecodedBodyBenchmarks*"
+```
+
+The corpus is a fixed-seed payload encoded with yEnc line size 128, NNTP
+dot-stuffed, with a single-part `=ybegin` / `=yend` / `.` wrapper. Parameters
+are decoded size (4 MiB and 32 MiB) and `YencCrcValidationMode` (`Off` or
+`Require`). Compare mean time, decoded MiB/s, and allocations only on the same
+machine and runtime. Timing stays manual and is not a PR gate.
+
+On macOS, set `RAPIDYENC_LIBRARY_PATH` to the host `librapidyenc.dylib` (see
+`scripts/run-backend.sh`).
+
 ## Tool decision
 
 Issue [#854](https://github.com/infinidysk/infinidysk/issues/854) asked to

--- a/libs/UsenetSharp/Clients/NntpLineReader.cs
+++ b/libs/UsenetSharp/Clients/NntpLineReader.cs
@@ -1,18 +1,45 @@
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using UsenetSharp.Exceptions;
 
 namespace UsenetSharp.Clients;
 
-internal sealed class NntpLineReader(Stream stream, int maximumLineLength = 64 * 1024) : IDisposable
+internal readonly record struct NntpReadBuffer(ReadOnlyMemory<byte> Memory);
+
+[SuppressMessage(
+    "Reliability",
+    "CA2213:Disposable fields should be disposed",
+    Justification = "NntpLineReader does not own the NNTP stream.")]
+internal sealed class NntpLineReader : IDisposable
 {
-    private const int BufferSize = 64 * 1024;
-    private readonly byte[] _buffer = ArrayPool<byte>.Shared.Rent(BufferSize);
+    private const int DefaultBufferSize = 64 * 1024;
+
+    private readonly Stream _stream;
+    private readonly int _maximumLineLength;
+    private readonly int _bufferSize;
+    private readonly byte[] _buffer;
     private byte[]? _lineBuffer;
     private int _lineBufferLength;
     private int _position;
     private int _length;
+    private int _exposedLength;
+    private bool _exposedFromLineBuffer;
     private bool _disposed;
+
+    internal NntpLineReader(
+        Stream stream,
+        int maximumLineLength = 64 * 1024,
+        int bufferSize = DefaultBufferSize)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumLineLength);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bufferSize);
+        _stream = stream;
+        _maximumLineLength = maximumLineLength;
+        _bufferSize = bufferSize;
+        _buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+    }
 
     public async ValueTask<string?> ReadLineAsync(CancellationToken cancellationToken)
     {
@@ -23,13 +50,14 @@ internal sealed class NntpLineReader(Stream stream, int maximumLineLength = 64 *
     public async ValueTask<ReadOnlyMemory<byte>?> ReadLineBytesAsync(CancellationToken cancellationToken)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
+        ThrowIfExposureActive();
 
         while (true)
         {
             if (_position >= _length)
             {
-                var bytesRead = await stream.ReadAsync(
-                        _buffer.AsMemory(0, BufferSize), cancellationToken)
+                var bytesRead = await _stream.ReadAsync(
+                        _buffer.AsMemory(0, _bufferSize), cancellationToken)
                     .ConfigureAwait(false);
                 _position = 0;
                 _length = bytesRead;
@@ -41,8 +69,7 @@ internal sealed class NntpLineReader(Stream stream, int maximumLineLength = 64 *
                     }
 
                     _lineBufferLength = 0;
-                    throw new UsenetProtocolException(
-                        "The NNTP stream ended with an unterminated line.");
+                    throw CreateUnterminatedLineException();
                 }
             }
 
@@ -50,10 +77,9 @@ internal sealed class NntpLineReader(Stream stream, int maximumLineLength = 64 *
             var newlineIndex = available.IndexOf((byte)'\n');
             var count = newlineIndex >= 0 ? newlineIndex : available.Length;
 
-            if (_lineBufferLength + count > maximumLineLength)
+            if (_lineBufferLength + count > _maximumLineLength)
             {
-                throw new UsenetProtocolException(
-                    $"NNTP response line exceeded the {maximumLineLength}-byte limit.");
+                throw CreateMaximumLineLengthException();
             }
 
             if (newlineIndex >= 0)
@@ -66,7 +92,7 @@ internal sealed class NntpLineReader(Stream stream, int maximumLineLength = 64 *
                     return TrimCarriageReturn(_buffer.AsMemory(lineStart, count));
                 }
 
-                EnsureLineBufferCapacity(_lineBufferLength + count);
+                EnsureLineBufferCapacity(_lineBufferLength + count, _maximumLineLength);
                 available[..count].CopyTo(_lineBuffer.AsSpan(_lineBufferLength));
                 var assembledLine = TrimCarriageReturn(
                     _lineBuffer.AsMemory(0, _lineBufferLength + count));
@@ -74,10 +100,171 @@ internal sealed class NntpLineReader(Stream stream, int maximumLineLength = 64 *
                 return assembledLine;
             }
 
-            EnsureLineBufferCapacity(_lineBufferLength + count);
+            EnsureLineBufferCapacity(_lineBufferLength + count, _maximumLineLength);
             available[..count].CopyTo(_lineBuffer.AsSpan(_lineBufferLength));
             _lineBufferLength += count;
             _position += count;
+        }
+    }
+
+    public async ValueTask<NntpReadBuffer?> ReadCompleteLinesAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ThrowIfExposureActive();
+
+        while (true)
+        {
+            if (_position >= _length)
+            {
+                var bytesRead = await _stream.ReadAsync(
+                        _buffer.AsMemory(0, _bufferSize), cancellationToken)
+                    .ConfigureAwait(false);
+                _position = 0;
+                _length = bytesRead;
+                if (_length == 0)
+                {
+                    if (_lineBufferLength == 0)
+                    {
+                        return null;
+                    }
+
+                    _lineBufferLength = 0;
+                    throw CreateUnterminatedLineException();
+                }
+            }
+
+            var available = _buffer.AsMemory(_position, _length - _position);
+            var availableSpan = available.Span;
+
+            if (_lineBufferLength > 0)
+            {
+                var newlineIndex = availableSpan.IndexOf((byte)'\n');
+                if (newlineIndex < 0)
+                {
+                    if (_lineBufferLength + availableSpan.Length > _maximumLineLength)
+                    {
+                        throw CreateMaximumLineLengthException();
+                    }
+
+                    EnsureLineBufferCapacity(
+                        _lineBufferLength + availableSpan.Length, _maximumLineLength);
+                    availableSpan.CopyTo(_lineBuffer.AsSpan(_lineBufferLength));
+                    _lineBufferLength += availableSpan.Length;
+                    _position += availableSpan.Length;
+                    continue;
+                }
+
+                if (_lineBufferLength + newlineIndex > _maximumLineLength)
+                {
+                    throw CreateMaximumLineLengthException();
+                }
+
+                var rawCount = newlineIndex + 1;
+                EnsureLineBufferCapacity(
+                    _lineBufferLength + rawCount, _maximumLineLength + 1);
+                availableSpan[..rawCount].CopyTo(_lineBuffer.AsSpan(_lineBufferLength));
+                _lineBufferLength += rawCount;
+                _position += rawCount;
+                _exposedLength = _lineBufferLength;
+                _exposedFromLineBuffer = true;
+                return new NntpReadBuffer(_lineBuffer.AsMemory(0, _lineBufferLength));
+            }
+
+            var lastNewline = availableSpan.LastIndexOf((byte)'\n');
+            if (lastNewline >= 0)
+            {
+                var count = lastNewline + 1;
+                _exposedLength = count;
+                _exposedFromLineBuffer = false;
+                return new NntpReadBuffer(available[..count]);
+            }
+
+            if (availableSpan.Length > _maximumLineLength)
+            {
+                throw CreateMaximumLineLengthException();
+            }
+
+            EnsureLineBufferCapacity(availableSpan.Length, _maximumLineLength);
+            availableSpan.CopyTo(_lineBuffer.AsSpan(_lineBufferLength));
+            _lineBufferLength += availableSpan.Length;
+            _position += availableSpan.Length;
+        }
+    }
+
+    public void Advance(int byteCount)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_exposedLength == 0)
+        {
+            throw new InvalidOperationException("No NNTP read buffer is active.");
+        }
+
+        if (byteCount <= 0 || byteCount > _exposedLength)
+        {
+            throw new ArgumentOutOfRangeException(nameof(byteCount));
+        }
+
+        if (GetExposedSpan()[byteCount - 1] != (byte)'\n')
+        {
+            throw new ArgumentException(
+                "NNTP input must be advanced at a complete-line boundary.",
+                nameof(byteCount));
+        }
+
+        if (_exposedFromLineBuffer)
+        {
+            if (byteCount != _exposedLength)
+            {
+                throw new ArgumentException(
+                    "An assembled NNTP line must be consumed as one unit.",
+                    nameof(byteCount));
+            }
+
+            _lineBufferLength = 0;
+        }
+        else
+        {
+            _position += byteCount;
+        }
+
+        _exposedLength = 0;
+        _exposedFromLineBuffer = false;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _exposedLength = 0;
+        _exposedFromLineBuffer = false;
+        ArrayPool<byte>.Shared.Return(_buffer);
+        if (_lineBuffer != null)
+        {
+            ArrayPool<byte>.Shared.Return(_lineBuffer);
+            _lineBuffer = null;
+        }
+    }
+
+    private ReadOnlySpan<byte> GetExposedSpan()
+    {
+        if (_exposedFromLineBuffer)
+        {
+            return _lineBuffer.AsSpan(0, _exposedLength);
+        }
+
+        return _buffer.AsSpan(_position, _exposedLength);
+    }
+
+    private void ThrowIfExposureActive()
+    {
+        if (_exposedLength != 0)
+        {
+            throw new InvalidOperationException(
+                "An NNTP read buffer is already active.");
         }
     }
 
@@ -91,36 +278,38 @@ internal sealed class NntpLineReader(Stream stream, int maximumLineLength = 64 *
         return line;
     }
 
-    private void EnsureLineBufferCapacity(int requiredLength)
+    private void EnsureLineBufferCapacity(int requiredLength, int maximumLength)
     {
+        if (requiredLength > maximumLength)
+        {
+            throw CreateMaximumLineLengthException();
+        }
+
         if (_lineBuffer is { Length: var length } && length >= requiredLength)
         {
             return;
         }
 
-        var replacement = ArrayPool<byte>.Shared.Rent(
-            Math.Min(maximumLineLength, Math.Max(requiredLength, _lineBuffer?.Length * 2 ?? BufferSize)));
+        var rentSize = Math.Min(
+            maximumLength,
+            Math.Max(requiredLength, _lineBuffer?.Length * 2 ?? _bufferSize));
+        var replacement = ArrayPool<byte>.Shared.Rent(rentSize);
         if (_lineBuffer != null)
         {
+            if (_lineBufferLength > 0)
+            {
+                _lineBuffer.AsSpan(0, _lineBufferLength).CopyTo(replacement);
+            }
+
             ArrayPool<byte>.Shared.Return(_lineBuffer);
         }
 
         _lineBuffer = replacement;
     }
 
-    public void Dispose()
-    {
-        if (_disposed)
-        {
-            return;
-        }
+    private UsenetProtocolException CreateMaximumLineLengthException() =>
+        new($"NNTP response line exceeded the {_maximumLineLength}-byte limit.");
 
-        _disposed = true;
-        ArrayPool<byte>.Shared.Return(_buffer);
-        if (_lineBuffer != null)
-        {
-            ArrayPool<byte>.Shared.Return(_lineBuffer);
-            _lineBuffer = null;
-        }
-    }
+    private static UsenetProtocolException CreateUnterminatedLineException() =>
+        new("The NNTP stream ended with an unterminated line.");
 }

--- a/libs/UsenetSharp/Clients/NntpLineReader.cs
+++ b/libs/UsenetSharp/Clients/NntpLineReader.cs
@@ -174,6 +174,11 @@ internal sealed class NntpLineReader : IDisposable
             if (lastNewline >= 0)
             {
                 var count = lastNewline + 1;
+                if (lastNewline > _maximumLineLength)
+                {
+                    ThrowIfAnyCompleteLineExceedsLimit(availableSpan[..count]);
+                }
+
                 _exposedLength = count;
                 _exposedFromLineBuffer = false;
                 return new NntpReadBuffer(available[..count]);
@@ -265,6 +270,26 @@ internal sealed class NntpLineReader : IDisposable
         {
             throw new InvalidOperationException(
                 "An NNTP read buffer is already active.");
+        }
+    }
+
+    private void ThrowIfAnyCompleteLineExceedsLimit(ReadOnlySpan<byte> completeLines)
+    {
+        var start = 0;
+        while (start < completeLines.Length)
+        {
+            var newlineIndex = completeLines[start..].IndexOf((byte)'\n');
+            if (newlineIndex < 0)
+            {
+                return;
+            }
+
+            if (newlineIndex > _maximumLineLength)
+            {
+                throw CreateMaximumLineLengthException();
+            }
+
+            start += newlineIndex + 1;
         }
     }
 

--- a/libs/UsenetSharp/Clients/NntpYencBodyDecoder.cs
+++ b/libs/UsenetSharp/Clients/NntpYencBodyDecoder.cs
@@ -1,0 +1,464 @@
+using System.Buffers;
+using System.Buffers.Text;
+using System.IO.Pipelines;
+using System.Text;
+using RapidYencSharp;
+using UsenetSharp.Exceptions;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace UsenetSharp.Clients;
+
+internal sealed class NntpYencBodyDecoder(
+    NntpLineReader reader,
+    PipeWriter writer,
+    TaskCompletionSource<UsenetYencHeader?> headersCompletion,
+    DecodedBodyReadStream decodedStream,
+    UsenetClientOptions options,
+    int flushThreshold)
+{
+    private enum BodyPhase
+    {
+        SeekingYBegin,
+        AwaitingYPartOrData,
+        DecodingData,
+        AfterYEnd
+    }
+
+    public async Task ReadAsync(
+        CoalescedReadTimeout readTimeout,
+        CancellationToken cancellationToken = default)
+    {
+        byte[]? ybeginBuffer = null;
+        byte[]? yendBuffer = null;
+        try
+        {
+            var unflushedDecodedBytes = 0;
+            var shouldWrite = true;
+            var phase = BodyPhase.SeekingYBegin;
+            var isMultipart = false;
+            long drainedBytes = 0;
+            long skippedBytes = 0;
+            var ybeginLength = 0;
+            var yendLength = 0;
+            RapidYencDecoderState? decoderState = RapidYencDecoderState.RYDEC_STATE_CRLF;
+            uint decodedCrc32 = 0;
+
+            void DecodePayload(ReadOnlySpan<byte> rawPayload)
+            {
+                if (!shouldWrite || rawPayload.IsEmpty)
+                {
+                    return;
+                }
+
+                var destination = writer.GetSpan(rawPayload.Length);
+                var decodedLength = YencDecoder.DecodeEx(
+                    rawPayload, destination, ref decoderState, isRaw: true);
+                if (options.CrcValidation != YencCrcValidationMode.Off)
+                {
+                    decodedCrc32 = Crc32.Compute(destination[..decodedLength], decodedCrc32);
+                }
+
+                decodedStream.AddBufferedBytes(decodedLength);
+                writer.Advance(decodedLength);
+                unflushedDecodedBytes += decodedLength;
+            }
+
+            async ValueTask FlushDecodedAsync()
+            {
+                if (!shouldWrite || unflushedDecodedBytes == 0)
+                {
+                    return;
+                }
+
+                var result = await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+                unflushedDecodedBytes = 0;
+                shouldWrite = !result.IsCompleted && !result.IsCanceled;
+            }
+
+            while (true)
+            {
+                NntpReadBuffer? batch;
+                try
+                {
+                    batch = await ReadCompleteLinesAsync(readTimeout).ConfigureAwait(false);
+                }
+                catch (IOException)
+                {
+                    throw new UsenetProtocolException(
+                        "The NNTP connection closed before the article body terminator was received.");
+                }
+
+                if (!batch.HasValue)
+                {
+                    throw new UsenetProtocolException(
+                        "The NNTP connection closed before the article body terminator was received.");
+                }
+
+                var span = batch.Value.Memory.Span;
+                var offset = 0;
+                var payloadStart = -1;
+                var consume = 0;
+                var hitTerminator = false;
+                var hitYEnd = false;
+
+                try
+                {
+                    while (TryReadLine(
+                        span,
+                        ref offset,
+                        out var rawStart,
+                        out var rawLength,
+                        out var contentStart,
+                        out var contentLength))
+                    {
+                        var content = span.Slice(contentStart, contentLength);
+                        if (contentLength == 1 && content[0] == (byte)'.')
+                        {
+                            if (payloadStart >= 0)
+                            {
+                                DecodePayload(span[payloadStart..rawStart]);
+                            }
+
+                            payloadStart = -1;
+                            consume = rawStart + rawLength;
+                            if (phase == BodyPhase.SeekingYBegin)
+                            {
+                                throw new InvalidDataException(
+                                    "Reached end of NNTP body without finding =ybegin header.");
+                            }
+
+                            if (phase == BodyPhase.AwaitingYPartOrData)
+                            {
+                                headersCompletion.TrySetResult(
+                                    YencStream.ParseYencHeaders(
+                                        ybeginBuffer.AsSpan(0, ybeginLength)));
+                                phase = BodyPhase.DecodingData;
+                            }
+
+                            hitTerminator = true;
+                            break;
+                        }
+
+                        if (!shouldWrite)
+                        {
+                            payloadStart = -1;
+                            drainedBytes += contentLength + 2;
+                            if (drainedBytes > options.AbandonedBodyDrainLimit)
+                            {
+                                consume = rawStart + rawLength;
+                                throw new UsenetProtocolException(
+                                    "The abandoned NNTP body exceeded the configured drain limit.");
+                            }
+
+                            consume = rawStart + rawLength;
+                            continue;
+                        }
+
+                        if (phase == BodyPhase.AfterYEnd)
+                        {
+                            skippedBytes += contentLength + 2;
+                            if (skippedBytes > options.AbandonedBodyDrainLimit)
+                            {
+                                consume = rawStart + rawLength;
+                                throw new UsenetProtocolException(
+                                    "The NNTP body contained more non-yEnc data than the configured drain limit.");
+                            }
+
+                            consume = rawStart + rawLength;
+                            continue;
+                        }
+
+                        if (phase == BodyPhase.SeekingYBegin)
+                        {
+                            if (YencStream.StartsWithYBegin(content))
+                            {
+                                ybeginBuffer = ArrayPool<byte>.Shared.Rent(contentLength);
+                                content.CopyTo(ybeginBuffer);
+                                ybeginLength = contentLength;
+                                phase = BodyPhase.AwaitingYPartOrData;
+                            }
+                            else
+                            {
+                                skippedBytes += contentLength + 2;
+                                if (skippedBytes > options.AbandonedBodyDrainLimit)
+                                {
+                                    consume = rawStart + rawLength;
+                                    throw new UsenetProtocolException(
+                                        "The NNTP body contained more non-yEnc data than the configured drain limit.");
+                                }
+                            }
+
+                            consume = rawStart + rawLength;
+                            continue;
+                        }
+
+                        if (phase == BodyPhase.AwaitingYPartOrData)
+                        {
+                            if (YencStream.StartsWithYPart(content))
+                            {
+                                consume = rawStart + rawLength;
+                                headersCompletion.TrySetResult(
+                                    YencStream.ParseYencHeaders(
+                                        ybeginBuffer.AsSpan(0, ybeginLength), content));
+                                isMultipart = true;
+                                phase = BodyPhase.DecodingData;
+                                continue;
+                            }
+
+                            consume = rawStart + rawLength;
+                            headersCompletion.TrySetResult(
+                                YencStream.ParseYencHeaders(
+                                    ybeginBuffer.AsSpan(0, ybeginLength)));
+                            phase = BodyPhase.DecodingData;
+                        }
+
+                        if (YencStream.StartsWithYEnd(content))
+                        {
+                            if (payloadStart >= 0)
+                            {
+                                DecodePayload(span[payloadStart..rawStart]);
+                            }
+
+                            payloadStart = -1;
+                            if (yendBuffer != null)
+                            {
+                                ArrayPool<byte>.Shared.Return(yendBuffer);
+                            }
+
+                            yendBuffer = ArrayPool<byte>.Shared.Rent(contentLength);
+                            content.CopyTo(yendBuffer);
+                            yendLength = contentLength;
+                            phase = BodyPhase.AfterYEnd;
+                            consume = rawStart + rawLength;
+                            hitYEnd = true;
+                            break;
+                        }
+
+                        if (payloadStart < 0)
+                        {
+                            payloadStart = rawStart;
+                        }
+
+                        consume = rawStart + rawLength;
+                    }
+
+                    if (payloadStart >= 0)
+                    {
+                        DecodePayload(span[payloadStart..consume]);
+                    }
+                }
+                catch
+                {
+                    if (consume > 0)
+                    {
+                        reader.Advance(consume);
+                    }
+
+                    throw;
+                }
+
+                if (consume > 0)
+                {
+                    reader.Advance(consume);
+                }
+
+                if (hitYEnd)
+                {
+                    await FlushDecodedAsync().ConfigureAwait(false);
+                    if (options.CrcValidation != YencCrcValidationMode.Off && shouldWrite)
+                    {
+                        ValidateDecodedBodyCrc32(
+                            yendBuffer.AsSpan(0, yendLength),
+                            isMultipart,
+                            decodedCrc32,
+                            options.CrcValidation);
+                    }
+
+                    continue;
+                }
+
+                if (unflushedDecodedBytes >= flushThreshold)
+                {
+                    await FlushDecodedAsync().ConfigureAwait(false);
+                }
+
+                if (hitTerminator)
+                {
+                    await FlushDecodedAsync().ConfigureAwait(false);
+                    if (options.CrcValidation == YencCrcValidationMode.Require &&
+                        phase != BodyPhase.AfterYEnd)
+                    {
+                        throw new InvalidDataException(
+                            "Reached end of NNTP body without finding a yEnc trailer.");
+                    }
+
+                    break;
+                }
+            }
+        }
+        finally
+        {
+            if (ybeginBuffer != null)
+            {
+                ArrayPool<byte>.Shared.Return(ybeginBuffer);
+            }
+
+            if (yendBuffer != null)
+            {
+                ArrayPool<byte>.Shared.Return(yendBuffer);
+            }
+        }
+    }
+
+    private async ValueTask<NntpReadBuffer?> ReadCompleteLinesAsync(
+        CoalescedReadTimeout readTimeout)
+    {
+        readTimeout.BeginIo();
+        try
+        {
+            return await reader.ReadCompleteLinesAsync(readTimeout.Token)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (readTimeout.IsTimeoutCancellation)
+        {
+            throw new TimeoutException("Timeout reading from NNTP stream.");
+        }
+        finally
+        {
+            readTimeout.EndIo();
+        }
+    }
+
+    private static bool TryReadLine(
+        ReadOnlySpan<byte> batch,
+        ref int offset,
+        out int rawStart,
+        out int rawLength,
+        out int contentStart,
+        out int contentLength)
+    {
+        if (offset >= batch.Length)
+        {
+            rawStart = 0;
+            rawLength = 0;
+            contentStart = 0;
+            contentLength = 0;
+            return false;
+        }
+
+        var relativeNewline = batch[offset..].IndexOf((byte)'\n');
+        if (relativeNewline < 0)
+        {
+            throw new InvalidOperationException("NNTP batch ended without a line terminator.");
+        }
+
+        rawStart = offset;
+        rawLength = relativeNewline + 1;
+        contentStart = rawStart;
+        contentLength = relativeNewline;
+        if (contentLength > 0 && batch[contentStart + contentLength - 1] == (byte)'\r')
+        {
+            contentLength--;
+        }
+
+        offset += rawLength;
+        return true;
+    }
+
+    private static void ValidateDecodedBodyCrc32(
+        ReadOnlySpan<byte> yendLine,
+        bool isMultipart,
+        uint actualCrc32,
+        YencCrcValidationMode mode)
+    {
+        var fieldName = isMultipart ? "pcrc32"u8 : "crc32"u8;
+        if (!TryParseYencTrailerCrc32(yendLine, fieldName, out var expectedCrc32))
+        {
+            if (mode == YencCrcValidationMode.WhenPresent)
+            {
+                return;
+            }
+
+            throw new InvalidDataException(
+                $"The yEnc trailer does not contain a valid {Encoding.ASCII.GetString(fieldName)} value.");
+        }
+
+        if (actualCrc32 != expectedCrc32)
+        {
+            throw new InvalidDataException(
+                $"The decoded yEnc CRC32 was {actualCrc32:x8}, but the trailer expected {expectedCrc32:x8}.");
+        }
+    }
+
+    private static bool TryParseYencTrailerCrc32(
+        ReadOnlySpan<byte> trailer,
+        ReadOnlySpan<byte> fieldName,
+        out uint crc32)
+    {
+        var position = 0;
+        while (position < trailer.Length)
+        {
+            while (position < trailer.Length && IsAsciiWhitespace(trailer[position]))
+            {
+                position++;
+            }
+
+            var tokenStart = position;
+            while (position < trailer.Length && !IsAsciiWhitespace(trailer[position]))
+            {
+                position++;
+            }
+
+            var token = trailer[tokenStart..position];
+            var separator = token.IndexOf((byte)'=');
+            if (separator <= 0 ||
+                !AsciiEqualsIgnoreCase(token[..separator], fieldName))
+            {
+                continue;
+            }
+
+            var value = token[(separator + 1)..];
+            return Utf8Parser.TryParse(value, out crc32, out var consumed, 'X') &&
+                consumed == value.Length;
+        }
+
+        crc32 = 0;
+        return false;
+    }
+
+    private static bool AsciiEqualsIgnoreCase(
+        ReadOnlySpan<byte> left,
+        ReadOnlySpan<byte> right)
+    {
+        if (left.Length != right.Length)
+        {
+            return false;
+        }
+
+        for (var index = 0; index < left.Length; index++)
+        {
+            var leftValue = left[index];
+            var rightValue = right[index];
+            if (leftValue is >= (byte)'A' and <= (byte)'Z')
+            {
+                leftValue += (byte)('a' - 'A');
+            }
+
+            if (rightValue is >= (byte)'A' and <= (byte)'Z')
+            {
+                rightValue += (byte)('a' - 'A');
+            }
+
+            if (leftValue != rightValue)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsAsciiWhitespace(byte value) =>
+        value is (byte)' ' or (byte)'\t' or (byte)'\r' or (byte)'\n';
+}

--- a/libs/UsenetSharp/Clients/UsenetClient.BodyAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.BodyAsync.cs
@@ -1,9 +1,5 @@
-using System.Buffers;
-using System.Buffers.Text;
 using System.IO.Pipelines;
 using System.Runtime.ExceptionServices;
-using System.Text;
-using RapidYencSharp;
 using UsenetSharp.Exceptions;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
@@ -213,7 +209,6 @@ public partial class UsenetClient
     {
         Exception? failure = null;
         var connectionReusable = true;
-        byte[]? ybeginBuffer = null;
         CoalescedReadTimeout? ownedReadTimeout = null;
         try
         {
@@ -223,16 +218,6 @@ public partial class UsenetClient
                     "The NNTP connection closed before the article body was read.");
             }
 
-            var unflushedDecodedBytes = 0;
-            var shouldWrite = true;
-            var dataEnded = false;
-            var headersRead = false;
-            var isMultipart = false;
-            long drainedBytes = 0;
-            long skippedBytes = 0;
-            var ybeginLength = 0;
-            RapidYencDecoderState? decoderState = RapidYencDecoderState.RYDEC_STATE_CRLF;
-            uint decodedCrc32 = 0;
             var cancellationToken = operationCts.Token;
             if (sharedReadTimeout == null)
             {
@@ -240,166 +225,15 @@ public partial class UsenetClient
             }
 
             var readTimeout = sharedReadTimeout ?? ownedReadTimeout!;
+            var decoder = new NntpYencBodyDecoder(
+                _reader,
+                writer,
+                headersCompletion,
+                decodedStream,
+                _options,
+                DecodedBodyChunkSize);
 
-            while (true)
-            {
-                ReadOnlyMemory<byte>? lineMemory;
-                try
-                {
-                    lineMemory = await ReadLineBytesAsync(readTimeout)
-                        .ConfigureAwait(false);
-                }
-                catch (IOException)
-                {
-                    throw new UsenetProtocolException(
-                        "The NNTP connection closed before the article body terminator was received.");
-                }
-
-                if (!lineMemory.HasValue)
-                {
-                    throw new UsenetProtocolException(
-                        "The NNTP connection closed before the article body terminator was received.");
-                }
-
-                var lineBytes = lineMemory.Value;
-                if (lineBytes.Length == 1 && lineBytes.Span[0] == (byte)'.')
-                {
-                    if (!headersRead)
-                    {
-                        if (ybeginBuffer == null)
-                        {
-                            throw new InvalidDataException(
-                                "Reached end of NNTP body without finding =ybegin header.");
-                        }
-
-                        headersCompletion.TrySetResult(
-                            YencStream.ParseYencHeaders(ybeginBuffer.AsSpan(0, ybeginLength)));
-                    }
-
-                    if (shouldWrite && unflushedDecodedBytes > 0)
-                    {
-                        var result = await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
-                        shouldWrite = !result.IsCompleted && !result.IsCanceled;
-                    }
-
-                    if (_options.CrcValidation == YencCrcValidationMode.Require && !dataEnded)
-                    {
-                        throw new InvalidDataException(
-                            "Reached end of NNTP body without finding a yEnc trailer.");
-                    }
-
-                    break;
-                }
-
-                if (!shouldWrite)
-                {
-                    drainedBytes += lineBytes.Length + 2;
-                    if (drainedBytes > _options.AbandonedBodyDrainLimit)
-                    {
-                        throw new UsenetProtocolException(
-                            "The abandoned NNTP body exceeded the configured drain limit.");
-                    }
-
-                    continue;
-                }
-
-                if (dataEnded)
-                {
-                    skippedBytes += lineBytes.Length + 2;
-                    if (skippedBytes > _options.AbandonedBodyDrainLimit)
-                    {
-                        throw new UsenetProtocolException(
-                            "The NNTP body contained more non-yEnc data than the configured drain limit.");
-                    }
-
-                    continue;
-                }
-
-                if (!headersRead)
-                {
-                    if (ybeginBuffer == null)
-                    {
-                        if (YencStream.StartsWithYBegin(lineBytes.Span))
-                        {
-                            ybeginBuffer = ArrayPool<byte>.Shared.Rent(lineBytes.Length);
-                            lineBytes.Span.CopyTo(ybeginBuffer);
-                            ybeginLength = lineBytes.Length;
-                        }
-                        else
-                        {
-                            skippedBytes += lineBytes.Length + 2;
-                            if (skippedBytes > _options.AbandonedBodyDrainLimit)
-                            {
-                                throw new UsenetProtocolException(
-                                    "The NNTP body contained more non-yEnc data than the configured drain limit.");
-                            }
-                        }
-
-                        continue;
-                    }
-
-                    if (YencStream.StartsWithYPart(lineBytes.Span))
-                    {
-                        headersRead = true;
-                        isMultipart = true;
-                        headersCompletion.TrySetResult(
-                            YencStream.ParseYencHeaders(
-                                ybeginBuffer.AsSpan(0, ybeginLength), lineBytes.Span));
-                        continue;
-                    }
-
-                    headersRead = true;
-                    headersCompletion.TrySetResult(
-                        YencStream.ParseYencHeaders(ybeginBuffer.AsSpan(0, ybeginLength)));
-                }
-
-                if (YencStream.StartsWithYEnd(lineBytes.Span))
-                {
-                    dataEnded = true;
-                    if (unflushedDecodedBytes > 0)
-                    {
-                        var result = await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
-                        shouldWrite = !result.IsCompleted && !result.IsCanceled;
-                    }
-
-                    if (_options.CrcValidation != YencCrcValidationMode.Off && shouldWrite)
-                    {
-                        ValidateDecodedBodyCrc32(
-                            lineBytes.Span, isMultipart, decodedCrc32, _options.CrcValidation);
-                    }
-
-                    continue;
-                }
-
-                var encodedLine = lineBytes.Span;
-                if (encodedLine.Length >= 2 &&
-                    encodedLine[0] == (byte)'.' &&
-                    encodedLine[1] == (byte)'.')
-                {
-                    encodedLine = encodedLine[1..];
-                }
-
-                // NntpLineReader already obtains 64 KiB raw chunks and returns line views into
-                // that buffer. Decode those views directly into the pipe instead of copying every
-                // line into a second encoded staging buffer solely to reconstruct CRLF framing.
-                var destination = writer.GetSpan(encodedLine.Length);
-                var decodedLength = YencDecoder.DecodeEx(
-                    encodedLine, destination, ref decoderState, isRaw: false);
-                if (_options.CrcValidation != YencCrcValidationMode.Off)
-                {
-                    decodedCrc32 = Crc32.Compute(destination[..decodedLength], decodedCrc32);
-                }
-                decodedStream.AddBufferedBytes(decodedLength);
-                writer.Advance(decodedLength);
-                unflushedDecodedBytes += decodedLength;
-
-                if (unflushedDecodedBytes >= DecodedBodyChunkSize)
-                {
-                    var result = await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
-                    unflushedDecodedBytes = 0;
-                    shouldWrite = !result.IsCompleted && !result.IsCanceled;
-                }
-            }
+            await decoder.ReadAsync(readTimeout, operationCts.Token).ConfigureAwait(false);
         }
         catch (OperationCanceledException e) when (callerCancellationToken.IsCancellationRequested)
         {
@@ -427,11 +261,6 @@ public partial class UsenetClient
         }
         finally
         {
-            if (ybeginBuffer != null)
-            {
-                ArrayPool<byte>.Shared.Return(ybeginBuffer);
-            }
-
             if (failure != null)
             {
                 headersCompletion.TrySetException(failure);
@@ -490,102 +319,6 @@ public partial class UsenetClient
             // (completion callbacks must fire exactly once regardless).
         }
     }
-
-    private static void ValidateDecodedBodyCrc32(
-        ReadOnlySpan<byte> yendLine,
-        bool isMultipart,
-        uint actualCrc32,
-        YencCrcValidationMode mode)
-    {
-        var fieldName = isMultipart ? "pcrc32"u8 : "crc32"u8;
-        if (!TryParseYencTrailerCrc32(yendLine, fieldName, out var expectedCrc32))
-        {
-            if (mode == YencCrcValidationMode.WhenPresent)
-            {
-                return;
-            }
-
-            throw new InvalidDataException(
-                $"The yEnc trailer does not contain a valid {Encoding.ASCII.GetString(fieldName)} value.");
-        }
-
-        if (actualCrc32 != expectedCrc32)
-        {
-            throw new InvalidDataException(
-                $"The decoded yEnc CRC32 was {actualCrc32:x8}, but the trailer expected {expectedCrc32:x8}.");
-        }
-    }
-
-    private static bool TryParseYencTrailerCrc32(
-        ReadOnlySpan<byte> trailer,
-        ReadOnlySpan<byte> fieldName,
-        out uint crc32)
-    {
-        var position = 0;
-        while (position < trailer.Length)
-        {
-            while (position < trailer.Length && IsAsciiWhitespace(trailer[position]))
-            {
-                position++;
-            }
-
-            var tokenStart = position;
-            while (position < trailer.Length && !IsAsciiWhitespace(trailer[position]))
-            {
-                position++;
-            }
-
-            var token = trailer[tokenStart..position];
-            var separator = token.IndexOf((byte)'=');
-            if (separator <= 0 ||
-                !AsciiEqualsIgnoreCase(token[..separator], fieldName))
-            {
-                continue;
-            }
-
-            var value = token[(separator + 1)..];
-            return Utf8Parser.TryParse(value, out crc32, out var consumed, 'X') &&
-                consumed == value.Length;
-        }
-
-        crc32 = 0;
-        return false;
-    }
-
-    private static bool AsciiEqualsIgnoreCase(
-        ReadOnlySpan<byte> left,
-        ReadOnlySpan<byte> right)
-    {
-        if (left.Length != right.Length)
-        {
-            return false;
-        }
-
-        for (var index = 0; index < left.Length; index++)
-        {
-            var leftValue = left[index];
-            var rightValue = right[index];
-            if (leftValue is >= (byte)'A' and <= (byte)'Z')
-            {
-                leftValue += (byte)('a' - 'A');
-            }
-
-            if (rightValue is >= (byte)'A' and <= (byte)'Z')
-            {
-                rightValue += (byte)('a' - 'A');
-            }
-
-            if (leftValue != rightValue)
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private static bool IsAsciiWhitespace(byte value) =>
-        value is (byte)' ' or (byte)'\t' or (byte)'\r' or (byte)'\n';
 
     private async Task ReadBodyToPipeAsync(
         PipeWriter writer,

--- a/libs/UsenetSharp/UsenetSharp.csproj
+++ b/libs/UsenetSharp/UsenetSharp.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="UsenetSharpTest" />
     <InternalsVisibleTo Include="UsenetSharp.Benchmarks" />
+    <InternalsVisibleTo Include="NzbWebDAV.Benchmarks" />
   </ItemGroup>
 
 </Project>

--- a/tests/UsenetSharp.Tests/Clients/NntpLineReaderTests.cs
+++ b/tests/UsenetSharp.Tests/Clients/NntpLineReaderTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using UsenetSharp.Clients;
 using UsenetSharp.Exceptions;
+using UsenetSharpTest.Support;
 
 namespace UsenetSharpTest.Protocol;
 
@@ -47,6 +48,238 @@ public class NntpLineReaderTests
 
         Assert.That(await reader.ReadLineAsync(CancellationToken.None), Is.EqualTo("205 Goodbye"));
         Assert.That(await reader.ReadLineAsync(CancellationToken.None), Is.Null);
+    }
+
+    [Test]
+    public async Task ReadCompleteLinesAsync_ExposesLargestCompletePrefixWithoutAdvancing()
+    {
+        var input = Encoding.ASCII.GetBytes("one\r\ntwo\r\nthr");
+        await using var stream = new MemoryStream(input);
+        using var reader = new NntpLineReader(stream, bufferSize: 32);
+
+        var first = await reader.ReadCompleteLinesAsync(CancellationToken.None);
+        Assert.That(first.HasValue, Is.True);
+        Assert.That(Encoding.ASCII.GetString(first!.Value.Memory.Span), Is.EqualTo("one\r\ntwo\r\n"));
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await reader.ReadCompleteLinesAsync(CancellationToken.None));
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await reader.ReadLineBytesAsync(CancellationToken.None));
+
+        reader.Advance("one\r\n".Length);
+        var second = await reader.ReadCompleteLinesAsync(CancellationToken.None);
+        Assert.That(Encoding.ASCII.GetString(second!.Value.Memory.Span), Is.EqualTo("two\r\n"));
+
+        reader.Advance("two\r\n".Length);
+        Assert.ThrowsAsync<UsenetProtocolException>(async () =>
+            await reader.ReadCompleteLinesAsync(CancellationToken.None));
+    }
+
+    [Test]
+    public async Task ReadCompleteLinesAsync_AssemblesCrLfSplitAcrossBuffers()
+    {
+        var input = Encoding.ASCII.GetBytes("x\r\n");
+        await using var stream = new MemoryStream(input);
+        using var reader = new NntpLineReader(stream, bufferSize: 2);
+
+        var batch = await reader.ReadCompleteLinesAsync(CancellationToken.None);
+        Assert.That(Encoding.ASCII.GetString(batch!.Value.Memory.Span), Is.EqualTo("x\r\n"));
+        reader.Advance(batch.Value.Memory.Length);
+        Assert.That(await reader.ReadCompleteLinesAsync(CancellationToken.None), Is.Null);
+    }
+
+    [TestCase("=ybegin line=128 size=1 name=test.bin\r\n")]
+    [TestCase("=ypart begin=1 end=1\r\n")]
+    [TestCase("=yend size=1 crc32=89abcdef\r\n")]
+    public async Task ReadCompleteLinesAsync_AssemblesControlLineSplitAtEveryByte(string line)
+    {
+        var bytes = Encoding.ASCII.GetBytes(line);
+        for (var split = 1; split < bytes.Length; split++)
+        {
+            await using var stream = new FragmentedReadStream(bytes, [split, int.MaxValue]);
+            using var reader = new NntpLineReader(stream, bufferSize: Math.Max(split, 1));
+            var batch = await reader.ReadCompleteLinesAsync(CancellationToken.None);
+            Assert.That(
+                Encoding.ASCII.GetString(batch!.Value.Memory.Span),
+                Is.EqualTo(line),
+                $"split={split}");
+            reader.Advance(batch.Value.Memory.Length);
+        }
+    }
+
+    [Test]
+    public async Task ReadCompleteLinesAsync_AssemblesDotTerminatorSplitAtEveryByte()
+    {
+        const string terminator = ".\r\n";
+        var bytes = Encoding.ASCII.GetBytes(terminator);
+        for (var split = 1; split < bytes.Length; split++)
+        {
+            await using var stream = new FragmentedReadStream(bytes, [split, int.MaxValue]);
+            using var reader = new NntpLineReader(stream, bufferSize: 1);
+            var batch = await reader.ReadCompleteLinesAsync(CancellationToken.None);
+            Assert.That(
+                Encoding.ASCII.GetString(batch!.Value.Memory.Span),
+                Is.EqualTo(terminator),
+                $"split={split}");
+            reader.Advance(batch.Value.Memory.Length);
+        }
+    }
+
+    [Test]
+    public async Task ReadCompleteLinesAsync_AssemblesCrLfDotAsSeparateFills()
+    {
+        var bytes = Encoding.ASCII.GetBytes("payload\r\n.\r\n");
+        await using var stream = new FragmentedReadStream(bytes, [1]);
+        using var reader = new NntpLineReader(stream, bufferSize: 1);
+
+        var first = await reader.ReadCompleteLinesAsync(CancellationToken.None);
+        Assert.That(Encoding.ASCII.GetString(first!.Value.Memory.Span), Is.EqualTo("payload\r\n"));
+        reader.Advance(first.Value.Memory.Length);
+
+        var second = await reader.ReadCompleteLinesAsync(CancellationToken.None);
+        Assert.That(Encoding.ASCII.GetString(second!.Value.Memory.Span), Is.EqualTo(".\r\n"));
+        reader.Advance(second.Value.Memory.Length);
+    }
+
+    [Test]
+    public async Task Advance_RejectsNonLineBoundaryAndOutOfRangeCounts()
+    {
+        var input = Encoding.ASCII.GetBytes("one\r\ntwo\r\n");
+        await using var stream = new MemoryStream(input);
+        using var reader = new NntpLineReader(stream);
+
+        var batch = await reader.ReadCompleteLinesAsync(CancellationToken.None);
+        Assert.That(batch.HasValue, Is.True);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => reader.Advance(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => reader.Advance(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => reader.Advance(batch!.Value.Memory.Length + 1));
+        Assert.Throws<ArgumentException>(() => reader.Advance(1));
+
+        reader.Advance(batch!.Value.Memory.Length);
+        Assert.Throws<InvalidOperationException>(() => reader.Advance(1));
+    }
+
+    [Test]
+    public async Task Advance_ThroughTerminator_PreservesFollowingResponse()
+    {
+        var input = Encoding.ASCII.GetBytes("last-line\r\n.\r\n222 0 <next@example> body\r\n");
+        await using var stream = new MemoryStream(input);
+        using var reader = new NntpLineReader(stream);
+
+        var batch = await reader.ReadCompleteLinesAsync(CancellationToken.None);
+        var span = batch!.Value.Memory.Span;
+        var terminatorAt = span.LastIndexOf(".\r\n"u8);
+        Assert.That(terminatorAt, Is.GreaterThanOrEqualTo(0));
+        reader.Advance(terminatorAt + 3);
+
+        var next = await reader.ReadLineAsync(CancellationToken.None);
+        Assert.That(next, Is.EqualTo("222 0 <next@example> body"));
+    }
+
+    [Test]
+    public async Task ReadCompleteLinesAsync_ThenReadLineBytesAsync_PreservesUnreadBytes()
+    {
+        var input = Encoding.ASCII.GetBytes("alpha\r\nbeta\r\n");
+        await using var stream = new MemoryStream(input);
+        using var reader = new NntpLineReader(stream);
+
+        var batch = await reader.ReadCompleteLinesAsync(CancellationToken.None);
+        reader.Advance("alpha\r\n".Length);
+        var line = await reader.ReadLineAsync(CancellationToken.None);
+        Assert.That(line, Is.EqualTo("beta"));
+        Assert.That(batch!.Value.Memory.Length, Is.EqualTo("alpha\r\nbeta\r\n".Length));
+    }
+
+    [Test]
+    public async Task ReadLineBytesAsync_ThenReadCompleteLinesAsync_PreservesUnreadBytes()
+    {
+        var input = Encoding.ASCII.GetBytes("alpha\r\nbeta\r\ngamma\r\n");
+        await using var stream = new MemoryStream(input);
+        using var reader = new NntpLineReader(stream);
+
+        Assert.That(await reader.ReadLineAsync(CancellationToken.None), Is.EqualTo("alpha"));
+        var batch = await reader.ReadCompleteLinesAsync(CancellationToken.None);
+        Assert.That(Encoding.ASCII.GetString(batch!.Value.Memory.Span), Is.EqualTo("beta\r\ngamma\r\n"));
+        reader.Advance(batch.Value.Memory.Length);
+    }
+
+    [Test]
+    public async Task ReadCompleteLinesAsync_CancelledRefillDoesNotReplayConsumedBytes()
+    {
+        var first = Encoding.ASCII.GetBytes("first\r\n");
+        var second = Encoding.ASCII.GetBytes("second\r\n");
+        var combined = new byte[first.Length + second.Length];
+        first.CopyTo(combined, 0);
+        second.CopyTo(combined, first.Length);
+
+        await using var stream = new FragmentedReadStream(
+            combined,
+            [first.Length, second.Length],
+            cancelOnRead: 2);
+        using var reader = new NntpLineReader(stream, bufferSize: first.Length);
+
+        var batch = await reader.ReadCompleteLinesAsync(CancellationToken.None);
+        Assert.That(Encoding.ASCII.GetString(batch!.Value.Memory.Span), Is.EqualTo("first\r\n"));
+        reader.Advance(batch.Value.Memory.Length);
+
+        using var cancellation = new CancellationTokenSource();
+        var cancelledRead = reader.ReadCompleteLinesAsync(cancellation.Token).AsTask();
+        await stream.RefillStarted.WaitAsync(TimeSpan.FromSeconds(2));
+        cancellation.Cancel();
+        Assert.CatchAsync<OperationCanceledException>(async () => await cancelledRead);
+
+        var line = await reader.ReadLineAsync(CancellationToken.None);
+        Assert.That(line, Is.EqualTo("second"));
+    }
+
+    [Test]
+    public async Task ReadCompleteLinesAsync_EofWithUnterminatedLine_Throws()
+    {
+        await using var stream = new MemoryStream(Encoding.ASCII.GetBytes("22"));
+        using var reader = new NntpLineReader(stream);
+
+        var exception = Assert.ThrowsAsync<UsenetProtocolException>(async () =>
+            await reader.ReadCompleteLinesAsync(CancellationToken.None));
+        Assert.That(exception!.Message, Does.Contain("unterminated line"));
+    }
+
+    [Test]
+    public async Task ReadCompleteLinesAsync_CleanEofAtBoundary_ReturnsNull()
+    {
+        await using var stream = new MemoryStream(Encoding.ASCII.GetBytes("205 Goodbye\r\n"));
+        using var reader = new NntpLineReader(stream);
+
+        var batch = await reader.ReadCompleteLinesAsync(CancellationToken.None);
+        Assert.That(Encoding.ASCII.GetString(batch!.Value.Memory.Span), Is.EqualTo("205 Goodbye\r\n"));
+        reader.Advance(batch.Value.Memory.Length);
+        Assert.That(await reader.ReadCompleteLinesAsync(CancellationToken.None), Is.Null);
+    }
+
+    [Test]
+    public async Task ReadCompleteLinesAsync_OverlongBoundarySpanningLine_Throws()
+    {
+        var line = Encoding.ASCII.GetBytes(new string('a', 9) + "\r\n");
+        await using var stream = new FragmentedReadStream(line, [3, 3, 5]);
+        using var reader = new NntpLineReader(stream, maximumLineLength: 8, bufferSize: 3);
+
+        var exception = Assert.ThrowsAsync<UsenetProtocolException>(async () =>
+            await reader.ReadCompleteLinesAsync(CancellationToken.None));
+        Assert.That(exception!.Message, Does.Contain("8-byte limit"));
+    }
+
+    [Test]
+    public async Task Dispose_WithOutstandingExposure_ReturnsEachPooledArrayOnce()
+    {
+        await using var stream = new MemoryStream(Encoding.ASCII.GetBytes("one\r\ntwo\r\n"));
+        var reader = new NntpLineReader(stream, bufferSize: 4);
+        var batch = await reader.ReadCompleteLinesAsync(CancellationToken.None);
+        Assert.That(batch.HasValue, Is.True);
+
+        reader.Dispose();
+        reader.Dispose();
+        Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            await reader.ReadCompleteLinesAsync(CancellationToken.None));
     }
 
     private sealed class CancelledRefillStream(

--- a/tests/UsenetSharp.Tests/Clients/NntpLineReaderTests.cs
+++ b/tests/UsenetSharp.Tests/Clients/NntpLineReaderTests.cs
@@ -57,9 +57,8 @@ public class NntpLineReaderTests
         await using var stream = new MemoryStream(input);
         using var reader = new NntpLineReader(stream, bufferSize: 32);
 
-        var first = await reader.ReadCompleteLinesAsync(CancellationToken.None);
-        Assert.That(first.HasValue, Is.True);
-        Assert.That(Encoding.ASCII.GetString(first!.Value.Memory.Span), Is.EqualTo("one\r\ntwo\r\n"));
+        var first = RequireBatch(await reader.ReadCompleteLinesAsync(CancellationToken.None));
+        Assert.That(Encoding.ASCII.GetString(first.Memory.Span), Is.EqualTo("one\r\ntwo\r\n"));
 
         Assert.ThrowsAsync<InvalidOperationException>(async () =>
             await reader.ReadCompleteLinesAsync(CancellationToken.None));
@@ -67,8 +66,8 @@ public class NntpLineReaderTests
             await reader.ReadLineBytesAsync(CancellationToken.None));
 
         reader.Advance("one\r\n".Length);
-        var second = await reader.ReadCompleteLinesAsync(CancellationToken.None);
-        Assert.That(Encoding.ASCII.GetString(second!.Value.Memory.Span), Is.EqualTo("two\r\n"));
+        var second = RequireBatch(await reader.ReadCompleteLinesAsync(CancellationToken.None));
+        Assert.That(Encoding.ASCII.GetString(second.Memory.Span), Is.EqualTo("two\r\n"));
 
         reader.Advance("two\r\n".Length);
         Assert.ThrowsAsync<UsenetProtocolException>(async () =>
@@ -82,9 +81,9 @@ public class NntpLineReaderTests
         await using var stream = new MemoryStream(input);
         using var reader = new NntpLineReader(stream, bufferSize: 2);
 
-        var batch = await reader.ReadCompleteLinesAsync(CancellationToken.None);
-        Assert.That(Encoding.ASCII.GetString(batch!.Value.Memory.Span), Is.EqualTo("x\r\n"));
-        reader.Advance(batch.Value.Memory.Length);
+        var batch = RequireBatch(await reader.ReadCompleteLinesAsync(CancellationToken.None));
+        Assert.That(Encoding.ASCII.GetString(batch.Memory.Span), Is.EqualTo("x\r\n"));
+        reader.Advance(batch.Memory.Length);
         Assert.That(await reader.ReadCompleteLinesAsync(CancellationToken.None), Is.Null);
     }
 
@@ -98,12 +97,12 @@ public class NntpLineReaderTests
         {
             await using var stream = new FragmentedReadStream(bytes, [split, int.MaxValue]);
             using var reader = new NntpLineReader(stream, bufferSize: Math.Max(split, 1));
-            var batch = await reader.ReadCompleteLinesAsync(CancellationToken.None);
+            var batch = RequireBatch(await reader.ReadCompleteLinesAsync(CancellationToken.None));
             Assert.That(
-                Encoding.ASCII.GetString(batch!.Value.Memory.Span),
+                Encoding.ASCII.GetString(batch.Memory.Span),
                 Is.EqualTo(line),
                 $"split={split}");
-            reader.Advance(batch.Value.Memory.Length);
+            reader.Advance(batch.Memory.Length);
         }
     }
 
@@ -116,12 +115,12 @@ public class NntpLineReaderTests
         {
             await using var stream = new FragmentedReadStream(bytes, [split, int.MaxValue]);
             using var reader = new NntpLineReader(stream, bufferSize: 1);
-            var batch = await reader.ReadCompleteLinesAsync(CancellationToken.None);
+            var batch = RequireBatch(await reader.ReadCompleteLinesAsync(CancellationToken.None));
             Assert.That(
-                Encoding.ASCII.GetString(batch!.Value.Memory.Span),
+                Encoding.ASCII.GetString(batch.Memory.Span),
                 Is.EqualTo(terminator),
                 $"split={split}");
-            reader.Advance(batch.Value.Memory.Length);
+            reader.Advance(batch.Memory.Length);
         }
     }
 
@@ -132,13 +131,13 @@ public class NntpLineReaderTests
         await using var stream = new FragmentedReadStream(bytes, [1]);
         using var reader = new NntpLineReader(stream, bufferSize: 1);
 
-        var first = await reader.ReadCompleteLinesAsync(CancellationToken.None);
-        Assert.That(Encoding.ASCII.GetString(first!.Value.Memory.Span), Is.EqualTo("payload\r\n"));
-        reader.Advance(first.Value.Memory.Length);
+        var first = RequireBatch(await reader.ReadCompleteLinesAsync(CancellationToken.None));
+        Assert.That(Encoding.ASCII.GetString(first.Memory.Span), Is.EqualTo("payload\r\n"));
+        reader.Advance(first.Memory.Length);
 
-        var second = await reader.ReadCompleteLinesAsync(CancellationToken.None);
-        Assert.That(Encoding.ASCII.GetString(second!.Value.Memory.Span), Is.EqualTo(".\r\n"));
-        reader.Advance(second.Value.Memory.Length);
+        var second = RequireBatch(await reader.ReadCompleteLinesAsync(CancellationToken.None));
+        Assert.That(Encoding.ASCII.GetString(second.Memory.Span), Is.EqualTo(".\r\n"));
+        reader.Advance(second.Memory.Length);
     }
 
     [Test]
@@ -148,15 +147,14 @@ public class NntpLineReaderTests
         await using var stream = new MemoryStream(input);
         using var reader = new NntpLineReader(stream);
 
-        var batch = await reader.ReadCompleteLinesAsync(CancellationToken.None);
-        Assert.That(batch.HasValue, Is.True);
+        var batch = RequireBatch(await reader.ReadCompleteLinesAsync(CancellationToken.None));
 
         Assert.Throws<ArgumentOutOfRangeException>(() => reader.Advance(0));
         Assert.Throws<ArgumentOutOfRangeException>(() => reader.Advance(-1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => reader.Advance(batch!.Value.Memory.Length + 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => reader.Advance(batch.Memory.Length + 1));
         Assert.Throws<ArgumentException>(() => reader.Advance(1));
 
-        reader.Advance(batch!.Value.Memory.Length);
+        reader.Advance(batch.Memory.Length);
         Assert.Throws<InvalidOperationException>(() => reader.Advance(1));
     }
 
@@ -167,8 +165,8 @@ public class NntpLineReaderTests
         await using var stream = new MemoryStream(input);
         using var reader = new NntpLineReader(stream);
 
-        var batch = await reader.ReadCompleteLinesAsync(CancellationToken.None);
-        var span = batch!.Value.Memory.Span;
+        var batch = RequireBatch(await reader.ReadCompleteLinesAsync(CancellationToken.None));
+        var span = batch.Memory.Span;
         var terminatorAt = span.LastIndexOf(".\r\n"u8);
         Assert.That(terminatorAt, Is.GreaterThanOrEqualTo(0));
         reader.Advance(terminatorAt + 3);
@@ -184,11 +182,11 @@ public class NntpLineReaderTests
         await using var stream = new MemoryStream(input);
         using var reader = new NntpLineReader(stream);
 
-        var batch = await reader.ReadCompleteLinesAsync(CancellationToken.None);
+        var batch = RequireBatch(await reader.ReadCompleteLinesAsync(CancellationToken.None));
         reader.Advance("alpha\r\n".Length);
         var line = await reader.ReadLineAsync(CancellationToken.None);
         Assert.That(line, Is.EqualTo("beta"));
-        Assert.That(batch!.Value.Memory.Length, Is.EqualTo("alpha\r\nbeta\r\n".Length));
+        Assert.That(batch.Memory.Length, Is.EqualTo("alpha\r\nbeta\r\n".Length));
     }
 
     [Test]
@@ -199,9 +197,9 @@ public class NntpLineReaderTests
         using var reader = new NntpLineReader(stream);
 
         Assert.That(await reader.ReadLineAsync(CancellationToken.None), Is.EqualTo("alpha"));
-        var batch = await reader.ReadCompleteLinesAsync(CancellationToken.None);
-        Assert.That(Encoding.ASCII.GetString(batch!.Value.Memory.Span), Is.EqualTo("beta\r\ngamma\r\n"));
-        reader.Advance(batch.Value.Memory.Length);
+        var batch = RequireBatch(await reader.ReadCompleteLinesAsync(CancellationToken.None));
+        Assert.That(Encoding.ASCII.GetString(batch.Memory.Span), Is.EqualTo("beta\r\ngamma\r\n"));
+        reader.Advance(batch.Memory.Length);
     }
 
     [Test]
@@ -219,9 +217,9 @@ public class NntpLineReaderTests
             cancelOnRead: 2);
         using var reader = new NntpLineReader(stream, bufferSize: first.Length);
 
-        var batch = await reader.ReadCompleteLinesAsync(CancellationToken.None);
-        Assert.That(Encoding.ASCII.GetString(batch!.Value.Memory.Span), Is.EqualTo("first\r\n"));
-        reader.Advance(batch.Value.Memory.Length);
+        var batch = RequireBatch(await reader.ReadCompleteLinesAsync(CancellationToken.None));
+        Assert.That(Encoding.ASCII.GetString(batch.Memory.Span), Is.EqualTo("first\r\n"));
+        reader.Advance(batch.Memory.Length);
 
         using var cancellation = new CancellationTokenSource();
         var cancelledRead = reader.ReadCompleteLinesAsync(cancellation.Token).AsTask();
@@ -250,9 +248,9 @@ public class NntpLineReaderTests
         await using var stream = new MemoryStream(Encoding.ASCII.GetBytes("205 Goodbye\r\n"));
         using var reader = new NntpLineReader(stream);
 
-        var batch = await reader.ReadCompleteLinesAsync(CancellationToken.None);
-        Assert.That(Encoding.ASCII.GetString(batch!.Value.Memory.Span), Is.EqualTo("205 Goodbye\r\n"));
-        reader.Advance(batch.Value.Memory.Length);
+        var batch = RequireBatch(await reader.ReadCompleteLinesAsync(CancellationToken.None));
+        Assert.That(Encoding.ASCII.GetString(batch.Memory.Span), Is.EqualTo("205 Goodbye\r\n"));
+        reader.Advance(batch.Memory.Length);
         Assert.That(await reader.ReadCompleteLinesAsync(CancellationToken.None), Is.Null);
     }
 
@@ -268,18 +266,41 @@ public class NntpLineReaderTests
         Assert.That(exception!.Message, Does.Contain("8-byte limit"));
     }
 
+    [TestCase("aaaaaaaaaa\r\n")]
+    [TestCase("ok\r\naaaaaaaaaa\r\n")]
+    public async Task ReadCompleteLinesAsync_OverlongCompleteLineInOneBuffer_Throws(string input)
+    {
+        var bytes = Encoding.ASCII.GetBytes(input);
+        await using var stream = new MemoryStream(bytes);
+        using var reader = new NntpLineReader(stream, maximumLineLength: 8, bufferSize: 64);
+
+        var exception = Assert.ThrowsAsync<UsenetProtocolException>(async () =>
+            await reader.ReadCompleteLinesAsync(CancellationToken.None));
+        Assert.That(exception!.Message, Does.Contain("8-byte limit"));
+    }
+
     [Test]
     public async Task Dispose_WithOutstandingExposure_ReturnsEachPooledArrayOnce()
     {
         await using var stream = new MemoryStream(Encoding.ASCII.GetBytes("one\r\ntwo\r\n"));
         var reader = new NntpLineReader(stream, bufferSize: 4);
-        var batch = await reader.ReadCompleteLinesAsync(CancellationToken.None);
-        Assert.That(batch.HasValue, Is.True);
+        RequireBatch(await reader.ReadCompleteLinesAsync(CancellationToken.None));
 
         reader.Dispose();
         reader.Dispose();
         Assert.ThrowsAsync<ObjectDisposedException>(async () =>
             await reader.ReadCompleteLinesAsync(CancellationToken.None));
+    }
+
+    private static NntpReadBuffer RequireBatch(NntpReadBuffer? batch)
+    {
+        if (!batch.HasValue)
+        {
+            Assert.Fail("Expected a complete NNTP line batch.");
+            throw new InvalidOperationException("Expected a complete NNTP line batch.");
+        }
+
+        return batch.Value;
     }
 
     private sealed class CancelledRefillStream(

--- a/tests/UsenetSharp.Tests/Clients/NntpYencBodyDecoderTests.cs
+++ b/tests/UsenetSharp.Tests/Clients/NntpYencBodyDecoderTests.cs
@@ -1,0 +1,519 @@
+using System.IO.Pipelines;
+using System.Text;
+using RapidYencSharp;
+using UsenetSharp.Clients;
+using UsenetSharp.Exceptions;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+using UsenetSharpTest.Support;
+
+namespace UsenetSharpTest.Protocol;
+
+[TestFixture]
+public class NntpYencBodyDecoderTests
+{
+    [Test]
+    public async Task DecodeAsync_EmptyPayload_RoundTrips()
+    {
+        var body = YencWireBodies.SinglePart([]);
+        var result = await DecodeAsync(body.Wire, [int.MaxValue]);
+        AssertSuccessful(result, body);
+    }
+
+    [Test]
+    public async Task DecodeAsync_OneBytePayload_RoundTrips()
+    {
+        var body = YencWireBodies.SinglePart([0x04]);
+        var result = await DecodeAsync(body.Wire, [1]);
+        AssertSuccessful(result, body);
+    }
+
+    [Test]
+    public async Task DecodeAsync_AllByteValues_RoundTrips()
+    {
+        var decoded = Enumerable.Range(0, 256).Select(value => (byte)value).ToArray();
+        var body = YencWireBodies.SinglePart(decoded, fileName: "all.bin");
+        var result = await DecodeAsync(body.Wire, [17, 64, 3]);
+        AssertSuccessful(result, body);
+    }
+
+    [Test]
+    public async Task DecodeAsync_DotStuffedAndEscapedPayload_RoundTrips()
+    {
+        var decoded = new byte[] { 0x00, (byte)'\n', (byte)'\r', (byte)'=', 0x04, (byte)'.' };
+        var body = YencWireBodies.SinglePart(decoded, fileName: "esc.bin");
+        var result = await DecodeAsync(body.Wire, [1], readerBufferSize: 2);
+        AssertSuccessful(result, body);
+    }
+
+    [Test]
+    public async Task DecodeAsync_FlushThresholdEdges_RoundTrip(
+        [Values(64 * 1024 - 1, 64 * 1024, 64 * 1024 + 1)] int size)
+    {
+        var decoded = Enumerable.Range(0, size).Select(index => (byte)index).ToArray();
+        var body = YencWireBodies.SinglePart(decoded);
+        var result = await DecodeAsync(body.Wire, [4096]);
+        AssertSuccessful(result, body);
+    }
+
+    [Test]
+    public async Task DecodeAsync_LargerThanPauseThreshold_RoundTrips()
+    {
+        var decoded = Enumerable.Range(0, 1_200_000).Select(index => (byte)(index * 13)).ToArray();
+        var body = YencWireBodies.SinglePart(decoded);
+        var result = await DecodeAsync(
+            body.Wire,
+            [64 * 1024],
+            pauseWriterThreshold: 4096,
+            resumeWriterThreshold: 2048);
+        AssertSuccessful(result, body);
+    }
+
+    [Test]
+    public async Task DecodeAsync_FourMiBArticle_RoundTrips()
+    {
+        var decoded = new byte[4 * 1024 * 1024];
+        new Random(1023).NextBytes(decoded);
+        var body = YencWireBodies.SinglePart(decoded, fileName: "article.bin");
+        var result = await DecodeAsync(body.Wire, [64 * 1024]);
+        AssertSuccessful(result, body);
+    }
+
+    [Test]
+    public async Task DecodeAsync_PreambleAndPostTrailer_RoundTrips()
+    {
+        var body = YencWireBodies.SinglePart(
+            "hello"u8.ToArray(),
+            preamble: "ignored preamble\r\n",
+            postTrailer: "junk-after-yend\r\n");
+        var result = await DecodeAsync(body.Wire, [8]);
+        AssertSuccessful(result, body);
+    }
+
+    [Test]
+    public async Task DecodeAsync_MultipartHeaders_AreExact()
+    {
+        var decoded = Encoding.ASCII.GetBytes("multipart-payload");
+        var body = YencWireBodies.Multipart(
+            decoded,
+            fileName: "chunk.bin",
+            partNumber: 3,
+            totalParts: 8,
+            partOffset: 360000,
+            fileSize: 1_440_000);
+        var result = await DecodeAsync(body.Wire, [5, 11, 64]);
+        AssertSuccessful(result, body);
+        Assert.That(result.Headers!.PartNumber, Is.EqualTo(3));
+        Assert.That(result.Headers.TotalParts, Is.EqualTo(8));
+        Assert.That(result.Headers.PartOffset, Is.EqualTo(360000));
+        Assert.That(result.Headers.FileSize, Is.EqualTo(1_440_000));
+    }
+
+    [Test]
+    public async Task DecodeAsync_FollowingResponse_RemainsUnread()
+    {
+        var body = YencWireBodies.SinglePart(
+            "keep-next"u8.ToArray(),
+            followingResponse: "222 0 <next@example> body\r\n");
+        var result = await DecodeAsync(body.Wire, [int.MaxValue], readFollowingLine: true);
+        AssertSuccessful(result, body);
+        Assert.That(result.FollowingLine, Is.EqualTo("222 0 <next@example> body"));
+    }
+
+    [TestCaseSource(nameof(ControlSplitCases))]
+    public async Task DecodeAsync_ControlAndTerminatorSplits_PreserveBytes(
+        string tokenName,
+        int split)
+    {
+        var decoded = Encoding.ASCII.GetBytes("1234567890123");
+        var following = tokenName == "terminator-follow" ? "222 0 <next@example> body\r\n" : null;
+        var body = tokenName.StartsWith("ypart", StringComparison.Ordinal)
+            ? YencWireBodies.Multipart(decoded, fileName: "long-file-name.bin")
+            : YencWireBodies.SinglePart(
+                decoded,
+                fileName: "long-file-name.bin",
+                preamble: tokenName == "preamble-crlf" ? "skip-me\r\n" : null,
+                followingResponse: following);
+
+        var splitOffset = tokenName switch
+        {
+            "ybegin" => body.YBeginOffset,
+            "ypart" => body.YPartOffset,
+            "yend" => body.YEndOffset,
+            "terminator" or "terminator-follow" => body.TerminatorOffset,
+            "preamble-crlf" => body.YBeginOffset - 2,
+            _ => throw new ArgumentOutOfRangeException(nameof(tokenName))
+        };
+
+        var result = await DecodeAsync(
+            body.Wire,
+            [splitOffset + split, int.MaxValue],
+            readerBufferSize: Math.Max(split, 1),
+            readFollowingLine: following != null);
+        AssertSuccessful(result, body);
+        if (following != null)
+        {
+            Assert.That(result.FollowingLine, Is.EqualTo("222 0 <next@example> body"));
+        }
+    }
+
+    [Test]
+    public async Task DecodeAsync_DotStuffedPrefixSplitBetweenDots_RoundTrips()
+    {
+        var wire = Encoding.ASCII.GetBytes(
+            "=ybegin line=128 size=1 name=dot.bin\r\n" +
+            "..\r\n" +
+            "=yend size=1\r\n" +
+            ".\r\n");
+        var stuffedAt = IndexOf(wire, ".."u8);
+        Assert.That(stuffedAt, Is.GreaterThanOrEqualTo(0));
+        var result = await DecodeAsync(
+            wire,
+            [stuffedAt + 1, int.MaxValue],
+            crcMode: YencCrcValidationMode.Off,
+            readerBufferSize: 1);
+        Assert.That(result.ProducerException, Is.Null, result.ProducerException?.ToString());
+        Assert.That(result.Decoded, Is.EqualTo(new byte[] { 0x04 }));
+    }
+
+    [Test]
+    public async Task DecodeAsync_CrLfSplit_DoesNotLeakIntoOutput()
+    {
+        var body = YencWireBodies.SinglePart("crlf"u8.ToArray());
+        var crIndex = IndexOf(body.Wire, "\r\n"u8);
+        var result = await DecodeAsync(body.Wire, [crIndex + 1, int.MaxValue], readerBufferSize: 1);
+        AssertSuccessful(result, body);
+        Assert.That(result.Decoded, Does.Not.Contain((byte)'\r'));
+    }
+
+    [TestCase(YencCrcValidationMode.Off, false, false, false, true)]
+    [TestCase(YencCrcValidationMode.Off, true, false, false, true)]
+    [TestCase(YencCrcValidationMode.Off, false, true, false, true)]
+    [TestCase(YencCrcValidationMode.WhenPresent, false, false, false, true)]
+    [TestCase(YencCrcValidationMode.WhenPresent, true, false, false, false)]
+    [TestCase(YencCrcValidationMode.WhenPresent, false, true, false, true)]
+    [TestCase(YencCrcValidationMode.Require, false, false, false, true)]
+    [TestCase(YencCrcValidationMode.Require, true, false, false, false)]
+    [TestCase(YencCrcValidationMode.Require, false, true, false, false)]
+    [TestCase(YencCrcValidationMode.Require, false, false, true, false)]
+    public async Task DecodeAsync_CrcMatrix(
+        YencCrcValidationMode mode,
+        bool corruptCrc,
+        bool missingCrc,
+        bool omitYend,
+        bool success)
+    {
+        var body = YencWireBodies.SinglePart(
+            Encoding.ASCII.GetBytes("crc-matrix"),
+            includeCrc: !missingCrc,
+            corruptCrc: corruptCrc,
+            omitYend: omitYend);
+        var result = await DecodeAsync(body.Wire, [32], crcMode: mode);
+        if (success)
+        {
+            Assert.That(result.ProducerException, Is.Null);
+            Assert.That(result.Decoded, Is.EqualTo(body.Decoded));
+        }
+        else
+        {
+            Assert.That(result.ProducerException, Is.TypeOf<InvalidDataException>());
+        }
+    }
+
+    [Test]
+    public async Task DecodeAsync_MultipartCrcUsesPcrc32()
+    {
+        var decoded = Encoding.ASCII.GetBytes("pcrc-payload");
+        var good = RapidYencSharp.Crc32.Compute(decoded);
+        var body = YencWireBodies.Multipart(decoded, fileName: "crc.bin");
+        var result = await DecodeAsync(body.Wire, [16], crcMode: YencCrcValidationMode.Require);
+        Assert.That(result.ProducerException, Is.Null, result.ProducerException?.ToString());
+        Assert.That(result.Decoded, Is.EqualTo(decoded));
+        Assert.That(good, Is.EqualTo(RapidYencSharp.Crc32.Compute(result.Decoded)));
+    }
+
+    [Test]
+    public async Task DecodeAsync_MalformedCrcToken_FailsWhenRequired()
+    {
+        var body = YencWireBodies.SinglePart(
+            "badhex"u8.ToArray(),
+            includeCrc: false,
+            extraYendFields: " crc32=not-hex");
+        var result = await DecodeAsync(body.Wire, [int.MaxValue], crcMode: YencCrcValidationMode.Require);
+        Assert.That(result.ProducerException, Is.TypeOf<InvalidDataException>());
+    }
+
+    [Test]
+    public async Task DecodeAsync_YendingPrefix_IsTreatedAsTrailer()
+    {
+        var decoded = Encoding.ASCII.GetBytes("x");
+        int? column = 0;
+        var encoded = YencEncoder.EncodeEx(decoded, ref column, 128, true);
+        encoded = YencWireBodies.DotStuff(encoded);
+        using var output = new MemoryStream();
+        output.Write("=ybegin line=128 size=1 name=x.bin\r\n"u8);
+        output.Write(encoded);
+        output.Write("\r\n=yending size=1\r\n.\r\n"u8);
+        var result = await DecodeAsync(output.ToArray(), [3], crcMode: YencCrcValidationMode.Off);
+        Assert.That(result.ProducerException, Is.Null, result.ProducerException?.ToString());
+        Assert.That(result.Decoded, Is.EqualTo(decoded));
+    }
+
+    [Test]
+    public async Task DecodeAsync_EqualsDataThatIsNotControl_Decodes()
+    {
+        // Encoded output may start a line with '=' for escaped bytes; that is payload.
+        var decoded = Enumerable.Repeat((byte)0, 200).ToArray();
+        var body = YencWireBodies.SinglePart(decoded);
+        var result = await DecodeAsync(body.Wire, [7, 1, 64]);
+        AssertSuccessful(result, body);
+    }
+
+    [Test]
+    public async Task DecodeAsync_EofBeforeTerminator_ThrowsProtocolException()
+    {
+        var body = YencWireBodies.SinglePart("truncated"u8.ToArray());
+        var truncated = body.Wire.AsSpan(0, body.TerminatorOffset).ToArray();
+        var result = await DecodeAsync(truncated, [8]);
+        Assert.That(result.ProducerException, Is.TypeOf<UsenetProtocolException>());
+        Assert.That(result.ProducerException!.Message, Does.Contain("terminator"));
+    }
+
+    [Test]
+    public async Task DecodeAsync_TerminatorBeforeYBegin_ThrowsMissingHeader()
+    {
+        var wire = Encoding.ASCII.GetBytes("not-yenc\r\n.\r\n");
+        var result = await DecodeAsync(wire, [1]);
+        Assert.That(result.ProducerException, Is.TypeOf<InvalidDataException>());
+        Assert.That(result.ProducerException!.Message, Does.Contain("=ybegin"));
+    }
+
+    [Test]
+    public async Task DecodeAsync_OverlongLine_Throws()
+    {
+        var line = new string('a', 20) + "\r\n.\r\n";
+        var result = await DecodeAsync(
+            Encoding.ASCII.GetBytes(line),
+            [3],
+            readerBufferSize: 4,
+            maximumLineLength: 8);
+        Assert.That(result.ProducerException, Is.TypeOf<UsenetProtocolException>());
+        Assert.That(result.ProducerException!.Message, Does.Contain("8-byte limit"));
+    }
+
+    [Test]
+    public async Task DecodeAsync_PreambleBeyondDrainLimit_Throws()
+    {
+        var preamble = string.Concat(Enumerable.Repeat("skip\r\n", 20));
+        var body = YencWireBodies.SinglePart("x"u8.ToArray(), preamble: preamble);
+        var result = await DecodeAsync(body.Wire, [int.MaxValue], drainLimit: 10);
+        Assert.That(result.ProducerException, Is.TypeOf<UsenetProtocolException>());
+        Assert.That(result.ProducerException!.Message, Does.Contain("non-yEnc"));
+    }
+
+    [Test]
+    public async Task DecodeAsync_TimeoutDuringRefill_ThrowsTimeoutException()
+    {
+        var body = YencWireBodies.SinglePart("stall"u8.ToArray());
+        var timeProvider = new ManualTimeProvider();
+        var source = new FragmentedReadStream(body.Wire, [body.PayloadOffset, int.MaxValue], cancelOnRead: 2);
+        var decodeTask = DecodeAsync(
+            body.Wire,
+            [body.PayloadOffset, int.MaxValue],
+            crcMode: YencCrcValidationMode.Off,
+            timeProvider: timeProvider,
+            readTimeout: TimeSpan.FromSeconds(1),
+            source: source);
+        await source.RefillStarted.WaitAsync(TimeSpan.FromSeconds(2));
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        var result = await decodeTask.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.That(result.ProducerException, Is.TypeOf<TimeoutException>());
+    }
+
+    [Test]
+    public async Task DecodeAsync_ObserverBalanceReturnsToZero()
+    {
+        var body = YencWireBodies.SinglePart(Encoding.ASCII.GetBytes("observer"));
+        var result = await DecodeAsync(body.Wire, [9]);
+        AssertSuccessful(result, body);
+        Assert.That(result.ObserverBalance, Is.EqualTo(0));
+    }
+
+    private static IEnumerable<TestCaseData> ControlSplitCases()
+    {
+        foreach (var data in SplitCaseList("ybegin", "=ybegin line=128 size=13 name=long-file-name.bin\r\n"))
+        {
+            yield return data;
+        }
+
+        foreach (var data in SplitCaseList("ypart", "=ypart begin=1 end=13\r\n"))
+        {
+            yield return data;
+        }
+
+        foreach (var data in SplitCaseList("yend", "=yend size=13 crc32=89abcdef\r\n"))
+        {
+            yield return data;
+        }
+
+        foreach (var data in SplitCaseList("terminator", ".\r\n"))
+        {
+            yield return data;
+        }
+
+        foreach (var data in SplitCaseList("terminator-follow", ".\r\n"))
+        {
+            yield return data;
+        }
+
+        foreach (var data in SplitCaseList("preamble-crlf", "\r\n"))
+        {
+            yield return data;
+        }
+    }
+
+    private static IEnumerable<TestCaseData> SplitCaseList(string name, string token)
+    {
+        var bytes = Encoding.ASCII.GetBytes(token);
+        for (var split = 1; split < bytes.Length; split++)
+        {
+            yield return new TestCaseData(name, split).SetName($"{name}_split_{split}");
+        }
+    }
+
+    private static void AssertSuccessful(DecodeResult result, YencWireBody body)
+    {
+        Assert.That(result.ProducerException, Is.Null, result.ProducerException?.ToString());
+        Assert.That(result.Decoded, Is.EqualTo(body.Decoded));
+        Assert.That(result.Headers, Is.Not.Null);
+        Assert.That(result.Headers!.FileName, Is.EqualTo(body.FileName));
+        Assert.That(result.Headers.FileSize, Is.EqualTo(body.FileSize));
+        Assert.That(result.ObserverBalance, Is.EqualTo(0));
+    }
+
+    private static int IndexOf(byte[] haystack, ReadOnlySpan<byte> needle)
+    {
+        var span = haystack.AsSpan();
+        var index = span.IndexOf(needle);
+        return index;
+    }
+
+    private static async Task<DecodeResult> DecodeAsync(
+        byte[] wireBody,
+        int[] fragmentSizes,
+        YencCrcValidationMode crcMode = YencCrcValidationMode.Require,
+        int readerBufferSize = 64 * 1024,
+        int maximumLineLength = 64 * 1024,
+        long drainLimit = 1024 * 1024,
+        long pauseWriterThreshold = 1024 * 1024,
+        long resumeWriterThreshold = 512 * 1024,
+        bool readFollowingLine = false,
+        TimeProvider? timeProvider = null,
+        TimeSpan? readTimeout = null,
+        FragmentedReadStream? source = null)
+    {
+        source ??= new FragmentedReadStream(wireBody, fragmentSizes);
+        using var reader = new NntpLineReader(source, maximumLineLength, readerBufferSize);
+        var pipe = new Pipe(new PipeOptions(
+            pauseWriterThreshold: pauseWriterThreshold,
+            resumeWriterThreshold: resumeWriterThreshold,
+            minimumSegmentSize: 64 * 1024,
+            useSynchronizationContext: false));
+        var observerBalance = 0L;
+        await using var decodedStream = new DecodedBodyReadStream(
+            pipe.Reader.AsStream(),
+            delta => Interlocked.Add(ref observerBalance, delta));
+        var headers = new TaskCompletionSource<UsenetYencHeader?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var operationCts = new CancellationTokenSource();
+        using var timeout = new CoalescedReadTimeout(
+            readTimeout ?? TimeSpan.FromSeconds(30),
+            timeProvider ?? TimeProvider.System,
+            operationCts.Token);
+        var options = new UsenetClientOptions
+        {
+            CrcValidation = crcMode,
+            AbandonedBodyDrainLimit = drainLimit,
+            DecodedBodyPauseWriterThreshold = pauseWriterThreshold,
+            DecodedBodyResumeWriterThreshold = resumeWriterThreshold
+        };
+
+        var decoder = new NntpYencBodyDecoder(
+            reader, pipe.Writer, headers, decodedStream, options, 64 * 1024);
+        var producer = ProduceAsync(() => decoder.ReadAsync(timeout, operationCts.Token), pipe.Writer);
+
+        using var decoded = new MemoryStream();
+        Exception? consumerException = null;
+        try
+        {
+            await decodedStream.CopyToAsync(decoded).ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            consumerException = exception;
+        }
+
+        Exception? producerException = null;
+        try
+        {
+            await producer.ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            producerException = exception;
+        }
+
+        UsenetYencHeader? parsedHeaders = null;
+        if (headers.Task.IsCompleted)
+        {
+            try
+            {
+                parsedHeaders = await headers.Task.ConfigureAwait(false);
+            }
+            catch (Exception exception) when (exception is not OutOfMemoryException)
+            {
+                producerException ??= exception;
+            }
+        }
+
+        string? followingLine = null;
+        if (readFollowingLine && producerException is null)
+        {
+            followingLine = await reader.ReadLineAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+
+        return new DecodeResult(
+            decoded.ToArray(),
+            parsedHeaders,
+            producerException ?? consumerException,
+            Volatile.Read(ref observerBalance),
+            source.SourceOffset,
+            followingLine);
+    }
+
+    private static async Task ProduceAsync(Func<Task> readAsync, PipeWriter writer)
+    {
+        Exception? failure = null;
+        try
+        {
+            await readAsync().ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            failure = exception;
+            throw;
+        }
+        finally
+        {
+            await writer.CompleteAsync(failure).ConfigureAwait(false);
+        }
+    }
+
+    private sealed record DecodeResult(
+        byte[] Decoded,
+        UsenetYencHeader? Headers,
+        Exception? ProducerException,
+        long ObserverBalance,
+        int SourceBytesConsumed,
+        string? FollowingLine);
+}

--- a/tests/UsenetSharp.Tests/Clients/UsenetClientDeterministicTests.cs
+++ b/tests/UsenetSharp.Tests/Clients/UsenetClientDeterministicTests.cs
@@ -369,6 +369,41 @@ public class UsenetClientDeterministicTests
     }
 
     [Test]
+    public async Task DecodedBodyAsync_TerminatorAndNextResponseShareSocketWrite_ThenDateAsyncSucceeds()
+    {
+        var expected = Encoding.ASCII.GetBytes("shared-write");
+        int? column = 0;
+        var encoded = RapidYencSharp.YencEncoder.EncodeEx(expected, ref column, 128, true);
+        var wireEncoded = DotStuff(encoded);
+        await using var server = ScriptedNntpServer.StartConnectionScript(
+            async (reader, writer, cancellationToken) =>
+            {
+                Assert.That(
+                    await reader.ReadLineAsync(cancellationToken),
+                    Is.EqualTo("BODY <article@example.com>"));
+                await writer.WriteAsync(
+                    "222 body follows\r\n" +
+                    $"=ybegin line=128 size={expected.Length} name=shared.bin\r\n");
+                await writer.WriteAsync(Encoding.Latin1.GetString(wireEncoded));
+                await writer.WriteAsync(
+                    $"\r\n=yend size={expected.Length}\r\n.\r\n111 20260709213000\r\n");
+                Assert.That(await reader.ReadLineAsync(cancellationToken), Is.EqualTo("DATE"));
+            });
+        await using var client = new UsenetClient();
+        await client.ConnectAsync("127.0.0.1", server.Port, false, CancellationToken.None);
+
+        var response = await client.DecodedBodyAsync(
+            "article@example.com", CancellationToken.None);
+        using var decoded = new MemoryStream();
+        await response.Stream!.CopyToAsync(decoded);
+        Assert.That(decoded.ToArray(), Is.EqualTo(expected));
+
+        var date = await client.DateAsync(CancellationToken.None);
+        Assert.That(date.ResponseCode, Is.EqualTo((int)UsenetResponseType.DateAndTime));
+        Assert.That(client.IsHealthy, Is.True);
+    }
+
+    [Test]
     public async Task DecodedBodyAsync_RawModeDotUnstuffsPayload()
     {
         await using var server = new ScriptedNntpServer(async (_, writer, _) =>

--- a/tests/UsenetSharp.Tests/Support/FragmentedReadStream.cs
+++ b/tests/UsenetSharp.Tests/Support/FragmentedReadStream.cs
@@ -1,0 +1,89 @@
+namespace UsenetSharpTest.Support;
+
+internal sealed class FragmentedReadStream(
+    ReadOnlyMemory<byte> source,
+    IReadOnlyList<int> fragmentSizes,
+    int? cancelOnRead = null) : Stream
+{
+    private readonly int[] _fragmentSizes = ValidateFragmentSizes(fragmentSizes);
+    private readonly TaskCompletionSource? _refillStarted = cancelOnRead is null
+        ? null
+        : new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _offset;
+    private int _fragmentIndex;
+    private int _readCount;
+
+    public int ReadCallCount => Volatile.Read(ref _readCount);
+    public int SourceOffset => _offset;
+    public Task RefillStarted => _refillStarted?.Task ?? Task.CompletedTask;
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override async ValueTask<int> ReadAsync(
+        Memory<byte> buffer,
+        CancellationToken cancellationToken = default)
+    {
+        var readNumber = Interlocked.Increment(ref _readCount);
+        if (cancelOnRead == readNumber)
+        {
+            _refillStarted?.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_offset >= source.Length)
+        {
+            return 0;
+        }
+
+        var fragment = _fragmentIndex < _fragmentSizes.Length
+            ? _fragmentSizes[_fragmentIndex]
+            : _fragmentSizes[^1];
+        _fragmentIndex++;
+        var take = Math.Min(Math.Min(fragment, buffer.Length), source.Length - _offset);
+        source.Span.Slice(_offset, take).CopyTo(buffer.Span);
+        _offset += take;
+        return take;
+    }
+
+    public override void Flush() => throw new NotSupportedException();
+
+    public override int Read(byte[] buffer, int offset, int count) =>
+        throw new NotSupportedException();
+
+    public override long Seek(long offset, SeekOrigin origin) =>
+        throw new NotSupportedException();
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) =>
+        throw new NotSupportedException();
+
+    private static int[] ValidateFragmentSizes(IReadOnlyList<int> fragmentSizes)
+    {
+        ArgumentNullException.ThrowIfNull(fragmentSizes);
+        if (fragmentSizes.Count == 0)
+        {
+            throw new ArgumentException(
+                "At least one fragment size is required.", nameof(fragmentSizes));
+        }
+
+        var copy = new int[fragmentSizes.Count];
+        for (var index = 0; index < fragmentSizes.Count; index++)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(fragmentSizes[index]);
+            copy[index] = fragmentSizes[index];
+        }
+
+        return copy;
+    }
+}

--- a/tests/UsenetSharp.Tests/Support/YencWireBodies.cs
+++ b/tests/UsenetSharp.Tests/Support/YencWireBodies.cs
@@ -1,0 +1,211 @@
+using System.Text;
+using RapidYencSharp;
+
+namespace UsenetSharpTest.Support;
+
+internal sealed record YencWireBody(
+    byte[] Wire,
+    byte[] Decoded,
+    uint Crc32,
+    string FileName,
+    long FileSize,
+    int PartNumber,
+    int TotalParts,
+    long PartOffset,
+    long PartSize,
+    int YBeginOffset,
+    int YPartOffset,
+    int PayloadOffset,
+    int YEndOffset,
+    int TerminatorOffset,
+    int FollowingResponseOffset);
+
+internal static class YencWireBodies
+{
+    public static YencWireBody SinglePart(
+        byte[] decoded,
+        string fileName = "test.bin",
+        bool includeCrc = true,
+        bool corruptCrc = false,
+        bool omitYend = false,
+        string? preamble = null,
+        string? postTrailer = null,
+        string? followingResponse = null,
+        string extraYendFields = "",
+        bool uppercaseCrc = false)
+    {
+        return Build(
+            decoded,
+            fileName,
+            multipart: false,
+            includeCrc,
+            corruptCrc,
+            omitYend,
+            preamble,
+            postTrailer,
+            followingResponse,
+            extraYendFields,
+            uppercaseCrc);
+    }
+
+    public static YencWireBody Multipart(
+        byte[] decoded,
+        string fileName = "part.bin",
+        int partNumber = 2,
+        int totalParts = 2,
+        long partOffset = 0,
+        long fileSize = -1,
+        bool includeCrc = true,
+        bool corruptCrc = false,
+        bool uppercaseCrc = false)
+    {
+        return Build(
+            decoded,
+            fileName,
+            multipart: true,
+            includeCrc,
+            corruptCrc,
+            omitYend: false,
+            preamble: null,
+            postTrailer: null,
+            followingResponse: null,
+            extraYendFields: "",
+            uppercaseCrc,
+            partNumber,
+            totalParts,
+            partOffset,
+            fileSize < 0 ? decoded.Length : fileSize);
+    }
+
+    private static YencWireBody Build(
+        byte[] decoded,
+        string fileName,
+        bool multipart,
+        bool includeCrc,
+        bool corruptCrc,
+        bool omitYend,
+        string? preamble,
+        string? postTrailer,
+        string? followingResponse,
+        string extraYendFields,
+        bool uppercaseCrc,
+        int partNumber = 0,
+        int totalParts = 0,
+        long partOffset = 0,
+        long fileSize = -1)
+    {
+        YencEncoder.EnsureInitialized();
+        Crc32.EnsureInitialized();
+        var crc32 = Crc32.Compute(decoded);
+        if (corruptCrc)
+        {
+            crc32 ^= 1;
+        }
+
+        int? column = 0;
+        var encoded = decoded.Length == 0
+            ? []
+            : YencEncoder.EncodeEx(decoded, ref column, 128, true);
+        encoded = DotStuff(encoded);
+
+        using var output = new MemoryStream();
+        if (!string.IsNullOrEmpty(preamble))
+        {
+            WriteAscii(output, preamble);
+        }
+
+        var ybeginOffset = (int)output.Length;
+        var resolvedFileSize = fileSize < 0 ? decoded.Length : fileSize;
+        if (multipart)
+        {
+            WriteAscii(
+                output,
+                $"=ybegin part={partNumber} total={totalParts} line=128 size={resolvedFileSize} name={fileName}\r\n");
+        }
+        else
+        {
+            WriteAscii(output, $"=ybegin line=128 size={resolvedFileSize} name={fileName}\r\n");
+        }
+
+        var ypartOffset = -1;
+        if (multipart)
+        {
+            ypartOffset = (int)output.Length;
+            WriteAscii(
+                output,
+                $"=ypart begin={partOffset + 1} end={partOffset + decoded.Length}\r\n");
+        }
+
+        var payloadOffset = (int)output.Length;
+        output.Write(encoded);
+        if (encoded.Length > 0)
+        {
+            WriteAscii(output, "\r\n");
+        }
+
+        var yendOffset = (int)output.Length;
+        if (!omitYend)
+        {
+            var crcField = includeCrc
+                ? (multipart
+                    ? $" pcrc32={(uppercaseCrc ? crc32.ToString("X8") : crc32.ToString("x8"))}"
+                    : $" crc32={(uppercaseCrc ? crc32.ToString("X8") : crc32.ToString("x8"))}")
+                : string.Empty;
+            var partFields = multipart ? $" part={partNumber}" : string.Empty;
+            WriteAscii(
+                output,
+                $"=yend size={decoded.Length}{partFields}{crcField}{extraYendFields}\r\n");
+        }
+
+        if (!string.IsNullOrEmpty(postTrailer))
+        {
+            WriteAscii(output, postTrailer);
+        }
+
+        var terminatorOffset = (int)output.Length;
+        WriteAscii(output, ".\r\n");
+        var followingOffset = (int)output.Length;
+        if (!string.IsNullOrEmpty(followingResponse))
+        {
+            WriteAscii(output, followingResponse);
+        }
+
+        return new YencWireBody(
+            output.ToArray(),
+            decoded,
+            includeCrc && !corruptCrc ? Crc32.Compute(decoded) : crc32,
+            fileName,
+            resolvedFileSize,
+            partNumber,
+            totalParts,
+            partOffset,
+            decoded.Length,
+            ybeginOffset,
+            ypartOffset,
+            payloadOffset,
+            yendOffset,
+            terminatorOffset,
+            followingOffset);
+    }
+
+    public static byte[] DotStuff(ReadOnlySpan<byte> data)
+    {
+        using var stuffed = new MemoryStream(data.Length);
+        var atLineStart = true;
+        foreach (var value in data)
+        {
+            if (atLineStart && value == (byte)'.')
+            {
+                stuffed.WriteByte(value);
+            }
+
+            stuffed.WriteByte(value);
+            atLineStart = value == (byte)'\n';
+        }
+
+        return stuffed.ToArray();
+    }
+
+    private static void WriteAscii(Stream output, string value) =>
+        output.Write(Encoding.ASCII.GetBytes(value));
+}


### PR DESCRIPTION
## Summary
- Playback still read 64 KiB NNTP fills one ~128-byte yEnc line at a time after #1029 removed the staging copy. `NntpLineReader` now exposes complete-line batches with explicit `Advance`, and `NntpYencBodyDecoder` scans control lines in-buffer then calls `YencDecoder.DecodeEx(..., isRaw: true)` once per contiguous payload range.
- Outer BODY lifecycle is unchanged: cancellation drain, command lock, pipe completion, and exactly-once callbacks stay in `ReadDecodedBodyToPipeAsync`. Input stops at the NNTP `.` terminator so the next pipelined response is not consumed.
- RapidYencSharp and the native submodule are unchanged. Managed batching already collapsed per-line await/P/Invoke cost enough that the RapidYencSharp consumed-pointer gate was not met.

Fixes #1023

## Performance
`NntpDecodedBodyBenchmarks` on Apple M4 Pro, .NET 10.0.11, same corpus/runtime before vs after (1 warmup + 5 iterations):

| Case | Before | After | Change | Before alloc | After alloc |
|---|---:|---:|---:|---:|---:|
| 4 MiB, CRC off | 4.939 ms (~810 MiB/s) | 1.007 ms (~3972 MiB/s) | 4.9× | 83.7 KB | 76.4 KB |
| 4 MiB, CRC require | 5.479 ms (~730 MiB/s) | 1.529 ms (~2616 MiB/s) | 3.6× | 83.7 KB | 76.4 KB |
| 32 MiB, CRC off | 39.851 ms (~803 MiB/s) | 7.984 ms (~4008 MiB/s) | 5.0× | 223.7 KB | 148.8 KB |
| 32 MiB, CRC require | 44.090 ms (~726 MiB/s) | 12.366 ms (~2588 MiB/s) | 3.6× | 223.5 KB | 147.7 KB |

Live two-core CPU seconds/GB against a provider (issue cited 37.5 vs 9.0–9.4) was not run in this environment and remains an operator follow-up on the same NZB/ranges/20 TLS connections.

## Test plan
- [x] `NntpLineReaderTests` including line/batch interoperability, CR/LF splits, and terminator leaving the next response
- [x] `NntpYencBodyDecoderTests` split-boundary corpus, CRC matrix, drain/timeout/EOF, following-response preservation
- [x] `DecodedBodyAsync` / `DecodedBodiesAsync` / `EnumerateDecodedBodiesAsync` plus shared-write `DateAsync` regression
- [x] Full UsenetSharp suite excluding live Integration (392 passed)
- [x] NzbWebDAV suite (3454 passed; one timing-sensitive watchdog test failed once then passed on retry)
- [x] `dotnet format whitespace --verify-no-changes` on touched folders
- [ ] Optional: two-core external CPU s/GB + hash check from issue #1023