### PR TITLE
fix(sab): queue and history panels no longer fail with server errors on PostgreSQL

### DIFF
--- a/backend/Api/SabControllers/GetHistory/GetHistoryController.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryController.cs
@@ -31,23 +31,22 @@ public class GetHistoryController(
         else if (request.Status is { } status)
             query = query.Where(q => q.DownloadStatus == status);
 
-        // get total count
-        var totalCountPromise = query
-            .CountAsync(request.CancellationToken);
+        // Get total count before querying the page: DbContext does not support
+        // concurrent operations.
+        var totalCount = await query
+            .CountAsync(request.CancellationToken)
+            .ConfigureAwait(false);
 
         // get history items
-        var historyItemsPromise = SabListQuery.ApplyHistorySort(
+        var historyItems = await SabListQuery.ApplyHistorySort(
                 query,
                 request.Sort,
                 request.Direction,
                 dbClient.Ctx.Database.IsNpgsql())
             .Skip(request.Start)
             .Take(request.Limit)
-            .ToArrayAsync(request.CancellationToken);
-
-        // await results
-        var totalCount = await totalCountPromise.ConfigureAwait(false);
-        var historyItems = await historyItemsPromise.ConfigureAwait(false);
+            .ToArrayAsync(request.CancellationToken)
+            .ConfigureAwait(false);
 
         // get download folders
         var downloadFolderIds = historyItems.Select(x => x.DownloadDirId).Where(x => x.HasValue).Select(x => x!.Value);

--- a/backend/Api/SabControllers/GetQueue/GetQueueController.cs
+++ b/backend/Api/SabControllers/GetQueue/GetQueueController.cs
@@ -62,7 +62,9 @@ public class GetQueueController(
             _ => queuedQuery,
         };
 
-        var queuedCountTask = queuedQuery.CountAsync(ct);
+        // Count before querying the page: DbContext does not support concurrent
+        // operations.
+        var queuedCount = await queuedQuery.CountAsync(ct).ConfigureAwait(false);
         var activeItems = inProgress.Select(x => x.QueueItem).ToList();
         var activePage = activeItems
             .Skip(request.Start)
@@ -72,19 +74,18 @@ public class GetQueueController(
             ? int.MaxValue
             : Math.Max(0, request.Limit - activePage.Count);
         var queuedStart = Math.Max(0, request.Start - activeItems.Count);
-        var queuedItemsTask = remainingLimit == 0
-            ? Task.FromResult(Array.Empty<QueueItem>())
-            : SabListQuery.ApplyQueueSort(
+        var queuedItems = remainingLimit == 0
+            ? Array.Empty<QueueItem>()
+            : await SabListQuery.ApplyQueueSort(
                     queuedQuery,
                     request.Sort,
                     request.Direction,
                     dbClient.Ctx.Database.IsNpgsql())
                 .Skip(queuedStart)
                 .Take(remainingLimit)
-                .ToArrayAsync(ct);
+                .ToArrayAsync(ct)
+                .ConfigureAwait(false);
 
-        var queuedCount = await queuedCountTask.ConfigureAwait(false);
-        var queuedItems = await queuedItemsTask.ConfigureAwait(false);
         var totalCount = checked(activeItems.Count + queuedCount);
         var merged = activePage.Concat(queuedItems).ToList();
 

--- a/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
@@ -251,9 +251,9 @@ public sealed class PostgresMigrationTests
         {
             if (_releaseCommand is { } releaseCommand)
             {
-                _releaseCommand = null;
                 _commandStarted?.TrySetResult();
                 await releaseCommand.Task.ConfigureAwait(false);
+                _releaseCommand = null;
             }
 
             return await base.ReaderExecutingAsync(command, eventData, result, cancellationToken)

--- a/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
@@ -173,7 +173,7 @@ public sealed class PostgresMigrationTests
                 context.QueueItems.Add(new QueueItem
                 {
                     Id = Guid.NewGuid(),
-                    CreatedAt = DateTime.UtcNow,
+                    CreatedAt = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified),
                     FileName = "queue.nzb",
                     JobName = "queue",
                     Priority = QueueItem.PriorityOption.Normal,
@@ -181,7 +181,7 @@ public sealed class PostgresMigrationTests
                 context.HistoryItems.Add(new HistoryItem
                 {
                     Id = Guid.NewGuid(),
-                    CreatedAt = DateTime.UtcNow,
+                    CreatedAt = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified),
                     FileName = "history.nzb",
                     JobName = "history",
                     DownloadStatus = HistoryItem.DownloadStatusOption.Completed,

--- a/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
@@ -1,6 +1,19 @@
+using System.Data.Common;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
 using Npgsql;
+using NzbWebDAV.Api.SabControllers.GetHistory;
+using NzbWebDAV.Api.SabControllers.GetQueue;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
 using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
+using NzbWebDAV.Websocket;
 
 namespace NzbWebDAV.Tests.Database;
 
@@ -43,9 +56,205 @@ public sealed class PostgresMigrationTests
         }
     }
 
+    [SkippableFact]
+    public async Task SabQueue_CountAndPageQueriesAreSequenced()
+    {
+        Skip.IfNot(DatabaseProviderConfig.IsPostgres,
+            "PostgreSQL tests require DATABASE_PROVIDER=postgres.");
+
+        await using var fixture = await SabControllerFixture.CreateAsync();
+        var commandStarted = fixture.Interceptor.DelayNextCommand();
+        var responseTask = fixture.QueueController.GetQueueAsync(fixture.CreateQueueRequest());
+
+        try
+        {
+            await commandStarted.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+        finally
+        {
+            fixture.Interceptor.ReleaseDelayedCommand();
+        }
+
+        var response = await responseTask;
+        Assert.Single(response.Queue.Slots);
+        Assert.Equal(1, response.Queue.TotalCount);
+    }
+
+    [SkippableFact]
+    public async Task SabHistory_CountAndPageQueriesAreSequenced()
+    {
+        Skip.IfNot(DatabaseProviderConfig.IsPostgres,
+            "PostgreSQL tests require DATABASE_PROVIDER=postgres.");
+
+        await using var fixture = await SabControllerFixture.CreateAsync();
+        var commandStarted = fixture.Interceptor.DelayNextCommand();
+        var responseTask = fixture.HistoryController.GetHistoryAsync(fixture.CreateHistoryRequest());
+
+        try
+        {
+            await commandStarted.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+        finally
+        {
+            fixture.Interceptor.ReleaseDelayedCommand();
+        }
+
+        var response = await responseTask;
+        Assert.Single(response.History.Slots);
+        Assert.Equal(1, response.History.TotalCount);
+    }
+
     private static async Task ExecuteAsync(NpgsqlConnection connection, string commandText)
     {
         await using var command = new NpgsqlCommand(commandText, connection);
         await command.ExecuteNonQueryAsync();
+    }
+
+    private sealed class SabControllerFixture : IAsyncDisposable
+    {
+        private readonly string _schema;
+        private readonly NpgsqlConnection _adminConnection;
+        private readonly PostgresDavDatabaseContext _context;
+        private readonly QueueManager _queueManager;
+        private readonly ConfigManager _configManager;
+        private readonly DavDatabaseClient _dbClient;
+        public DelayingDbCommandInterceptor Interceptor { get; }
+
+        private SabControllerFixture(
+            string schema,
+            NpgsqlConnection adminConnection,
+            PostgresDavDatabaseContext context,
+            QueueManager queueManager,
+            ConfigManager configManager,
+            DavDatabaseClient dbClient,
+            DelayingDbCommandInterceptor interceptor)
+        {
+            _schema = schema;
+            _adminConnection = adminConnection;
+            _context = context;
+            _queueManager = queueManager;
+            _configManager = configManager;
+            _dbClient = dbClient;
+            Interceptor = interceptor;
+        }
+
+        public GetQueueController QueueController =>
+            new(new DefaultHttpContext(), _dbClient, _queueManager, _configManager, new ProviderUsageTracker());
+
+        public GetHistoryController HistoryController =>
+            new(new DefaultHttpContext(), _dbClient, _configManager, new ProviderUsageTracker());
+
+        public GetQueueRequest CreateQueueRequest() =>
+            new(new DefaultHttpContext(), _configManager);
+
+        public GetHistoryRequest CreateHistoryRequest() =>
+            new(new DefaultHttpContext(), _configManager);
+
+        public static async Task<SabControllerFixture> CreateAsync()
+        {
+            var schema = $"nzbdav_sab_test_{Guid.NewGuid():N}";
+            var adminConnection = new NpgsqlConnection(DatabaseProviderConfig.PostgresConnectionString);
+            await adminConnection.OpenAsync();
+            await ExecuteAsync(adminConnection, $"CREATE SCHEMA \"{schema}\"");
+
+            try
+            {
+                var connectionString = new NpgsqlConnectionStringBuilder(
+                    DatabaseProviderConfig.PostgresConnectionString) { SearchPath = schema }.ConnectionString;
+                var interceptor = new DelayingDbCommandInterceptor();
+                var options = new DbContextOptionsBuilder<PostgresDavDatabaseContext>()
+                    .UseNpgsql(connectionString)
+                    .AddInterceptors(interceptor)
+                    .Options;
+                var context = new PostgresDavDatabaseContext(options);
+                await context.Database.MigrateAsync();
+
+                context.QueueItems.Add(new QueueItem
+                {
+                    Id = Guid.NewGuid(),
+                    CreatedAt = DateTime.UtcNow,
+                    FileName = "queue.nzb",
+                    JobName = "queue",
+                    Priority = QueueItem.PriorityOption.Normal,
+                });
+                context.HistoryItems.Add(new HistoryItem
+                {
+                    Id = Guid.NewGuid(),
+                    CreatedAt = DateTime.UtcNow,
+                    FileName = "history.nzb",
+                    JobName = "history",
+                    DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+                });
+                await context.SaveChangesAsync();
+                context.ChangeTracker.Clear();
+
+                var configManager = new ConfigManager();
+                configManager.UpdateValues([
+                    new ConfigItem
+                    {
+                        ConfigName = ConfigKeys.UsenetProviders,
+                        ConfigValue = "{\"providers\":[]}",
+                    },
+                ]);
+                var websocketManager = new WebsocketManager();
+                var queueManager = new QueueManager(
+                    new UsenetStreamingClient(
+                        configManager, websocketManager, new ProviderUsageTracker(), new MetricsWriter(),
+                        new ProviderBytesTracker(), new StreamTraceBuffer(100), new ActiveReadRegistry()),
+                    configManager, websocketManager, new ProviderUsageTracker(), new WatchdogLog(),
+                    new QueueItemSourceTracker(), new BenchmarkGate(), startLoop: false);
+                return new SabControllerFixture(schema, adminConnection, context, queueManager,
+                    configManager, new DavDatabaseClient(context), interceptor);
+            }
+            catch
+            {
+                await ExecuteAsync(adminConnection, $"DROP SCHEMA IF EXISTS \"{schema}\" CASCADE");
+                await adminConnection.DisposeAsync();
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            _queueManager.Dispose();
+            await _context.DisposeAsync();
+            await ExecuteAsync(_adminConnection, $"DROP SCHEMA IF EXISTS \"{_schema}\" CASCADE");
+            await _adminConnection.DisposeAsync();
+        }
+    }
+
+    private sealed class DelayingDbCommandInterceptor : DbCommandInterceptor
+    {
+        private TaskCompletionSource? _commandStarted;
+        private TaskCompletionSource? _releaseCommand;
+
+        public Task DelayNextCommand()
+        {
+            _commandStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            _releaseCommand = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            return _commandStarted.Task;
+        }
+
+        public void ReleaseDelayedCommand() => _releaseCommand?.TrySetResult();
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default) =>
+            DelayAsync(command, eventData, result, cancellationToken);
+
+        private async ValueTask<InterceptionResult<DbDataReader>> DelayAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken)
+        {
+            if (_releaseCommand is { } releaseCommand)
+            {
+                _releaseCommand = null;
+                _commandStarted?.TrySetResult();
+                await releaseCommand.Task.ConfigureAwait(false);
+            }
+
+            return await base.ReaderExecutingAsync(command, eventData, result, cancellationToken)
+                .ConfigureAwait(false);
+        }
     }
 }

--- a/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
@@ -160,7 +160,8 @@ public sealed class PostgresMigrationTests
             try
             {
                 var connectionString = new NpgsqlConnectionStringBuilder(
-                    DatabaseProviderConfig.PostgresConnectionString) { SearchPath = schema }.ConnectionString;
+                    DatabaseProviderConfig.PostgresConnectionString)
+                { SearchPath = schema }.ConnectionString;
                 var interceptor = new DelayingDbCommandInterceptor();
                 var options = new DbContextOptionsBuilder<PostgresDavDatabaseContext>()
                     .UseNpgsql(connectionString)

--- a/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
@@ -176,6 +176,7 @@ public sealed class PostgresMigrationTests
                     CreatedAt = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified),
                     FileName = "queue.nzb",
                     JobName = "queue",
+                    Category = "test",
                     Priority = QueueItem.PriorityOption.Normal,
                 });
                 context.HistoryItems.Add(new HistoryItem
@@ -184,6 +185,7 @@ public sealed class PostgresMigrationTests
                     CreatedAt = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified),
                     FileName = "history.nzb",
                     JobName = "history",
+                    Category = "test",
                     DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
                 });
                 await context.SaveChangesAsync();


### PR DESCRIPTION
## Summary
- sequence the history count and page queries on the request-scoped EF Core context
- sequence the queued count and page queries for the same reason
- prevent SAB queue and history polling failures with asynchronous database providers such as PostgreSQL

Fixes #1086

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`