### PR TITLE
fix(db): remove EF Core startup warnings

### DIFF
--- a/backend/Database/DatabaseStartupGuards.cs
+++ b/backend/Database/DatabaseStartupGuards.cs
@@ -31,7 +31,7 @@ internal static class DatabaseStartupGuards
             // references s."Value" case-sensitively on PostgreSQL.
             var exists = await databaseContext.Database
                 .SqlQuery<bool>($"SELECT to_regclass(quote_ident({tableName})) IS NOT NULL AS \"Value\"")
-                .FirstAsync(cancellationToken)
+                .SingleAsync(cancellationToken)
                 .ConfigureAwait(false);
             return exists;
         }
@@ -43,7 +43,7 @@ internal static class DatabaseStartupGuards
                 FROM sqlite_master
                 WHERE type = 'table' AND name = {tableName}
                 """)
-            .FirstAsync(cancellationToken)
+            .SingleAsync(cancellationToken)
             .ConfigureAwait(false);
         return count > 0;
     }

--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -19,18 +19,113 @@ namespace NzbWebDAV.Database;
 public class DavDatabaseContext : DbContext
 {
     private static readonly ValueComparer<string[]> StringArrayComparer = new(
-        (left, right) => left.SequenceEqual(right),
-        value => value.Aggregate(0, (hash, item) => HashCode.Combine(hash, item)),
-        value => value.ToArray());
+        (left, right) => StringArraysEqual(left, right),
+        value => StringArrayHashCode(value),
+        value => CloneStringArray(value));
 
     private static readonly ValueComparer<DavRarFile.RarPart[]> RarPartsComparer = new(
-        (left, right) => JsonSerializer.Serialize(left, (JsonSerializerOptions?)null) ==
-                         JsonSerializer.Serialize(right, (JsonSerializerOptions?)null),
-        value => JsonSerializer.Serialize(value, (JsonSerializerOptions?)null).GetHashCode(),
-        value => JsonSerializer.Deserialize<DavRarFile.RarPart[]>(
-                     JsonSerializer.Serialize(value, (JsonSerializerOptions?)null),
-                     (JsonSerializerOptions?)null) ??
-                 Array.Empty<DavRarFile.RarPart>());
+        (left, right) => RarPartsEqual(left, right),
+        value => RarPartsHashCode(value),
+        value => CloneRarParts(value));
+
+    private static bool StringArraysEqual(string[]? left, string[]? right) =>
+        ReferenceEquals(left, right) ||
+        (left is not null && right is not null && left.SequenceEqual(right));
+
+    private static int StringArrayHashCode(string[]? value)
+    {
+        if (value is null) return 0;
+
+        var hash = new HashCode();
+        foreach (var item in value)
+            hash.Add(item, StringComparer.Ordinal);
+        return hash.ToHashCode();
+    }
+
+    private static string[] CloneStringArray(string[]? value) =>
+        value?.ToArray()!;
+
+    private static bool RarPartsEqual(DavRarFile.RarPart[]? left, DavRarFile.RarPart[]? right)
+    {
+        if (ReferenceEquals(left, right)) return true;
+        if (left is null || right is null || left.Length != right.Length) return false;
+
+        for (var index = 0; index < left.Length; index++)
+        {
+            var leftPart = left[index];
+            var rightPart = right[index];
+            if (!StringArraysEqual(leftPart.SegmentIds, rightPart.SegmentIds) ||
+                leftPart.PartSize != rightPart.PartSize ||
+                leftPart.Offset != rightPart.Offset ||
+                leftPart.ByteCount != rightPart.ByteCount ||
+                !NullableArraysEqual(leftPart.SegmentByteRanges, rightPart.SegmentByteRanges) ||
+                !NestedStringArraysEqual(leftPart.SegmentFallbackIds, rightPart.SegmentFallbackIds))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool NullableArraysEqual<T>(T[]? left, T[]? right) =>
+        ReferenceEquals(left, right) ||
+        (left is not null && right is not null && left.SequenceEqual(right));
+
+    private static bool NestedStringArraysEqual(string[][]? left, string[][]? right)
+    {
+        if (ReferenceEquals(left, right)) return true;
+        if (left is null || right is null || left.Length != right.Length) return false;
+
+        for (var index = 0; index < left.Length; index++)
+        {
+            if (!StringArraysEqual(left[index], right[index]))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static int RarPartsHashCode(DavRarFile.RarPart[]? value)
+    {
+        if (value is null) return 0;
+
+        var hash = new HashCode();
+        foreach (var part in value)
+        {
+            hash.Add(StringArrayHashCode(part.SegmentIds));
+            hash.Add(part.PartSize);
+            hash.Add(part.Offset);
+            hash.Add(part.ByteCount);
+
+            if (part.SegmentByteRanges is not null)
+            {
+                foreach (var range in part.SegmentByteRanges)
+                    hash.Add(range);
+            }
+
+            if (part.SegmentFallbackIds is not null)
+            {
+                foreach (var fallbackIds in part.SegmentFallbackIds)
+                    hash.Add(StringArrayHashCode(fallbackIds));
+            }
+        }
+
+        return hash.ToHashCode();
+    }
+
+    private static DavRarFile.RarPart[] CloneRarParts(DavRarFile.RarPart[]? value) =>
+        value?.Select(part => new DavRarFile.RarPart
+        {
+            SegmentIds = CloneStringArray(part.SegmentIds),
+            PartSize = part.PartSize,
+            Offset = part.Offset,
+            ByteCount = part.ByteCount,
+            SegmentByteRanges = part.SegmentByteRanges?.Select(range => range with { }).ToArray(),
+            SegmentFallbackIds = part.SegmentFallbackIds?
+                .Select(CloneStringArray)
+                .ToArray()
+        }).ToArray()!;
 
     public DavDatabaseContext() : base(Options.Value)
     {

--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Data.Sqlite;
@@ -17,6 +18,20 @@ namespace NzbWebDAV.Database;
 
 public class DavDatabaseContext : DbContext
 {
+    private static readonly ValueComparer<string[]> StringArrayComparer = new(
+        (left, right) => left.SequenceEqual(right),
+        value => value.Aggregate(0, (hash, item) => HashCode.Combine(hash, item)),
+        value => value.ToArray());
+
+    private static readonly ValueComparer<DavRarFile.RarPart[]> RarPartsComparer = new(
+        (left, right) => JsonSerializer.Serialize(left, (JsonSerializerOptions?)null) ==
+                         JsonSerializer.Serialize(right, (JsonSerializerOptions?)null),
+        value => JsonSerializer.Serialize(value, (JsonSerializerOptions?)null).GetHashCode(),
+        value => JsonSerializer.Deserialize<DavRarFile.RarPart[]>(
+                     JsonSerializer.Serialize(value, (JsonSerializerOptions?)null),
+                     (JsonSerializerOptions?)null) ??
+                 Array.Empty<DavRarFile.RarPart>());
+
     public DavDatabaseContext() : base(Options.Value)
     {
     }
@@ -257,7 +272,7 @@ public class DavDatabaseContext : DbContext
                 (
                     v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
                     v => DeserializeOrFallback<string[]>(v) ?? Array.Empty<string>()
-                ))
+                ), StringArrayComparer)
                 .HasColumnType("TEXT") // store raw JSON
                 .IsRequired();
 
@@ -281,7 +296,7 @@ public class DavDatabaseContext : DbContext
                 (
                     v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
                     v => DeserializeOrFallback<DavRarFile.RarPart[]>(v) ?? Array.Empty<DavRarFile.RarPart>()
-                ))
+                ), RarPartsComparer)
                 .HasColumnType("TEXT") // store raw JSON
                 .IsRequired();
 
@@ -799,7 +814,7 @@ public class DavDatabaseContext : DbContext
                 (
                     v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
                     v => DeserializeOrFallback<string[]>(v) ?? Array.Empty<string>()
-                ))
+                ), StringArrayComparer)
                 .HasColumnType("TEXT")
                 .IsRequired();
 

--- a/backend/Services/BlobCleanupService.cs
+++ b/backend/Services/BlobCleanupService.cs
@@ -58,6 +58,7 @@ public class BlobCleanupService(IDbContextFactory<DavDatabaseContext> dbContextF
     {
         // Get the first item from the queue
         var cleanupItem = await dbContext.BlobCleanupItems
+            .OrderBy(item => item.Id)
             .FirstOrDefaultAsync(ct)
             .ConfigureAwait(false);
 

--- a/backend/Services/DavCleanupService.cs
+++ b/backend/Services/DavCleanupService.cs
@@ -89,7 +89,7 @@ public class DavCleanupService(IDbContextFactory<DavDatabaseContext> dbContextFa
         // Preserve the stored text casing: materializing as Guid would normalize it to
         // uppercase when bound again and miss lowercase rows in SQLite.
         var cleanupItemId = await dbContext.Database
-            .SqlQueryRaw<string>("SELECT Id AS Value FROM DavCleanupItems LIMIT 1")
+            .SqlQueryRaw<string>("SELECT Id AS Value FROM DavCleanupItems ORDER BY Id LIMIT 1")
             .SingleOrDefaultAsync(cancellationToken)
             .ConfigureAwait(false);
 

--- a/backend/Services/DavCleanupService.cs
+++ b/backend/Services/DavCleanupService.cs
@@ -50,6 +50,7 @@ public class DavCleanupService(IDbContextFactory<DavDatabaseContext> dbContextFa
         {
             var cleanupItemIdPg = await dbContext.DavCleanupItems
                 .AsNoTracking()
+                .OrderBy(x => x.Id)
                 .Select(x => (Guid?)x.Id)
                 .FirstOrDefaultAsync(cancellationToken)
                 .ConfigureAwait(false);
@@ -89,7 +90,7 @@ public class DavCleanupService(IDbContextFactory<DavDatabaseContext> dbContextFa
         // uppercase when bound again and miss lowercase rows in SQLite.
         var cleanupItemId = await dbContext.Database
             .SqlQueryRaw<string>("SELECT Id AS Value FROM DavCleanupItems LIMIT 1")
-            .FirstOrDefaultAsync(cancellationToken)
+            .SingleOrDefaultAsync(cancellationToken)
             .ConfigureAwait(false);
 
         if (cleanupItemId == null)

--- a/backend/Services/HistoryCleanupService.cs
+++ b/backend/Services/HistoryCleanupService.cs
@@ -18,6 +18,7 @@ public class HistoryCleanupService(IDbContextFactory<DavDatabaseContext> dbConte
 
                 // Get the first item from the queue
                 var cleanupItem = await dbContext.HistoryCleanupItems
+                    .OrderBy(item => item.Id)
                     .FirstOrDefaultAsync(stoppingToken)
                     .ConfigureAwait(false);
 

--- a/backend/Services/NzbBlobCleanupService.cs
+++ b/backend/Services/NzbBlobCleanupService.cs
@@ -59,6 +59,7 @@ public class NzbBlobCleanupService(IDbContextFactory<DavDatabaseContext> dbConte
     {
         // Get the first item from the queue
         var cleanupItem = await dbContext.NzbBlobCleanupItems
+            .OrderBy(item => item.Id)
             .FirstOrDefaultAsync(ct)
             .ConfigureAwait(false);
 

--- a/backend/Services/UsenetFileToBlobstoreMigrationService.cs
+++ b/backend/Services/UsenetFileToBlobstoreMigrationService.cs
@@ -42,7 +42,7 @@ public class UsenetFileToBlobstoreMigrationService(
     private Task<int> MigrateNzbFiles(int totalRemaining, int initialRemaining, CancellationToken ct)
     {
         return MigrateUsenetFiles<DavNzbFile>(
-            (dbContext) => dbContext.NzbFiles.FirstOrDefaultAsync(ct),
+            (dbContext) => dbContext.NzbFiles.OrderBy(file => file.Id).FirstOrDefaultAsync(ct),
             (file) => file.Id,
             (file) => file.Id = Guid.NewGuid(),
             (dbContext, id) => dbContext.NzbFiles.Remove(new DavNzbFile { Id = id }),
@@ -55,7 +55,7 @@ public class UsenetFileToBlobstoreMigrationService(
     private Task<int> MigrateRarFiles(int totalRemaining, int initialRemaining, CancellationToken ct)
     {
         return MigrateUsenetFiles<DavRarFile>(
-            (dbContext) => dbContext.RarFiles.FirstOrDefaultAsync(ct),
+            (dbContext) => dbContext.RarFiles.OrderBy(file => file.Id).FirstOrDefaultAsync(ct),
             (file) => file.Id,
             (file) => file.Id = Guid.NewGuid(),
             (dbContext, id) => dbContext.RarFiles.Remove(new DavRarFile { Id = id }),
@@ -68,7 +68,7 @@ public class UsenetFileToBlobstoreMigrationService(
     private Task<int> MigrateMultipartFiles(int totalRemaining, int initialRemaining, CancellationToken ct)
     {
         return MigrateUsenetFiles<DavMultipartFile>(
-            (dbContext) => dbContext.MultipartFiles.FirstOrDefaultAsync(ct),
+            (dbContext) => dbContext.MultipartFiles.OrderBy(file => file.Id).FirstOrDefaultAsync(ct),
             (file) => file.Id,
             (file) => file.Id = Guid.NewGuid(),
             (dbContext, id) => dbContext.MultipartFiles.Remove(new DavMultipartFile { Id = id }),

--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -242,7 +242,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
         // PostgreSQL returns bigint, which Npgsql will not read as int.
         return await dbContext.Database
             .SqlQueryRaw<int>("SELECT CAST(COUNT(*) AS INT) AS \"Value\" FROM TMP_LINKED_FILES")
-            .FirstAsync()
+            .SingleAsync()
             .ConfigureAwait(false);
     }
 
@@ -389,7 +389,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
                    AND i."HistoryItemId" IS NULL
                    AND i."CreatedAt" < {createdBefore}
                  """)
-            .FirstAsync()
+            .SingleAsync()
             .ConfigureAwait(false);
     }
 
@@ -415,7 +415,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
                    AND i."CreatedAt" < {createdBefore}
                    AND t.Id IS NULL
                  """)
-            .FirstAsync()
+            .SingleAsync()
             .ConfigureAwait(false);
 
         return count;


### PR DESCRIPTION
## Summary
- add structural value comparers for JSON-backed Usenet segment metadata
- make cleanup and migration queue reads deterministic
- use single-row query operators for scalar SQL queries

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [x] Start the backend against a fresh SQLite config and confirm the targeted EF Core warnings are absent
