### PR TITLE
fix(webdav): resume playback without scanning lazy RAR volumes

### DIFF
--- a/backend/Services/LazyRarResolver.cs
+++ b/backend/Services/LazyRarResolver.cs
@@ -211,7 +211,7 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
         return new DavMultipartFile.FilePart
         {
             SegmentIds = pending.SegmentIds,
-            SegmentIdByteRange = LongRange.FromStartAndSize(0, dataStart + dataSize),
+            SegmentIdByteRange = LongRange.FromStartAndSize(0, Math.Max(fileSize, dataStart + dataSize)),
             FilePartByteRange = LongRange.FromStartAndSize(dataStart, dataSize),
             SegmentFallbackIds = pending.SegmentFallbackIds,
         };

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -224,7 +224,22 @@ public class NzbFileStream(
                     try
                     {
                         var header = await usenetClient.GetYencHeadersAsync(fileSegmentIds[guess], ct).ConfigureAwait(false);
-                        return new LongRange(header.PartOffset, header.PartOffset + header.PartSize);
+                        var range = new LongRange(header.PartOffset, header.PartOffset + header.PartSize);
+
+                        // A lazy RAR part's logical length ends with its packed file
+                        // data, while its final yEnc segment can also contain trailing
+                        // archive structure. Keep the generic interpolation search
+                        // strict, but trim this known end-only probe overflow so valid
+                        // tail seeks can still locate the final segment.
+                        if (range.StartInclusive >= 0 &&
+                            range.StartInclusive < fileSize &&
+                            range.EndExclusive > fileSize &&
+                            range.Contains(byteOffset))
+                        {
+                            range = new LongRange(range.StartInclusive, fileSize);
+                        }
+
+                        return range;
                     }
                     catch (UsenetArticleNotFoundException e)
                     {

--- a/tests/NzbWebDAV.Tests/Services/LazyRarResolverTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/LazyRarResolverTests.cs
@@ -96,7 +96,7 @@ public class LazyRarResolverTests
     {
         const string pathInArchive = "movie.mkv";
         const int packedSize = 1000;
-        var volumeBytes = BuildRar4ContinuationVolume(pathInArchive, packedSize);
+        var volumeBytes = BuildRar4ContinuationVolume(pathInArchive, packedSize, trailingBytes: 12);
         const string segmentId = "vol2-seg0";
         var client = new MeasuringNntpClient(segmentId, volumeBytes.Length);
         Guid? reconciledBlobId = null;
@@ -152,6 +152,7 @@ public class LazyRarResolverTests
 
             var meta = await resolver.EnsureResolvedThroughAsync(mpf, long.MaxValue, CancellationToken.None);
             Assert.False(meta.IsLazy);
+            Assert.Equal(volumeBytes.Length, meta.FileParts[1].SegmentIdByteRange.Count);
 
             for (var i = 0; i < 100 && reconciledSize is null; i++)
                 await Task.Delay(20);
@@ -169,7 +170,7 @@ public class LazyRarResolverTests
 
     // Minimal RAR4 multi-volume continuation: mark + archive(VOLUME) +
     // stored file header (HAS_DATA|SPLIT_BEFORE) + packed payload.
-    private static byte[] BuildRar4ContinuationVolume(string fileName, int packedSize)
+    private static byte[] BuildRar4ContinuationVolume(string fileName, int packedSize, int trailingBytes = 0)
     {
         using var ms = new MemoryStream();
         ms.Write([0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x00]);
@@ -215,6 +216,7 @@ public class LazyRarResolverTests
         }
 
         ms.Write(new byte[packedSize]);
+        ms.Write(new byte[trailingBytes]);
         return ms.ToArray();
     }
 

--- a/tests/NzbWebDAV.Tests/Streams/DavMultipartFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/DavMultipartFileStreamTests.cs
@@ -51,6 +51,42 @@ public class DavMultipartFileStreamTests
     }
 
     [Fact]
+    public async Task ReadAsync_TailOfPersistedLazyPartWithTrailingArchiveBytes_Succeeds()
+    {
+        var volumeBytes = Enumerable.Range(0, 16).Select(x => (byte)x).ToArray();
+        using var client = new FakeNntpClient(
+            new Dictionary<string, byte[]> { ["segment"] = volumeBytes },
+            useCachedYencStreams: true,
+            segmentRanges: new Dictionary<string, LongRange> { ["segment"] = new(0, 16) });
+        // Mimic an already-persisted lazy part where the recorded packed-data
+        // end excludes the trailing RAR structure in its final yEnc segment.
+        var multipart = MultipartFile(
+            segmentRange: LongRange.FromStartAndSize(0, 12),
+            fileRange: LongRange.FromStartAndSize(4, 8));
+        var previousBudget = NzbWebDAV.WebDav.Requests.RangeContext.GetReadBudget();
+        NzbWebDAV.WebDav.Requests.RangeContext.SetReadBudget(1);
+        try
+        {
+            await using var stream = new DavMultipartFileStream(
+                multipart,
+                client,
+                articleBufferSize: 0,
+                resolver: null,
+                usePipelinedBodyRequests: false,
+                fileName: "movie.mkv");
+            stream.Seek(7, SeekOrigin.Begin);
+
+            var buffer = new byte[1];
+            Assert.Equal(1, await stream.ReadAsync(buffer));
+            Assert.Equal(11, buffer[0]);
+        }
+        finally
+        {
+            NzbWebDAV.WebDav.Requests.RangeContext.SetReadBudget(previousBudget);
+        }
+    }
+
+    [Fact]
     public void Read_PreservesSynchronousArchiveParserCompatibility()
     {
         var volumeBytes = Enumerable.Range(0, 16).Select(x => (byte)x).ToArray();

--- a/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
@@ -106,6 +106,66 @@ public class NzbFileStreamTests
         }
     }
 
+    [Fact]
+    public async Task Seek_WhenFinalHeaderRangeExtendsPastLogicalFileSize_ReadsTailBytes()
+    {
+        var bytes = Enumerable.Range(0, 16).Select(value => (byte)value).ToArray();
+        var client = new FakeNntpClient(
+            new Dictionary<string, byte[]> { ["segment"] = bytes },
+            useCachedYencStreams: true,
+            segmentRanges: new Dictionary<string, LongRange> { ["segment"] = new(0, 16) });
+        var previousBudget = NzbWebDAV.WebDav.Requests.RangeContext.GetReadBudget();
+        NzbWebDAV.WebDav.Requests.RangeContext.SetReadBudget(1);
+        try
+        {
+            await using var stream = new NzbFileStream(
+                ["segment"],
+                fileSize: 12,
+                client,
+                articleBufferSize: 0,
+                segmentByteRanges: null,
+                usePipelinedBodyRequests: false);
+            stream.Seek(10, SeekOrigin.Begin);
+
+            var buffer = new byte[1];
+            Assert.Equal(1, await stream.ReadAsync(buffer));
+            Assert.Equal(10, buffer[0]);
+        }
+        finally
+        {
+            NzbWebDAV.WebDav.Requests.RangeContext.SetReadBudget(previousBudget);
+        }
+    }
+
+    [Fact]
+    public async Task Seek_WhenHeaderRangeDoesNotCoverLogicalFile_StillThrows()
+    {
+        var client = new FakeNntpClient(
+            new Dictionary<string, byte[]> { ["segment"] = new byte[4] },
+            useCachedYencStreams: true,
+            segmentRanges: new Dictionary<string, LongRange> { ["segment"] = new(12, 16) });
+        var previousBudget = NzbWebDAV.WebDav.Requests.RangeContext.GetReadBudget();
+        NzbWebDAV.WebDav.Requests.RangeContext.SetReadBudget(1);
+        try
+        {
+            await using var stream = new NzbFileStream(
+                ["segment"],
+                fileSize: 12,
+                client,
+                articleBufferSize: 0,
+                segmentByteRanges: null,
+                usePipelinedBodyRequests: false);
+            stream.Seek(10, SeekOrigin.Begin);
+
+            await Assert.ThrowsAsync<SeekPositionNotFoundException>(
+                async () => await stream.ReadAsync(new byte[1]));
+        }
+        finally
+        {
+            NzbWebDAV.WebDav.Requests.RangeContext.SetReadBudget(previousBudget);
+        }
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]


### PR DESCRIPTION
## Summary
- allow probe-based seeks to trim yEnc ranges that only overflow a lazy RAR part's logical end
- retain full resolved RAR volume lengths for future lazy resolutions
- cover tail reads for persisted lazy metadata and malformed probe ranges

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [ ] Verify a tail range on an affected mounted file returns `206 Partial Content` rather than `404`