### PR TITLE
fix(api): keep SQL command spam out of the event log

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -81,6 +81,7 @@ public partial class Program
             .MinimumLevel.Is(level)
             .MinimumLevel.Override("NWebDAV", AtLeast(level, LogEventLevel.Warning))
             .MinimumLevel.Override("Microsoft", AtLeast(level, LogEventLevel.Information))
+            .MinimumLevel.Override("Microsoft.EntityFrameworkCore.Database.Command", AtLeast(level, LogEventLevel.Warning))
             .MinimumLevel.Override("Microsoft.AspNetCore.Hosting", AtLeast(level, LogEventLevel.Warning))
             .MinimumLevel.Override("Microsoft.AspNetCore.Mvc", AtLeast(level, LogEventLevel.Warning))
             .MinimumLevel.Override("Microsoft.AspNetCore.Routing", AtLeast(level, LogEventLevel.Warning))


### PR DESCRIPTION
## Summary
- suppress EF Core's Information-level per-query `Executed DbCommand` events
- retain Warning+ EF Core diagnostics and normal startup migration progress

## Test plan
- [x] `dotnet build backend/NzbWebDAV.csproj -c Release --no-restore`
- [x] Started an isolated backend instance, ran its migrations and requested `/health`; no `Executed DbCommand` log entries were emitted