### PR TITLE
fix(sab): addurl no longer crashes with a zero-second HTTP timeout

### DIFF
--- a/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
@@ -14,11 +14,12 @@ namespace NzbWebDAV.Api.SabControllers.AddUrl;
 
 public class AddUrlRequest() : AddFileRequest
 {
+    // Static fields initialize in declaration order; InitializeHttpClient uses this timeout.
+    private static readonly TimeSpan FetchTimeout = TimeSpan.FromSeconds(60);
+    private const int MaxAutomaticRedirections = 10;
     private static readonly HttpClient StrictDirectHttpClient = InitializeHttpClient(skipTlsVerification: false);
     private static readonly HttpClient PermissiveDirectHttpClient = InitializeHttpClient(skipTlsVerification: true);
     private static readonly HttpRequestOptionsKey<TrustedHostsMatcher> TrustedHostsOptionKey = new("TrustedHosts");
-    private const int MaxAutomaticRedirections = 10;
-    private static readonly TimeSpan FetchTimeout = TimeSpan.FromSeconds(60);
 
     public static async Task<AddUrlRequest> New(HttpContext context, ConfigManager configManager, IndexerHitTracker hitTracker)
     {

--- a/tests/NzbWebDAV.Tests/Api/AddUrlRequestStaticInitTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AddUrlRequestStaticInitTests.cs
@@ -1,0 +1,16 @@
+using System.Runtime.CompilerServices;
+using NzbWebDAV.Api.SabControllers.AddUrl;
+
+namespace NzbWebDAV.Tests.Api;
+
+public class AddUrlRequestStaticInitTests
+{
+    [Fact]
+    public void StaticInitializer_CompletesSuccessfully()
+    {
+        var exception = Record.Exception(() =>
+            RuntimeHelpers.RunClassConstructor(typeof(AddUrlRequest).TypeHandle));
+
+        Assert.Null(exception);
+    }
+}


### PR DESCRIPTION
## Summary
- initialize the addurl fetch timeout before static HTTP clients are constructed
- restore URL-based NZB submissions for AIOStreams and other SAB `addurl` clients
- add a regression test for the AddUrlRequest static initializer

Affected releases: v1.2.0 through v1.2.2. There is no configuration workaround; users need an image containing this patch.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~AddUrlRequestStaticInitTests`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`