### PR TITLE
fix(queue): large NZBs no longer rejected with too many segments during import

### DIFF
--- a/backend/Api/Errors/NzbInputLimits.cs
+++ b/backend/Api/Errors/NzbInputLimits.cs
@@ -12,7 +12,6 @@ public sealed class NzbInputLimits
     public int MaxXmlBytes { get; init; } = 64 * 1024 * 1024;
     public int MaxFiles { get; init; } = 10_000;
     public int MaxTotalSegments { get; init; } = 500_000;
-    public int MaxSegmentsPerFile { get; init; } = 100_000;
     public int MaxNameLength { get; init; } = 255;
     public int MaxMessageIdLength { get; init; } = 248;
 }

--- a/backend/Models/Nzb/NzbInputValidator.cs
+++ b/backend/Models/Nzb/NzbInputValidator.cs
@@ -66,8 +66,10 @@ public static class NzbInputValidator
                     if (subject.Length > limits.MaxNameLength)
                         errors.Add("nzb", "An NZB file subject exceeds the maximum name length.");
 
-                    totalBytes += ReadFileSegments(
-                        reader, limits, errors, ref totalSegments);
+                    totalBytes = AddSegmentBytesOrThrow(
+                        totalBytes,
+                        ReadFileSegments(reader, limits, errors, ref totalSegments),
+                        errors);
                 }
             }
         }
@@ -112,7 +114,7 @@ public static class NzbInputValidator
                 if (!long.TryParse(bytesAttr, out var bytes) || bytes < 0)
                     errors.Add("nzb", "An NZB segment has an invalid byte count.");
                 else
-                    fileBytes += bytes;
+                    fileBytes = AddSegmentBytesOrThrow(fileBytes, bytes, errors);
 
                 var numberAttr = reader.GetAttribute("number");
                 if (numberAttr is not null)
@@ -137,6 +139,22 @@ public static class NzbInputValidator
         }
 
         return fileBytes;
+    }
+
+    private static long AddSegmentBytesOrThrow(long total, long bytes, ValidationErrors errors)
+    {
+        try
+        {
+            return checked(total + bytes);
+        }
+        catch (OverflowException)
+        {
+            errors.Add(
+                "nzb",
+                "The NZB document's total segment byte count exceeds the maximum supported size.");
+            errors.ThrowIfAny();
+            return 0;
+        }
     }
 
     private static void Throw(string field, string message)

--- a/backend/Models/Nzb/NzbInputValidator.cs
+++ b/backend/Models/Nzb/NzbInputValidator.cs
@@ -56,7 +56,9 @@ public static class NzbInputValidator
                     fileCount++;
                     if (fileCount > limits.MaxFiles)
                     {
-                        errors.Add("nzb", "The NZB document contains too many files.");
+                        errors.Add(
+                            "nzb",
+                            $"The NZB document contains too many files ({fileCount}; limit {limits.MaxFiles}).");
                         errors.ThrowIfAny();
                     }
 
@@ -86,7 +88,6 @@ public static class NzbInputValidator
         ref int totalSegments)
     {
         long fileBytes = 0;
-        var segmentsInFile = 0;
         var seenNumbers = new HashSet<int>();
         if (reader.IsEmptyElement)
             return 0;
@@ -98,17 +99,12 @@ public static class NzbInputValidator
 
             if (reader is { NodeType: XmlNodeType.Element, LocalName: "segment" })
             {
-                segmentsInFile++;
                 totalSegments++;
-                if (segmentsInFile > limits.MaxSegmentsPerFile)
-                {
-                    errors.Add("nzb", "An NZB file contains too many segments.");
-                    errors.ThrowIfAny();
-                }
-
                 if (totalSegments > limits.MaxTotalSegments)
                 {
-                    errors.Add("nzb", "The NZB document contains too many segments.");
+                    errors.Add(
+                        "nzb",
+                        $"The NZB document contains too many segments ({totalSegments}; limit {limits.MaxTotalSegments}).");
                     errors.ThrowIfAny();
                 }
 

--- a/tests/NzbWebDAV.Tests/Api/NzbInputValidatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/NzbInputValidatorTests.cs
@@ -11,7 +11,7 @@ public class NzbInputValidatorTests
     {
         var xml = BuildNzb(fileCount: 1, segmentsPerFile: 2);
         using var stream = Bytes(xml);
-        var limits = new NzbInputLimits { MaxFiles = 1, MaxSegmentsPerFile = 2, MaxTotalSegments = 2 };
+        var limits = new NzbInputLimits { MaxFiles = 1, MaxTotalSegments = 2 };
 
         var bytes = NzbInputValidator.ValidateAndSumSegmentBytes(stream, limits);
 
@@ -23,23 +23,40 @@ public class NzbInputValidatorTests
     {
         var xml = BuildNzb(fileCount: 2, segmentsPerFile: 1);
         using var stream = Bytes(xml);
-        var limits = new NzbInputLimits { MaxFiles = 1, MaxSegmentsPerFile = 10, MaxTotalSegments = 10 };
+        var limits = new NzbInputLimits { MaxFiles = 1, MaxTotalSegments = 10 };
 
         var ex = Assert.Throws<ApiValidationException>(
             () => NzbInputValidator.ValidateAndSumSegmentBytes(stream, limits));
         Assert.Contains("too many files", ex.Errors["nzb"][0], StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("2; limit 1", ex.Errors["nzb"][0], StringComparison.Ordinal);
     }
 
     [Fact]
-    public void RejectsOneSegmentPastPerFileLimit()
+    public void AcceptsLargeSingleFileRemux()
+    {
+        const int segmentCount = 100_001;
+        const long segmentBytes = 700_000;
+        var xml = BuildNzb(fileCount: 1, segmentsPerFile: segmentCount, segmentBytes);
+        using var stream = Bytes(xml);
+
+        var bytes = NzbInputValidator.ValidateAndSumSegmentBytes(stream, NzbInputLimits.Default);
+
+        Assert.Equal(segmentCount * segmentBytes, bytes);
+        Assert.True(bytes > 70_000_000_000);
+    }
+
+    [Fact]
+    public void RejectsOneSegmentPastTotalLimitWithCountAndLimit()
     {
         var xml = BuildNzb(fileCount: 1, segmentsPerFile: 2);
         using var stream = Bytes(xml);
-        var limits = new NzbInputLimits { MaxFiles = 5, MaxSegmentsPerFile = 1, MaxTotalSegments = 10 };
+        var limits = new NzbInputLimits { MaxTotalSegments = 1 };
 
         var ex = Assert.Throws<ApiValidationException>(
             () => NzbInputValidator.ValidateAndSumSegmentBytes(stream, limits));
+
         Assert.Contains("too many segments", ex.Errors["nzb"][0], StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("2; limit 1", ex.Errors["nzb"][0], StringComparison.Ordinal);
     }
 
     [Fact]
@@ -72,7 +89,7 @@ public class NzbInputValidatorTests
         Assert.DoesNotContain("aaaa", ex.Message, StringComparison.Ordinal);
     }
 
-    private static string BuildNzb(int fileCount, int segmentsPerFile)
+    private static string BuildNzb(int fileCount, int segmentsPerFile, long segmentBytes = 15)
     {
         var builder = new StringBuilder("<nzb>");
         for (var file = 1; file <= fileCount; file++)
@@ -81,7 +98,7 @@ public class NzbInputValidatorTests
             for (var segment = 1; segment <= segmentsPerFile; segment++)
             {
                 builder.Append(
-                    $"<segment bytes=\"15\" number=\"{segment}\">id-{file}-{segment}@example</segment>");
+                    $"<segment bytes=\"{segmentBytes}\" number=\"{segment}\">id-{file}-{segment}@example</segment>");
             }
 
             builder.Append("</segments></file>");

--- a/tests/NzbWebDAV.Tests/Api/NzbInputValidatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/NzbInputValidatorTests.cs
@@ -59,6 +59,20 @@ public class NzbInputValidatorTests
         Assert.Contains("2; limit 1", ex.Errors["nzb"][0], StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData(1, 2)]
+    [InlineData(2, 1)]
+    public void RejectsSegmentByteTotalOverflow(int fileCount, int segmentsPerFile)
+    {
+        var xml = BuildNzb(fileCount, segmentsPerFile, long.MaxValue);
+        using var stream = Bytes(xml);
+
+        var ex = Assert.Throws<ApiValidationException>(
+            () => NzbInputValidator.ValidateAndSumSegmentBytes(stream, NzbInputLimits.Default));
+
+        Assert.Contains("total segment byte count", ex.Errors["nzb"][0], StringComparison.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public void RejectsInvalidByteCountAndDuplicateNumbers()
     {


### PR DESCRIPTION
## Summary
- remove the redundant per-file NZB segment cap that rejected large single-file Blu-ray remuxes
- retain document-wide XML and total-segment safeguards
- report observed counts and limits when document-wide limits are reached

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~NzbInputValidatorTests`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`