### PR TITLE
fix(db): PostgreSQL installs no longer log timestamp errors

### DIFF
--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -1100,9 +1100,9 @@ public class GetOverviewStatsController(
         };
     }
 
-    private static async Task<GetOverviewStatsResponse.CatalogueBlock> BuildCatalogueAsync(DavDatabaseContext ctx)
+    internal static async Task<GetOverviewStatsResponse.CatalogueBlock> BuildCatalogueAsync(DavDatabaseContext ctx)
     {
-        var sevenDaysAgo = DateTime.UtcNow.AddDays(-7);
+        var sevenDaysAgo = DateTime.Now.AddDays(-7);
 
         var files = ctx.Items.Where(i => i.Type == DavItem.ItemType.UsenetFile);
         var fileCount = await files.CountAsync().ConfigureAwait(false);
@@ -1137,9 +1137,9 @@ public class GetOverviewStatsController(
         };
     }
 
-    private static async Task<List<GetOverviewStatsResponse.IndexerRow>> BuildIndexersAsync(DavDatabaseContext ctx)
+    internal static async Task<List<GetOverviewStatsResponse.IndexerRow>> BuildIndexersAsync(DavDatabaseContext ctx)
     {
-        var cutoff = DateTime.UtcNow.AddDays(-30);
+        var cutoff = DateTime.Now.AddDays(-30);
         var rows = await ctx.HistoryItems
             .Where(h => h.CreatedAt >= cutoff && h.IndexerName != null)
             .GroupBy(h => h.IndexerName!)

--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -28,6 +28,22 @@ public class DavDatabaseContext : DbContext
         value => RarPartsHashCode(value),
         value => CloneRarParts(value));
 
+    private static readonly ValueConverter<DateTime, DateTime> PostgresWallClockDateTimeConverter = new(
+        value => value.Kind == DateTimeKind.Utc
+            ? DateTime.SpecifyKind(value.ToLocalTime(), DateTimeKind.Unspecified)
+            : DateTime.SpecifyKind(value, DateTimeKind.Unspecified),
+        value => DateTime.SpecifyKind(value, DateTimeKind.Unspecified));
+
+    private static readonly ValueConverter<DateTime?, DateTime?> PostgresNullableWallClockDateTimeConverter = new(
+        value => value.HasValue
+            ? value.Value.Kind == DateTimeKind.Utc
+                ? DateTime.SpecifyKind(value.Value.ToLocalTime(), DateTimeKind.Unspecified)
+                : DateTime.SpecifyKind(value.Value, DateTimeKind.Unspecified)
+            : null,
+        value => value.HasValue
+            ? DateTime.SpecifyKind(value.Value, DateTimeKind.Unspecified)
+            : null);
+
     private static bool StringArraysEqual(string[]? left, string[]? right) =>
         ReferenceEquals(left, right) ||
         (left is not null && right is not null && left.SequenceEqual(right));
@@ -961,12 +977,20 @@ public class DavDatabaseContext : DbContext
         if (DatabaseProviderConfig.IsPostgres)
         {
             // Existing installs store these values as SQLite date/time text with
-            // wall-clock semantics. Mapping to timestamp without time zone preserves
-            // that behavior and accepts the local DateTime values created by the app.
-            b.Entity<DavItem>().Property(x => x.CreatedAt).HasColumnType("timestamp without time zone");
-            b.Entity<QueueItem>().Property(x => x.CreatedAt).HasColumnType("timestamp without time zone");
-            b.Entity<QueueItem>().Property(x => x.PauseUntil).HasColumnType("timestamp without time zone");
-            b.Entity<HistoryItem>().Property(x => x.CreatedAt).HasColumnType("timestamp without time zone");
+            // wall-clock semantics. Normalize their kind so Npgsql accepts UTC
+            // values supplied by callers without changing their intended time basis.
+            b.Entity<DavItem>().Property(x => x.CreatedAt)
+                .HasColumnType("timestamp without time zone")
+                .HasConversion(PostgresWallClockDateTimeConverter);
+            b.Entity<QueueItem>().Property(x => x.CreatedAt)
+                .HasColumnType("timestamp without time zone")
+                .HasConversion(PostgresWallClockDateTimeConverter);
+            b.Entity<QueueItem>().Property(x => x.PauseUntil)
+                .HasColumnType("timestamp without time zone")
+                .HasConversion(PostgresNullableWallClockDateTimeConverter);
+            b.Entity<HistoryItem>().Property(x => x.CreatedAt)
+                .HasColumnType("timestamp without time zone")
+                .HasConversion(PostgresWallClockDateTimeConverter);
         }
     }
 

--- a/backend/Database/Models/DavItem.cs
+++ b/backend/Database/Models/DavItem.cs
@@ -87,6 +87,9 @@ public class DavItem
     // static instances
     // Important: assigned values cannot be
     // changed without a database migration.
+    private static readonly DateTime WallClockUnixEpoch =
+        DateTime.SpecifyKind(DateTime.UnixEpoch, DateTimeKind.Unspecified);
+
     public static readonly DavItem Root = new()
     {
         Id = Guid.Parse("00000000-0000-0000-0000-000000000000"),
@@ -96,7 +99,7 @@ public class DavItem
         Type = ItemType.Directory,
         SubType = ItemSubType.WebdavRoot,
         Path = "/",
-        CreatedAt = DateTime.UnixEpoch,
+        CreatedAt = WallClockUnixEpoch,
     };
 
     public static readonly DavItem NzbFolder = new()
@@ -108,7 +111,7 @@ public class DavItem
         Type = ItemType.Directory,
         SubType = ItemSubType.NzbsRoot,
         Path = "/nzbs",
-        CreatedAt = DateTime.UnixEpoch,
+        CreatedAt = WallClockUnixEpoch,
     };
 
     public static readonly DavItem ContentFolder = new()
@@ -120,7 +123,7 @@ public class DavItem
         Type = ItemType.Directory,
         SubType = ItemSubType.ContentRoot,
         Path = "/content",
-        CreatedAt = DateTime.UnixEpoch,
+        CreatedAt = WallClockUnixEpoch,
     };
 
     public static readonly DavItem SymlinkFolder = new()
@@ -132,7 +135,7 @@ public class DavItem
         Type = ItemType.Directory,
         SubType = ItemSubType.SymlinkRoot,
         Path = "/completed-symlinks",
-        CreatedAt = DateTime.UnixEpoch,
+        CreatedAt = WallClockUnixEpoch,
     };
 
     public static readonly DavItem IdsFolder = new()
@@ -144,6 +147,6 @@ public class DavItem
         Type = ItemType.Directory,
         SubType = ItemSubType.IdsRoot,
         Path = "/.ids",
-        CreatedAt = DateTime.UnixEpoch,
+        CreatedAt = WallClockUnixEpoch,
     };
 }

--- a/backend/Services/HistoryRetentionService.cs
+++ b/backend/Services/HistoryRetentionService.cs
@@ -45,7 +45,7 @@ public class HistoryRetentionService(
     {
         if (retentionDays <= 0) return 0;
 
-        var cutoff = DateTime.UtcNow.AddDays(-retentionDays);
+        var cutoff = DateTime.Now.AddDays(-retentionDays);
         var totalRemoved = 0;
 
         while (true)

--- a/backend/Tasks/PruneCompletedHistoryTask.cs
+++ b/backend/Tasks/PruneCompletedHistoryTask.cs
@@ -86,7 +86,7 @@ public class PruneCompletedHistoryTask : BaseTask
         if (olderThanDays is > 0)
         {
             var days = olderThanDays.Value;
-            query = query.Where(h => h.CreatedAt < DateTime.UtcNow.AddDays(-days));
+            query = query.Where(h => h.CreatedAt < DateTime.Now.AddDays(-days));
         }
         return query;
     }

--- a/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
@@ -143,9 +143,12 @@ public sealed class PostgresMigrationTests
             context.ChangeTracker.Clear();
 
             var utcRoundTrip = await context.HistoryItems.SingleAsync(x => x.JobName == "utc");
+            var expectedUtcRoundTrip = DateTime.SpecifyKind(
+                utcCreatedAt.ToLocalTime(), DateTimeKind.Unspecified);
+            Assert.Equal(DateTimeKind.Unspecified, utcRoundTrip.CreatedAt.Kind);
             Assert.Equal(
-                DateTime.SpecifyKind(utcCreatedAt.ToLocalTime(), DateTimeKind.Unspecified),
-                utcRoundTrip.CreatedAt);
+                expectedUtcRoundTrip.Ticks - (expectedUtcRoundTrip.Ticks % 10),
+                utcRoundTrip.CreatedAt.Ticks);
 
             var matchingUtcRows = await context.HistoryItems
                 .Where(x => x.CreatedAt <= utcCreatedAt)

--- a/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Npgsql;
+using NzbWebDAV.Api.Controllers.GetOverviewStats;
 using NzbWebDAV.Api.SabControllers.GetHistory;
 using NzbWebDAV.Api.SabControllers.GetQueue;
 using NzbWebDAV.Clients.Usenet;
@@ -13,6 +14,7 @@ using NzbWebDAV.Queue;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Services.StreamTrace;
+using NzbWebDAV.Tasks;
 using NzbWebDAV.Websocket;
 
 namespace NzbWebDAV.Tests.Database;
@@ -104,6 +106,109 @@ public sealed class PostgresMigrationTests
         Assert.Equal(1, response.History.TotalCount);
     }
 
+    [SkippableFact]
+    public async Task WallClockTimestamps_AcceptUtcValuesAndAgeQueries()
+    {
+        Skip.IfNot(DatabaseProviderConfig.IsPostgres,
+            "PostgreSQL tests require DATABASE_PROVIDER=postgres.");
+
+        var schema = $"nzbdav_wall_clock_{Guid.NewGuid():N}";
+        var connectionString = DatabaseProviderConfig.PostgresConnectionString;
+        await using var adminConnection = new NpgsqlConnection(connectionString);
+        await adminConnection.OpenAsync();
+        await ExecuteAsync(adminConnection, $"CREATE SCHEMA \"{schema}\"");
+
+        try
+        {
+            var scopedConnectionString = new NpgsqlConnectionStringBuilder(connectionString)
+            {
+                SearchPath = schema
+            }.ConnectionString;
+            var options = new DbContextOptionsBuilder<PostgresDavDatabaseContext>()
+                .UseNpgsql(scopedConnectionString)
+                .Options;
+            await using var context = new PostgresDavDatabaseContext(options);
+            await context.Database.MigrateAsync();
+
+            var utcCreatedAt = DateTime.UtcNow;
+            var oldHistoryId = Guid.NewGuid();
+            context.HistoryItems.AddRange(
+                CreateHistory(oldHistoryId, "retention", DateTime.Now.AddDays(-100)),
+                CreateHistory(Guid.NewGuid(), "indexer", DateTime.Now.AddDays(-20), indexerName: "Example"),
+                CreateHistory(Guid.NewGuid(), "utc", utcCreatedAt));
+            context.Items.AddRange(
+                CreateItem("old-file", DateTime.Now.AddDays(-8)),
+                CreateItem("recent-file", DateTime.Now.AddDays(-2)));
+            await context.SaveChangesAsync();
+            context.ChangeTracker.Clear();
+
+            var utcRoundTrip = await context.HistoryItems.SingleAsync(x => x.JobName == "utc");
+            Assert.Equal(
+                DateTime.SpecifyKind(utcCreatedAt.ToLocalTime(), DateTimeKind.Unspecified),
+                utcRoundTrip.CreatedAt);
+
+            var matchingUtcRows = await context.HistoryItems
+                .Where(x => x.CreatedAt <= utcCreatedAt)
+                .CountAsync();
+            Assert.Equal(3, matchingUtcRows);
+
+            var catalogue = await GetOverviewStatsController.BuildCatalogueAsync(context);
+            Assert.Equal(2, catalogue.FileCount);
+            Assert.Equal(1, catalogue.AddedLast7Days);
+
+            var indexers = await GetOverviewStatsController.BuildIndexersAsync(context);
+            Assert.Equal("Example", Assert.Single(indexers).Name);
+
+            var dbClient = new DavDatabaseClient(context);
+            Assert.Equal(1, await HistoryRetentionService.SweepAsync(dbClient, 90, CancellationToken.None));
+            Assert.Null(await context.HistoryItems.FindAsync(oldHistoryId));
+
+            context.HistoryItems.Add(CreateHistory(Guid.NewGuid(), "prune", DateTime.Now.AddDays(-100),
+                category: "prune"));
+            await context.SaveChangesAsync();
+
+            Assert.Equal(1, await PruneCompletedHistoryTask.BuildFilterQuery(context, "prune", 90)
+                .CountAsync());
+        }
+        finally
+        {
+            await ExecuteAsync(adminConnection, $"DROP SCHEMA IF EXISTS \"{schema}\" CASCADE");
+        }
+    }
+
+    private static DavItem CreateItem(string name, DateTime createdAt)
+    {
+        var id = Guid.NewGuid();
+        return new DavItem
+        {
+            Id = id,
+            IdPrefix = id.ToString("N")[..DavItem.IdPrefixLength],
+            CreatedAt = createdAt,
+            ParentId = DavItem.Root.Id,
+            Name = name,
+            FileSize = 42,
+            Type = DavItem.ItemType.UsenetFile,
+            SubType = DavItem.ItemSubType.NzbFile,
+            Path = $"/content/{name}",
+        };
+    }
+
+    private static HistoryItem CreateHistory(
+        Guid id,
+        string jobName,
+        DateTime createdAt,
+        string category = "test",
+        string? indexerName = null) => new()
+        {
+            Id = id,
+            CreatedAt = createdAt,
+            FileName = $"{jobName}.nzb",
+            JobName = jobName,
+            Category = category,
+            IndexerName = indexerName,
+            DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+        };
+
     private static async Task ExecuteAsync(NpgsqlConnection connection, string commandText)
     {
         await using var command = new NpgsqlCommand(commandText, connection);
@@ -173,7 +278,7 @@ public sealed class PostgresMigrationTests
                 context.QueueItems.Add(new QueueItem
                 {
                     Id = Guid.NewGuid(),
-                    CreatedAt = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified),
+                    CreatedAt = DateTime.Now,
                     FileName = "queue.nzb",
                     JobName = "queue",
                     Category = "test",
@@ -182,7 +287,7 @@ public sealed class PostgresMigrationTests
                 context.HistoryItems.Add(new HistoryItem
                 {
                     Id = Guid.NewGuid(),
-                    CreatedAt = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified),
+                    CreatedAt = DateTime.Now,
                     FileName = "history.nzb",
                     JobName = "history",
                     Category = "test",


### PR DESCRIPTION
## Summary
- normalize DateTime values for PostgreSQL wall-clock timestamp columns
- use local wall-clock cutoffs in history retention, pruning, and overview statistics
- cover UTC input and affected queries in PostgreSQL migration tests

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [x] `ReadLints` on modified files
- [ ] PostgreSQL integration suite (local Docker daemon was unavailable)