### PR TITLE
fix(health): Health page no longer shows a stuck initial scan pending banner

### DIFF
--- a/backend/Api/Controllers/GetHealthCheckQueue/GetHealthCheckQueueController.cs
+++ b/backend/Api/Controllers/GetHealthCheckQueue/GetHealthCheckQueueController.cs
@@ -27,9 +27,14 @@ public class GetHealthCheckQueueController(DavDatabaseClient dbClient) : BaseApi
             }
         }
 
-        var uncheckedCount = await HealthCheckService.GetHealthCheckQueueItemsQuery(dbClient)
+        // Match HealthCheckService.ExecuteAsync: only media/archive candidates are ever
+        // processed, so non-media files (nfo/srt/jpg/…) must not inflate this count or
+        // the Health UI "initial scan pending" banner never clears.
+        var uncheckedCount = (await HealthCheckService.GetHealthCheckQueueItemsQuery(dbClient)
             .Where(x => x.NextHealthCheck == null)
-            .CountAsync().ConfigureAwait(false);
+            .Select(x => x.Name)
+            .ToListAsync().ConfigureAwait(false))
+            .Count(FilenameUtil.IsHealthCheckCandidate);
 
         return new GetHealthCheckQueueResponse()
         {

--- a/backend/Api/Controllers/GetHealthCheckQueue/GetHealthCheckQueueController.cs
+++ b/backend/Api/Controllers/GetHealthCheckQueue/GetHealthCheckQueueController.cs
@@ -30,11 +30,15 @@ public class GetHealthCheckQueueController(DavDatabaseClient dbClient) : BaseApi
         // Match HealthCheckService.ExecuteAsync: only media/archive candidates are ever
         // processed, so non-media files (nfo/srt/jpg/…) must not inflate this count or
         // the Health UI "initial scan pending" banner never clears.
-        var uncheckedCount = (await HealthCheckService.GetHealthCheckQueueItemsQuery(dbClient)
+        var uncheckedCount = 0;
+        await foreach (var name in HealthCheckService.GetHealthCheckQueueItemsQuery(dbClient)
             .Where(x => x.NextHealthCheck == null)
             .Select(x => x.Name)
-            .ToListAsync().ConfigureAwait(false))
-            .Count(FilenameUtil.IsHealthCheckCandidate);
+            .AsAsyncEnumerable()
+            .ConfigureAwait(false))
+        {
+            if (FilenameUtil.IsHealthCheckCandidate(name)) uncheckedCount++;
+        }
 
         return new GetHealthCheckQueueResponse()
         {

--- a/tests/NzbWebDAV.Tests/Api/AdminContractTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AdminContractTests.cs
@@ -86,6 +86,41 @@ public sealed class AdminContractTests
     }
 
     [Fact]
+    public async Task HealthCheckQueue_UncheckedCountExcludesNonMediaFiles()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        using var client = factory.CreateAuthenticatedClient();
+
+        // Three health-check candidates and four sidecar files, all never checked.
+        // Only candidates may count toward the Health UI "initial scan pending" banner.
+        await factory.AddDavItemsAsync(
+            NewUncheckedUsenetFile("movie.mkv"),
+            NewUncheckedUsenetFile("track.flac"),
+            NewUncheckedUsenetFile("archive.rar"),
+            NewUncheckedUsenetFile("cover.jpg"),
+            NewUncheckedUsenetFile("subs.srt"),
+            NewUncheckedUsenetFile("info.nfo"),
+            NewUncheckedUsenetFile("checksums.par2"));
+
+        using var response = await client.GetAsync("/api/get-health-check-queue?pageSize=30");
+        using var json = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(3, json.RootElement.GetProperty("uncheckedCount").GetInt32());
+    }
+
+    private static DavItem NewUncheckedUsenetFile(string name) => DavItem.New(
+        Guid.NewGuid(),
+        DavItem.ContentFolder,
+        name,
+        fileSize: 100,
+        DavItem.ItemType.UsenetFile,
+        DavItem.ItemSubType.NzbFile,
+        releaseDate: DateTimeOffset.UtcNow.AddDays(-1),
+        lastHealthCheck: null,
+        historyItemId: null,
+        fileBlobId: null);
+
+    [Fact]
     public async Task WebDavItemList_ReturnsSeededDirectoryChildren()
     {
         await using var factory = new NzbDavWebApplicationFactory();

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckQueueItemsQueryTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckQueueItemsQueryTests.cs
@@ -107,6 +107,33 @@ public sealed class HealthCheckQueueItemsQueryTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task UncheckedCount_ExcludesNonMediaFiles()
+    {
+        var videoFile = NewUsenetFile("movie.mkv", null, nextHealthCheck: null);
+        var audioFile = NewUsenetFile("track.flac", null, nextHealthCheck: null);
+        var archiveFile = NewUsenetFile("archive.rar", null, nextHealthCheck: null);
+        var imageFile = NewUsenetFile("cover.jpg", null, nextHealthCheck: null);
+        var subtitleFile = NewUsenetFile("subs.srt", null, nextHealthCheck: null);
+        var nfoFile = NewUsenetFile("info.nfo", null, nextHealthCheck: null);
+        var scheduledMedia = NewUsenetFile("already-checked.mkv", null, DateTimeOffset.UtcNow.AddHours(1));
+
+        _context.Items.AddRange(
+            videoFile, audioFile, archiveFile, imageFile, subtitleFile, nfoFile, scheduledMedia);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        // Mirror GetHealthCheckQueueController uncheckedCount: never-checked files that
+        // HealthCheckService will actually process.
+        var uncheckedCount = (await HealthCheckService.GetHealthCheckQueueItemsQuery(_dbClient)
+            .Where(x => x.NextHealthCheck == null)
+            .Select(x => x.Name)
+            .ToListAsync())
+            .Count(FilenameUtil.IsHealthCheckCandidate);
+
+        Assert.Equal(3, uncheckedCount);
+    }
+
+    [Fact]
     public async Task OrderedQuery_PrioritizesUrgentThenUncheckedThenScheduledItems()
     {
         var historyId = Guid.NewGuid();


### PR DESCRIPTION
## Summary
The Health page "Initial health scan pending" banner stayed visible after the real media scan finished. `uncheckedCount` included never-checked sidecar files (nfo, srt, jpg, …) that `HealthCheckService` never processes, so the count never dropped below the UI threshold of 20.

`GET /api/get-health-check-queue` now counts only `IsHealthCheckCandidate` filenames, matching the background health loop.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (3456 passed, 10 skipped)
- [ ] On a library with leftover nfo/srt/jpg files and a completed media health scan, confirm the pending banner is gone (or only appears when more than 20 media/archive files are still unchecked)