### PR TITLE
fix(ui): provider cards show warm connection counts

### DIFF
--- a/backend/Clients/Usenet/Connections/ConnectionPoolStats.cs
+++ b/backend/Clients/Usenet/Connections/ConnectionPoolStats.cs
@@ -31,6 +31,11 @@ public class ConnectionPoolStats
 
     public ConnectionPoolStats(UsenetProviderConfig providerConfig, WebsocketManager websocketManager)
     {
+        // Provider indexes are the cxs replay keys. A replacement configuration may
+        // have fewer or reordered providers, so discard the retired generation's state
+        // before the new pools publish their initial snapshots.
+        websocketManager.ClearKeyedState(WebsocketTopic.UsenetConnections);
+
         var count = providerConfig.Providers.Count;
         _live = new int[count];
         _idle = new int[count];

--- a/backend/Websocket/WebsocketManager.cs
+++ b/backend/Websocket/WebsocketManager.cs
@@ -19,8 +19,10 @@ public class WebsocketManager : IWebsocketPublisher
 
     private readonly Dictionary<WebSocket, SocketSession> _sessions = new();
     private readonly Dictionary<WebsocketTopic, string> _lastMessage = new();
+    private readonly Dictionary<WebsocketTopic, Dictionary<string, KeyedState>> _lastKeyedMessages = new();
     private readonly ConcurrentDictionary<WebsocketTopic, int> _subscriberCounts = new();
     private long _skippedPublishes;
+    private long _stateSequence;
 
     /// <summary>
     /// Whether at least one downstream browser client is subscribed to the given topic.
@@ -79,7 +81,20 @@ public class WebsocketManager : IWebsocketPublisher
     /// <param name="message">The message to send</param>
     public Task SendMessage(WebsocketTopic topic, string message)
     {
-        lock (_lastMessage) _lastMessage[topic] = message;
+        lock (_lastMessage)
+        {
+            if (topic.ReplayAllKeys && GetMessageKey(topic, message) is { } key)
+            {
+                if (!_lastKeyedMessages.TryGetValue(topic, out var messages))
+                    _lastKeyedMessages[topic] = messages = new Dictionary<string, KeyedState>();
+
+                messages[key] = new KeyedState(message, ++_stateSequence);
+            }
+            else
+            {
+                _lastMessage[topic] = message;
+            }
+        }
         List<SocketSession> sessions;
         lock (_sessions) sessions = _sessions.Values.ToList();
         if (sessions.Count == 0) return Task.CompletedTask;
@@ -101,7 +116,22 @@ public class WebsocketManager : IWebsocketPublisher
     internal string? PeekLastMessage(WebsocketTopic topic)
     {
         lock (_lastMessage)
-            return _lastMessage.TryGetValue(topic, out var message) ? message : null;
+        {
+            if (_lastMessage.TryGetValue(topic, out var message))
+                return message;
+            return _lastKeyedMessages.TryGetValue(topic, out var messages)
+                ? messages.Values.MaxBy(entry => entry.Sequence)?.Message
+                : null;
+        }
+    }
+
+    internal void ClearKeyedState(WebsocketTopic topic)
+    {
+        if (!topic.ReplayAllKeys)
+            throw new ArgumentException("Only topics that replay all keys can be cleared.", nameof(topic));
+
+        lock (_lastMessage)
+            _lastKeyedMessages.Remove(topic);
     }
 
     internal Func<Task> AttachAuthenticatedSocketForTests(WebSocket socket, bool replayState = false)
@@ -241,13 +271,10 @@ public class WebsocketManager : IWebsocketPublisher
     {
         if (topic.Type != WebsocketTopic.TopicType.State) return;
 
-        string? lastMsg;
         lock (_lastMessage)
         {
-            if (!_lastMessage.TryGetValue(topic, out lastMsg)) return;
+            EnqueueReplayState(session, topic);
         }
-
-        session.TryEnqueue(topic, GetMessageKey(topic, lastMsg), SerializeMessage(topic, lastMsg));
     }
 
     private SocketSession AddSocket(WebSocket socket, bool replayState = false)
@@ -267,12 +294,9 @@ public class WebsocketManager : IWebsocketPublisher
             lock (_sessions)
                 _sessions.Add(socket, session);
 
-            foreach (var message in _lastMessage)
-                if (message.Key.Type == WebsocketTopic.TopicType.State)
-                    session.TryEnqueue(
-                        message.Key,
-                        GetMessageKey(message.Key, message.Value),
-                        SerializeMessage(message.Key, message.Value));
+            foreach (var topic in _lastMessage.Keys.Concat(_lastKeyedMessages.Keys).Distinct())
+                if (topic.Type == WebsocketTopic.TopicType.State)
+                    EnqueueReplayState(session, topic);
         }
 
         return session;
@@ -408,11 +432,30 @@ public class WebsocketManager : IWebsocketPublisher
         return separator > 0 ? message[..separator] : null;
     }
 
+    private void EnqueueReplayState(SocketSession session, WebsocketTopic topic)
+    {
+        if (topic.ReplayAllKeys &&
+            _lastKeyedMessages.TryGetValue(topic, out var keyedMessages))
+        {
+            foreach (var keyedMessage in keyedMessages.Values.OrderBy(entry => entry.Sequence))
+                session.TryEnqueue(
+                    topic,
+                    GetMessageKey(topic, keyedMessage.Message),
+                    SerializeMessage(topic, keyedMessage.Message));
+            return;
+        }
+
+        if (_lastMessage.TryGetValue(topic, out var message))
+            session.TryEnqueue(topic, GetMessageKey(topic, message), SerializeMessage(topic, message));
+    }
+
     private sealed class TopicMessage(WebsocketTopic topic, string message)
     {
         public string Topic { get; } = topic.Name;
         public string Message { get; } = message;
     }
+
+    private sealed record KeyedState(string Message, long Sequence);
 
     private sealed class SocketSession : IDisposable
     {

--- a/backend/Websocket/WebsocketManager.cs
+++ b/backend/Websocket/WebsocketManager.cs
@@ -89,6 +89,7 @@ public class WebsocketManager : IWebsocketPublisher
                     _lastKeyedMessages[topic] = messages = new Dictionary<string, KeyedState>();
 
                 messages[key] = new KeyedState(message, ++_stateSequence);
+                _lastMessage.Remove(topic);
             }
             else
             {
@@ -132,6 +133,10 @@ public class WebsocketManager : IWebsocketPublisher
 
         lock (_lastMessage)
             _lastKeyedMessages.Remove(topic);
+
+        // The frontend relay retains state independently, so tell it to discard
+        // provider snapshots from the replaced generation as well.
+        _ = SendMessage(topic, "reset");
     }
 
     internal Func<Task> AttachAuthenticatedSocketForTests(WebSocket socket, bool replayState = false)
@@ -294,9 +299,11 @@ public class WebsocketManager : IWebsocketPublisher
             lock (_sessions)
                 _sessions.Add(socket, session);
 
-            foreach (var topic in _lastMessage.Keys.Concat(_lastKeyedMessages.Keys).Distinct())
-                if (topic.Type == WebsocketTopic.TopicType.State)
-                    EnqueueReplayState(session, topic);
+            foreach (var topic in _lastMessage.Keys
+                         .Concat(_lastKeyedMessages.Keys)
+                         .Distinct()
+                         .Where(topic => topic.Type == WebsocketTopic.TopicType.State))
+                EnqueueReplayState(session, topic);
         }
 
         return session;

--- a/backend/Websocket/WebsocketTopic.cs
+++ b/backend/Websocket/WebsocketTopic.cs
@@ -5,7 +5,7 @@ public class WebsocketTopic
     private static readonly Dictionary<string, WebsocketTopic> ByName = new(StringComparer.Ordinal);
 
     // Stateful topics
-    public static readonly WebsocketTopic UsenetConnections = new("cxs", TopicType.State);
+    public static readonly WebsocketTopic UsenetConnections = new("cxs", TopicType.State, isKeyed: true, replayAllKeys: true);
     public static readonly WebsocketTopic ActiveReads = new("ar", TopicType.State);
     public static readonly WebsocketTopic SymlinkTaskProgress = new("stp", TopicType.State);
     public static readonly WebsocketTopic CleanupTaskProgress = new("ctp", TopicType.State);
@@ -41,12 +41,14 @@ public class WebsocketTopic
     public readonly string Name;
     public readonly TopicType Type;
     public readonly bool IsKeyed;
+    public readonly bool ReplayAllKeys;
 
-    private WebsocketTopic(string name, TopicType type, bool isKeyed = false)
+    private WebsocketTopic(string name, TopicType type, bool isKeyed = false, bool replayAllKeys = false)
     {
         Name = name;
         Type = type;
         IsKeyed = isKeyed;
+        ReplayAllKeys = replayAllKeys;
         ByName[name] = this;
     }
 

--- a/frontend/app/routes/_index/components/live-usenet-connections/live-usenet-connections.tsx
+++ b/frontend/app/routes/_index/components/live-usenet-connections/live-usenet-connections.tsx
@@ -86,9 +86,15 @@ export function LiveUsenetConnections({ hasUsenetProviders }: LiveUsenetConnecti
           {hasUsenetProviders && connections && `${live}/${max}`}
           {showConnecting && <span className="loading loading-spinner loading-xs" />}
         </div>
-        <div className="stat-desc text-[10px] leading-none whitespace-nowrap text-base-content/50">
+        <div
+          className="stat-desc tooltip tooltip-bottom text-[10px] leading-none whitespace-nowrap text-base-content/50"
+          data-tip="Warm connections are pre-connected to your Usenet providers so playback can start faster."
+        >
           {!hasUsenetProviders && "No providers"}
-          {hasUsenetProviders && connections && !transportDown && `${active} active`}
+          {hasUsenetProviders &&
+            connections &&
+            !transportDown &&
+            `${active} active${idle > 0 ? ` · ${idle} warm` : ""}`}
           {showReconnecting && "Reconnecting"}
           {showConnecting && "Connecting"}
         </div>

--- a/frontend/server/websocket.server.test.ts
+++ b/frontend/server/websocket.server.test.ts
@@ -85,6 +85,22 @@ describe("connection state replay", () => {
 
     expect(replayStateMessages(lastMessage, "ls")).toEqual([message]);
   });
+
+  it("drops retired provider state when the backend resets connection replay", () => {
+    const lastMessage = new Map<string, string>();
+    const providerZero = JSON.stringify({ Topic: "cxs", Message: "0|8|8|8|60|8" });
+
+    cacheStateMessage(lastMessage, "cxs", "0|8|8|8|60|8", providerZero);
+    const shouldRelay = cacheStateMessage(
+      lastMessage,
+      "cxs",
+      "reset",
+      JSON.stringify({ Topic: "cxs", Message: "reset" }),
+    );
+
+    expect(shouldRelay).toBe(false);
+    expect(replayStateMessages(lastMessage, "cxs")).toEqual([]);
+  });
 });
 
 describe("nextBackendReconnectDelayMs", () => {

--- a/frontend/server/websocket.server.test.ts
+++ b/frontend/server/websocket.server.test.ts
@@ -3,10 +3,12 @@ import WebSocket from "ws";
 import {
   BACKEND_RECONNECT_INITIAL_MS,
   BACKEND_RECONNECT_MAX_MS,
+  cacheStateMessage,
   MAX_CLIENT_BUFFERED_AMOUNT,
   MAX_TOPICS_PER_SOCKET,
   nextBackendReconnectDelayMs,
   parseSubscriptionTopics,
+  replayStateMessages,
   sendToBrowserClient,
   UpstreamSubscriptionForwarder,
 } from "./websocket.server";
@@ -58,6 +60,30 @@ describe("sendToBrowserClient", () => {
 
     sendToBrowserClient(client, "msg");
     expect(send).toHaveBeenCalledWith("msg");
+  });
+});
+
+describe("connection state replay", () => {
+  it("replays the latest state for every provider with newest totals last", () => {
+    const lastMessage = new Map<string, string>();
+    const providerZero = JSON.stringify({ Topic: "cxs", Message: "0|8|8|13|90|13" });
+    const providerOne = JSON.stringify({ Topic: "cxs", Message: "1|5|5|13|90|13" });
+    const providerZeroUpdated = JSON.stringify({ Topic: "cxs", Message: "0|7|7|12|90|12" });
+
+    cacheStateMessage(lastMessage, "cxs", "0|8|8|13|90|13", providerZero);
+    cacheStateMessage(lastMessage, "cxs", "1|5|5|13|90|13", providerOne);
+    cacheStateMessage(lastMessage, "cxs", "0|7|7|12|90|12", providerZeroUpdated);
+
+    expect(replayStateMessages(lastMessage, "cxs")).toEqual([providerOne, providerZeroUpdated]);
+  });
+
+  it("keeps ordinary state topics as a single latest value", () => {
+    const lastMessage = new Map<string, string>();
+    const message = JSON.stringify({ Topic: "ls", Message: "latest" });
+
+    cacheStateMessage(lastMessage, "ls", "latest", message);
+
+    expect(replayStateMessages(lastMessage, "ls")).toEqual([message]);
   });
 });
 

--- a/frontend/server/websocket.server.ts
+++ b/frontend/server/websocket.server.ts
@@ -26,6 +26,7 @@ export type TopicKind = "state" | "stream" | "event";
 
 const TOPIC_KINDS = new Set<TopicKind>(["state", "stream", "event"]);
 export const KEYED_REPLAY_TOPICS = new Set(["cxs"]);
+export const KEYED_REPLAY_RESET_MESSAGE = "reset";
 const KEYED_REPLAY_SEPARATOR = "\0";
 
 type TrackedSocket = WebSocket & { isAlive?: boolean };
@@ -67,16 +68,22 @@ export function cacheStateMessage(
   topic: string,
   message: string,
   rawMessage: string,
-): void {
+): boolean {
+  if (KEYED_REPLAY_TOPICS.has(topic) && message === KEYED_REPLAY_RESET_MESSAGE) {
+    clearKeyedReplayState(lastMessage, topic);
+    return false;
+  }
+
   const keyedCacheKey = keyedReplayCacheKey(topic, message);
   if (!keyedCacheKey) {
     lastMessage.set(topic, rawMessage);
-    return;
+    return true;
   }
 
   // Reinsert updates so replay delivers the latest aggregate totals last.
   lastMessage.delete(keyedCacheKey);
   lastMessage.set(keyedCacheKey, rawMessage);
+  return true;
 }
 
 export function replayStateMessages(lastMessage: Map<string, string>, topic: string): string[] {
@@ -89,6 +96,13 @@ export function replayStateMessages(lastMessage: Map<string, string>, topic: str
   return [...lastMessage.entries()]
     .filter(([key]) => key.startsWith(prefix))
     .map(([, message]) => message);
+}
+
+export function clearKeyedReplayState(lastMessage: Map<string, string>, topic: string): void {
+  const prefix = `${topic}${KEYED_REPLAY_SEPARATOR}`;
+  for (const key of lastMessage.keys()) {
+    if (key.startsWith(prefix)) lastMessage.delete(key);
+  }
 }
 
 /**
@@ -301,7 +315,7 @@ export function initializeWebsocketClient(
         const { Topic: topic, Message: message } = topicMessage as Record<string, unknown>;
         if (typeof topic !== "string" || typeof message !== "string") return;
 
-        cacheStateMessage(lastMessage, topic, message, rawMessage);
+        if (!cacheStateMessage(lastMessage, topic, message, rawMessage)) return;
         const subscribed = subscriptions.get(topic) || [];
         subscribed.forEach((client) => {
           sendToBrowserClient(client, rawMessage);

--- a/frontend/server/websocket.server.ts
+++ b/frontend/server/websocket.server.ts
@@ -25,6 +25,8 @@ export const BACKEND_RECONNECT_MAX_MS = 30_000;
 export type TopicKind = "state" | "stream" | "event";
 
 const TOPIC_KINDS = new Set<TopicKind>(["state", "stream", "event"]);
+export const KEYED_REPLAY_TOPICS = new Set(["cxs"]);
+const KEYED_REPLAY_SEPARATOR = "\0";
 
 type TrackedSocket = WebSocket & { isAlive?: boolean };
 
@@ -52,6 +54,41 @@ export function sendToBrowserClient(client: WebSocket, rawMessage: string): void
   if (client.readyState !== WebSocket.OPEN) return;
   if (client.bufferedAmount > MAX_CLIENT_BUFFERED_AMOUNT) return;
   client.send(rawMessage);
+}
+
+function keyedReplayCacheKey(topic: string, message: string): string | null {
+  if (!KEYED_REPLAY_TOPICS.has(topic)) return null;
+  const separator = message.indexOf("|");
+  return separator > 0 ? `${topic}${KEYED_REPLAY_SEPARATOR}${message.slice(0, separator)}` : null;
+}
+
+export function cacheStateMessage(
+  lastMessage: Map<string, string>,
+  topic: string,
+  message: string,
+  rawMessage: string,
+): void {
+  const keyedCacheKey = keyedReplayCacheKey(topic, message);
+  if (!keyedCacheKey) {
+    lastMessage.set(topic, rawMessage);
+    return;
+  }
+
+  // Reinsert updates so replay delivers the latest aggregate totals last.
+  lastMessage.delete(keyedCacheKey);
+  lastMessage.set(keyedCacheKey, rawMessage);
+}
+
+export function replayStateMessages(lastMessage: Map<string, string>, topic: string): string[] {
+  if (!KEYED_REPLAY_TOPICS.has(topic)) {
+    const message = lastMessage.get(topic);
+    return message ? [message] : [];
+  }
+
+  const prefix = `${topic}${KEYED_REPLAY_SEPARATOR}`;
+  return [...lastMessage.entries()]
+    .filter(([key]) => key.startsWith(prefix))
+    .map(([, message]) => message);
 }
 
 /**
@@ -131,8 +168,9 @@ function initializeWebsocketServer(wss: WebSocketServer) {
         if (topicSubscriptions) topicSubscriptions.add(ws);
         else subscriptions.set(topic, new Set<TrackedSocket>([ws]));
         if (topics[topic] === "state") {
-          const messageToSend = lastMessage.get(topic);
-          if (messageToSend) sendToBrowserClient(ws, messageToSend);
+          for (const messageToSend of replayStateMessages(lastMessage, topic)) {
+            sendToBrowserClient(ws, messageToSend);
+          }
         }
       }
 
@@ -263,7 +301,7 @@ export function initializeWebsocketClient(
         const { Topic: topic, Message: message } = topicMessage as Record<string, unknown>;
         if (typeof topic !== "string" || typeof message !== "string") return;
 
-        lastMessage.set(topic, rawMessage);
+        cacheStateMessage(lastMessage, topic, message, rawMessage);
         const subscribed = subscriptions.get(topic) || [];
         subscribed.forEach((client) => {
           sendToBrowserClient(client, rawMessage);

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolStatsReplayTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolStatsReplayTests.cs
@@ -8,6 +8,36 @@ namespace NzbWebDAV.Tests.Clients.Usenet;
 public class ConnectionPoolStatsReplayTests
 {
     [Fact]
+    public async Task NewGeneration_ClearsRetiredProviderReplayState()
+    {
+        var websocketManager = new WebsocketManager();
+        await websocketManager.SendMessage(
+            WebsocketTopic.UsenetConnections,
+            "4|8|8|8|60|8");
+
+        _ = new ConnectionPoolStats(
+            new UsenetProviderConfig
+            {
+                Providers =
+                [
+                    new UsenetProviderConfig.ConnectionDetails
+                    {
+                        Type = ProviderType.Pooled,
+                        Host = "news.example.com",
+                        Port = 563,
+                        UseSsl = true,
+                        User = "user",
+                        Pass = "pass",
+                        MaxConnections = 10,
+                    },
+                ],
+            },
+            websocketManager);
+
+        Assert.Null(websocketManager.PeekLastMessage(WebsocketTopic.UsenetConnections));
+    }
+
+    [Fact]
     public async Task Flush_WithoutSubscribers_KeepsReplayStateFresh()
     {
         var websocketManager = new WebsocketManager();

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolStatsReplayTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolStatsReplayTests.cs
@@ -34,7 +34,7 @@ public class ConnectionPoolStatsReplayTests
             },
             websocketManager);
 
-        Assert.Null(websocketManager.PeekLastMessage(WebsocketTopic.UsenetConnections));
+        Assert.Equal("reset", websocketManager.PeekLastMessage(WebsocketTopic.UsenetConnections));
     }
 
     [Fact]
@@ -68,7 +68,8 @@ public class ConnectionPoolStatsReplayTests
             this,
             new ConnectionPoolStats.ConnectionPoolChangedEventArgs(3, 1, 10));
 
-        await WaitUntil(() => websocketManager.PeekLastMessage(WebsocketTopic.UsenetConnections) is not null);
+        await WaitUntil(() =>
+            websocketManager.PeekLastMessage(WebsocketTopic.UsenetConnections) == "0|3|1|3|10|1");
         Assert.Equal(
             "0|3|1|3|10|1",
             websocketManager.PeekLastMessage(WebsocketTopic.UsenetConnections));
@@ -103,7 +104,8 @@ public class ConnectionPoolStatsReplayTests
             this,
             new ConnectionPoolStats.ConnectionPoolChangedEventArgs(5, 2, 135));
 
-        await WaitUntil(() => websocketManager.PeekLastMessage(WebsocketTopic.UsenetConnections) is not null);
+        await WaitUntil(() =>
+            websocketManager.PeekLastMessage(WebsocketTopic.UsenetConnections) == "0|5|2|5|135|2");
         Assert.Equal(
             "0|5|2|5|135|2",
             websocketManager.PeekLastMessage(WebsocketTopic.UsenetConnections));

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/WrappingNntpClientRetirementTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/WrappingNntpClientRetirementTests.cs
@@ -120,7 +120,9 @@ public class WrappingNntpClientRetirementTests
             new ConnectionPoolStats.ConnectionPoolChangedEventArgs(1, 0, 50));
         await Task.Delay(500);
 
-        Assert.Null(websocketManager.PeekLastMessage(WebsocketTopic.UsenetConnections));
+        // Constructing the replacement generation clears stale provider snapshots.
+        // Deactivation must not overwrite that reset with a retired pool update.
+        Assert.Equal("reset", websocketManager.PeekLastMessage(WebsocketTopic.UsenetConnections));
     }
 
     private sealed class TestWrappingClient(INntpClient inner) : WrappingNntpClient(inner);

--- a/tests/NzbWebDAV.Tests/Websocket/WebsocketManagerTests.cs
+++ b/tests/NzbWebDAV.Tests/Websocket/WebsocketManagerTests.cs
@@ -301,8 +301,10 @@ public class WebsocketManagerTests
         try
         {
             await Task.Delay(100);
-            Assert.Empty(socket.Messages);
-            Assert.Null(manager.PeekLastMessage(WebsocketTopic.UsenetConnections));
+            Assert.Equal(
+                ["reset"],
+                socket.Messages.Select(Parse).Select(message => message.Message));
+            Assert.Equal("reset", manager.PeekLastMessage(WebsocketTopic.UsenetConnections));
         }
         finally
         {

--- a/tests/NzbWebDAV.Tests/Websocket/WebsocketManagerTests.cs
+++ b/tests/NzbWebDAV.Tests/Websocket/WebsocketManagerTests.cs
@@ -264,6 +264,53 @@ public class WebsocketManagerTests
     }
 
     [Fact]
+    public async Task UsenetConnectionReplay_ServesLatestStateForEveryProvider()
+    {
+        var manager = new WebsocketManager();
+        await manager.SendMessage(WebsocketTopic.UsenetConnections, "0|8|8|13|90|13");
+        await manager.SendMessage(WebsocketTopic.UsenetConnections, "1|5|5|13|90|13");
+        await manager.SendMessage(WebsocketTopic.UsenetConnections, "0|7|7|12|90|12");
+
+        using var socket = new TestWebSocket();
+        var detach = manager.AttachAuthenticatedSocketForTests(socket, replayState: true);
+
+        try
+        {
+            await WaitUntil(() => socket.Messages.Count == 2);
+
+            Assert.Equal(
+                ["1|5|5|13|90|13", "0|7|7|12|90|12"],
+                socket.Messages.Select(Parse).Select(message => message.Message));
+        }
+        finally
+        {
+            await detach();
+        }
+    }
+
+    [Fact]
+    public async Task ClearKeyedState_RemovesUsenetConnectionReplay()
+    {
+        var manager = new WebsocketManager();
+        await manager.SendMessage(WebsocketTopic.UsenetConnections, "0|8|8|8|60|8");
+        manager.ClearKeyedState(WebsocketTopic.UsenetConnections);
+
+        using var socket = new TestWebSocket();
+        var detach = manager.AttachAuthenticatedSocketForTests(socket, replayState: true);
+
+        try
+        {
+            await Task.Delay(100);
+            Assert.Empty(socket.Messages);
+            Assert.Null(manager.PeekLastMessage(WebsocketTopic.UsenetConnections));
+        }
+        finally
+        {
+            await detach();
+        }
+    }
+
+    [Fact]
     public async Task StreamTraceStatusTransitionWhileIdle_ReplaysToLateSubscriber()
     {
         var manager = new WebsocketManager();


### PR DESCRIPTION
## Summary
- replay the latest connection state for every provider after websocket subscriptions and relay reconnects
- discard retired provider snapshots when a connection-pool generation is replaced
- distinguish active downloads from warm idle sockets in the top-bar counter

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [x] `cd frontend && npm run typecheck && npm test`