### PR TITLE
fix(auth): keep UI sessions working after upgrades

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,8 +88,9 @@ COPY --from=backend-build /src/backend/publish ./backend
 
 # Entry and runtime setup
 COPY scripts/preflight-config-path.sh /preflight-config-path.sh
+COPY scripts/repair-config-path-ownership.sh /repair-config-path-ownership.sh
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh /preflight-config-path.sh
+RUN chmod +x /entrypoint.sh /preflight-config-path.sh /repair-config-path-ownership.sh
 
 # Set env variables
 EXPOSE 3000

--- a/backend/Database/ConfigPathPreflight.cs
+++ b/backend/Database/ConfigPathPreflight.cs
@@ -36,7 +36,6 @@ internal static class ConfigPathPreflight
     private static readonly string[] KnownStateFiles =
     [
         "pending-restore.json",
-        "session.key",
     ];
 
     public static void VerifyAccess()

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -47,7 +47,7 @@ docker compose up -d
 
 Set `PUID`/`PGID` from `id` on the host. Map `/mnt` (or your media paths) so completed downloads and library folders share paths with *Arr and media servers.
 
-The container fails startup before migrations if `/config` is missing, is a file, or is not writable by `PUID`/`PGID`. Ownership repair is best-effort; ACLs and group-writable mounts are accepted when the runtime user can create and delete a probe file. The image already contains an empty `/config` directory, so a path existing inside the container is not proof a host volume is mounted.
+The container fails startup before migrations if `/config` is missing, is a file, or is not writable by `PUID`/`PGID`. Ownership repair is best-effort; ACLs and group-writable mounts are accepted when the runtime user can create and delete a probe file. The image already contains an empty `/config` directory, so a path existing inside the container is not proof a host volume is mounted. The frontend session key at `/config/session.key` is mode `0600`; if your supervisor repairs ownership using an allowlist, include that file without recursively chowning `blobs/`.
 
 !!! tip "Headless Settings [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since }"
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -4,6 +4,7 @@
 
 - Check `docker logs nzbdav` for migration or backend health failures.
 - Ensure `CONFIG_PATH` (`/config`) exists as a directory and is writable by `PUID`/`PGID`. Startup now fails before migrations with a message that names the path and expected `PUID`/`PGID` instead of a later SQLite/EF error.
+- `/config/session.key` is the frontend cookie-signing secret and is mode `0600`. It must be owned by `PUID`/`PGID`; supervisors that chown only selected config files must include it. Fix that file directly rather than recursively chowning `blobs/`.
 - A `/config` path inside the image is not proof a persistent volume is mounted. Confirm the Compose `volumes:` mapping on the host.
 - Frontend `/healthz` should pass during long migrations; backend `/health` must eventually succeed.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -85,9 +85,15 @@ fi
 . /preflight-config-path.sh
 preflight_config_path || exit 1
 
-# Recursively update permissions when either database or its WAL files were
+# Repair the small state files used by the frontend and backend without walking
+# blobs or backup trees. The session key is mode 0600, so it must be owned by
+# the runtime user after an upgrade.
+# shellcheck disable=SC1091
+. /repair-config-path-ownership.sh
+repair_config_path_ownership
+
+# Recursively update permissions when a SQLite database or its WAL files were
 # created by a different container user.
-chown "$PUID:$PGID" "$CONFIG_PATH"
 OWNERSHIP_MISMATCH=""
 for DB_FILE in \
     "$CONFIG_PATH/db.sqlite" \
@@ -95,7 +101,13 @@ for DB_FILE in \
     "$CONFIG_PATH/db.sqlite-shm" \
     "$CONFIG_PATH/metrics.sqlite" \
     "$CONFIG_PATH/metrics.sqlite-wal" \
-    "$CONFIG_PATH/metrics.sqlite-shm"; do
+    "$CONFIG_PATH/metrics.sqlite-shm" \
+    "$CONFIG_PATH/warden.db" \
+    "$CONFIG_PATH/warden.db-wal" \
+    "$CONFIG_PATH/warden.db-shm" \
+    "$CONFIG_PATH/usenet-migration.db" \
+    "$CONFIG_PATH/usenet-migration.db-wal" \
+    "$CONFIG_PATH/usenet-migration.db-shm"; do
     if [ ! -e "$DB_FILE" ]; then
         continue
     fi

--- a/frontend/app/auth/authentication.server.test.ts
+++ b/frontend/app/auth/authentication.server.test.ts
@@ -1,4 +1,8 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import crypto from "crypto";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionResponseInit } from "./authentication.server";
 
 const { authenticateMock } = vi.hoisted(() => ({
@@ -24,6 +28,10 @@ beforeEach(() => {
   authenticateMock.mockReset();
 });
 
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
 function formRequest(username?: string, password?: string): Request {
   const body = new URLSearchParams();
   if (username !== undefined) body.set("username", username);
@@ -38,6 +46,40 @@ function getSetCookie(responseInit: SessionResponseInit): string {
 }
 
 describe("authentication sessions", () => {
+  it("persists generated session keys with private permissions", () => {
+    const configPath = fs.mkdtempSync(path.join(os.tmpdir(), "nzbdav-session-key-"));
+    vi.stubEnv("SESSION_KEY", "");
+    vi.stubEnv("CONFIG_PATH", configPath);
+
+    try {
+      const key = authentication.resolveSessionKey();
+      const keyPath = path.join(configPath, "session.key");
+
+      expect(fs.readFileSync(keyPath, "utf8")).toBe(key);
+      expect(fs.statSync(keyPath).mode & 0o777).toBe(0o600);
+    } finally {
+      fs.rmSync(configPath, { recursive: true, force: true });
+    }
+  });
+
+  it("warns when it cannot persist a session key", () => {
+    const configPath = path.join(os.tmpdir(), `nzbdav-session-key-file-${crypto.randomUUID()}`);
+    fs.writeFileSync(configPath, "not a directory");
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.stubEnv("SESSION_KEY", "");
+    vi.stubEnv("CONFIG_PATH", configPath);
+
+    try {
+      expect(authentication.resolveSessionKey()).toHaveLength(128);
+      expect(warning).toHaveBeenCalledWith(
+        expect.stringContaining("Unable to read or persist frontend session key"),
+      );
+    } finally {
+      warning.mockRestore();
+      fs.rmSync(configPath, { force: true });
+    }
+  });
+
   it("starts unauthenticated without a session cookie", async () => {
     await expect(authentication.isAuthenticated(new Request("http://localhost/"))).resolves.toBe(
       false,

--- a/frontend/app/auth/authentication.server.test.ts
+++ b/frontend/app/auth/authentication.server.test.ts
@@ -56,7 +56,9 @@ describe("authentication sessions", () => {
       const keyPath = path.join(configPath, "session.key");
 
       expect(fs.readFileSync(keyPath, "utf8")).toBe(key);
-      expect(fs.statSync(keyPath).mode & 0o777).toBe(0o600);
+      if (process.platform !== "win32") {
+        expect(fs.statSync(keyPath).mode & 0o777).toBe(0o600);
+      }
     } finally {
       fs.rmSync(configPath, { recursive: true, force: true });
     }

--- a/frontend/app/auth/authentication.server.ts
+++ b/frontend/app/auth/authentication.server.ts
@@ -37,7 +37,7 @@ function resolveSessionMaxAgeSeconds(): number {
   return parsed;
 }
 
-function resolveSessionKey(): string {
+export function resolveSessionKey(): string {
   if (process.env["SESSION_KEY"]) return process.env["SESSION_KEY"];
 
   const configPath = process.env["CONFIG_PATH"];
@@ -56,8 +56,11 @@ function resolveSessionKey(): string {
       fs.writeFileSync(keyPath, generated, { encoding: "utf8", mode: 0o600 });
       process.env["SESSION_KEY"] = generated;
       return generated;
-    } catch {
-      // Fall through to ephemeral key if CONFIG_PATH is unwritable.
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : "unknown error";
+      console.warn(
+        `Unable to read or persist frontend session key at ${keyPath}; login sessions will reset after restart. Reason: ${reason}`,
+      );
     }
   }
 

--- a/frontend/app/clients/admin-operations.test.ts
+++ b/frontend/app/clients/admin-operations.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -9,11 +9,19 @@ type OpenApiDocument = {
 };
 
 function loadContract(): OpenApiDocument {
-  const contractPath = resolve(
-    dirname(fileURLToPath(import.meta.url)),
-    "../../../contracts/openapi/admin-v1.json",
-  );
-  return JSON.parse(readFileSync(contractPath, "utf8")) as OpenApiDocument;
+  let directory = dirname(fileURLToPath(import.meta.url));
+  while (true) {
+    const contractPath = resolve(directory, "contracts/openapi/admin-v1.json");
+    if (existsSync(contractPath)) {
+      return JSON.parse(readFileSync(contractPath, "utf8")) as OpenApiDocument;
+    }
+
+    const parent = dirname(directory);
+    if (parent === directory) {
+      throw new Error("Could not find contracts/openapi/admin-v1.json.");
+    }
+    directory = parent;
+  }
 }
 
 describe("adminFrontendOperations", () => {

--- a/frontend/coverage-thresholds.json
+++ b/frontend/coverage-thresholds.json
@@ -10,7 +10,7 @@
       "lines": 83
     },
     "app/auth/**": {
-      "lines": 75
+      "lines": 85
     }
   }
 }

--- a/scripts/repair-config-path-ownership.sh
+++ b/scripts/repair-config-path-ownership.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# CONFIG_PATH ownership repair used by the container entrypoint.
+# Requires CONFIG_PATH, PUID, and PGID in the environment.
+
+repair_config_path_ownership() {
+    chown "$PUID:$PGID" "$CONFIG_PATH"
+
+    for STATE_FILE in \
+        "$CONFIG_PATH/session.key" \
+        "$CONFIG_PATH/pending-restore.json" \
+        "$CONFIG_PATH/db.sqlite" \
+        "$CONFIG_PATH/db.sqlite-wal" \
+        "$CONFIG_PATH/db.sqlite-shm" \
+        "$CONFIG_PATH/db.sqlite.maintenance.lock" \
+        "$CONFIG_PATH/metrics.sqlite" \
+        "$CONFIG_PATH/metrics.sqlite-wal" \
+        "$CONFIG_PATH/metrics.sqlite-shm" \
+        "$CONFIG_PATH/warden.db" \
+        "$CONFIG_PATH/warden.db-wal" \
+        "$CONFIG_PATH/warden.db-shm" \
+        "$CONFIG_PATH/usenet-migration.db" \
+        "$CONFIG_PATH/usenet-migration.db-wal" \
+        "$CONFIG_PATH/usenet-migration.db-shm"; do
+        [ -e "$STATE_FILE" ] || continue
+        chown "$PUID:$PGID" "$STATE_FILE"
+    done
+
+    if [ -d "$CONFIG_PATH/data-protection" ]; then
+        chown -R "$PUID:$PGID" "$CONFIG_PATH/data-protection"
+    fi
+}

--- a/scripts/test-entrypoint-config-ownership.sh
+++ b/scripts/test-entrypoint-config-ownership.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Fixture checks for scripts/repair-config-path-ownership.sh
+set -eu
+
+ROOT="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+REPAIR="$ROOT/scripts/repair-config-path-ownership.sh"
+STUBS="$(mktemp -d "${TMPDIR:-/tmp}/nzbdav-ownership-stubs.XXXXXX")"
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/nzbdav-ownership-work.XXXXXX")"
+
+cleanup() {
+    rm -rf "$STUBS" "$WORKDIR"
+}
+trap cleanup EXIT INT HUP TERM
+
+cat > "$STUBS/chown" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$CHOWN_LOG"
+EOF
+chmod +x "$STUBS/chown"
+
+export PATH="$STUBS:$PATH"
+export PUID=1000
+export PGID=1000
+export CONFIG_PATH="$WORKDIR/config"
+export CHOWN_LOG="$WORKDIR/chown.log"
+mkdir -p "$CONFIG_PATH"
+: > "$CONFIG_PATH/db.sqlite"
+: > "$CONFIG_PATH/session.key"
+
+# shellcheck disable=SC1090
+. "$REPAIR"
+repair_config_path_ownership
+
+if grep -Fqx "1000:1000 $CONFIG_PATH/session.key" "$CHOWN_LOG"; then
+    echo "ok - repairs session key ownership when databases already exist"
+else
+    echo "not ok - session key ownership was not repaired" >&2
+    exit 1
+fi

--- a/tests/NzbWebDAV.Tests/Database/ConfigPathPreflightTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/ConfigPathPreflightTests.cs
@@ -60,12 +60,23 @@ public sealed class ConfigPathPreflightTests : IDisposable
     }
 
     [Fact]
-    public void VerifyAccess_PassesWithExistingBackupAndSessionStateFiles()
+    public void VerifyAccess_PassesWithExistingBackupAndRestoreStateFiles()
     {
         Directory.CreateDirectory(Path.Join(_configRoot, "backups"));
         Directory.CreateDirectory(Path.Join(_configRoot, "restore-staging"));
         File.WriteAllText(Path.Join(_configRoot, "pending-restore.json"), "{}");
-        File.WriteAllText(Path.Join(_configRoot, "session.key"), "test-session-key");
+
+        ConfigPathPreflight.VerifyAccess();
+    }
+
+    [SkippableFact]
+    public void VerifyAccess_PassesWithUnreadableFrontendSessionKey()
+    {
+        Skip.If(OperatingSystem.IsWindows(), "Unix file modes are not enforced on Windows.");
+        var keyPath = Path.Join(_configRoot, "session.key");
+        File.WriteAllText(keyPath, "test-session-key");
+        SetMode(keyPath, UnixFileMode.None);
+        Skip.IfNot(PermissionsEnforced(keyPath), "Test is running as root; file modes are not enforced.");
 
         ConfigPathPreflight.VerifyAccess();
     }


### PR DESCRIPTION
## Summary
- Repair ownership of `session.key` and bounded runtime state before starting frontend or database maintenance, without walking blob or backup trees.
- Stop backend startup checks from treating the frontend-only session key as backend state, and warn operators if the frontend cannot persist it.
- Document the mode-0600 session-key ownership requirement for allowlist-based supervisors.

## Test plan
- [x] `sh scripts/test-entrypoint-config-ownership.sh`
- [x] `sh scripts/test-entrypoint-config-preflight.sh`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~ConfigPathPreflightTests"`
- [x] `cd frontend && npm test -- app/auth/authentication.server.test.ts`
- [x] `cd frontend && npm run typecheck`