### PR TITLE
fix(db): upgrades no longer fail on a pre-existing health-check index

### DIFF
--- a/backend/Database/Migrations/20260817185420_Add-NzbIdentity-To-HealthCheckResults.cs
+++ b/backend/Database/Migrations/20260817185420_Add-NzbIdentity-To-HealthCheckResults.cs
@@ -22,6 +22,10 @@ namespace NzbWebDAV.Database.Migrations
                 type: "TEXT",
                 nullable: true);
 
+            // Replace the partial/manual index state reported in #1104 with the
+            // canonical filtered index created by this migration.
+            migrationBuilder.Sql("""DROP INDEX IF EXISTS "IX_HealthCheckResults_RepairStatus_CreatedAt";""");
+
             migrationBuilder.CreateIndex(
                 name: "IX_HealthCheckResults_RepairStatus_CreatedAt",
                 table: "HealthCheckResults",

--- a/backend/Database/StartupDatabaseMigrator.cs
+++ b/backend/Database/StartupDatabaseMigrator.cs
@@ -1,4 +1,6 @@
 using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.Services;
 using Serilog;
 
@@ -101,7 +103,13 @@ internal static class StartupDatabaseMigrator
         }
         catch (Exception ex) when (ex is not OutOfMemoryException)
         {
-            progress.Fail(ex.Message);
+            var migrationConflict = ex.IsDuplicateSchemaObjectException();
+            progress.Fail(migrationConflict
+                ? new DatabaseMigrationConflictException(ex).Message
+                : ex.Message);
+            if (migrationConflict)
+                Log.Debug(ex, "Startup database migration encountered an existing schema object");
+
             if (statusServer is not null)
             {
                 try
@@ -113,6 +121,9 @@ internal static class StartupDatabaseMigrator
                     // Best-effort grace period before the status server is disposed.
                 }
             }
+
+            if (migrationConflict)
+                throw new DatabaseMigrationConflictException(ex);
 
             throw;
         }

--- a/backend/Exceptions/DatabaseMigrationConflictException.cs
+++ b/backend/Exceptions/DatabaseMigrationConflictException.cs
@@ -7,8 +7,9 @@ namespace NzbWebDAV.Exceptions;
 public sealed class DatabaseMigrationConflictException(Exception innerException)
     : Exception(
         "Database migration could not continue because a schema object already exists. " +
-        "Back up /config before making changes, then restore a pre-upgrade backup or remove " +
-        "the conflicting object and restart. See https://github.com/infinidysk/infinidysk/issues/1104.",
+        "Back up the directory specified by CONFIG_PATH (default: /config) before making changes, " +
+        "then restore a pre-upgrade backup or remove the conflicting object and restart. " +
+        "See https://github.com/infinidysk/infinidysk/issues/1104.",
         innerException)
 {
 }

--- a/backend/Exceptions/DatabaseMigrationConflictException.cs
+++ b/backend/Exceptions/DatabaseMigrationConflictException.cs
@@ -1,0 +1,14 @@
+namespace NzbWebDAV.Exceptions;
+
+/// <summary>
+/// Fatal startup error when a pending migration finds a schema object that already
+/// exists. Carries recovery guidance instead of exposing an EF Core stack trace.
+/// </summary>
+public sealed class DatabaseMigrationConflictException(Exception innerException)
+    : Exception(
+        "Database migration could not continue because a schema object already exists. " +
+        "Back up /config before making changes, then restore a pre-upgrade backup or remove " +
+        "the conflicting object and restart. See https://github.com/infinidysk/infinidysk/issues/1104.",
+        innerException)
+{
+}

--- a/backend/Extensions/ExceptionExtensions.cs
+++ b/backend/Extensions/ExceptionExtensions.cs
@@ -58,6 +58,23 @@ public static class ExceptionExtensions
     }
 
     /// <summary>
+    /// True when SQLite reports an existing schema object while applying DDL. The
+    /// generic SQLITE_ERROR code must be paired with the message check because it
+    /// also covers unrelated SQL errors.
+    /// </summary>
+    public static bool IsDuplicateSchemaObjectException(this Exception exception)
+    {
+        for (var current = exception; current != null; current = current.InnerException)
+        {
+            if (current is SqliteException { SqliteErrorCode: 1 } sqlite
+                && sqlite.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// True for write contention that can be retried by the caller's next sweep.
     /// PostgreSQL reports concurrent serialization/deadlock failures by SQLSTATE.
     /// </summary>

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -519,6 +519,14 @@ public partial class Program
             Environment.ExitCode = 1;
             return;
         }
+        catch (DatabaseMigrationConflictException exception)
+        {
+            // Operator-facing migration conflict — the migration boundary has already
+            // retained the original exception at Debug for maintainers.
+            Log.Fatal("{Message}", exception.Message);
+            Environment.ExitCode = 1;
+            return;
+        }
         catch (Exception exception)
         {
             Log.Fatal(exception, "NzbDav terminated unexpectedly");
@@ -789,10 +797,15 @@ public partial class Program
         }
         catch (Exception ex) when (ex is not OutOfMemoryException)
         {
-            progressFull.Fail(ex.Message);
+            var migrationConflict = ex.IsDuplicateSchemaObjectException();
+            progressFull.Fail(migrationConflict
+                ? new DatabaseMigrationConflictException(ex).Message
+                : ex.Message);
             // ConfigPathAccessException is already operator-actionable; Main logs the
             // single fatal line, so skip the stack dump here.
-            if (ex is not ConfigPathAccessException)
+            if (migrationConflict)
+                Log.Debug(ex, "Database migration encountered an existing schema object");
+            else if (ex is not ConfigPathAccessException)
                 Log.Error(ex, "Database migration failed");
 
             // Keep the failure visible on the status page briefly before exiting.
@@ -801,6 +814,9 @@ public partial class Program
                 try { await Task.Delay(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false); }
                 catch (OperationCanceledException) { /* shutting down */ }
             }
+
+            if (migrationConflict)
+                throw new DatabaseMigrationConflictException(ex);
 
             throw;
         }

--- a/tests/NzbWebDAV.Tests/Database/PreExistingHealthCheckRepairStatusIndexMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PreExistingHealthCheckRepairStatusIndexMigrationTests.cs
@@ -41,9 +41,10 @@ public sealed class PreExistingHealthCheckRepairStatusIndexMigrationTests
         Assert.Empty(await context.Database.GetPendingMigrationsAsync());
         Assert.True(await ColumnExistsAsync(context, "JobName"));
         Assert.True(await ColumnExistsAsync(context, "NzbFileName"));
-        Assert.Equal(
-            """CREATE INDEX "IX_HealthCheckResults_RepairStatus_CreatedAt" ON "HealthCheckResults" ("RepairStatus", "CreatedAt") WHERE "RepairStatus" IN (1, 2)""",
-            await IndexSqlAsync(context, RepairStatusIndex));
+        var indexSql = await IndexSqlAsync(context, RepairStatusIndex);
+        Assert.NotNull(indexSql);
+        Assert.Contains("""ON "HealthCheckResults" ("RepairStatus", "CreatedAt")""", indexSql);
+        Assert.Contains("""WHERE "RepairStatus" IN (1, 2)""", indexSql);
     }
 
     private static async Task<bool> IndexExistsAsync(DavDatabaseContext context, string indexName)

--- a/tests/NzbWebDAV.Tests/Database/PreExistingHealthCheckRepairStatusIndexMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PreExistingHealthCheckRepairStatusIndexMigrationTests.cs
@@ -1,0 +1,131 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+
+namespace NzbWebDAV.Tests.Database;
+
+/// <summary>
+/// Reproduces #1104, where a pre-existing health-check repair index prevented
+/// the Nzb identity migration from completing during an upgrade.
+/// </summary>
+public sealed class PreExistingHealthCheckRepairStatusIndexMigrationTests
+{
+    private const string PriorMigration = "20260731171110_Add-SingleAdmin-UniqueIndex";
+    private const string NzbIdentityMigration = "20260817185420_Add-NzbIdentity-To-HealthCheckResults";
+    private const string RepairStatusIndex = "IX_HealthCheckResults_RepairStatus_CreatedAt";
+
+    [Fact]
+    public async Task PreExistingRepairStatusIndex_IsReplacedByCanonicalFilteredIndex()
+    {
+        await using var harness = await MigrationHarness.CreateAsync();
+        var context = harness.Context;
+
+        await context.Database.ExecuteSqlRawAsync(
+            """
+            CREATE INDEX "IX_HealthCheckResults_RepairStatus_CreatedAt"
+            ON "HealthCheckResults" ("RepairStatus", "CreatedAt")
+            WHERE "RepairStatus" IN (1, 2);
+            """);
+        Assert.True(await IndexExistsAsync(context, RepairStatusIndex));
+        Assert.Contains(
+            NzbIdentityMigration,
+            await context.Database.GetPendingMigrationsAsync());
+
+        await context.Database.MigrateAsync();
+
+        Assert.Contains(
+            NzbIdentityMigration,
+            await context.Database.GetAppliedMigrationsAsync());
+        Assert.Empty(await context.Database.GetPendingMigrationsAsync());
+        Assert.True(await ColumnExistsAsync(context, "JobName"));
+        Assert.True(await ColumnExistsAsync(context, "NzbFileName"));
+        Assert.Equal(
+            """CREATE INDEX "IX_HealthCheckResults_RepairStatus_CreatedAt" ON "HealthCheckResults" ("RepairStatus", "CreatedAt") WHERE "RepairStatus" IN (1, 2)""",
+            await IndexSqlAsync(context, RepairStatusIndex));
+    }
+
+    private static async Task<bool> IndexExistsAsync(DavDatabaseContext context, string indexName)
+    {
+        await using var command = context.Database.GetDbConnection().CreateCommand();
+        if (command.Connection!.State != System.Data.ConnectionState.Open)
+            await command.Connection.OpenAsync();
+
+        command.CommandText =
+            "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = $name LIMIT 1;";
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "$name";
+        parameter.Value = indexName;
+        command.Parameters.Add(parameter);
+
+        return await command.ExecuteScalarAsync() is not null and not DBNull;
+    }
+
+    private static async Task<string?> IndexSqlAsync(DavDatabaseContext context, string indexName)
+    {
+        await using var command = context.Database.GetDbConnection().CreateCommand();
+        if (command.Connection!.State != System.Data.ConnectionState.Open)
+            await command.Connection.OpenAsync();
+
+        command.CommandText =
+            "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = $name LIMIT 1;";
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "$name";
+        parameter.Value = indexName;
+        command.Parameters.Add(parameter);
+
+        return await command.ExecuteScalarAsync() as string;
+    }
+
+    private static async Task<bool> ColumnExistsAsync(DavDatabaseContext context, string columnName)
+    {
+        await using var command = context.Database.GetDbConnection().CreateCommand();
+        if (command.Connection!.State != System.Data.ConnectionState.Open)
+            await command.Connection.OpenAsync();
+
+        command.CommandText = "SELECT 1 FROM pragma_table_info('HealthCheckResults') WHERE name = $name LIMIT 1;";
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "$name";
+        parameter.Value = columnName;
+        command.Parameters.Add(parameter);
+
+        return await command.ExecuteScalarAsync() is not null and not DBNull;
+    }
+
+    private sealed class MigrationHarness : IAsyncDisposable
+    {
+        private readonly string _databasePath;
+
+        private MigrationHarness(string databasePath, DavDatabaseContext context)
+        {
+            _databasePath = databasePath;
+            Context = context;
+        }
+
+        public DavDatabaseContext Context { get; }
+
+        public static async Task<MigrationHarness> CreateAsync()
+        {
+            var databasePath = Path.Join(
+                Path.GetTempPath(),
+                $"nzbdav-preexisting-health-check-index-{Guid.NewGuid():N}.sqlite");
+            var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite($"Data Source={databasePath}")
+                .AddInterceptors(new SqliteForeignKeyEnabler())
+                .ReplaceService<
+                    IMigrationsSqlGenerator,
+                    SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            var context = new DavDatabaseContext(options);
+            await context.Database.MigrateAsync(PriorMigration);
+            return new MigrationHarness(databasePath, context);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.DisposeAsync();
+            File.Delete(_databasePath);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Extensions/ExceptionExtensionsTests.cs
+++ b/tests/NzbWebDAV.Tests/Extensions/ExceptionExtensionsTests.cs
@@ -148,6 +148,36 @@ public class ExceptionExtensionsTests
     }
 
     [Fact]
+    public void IsDuplicateSchemaObjectException_RecognizesExistingSqliteObject()
+    {
+        var ex = new SqliteException(
+            "SQLite Error 1: 'index IX_HealthCheckResults_RepairStatus_CreatedAt already exists'.",
+            1);
+
+        Assert.True(ex.IsDuplicateSchemaObjectException());
+    }
+
+    [Fact]
+    public void IsDuplicateSchemaObjectException_RecognizesWrappedExistingSqliteObject()
+    {
+        var ex = new InvalidOperationException(
+            "Migration failed.",
+            new SqliteException("SQLite Error 1: 'table Foo already exists'.", 1));
+
+        Assert.True(ex.IsDuplicateSchemaObjectException());
+    }
+
+    [Theory]
+    [InlineData(1, "SQLite Error 1: 'near \"BROKEN\": syntax error'.")]
+    [InlineData(5, "SQLite Error 5: 'database is locked'.")]
+    public void IsDuplicateSchemaObjectException_RejectsOtherSqliteErrors(int errorCode, string message)
+    {
+        var ex = new SqliteException(message, errorCode);
+
+        Assert.False(ex.IsDuplicateSchemaObjectException());
+    }
+
+    [Fact]
     public void TryGetKnownErrorMessage_Corruption_ReturnsRecoveryGuidance()
     {
         var ex = new SqliteException("SQLite Error 11: 'database disk image is malformed'.", 11);


### PR DESCRIPTION
## Summary
- make the health-check identity migration replace a pre-existing conflicting index
- show duplicate SQLite schema failures as actionable startup errors without stack dumps
- cover the v1.1.x upgrade schema/history mismatch reported in #1104

Back up `/config` before upgrading.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`