### PR TITLE
feat(search): reject wrong-year movies and optionally sort profile results by quality

### DIFF
--- a/backend/Config/ProfileConfig.cs
+++ b/backend/Config/ProfileConfig.cs
@@ -36,6 +36,8 @@ public class ProfileConfig
         public List<string> IndexerNames { get; set; } = [];
         public List<string>? EnabledAdapters { get; set; }
 
+        public QualitySortMode QualitySort { get; set; } = QualitySortMode.Off;
+
         public FallbackMode MovieFallback { get; set; } = FallbackMode.Off;
         public FallbackMode TvFallback { get; set; } = FallbackMode.Off;
         public int MovieFallbackMinResults { get; set; } = 3;
@@ -64,5 +66,13 @@ public class ProfileConfig
         Off = 0,
         Title = 1,
         Broad = 2,
+    }
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum QualitySortMode
+    {
+        Off = 0,
+        Resolution = 1,
+        ResolutionAndSource = 2,
     }
 }

--- a/backend/Services/ImdbTitleResolver.cs
+++ b/backend/Services/ImdbTitleResolver.cs
@@ -1,8 +1,11 @@
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Text.Json;
 using Serilog;
 
 namespace NzbWebDAV.Services;
+
+public sealed record ResolvedTitleMetadata(string Title, int? Year);
 
 public class ImdbTitleResolver
 {
@@ -13,32 +16,40 @@ public class ImdbTitleResolver
     private readonly ConcurrentDictionary<string, CacheEntry> _cache = new();
 
     public async Task<string?> GetTitleAsync(string type, string? imdbDigits, int? tvdbId, CancellationToken ct)
+        => (await GetMetadataAsync(type, imdbDigits, tvdbId, ct).ConfigureAwait(false))?.Title;
+
+    public async Task<ResolvedTitleMetadata?> GetMetadataAsync(
+        string type, string? imdbDigits, int? tvdbId, CancellationToken ct)
     {
         var key = $"{type}|{imdbDigits ?? ""}|{tvdbId?.ToString() ?? ""}";
         if (_cache.TryGetValue(key, out var entry) && entry.ExpiresAt > DateTimeOffset.UtcNow)
-            return entry.Title;
+            return entry.Metadata;
 
-        string? title = null;
+        ResolvedTitleMetadata? metadata = null;
         try
         {
             if (type == "series")
             {
-                title = await TryTvmazeAsync(imdbDigits, tvdbId, ct).ConfigureAwait(false);
+                var title = await TryTvmazeAsync(imdbDigits, tvdbId, ct).ConfigureAwait(false);
                 if (string.IsNullOrWhiteSpace(title) && imdbDigits is not null)
-                    title = await TryWikidataAsync(imdbDigits, ct).ConfigureAwait(false);
+                    title = (await TryWikidataAsync(imdbDigits, ct).ConfigureAwait(false))?.Title;
+                // Series premiere/release years are not used for the movie-only year gate.
+                if (!string.IsNullOrWhiteSpace(title))
+                    metadata = new ResolvedTitleMetadata(title, Year: null);
             }
             else if (type == "movie" && imdbDigits is not null)
             {
-                title = await TryWikidataAsync(imdbDigits, ct).ConfigureAwait(false);
+                metadata = await TryWikidataAsync(imdbDigits, ct).ConfigureAwait(false);
             }
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException or InvalidOperationException)
         {
             Log.Warning("ImdbTitleResolver lookup failed for {Key}: {Message}", key, ex.Message);
+            Log.Debug(ex, "ImdbTitleResolver known lookup failure stack for {Key}", key);
         }
 
-        _cache[key] = new CacheEntry(title, DateTimeOffset.UtcNow.Add(title is null ? NegativeTtl : CacheTtl));
-        return title;
+        _cache[key] = new CacheEntry(metadata, DateTimeOffset.UtcNow.Add(metadata is null ? NegativeTtl : CacheTtl));
+        return metadata;
     }
 
     private static async Task<string?> TryTvmazeAsync(string? imdbDigits, int? tvdbId, CancellationToken ct)
@@ -58,15 +69,13 @@ public class ImdbTitleResolver
         }
         await using var stream = await resp.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
         using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
-        if (doc.RootElement.ValueKind != JsonValueKind.Object) return null;
-        if (!doc.RootElement.TryGetProperty("name", out var nameEl)) return null;
-        var name = nameEl.GetString();
-        return string.IsNullOrWhiteSpace(name) ? null : name;
+        return ParseTvmazeTitle(doc.RootElement);
     }
 
-    private static async Task<string?> TryWikidataAsync(string imdbDigits, CancellationToken ct)
+    private static async Task<ResolvedTitleMetadata?> TryWikidataAsync(string imdbDigits, CancellationToken ct)
     {
-        var query = $"SELECT ?label WHERE {{ ?item wdt:P345 \"tt{imdbDigits}\" . ?item rdfs:label ?label . FILTER(LANG(?label) = \"en\") }} LIMIT 1";
+        var query =
+            $"SELECT ?label ?date WHERE {{ ?item wdt:P345 \"tt{imdbDigits}\" . ?item rdfs:label ?label . FILTER(LANG(?label) = \"en\") OPTIONAL {{ ?item wdt:P577 ?date }} }}";
         var url = $"https://query.wikidata.org/sparql?query={Uri.EscapeDataString(query)}";
         using var req = new HttpRequestMessage(HttpMethod.Get, url);
         req.Headers.Accept.ParseAdd("application/sparql-results+json");
@@ -79,10 +88,84 @@ public class ImdbTitleResolver
         }
         await using var stream = await resp.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
         using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
-        var bindings = doc.RootElement.GetProperty("results").GetProperty("bindings");
-        if (bindings.GetArrayLength() == 0) return null;
-        var label = bindings[0].GetProperty("label").GetProperty("value").GetString();
-        return string.IsNullOrWhiteSpace(label) ? null : label;
+        return ParseWikidataMetadata(doc.RootElement);
+    }
+
+    internal static string? ParseTvmazeTitle(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object) return null;
+        if (!root.TryGetProperty("name", out var nameEl)) return null;
+        var name = nameEl.GetString();
+        return string.IsNullOrWhiteSpace(name) ? null : name;
+    }
+
+    internal static ResolvedTitleMetadata? ParseWikidataMetadata(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object) return null;
+        if (!root.TryGetProperty("results", out var results)
+            || !results.TryGetProperty("bindings", out var bindings)
+            || bindings.ValueKind != JsonValueKind.Array
+            || bindings.GetArrayLength() == 0)
+        {
+            return null;
+        }
+
+        string? title = null;
+        int? earliestYear = null;
+        foreach (var binding in bindings.EnumerateArray())
+        {
+            if (title is null
+                && binding.TryGetProperty("label", out var labelEl)
+                && TryReadSparqlString(labelEl, out var label)
+                && !string.IsNullOrWhiteSpace(label))
+            {
+                title = label;
+            }
+
+            if (TryReadSparqlYear(binding, out var year)
+                && (earliestYear is null || year < earliestYear))
+            {
+                earliestYear = year;
+            }
+        }
+
+        return title is null ? null : new ResolvedTitleMetadata(title, earliestYear);
+    }
+
+    private static bool TryReadSparqlString(JsonElement node, out string? value)
+    {
+        value = null;
+        if (node.ValueKind == JsonValueKind.Object
+            && node.TryGetProperty("value", out var valueEl))
+        {
+            value = valueEl.GetString();
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryReadSparqlYear(JsonElement binding, out int year)
+    {
+        year = 0;
+        if (binding.TryGetProperty("year", out var yearEl)
+            && TryReadSparqlString(yearEl, out var yearText)
+            && int.TryParse(yearText, NumberStyles.Integer, CultureInfo.InvariantCulture, out year)
+            && year is >= 1900 and <= 2199)
+        {
+            return true;
+        }
+
+        if (binding.TryGetProperty("date", out var dateEl)
+            && TryReadSparqlString(dateEl, out var dateText)
+            && dateText is { Length: >= 4 }
+            && int.TryParse(dateText.AsSpan(0, 4), NumberStyles.Integer, CultureInfo.InvariantCulture, out year)
+            && year is >= 1900 and <= 2199)
+        {
+            return true;
+        }
+
+        return false;
     }
 
     private static void LogStatus(string source, int status, string id)
@@ -93,5 +176,5 @@ public class ImdbTitleResolver
             Log.Debug("ImdbTitleResolver: {Source} returned HTTP {Status} for {Id}", source, status, id);
     }
 
-    private sealed record CacheEntry(string? Title, DateTimeOffset ExpiresAt);
+    private sealed record CacheEntry(ResolvedTitleMetadata? Metadata, DateTimeOffset ExpiresAt);
 }

--- a/backend/Services/SearchProfileService.cs
+++ b/backend/Services/SearchProfileService.cs
@@ -328,42 +328,35 @@ public class SearchProfileService(
         var perIndexer = await RunPerIndexerQueryAsync(indexers, queryParams, indexerConfig, globalProxy, now, ct)
             .ConfigureAwait(false);
 
-        var deduped = DedupeAndSort(perIndexer, excludePatterns, anyPreferDownloaded);
+        var deduped = DedupeAndSort(perIndexer, excludePatterns, profile.QualitySort, anyPreferDownloaded);
 
         var strictIndexers = indexers
             .Where(x => x.EnableStrictMatching)
             .Select(x => x.Name)
             .ToHashSet();
 
-        var strictExpected = strictIndexers.Count > 0
-            ? await BuildExpectedTitlesAsync(type, queryParams, ct).ConfigureAwait(false)
-            : new HashSet<string>(StringComparer.Ordinal);
+        var strictIdentity = strictIndexers.Count > 0
+            ? await BuildExpectedIdentityAsync(type, queryParams, ct).ConfigureAwait(false)
+            : new ProfileIdentityFilter.ExpectedIdentity(new HashSet<string>(StringComparer.Ordinal), null);
 
         List<IndexerHit> ApplyStrictMatching(List<IndexerHit> items)
         {
-            if (strictIndexers.Count == 0 || items.Count < 2) return items;
+            var before = items.Count;
+            var filtered = ProfileIdentityFilter.ApplyStrictMatching(
+                items,
+                x => x.IndexerName,
+                x => x.Item.Title,
+                strictIndexers,
+                strictIdentity,
+                applyMovieYear: type == "movie");
+            if (filtered.Count != before)
+            {
+                Log.Information(
+                    "Strict matching {Type}/{Id}: kept {Kept}/{Before} result(s)",
+                    type, id, filtered.Count, before);
+            }
 
-            if (strictExpected.Count > 0)
-                return items
-                    .Where(x => !strictIndexers.Contains(x.IndexerName)
-                                || FilenameMatcher.TitleMatches(strictExpected, x.Item.Title))
-                    .ToList();
-
-            var withHead = items
-                .Select(x => new { Entry = x, Head = FilenameMatcher.HeadTokens(x.Item.Title) })
-                .ToList();
-            var consensus = withHead
-                .Where(x => x.Head.Length > 0)
-                .GroupBy(x => string.Join(' ', x.Head))
-                .Select(g => new { g.First().Head, Count = g.Count() })
-                .OrderByDescending(x => x.Count)
-                .FirstOrDefault();
-            if (consensus is not { Count: >= 2 }) return items;
-            return withHead
-                .Where(x => !strictIndexers.Contains(x.Entry.IndexerName)
-                            || FilenameMatcher.TokensEqual(x.Head, consensus.Head))
-                .Select(x => x.Entry)
-                .ToList();
+            return filtered;
         }
 
         deduped = ApplyStrictMatching(deduped);
@@ -420,13 +413,7 @@ public class SearchProfileService(
                     .Select(g => g.First())
                     .ToList();
 
-                deduped = (anyPreferDownloaded
-                        ? combined.OrderByDescending(x => x.Item.Grabs ?? -1)
-                                  .ThenByDescending(x => x.Item.Size)
-                                  .ThenByDescending(x => x.Item.Posted ?? DateTimeOffset.MinValue)
-                        : combined.OrderByDescending(x => x.Item.Size)
-                                  .ThenByDescending(x => x.Item.Posted ?? DateTimeOffset.MinValue))
-                    .ToList();
+                deduped = SortHits(combined, profile.QualitySort, anyPreferDownloaded);
 
                 deduped = ApplyStrictMatching(deduped);
             }
@@ -684,6 +671,7 @@ public class SearchProfileService(
     private static List<IndexerHit> DedupeAndSort(
         IEnumerable<IndexerHit>[] perIndexer,
         IReadOnlyList<Regex> excludePatterns,
+        ProfileConfig.QualitySortMode qualitySort,
         bool anyPreferDownloaded)
     {
         var dedupedQuery = perIndexer
@@ -693,14 +681,21 @@ public class SearchProfileService(
             .GroupBy(x => x.Item.NzbUrl)
             .Select(g => g.First());
 
-        return (anyPreferDownloaded
-                ? dedupedQuery.OrderByDescending(x => x.Item.Grabs ?? -1)
-                              .ThenByDescending(x => x.Item.Size)
-                              .ThenByDescending(x => x.Item.Posted ?? DateTimeOffset.MinValue)
-                : dedupedQuery.OrderByDescending(x => x.Item.Size)
-                              .ThenByDescending(x => x.Item.Posted ?? DateTimeOffset.MinValue))
-            .ToList();
+        return SortHits(dedupedQuery, qualitySort, anyPreferDownloaded);
     }
+
+    private static List<IndexerHit> SortHits(
+        IEnumerable<IndexerHit> items,
+        ProfileConfig.QualitySortMode qualitySort,
+        bool anyPreferDownloaded) =>
+        ProfileResultSorter.Sort(
+            items,
+            x => x.Item.Title,
+            x => x.Item.Grabs,
+            x => x.Item.Size,
+            x => x.Item.Posted,
+            qualitySort,
+            anyPreferDownloaded);
 
     private async Task<IReadOnlyList<IReadOnlyDictionary<string, string>>> BuildFallbackQueriesAsync(
         string type,
@@ -771,17 +766,28 @@ public class SearchProfileService(
     private async Task<HashSet<string>> BuildExpectedTitlesAsync(
         string type, IReadOnlyDictionary<string, string> queryParams, CancellationToken ct)
     {
+        var identity = await BuildExpectedIdentityAsync(type, queryParams, ct).ConfigureAwait(false);
+        return identity.NormalizedTitles is HashSet<string> set
+            ? set
+            : new HashSet<string>(identity.NormalizedTitles, StringComparer.Ordinal);
+    }
+
+    private async Task<ProfileIdentityFilter.ExpectedIdentity> BuildExpectedIdentityAsync(
+        string type, IReadOnlyDictionary<string, string> queryParams, CancellationToken ct)
+    {
         var set = new HashSet<string>(StringComparer.Ordinal);
         var imdbDigits = queryParams.TryGetValue("imdbid", out var imdb) ? imdb : null;
         int? tvdbId = null;
         if (queryParams.TryGetValue("tvdbid", out var tvdbStr) && int.TryParse(tvdbStr, out var t)) tvdbId = t;
-        if (imdbDigits is null && tvdbId is null) return set;
+        if (imdbDigits is null && tvdbId is null)
+            return new ProfileIdentityFilter.ExpectedIdentity(set, null);
 
         var titleType = type == "movie" ? "movie" : "series";
-        var title = await titleResolver.GetTitleAsync(titleType, imdbDigits, tvdbId, ct).ConfigureAwait(false);
-        var norm = FilenameMatcher.NormalizeTitle(title);
+        var metadata = await titleResolver.GetMetadataAsync(titleType, imdbDigits, tvdbId, ct).ConfigureAwait(false);
+        var norm = FilenameMatcher.NormalizeTitle(metadata?.Title);
         if (norm.Length > 0) set.Add(norm);
-        return set;
+        var year = type == "movie" ? metadata?.Year : null;
+        return new ProfileIdentityFilter.ExpectedIdentity(set, year);
     }
 
     private static SearchResult Empty(string profileToken, string type, string id) =>

--- a/backend/Utils/FilenameMatcher.cs
+++ b/backend/Utils/FilenameMatcher.cs
@@ -14,6 +14,12 @@ public static class FilenameMatcher
         @"[^a-z0-9]+",
         RegexOptions.Compiled);
 
+    // Plausible standalone release years in 1900..2199. Resolution tokens such as
+    // 2160p / 1080i and WxH pairs (1920x1080) are excluded by the trailing lookahead.
+    private static readonly Regex ReleaseYearRegex = new(
+        @"(?<!\d)(?<year>(?:19|20|21)\d{2})(?![0-9pPiIxX])",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
     private static readonly Dictionary<char, string> LatinFolding = new()
     {
         ['ø'] = "o",
@@ -159,5 +165,52 @@ public static class FilenameMatcher
                 return expectedNormalized.Contains(string.Join(' ', head[..^1]));
         }
         return false;
+    }
+
+    public static IReadOnlyList<int> ParseReleaseYears(string? releaseTitle)
+    {
+        if (string.IsNullOrWhiteSpace(releaseTitle)) return [];
+        var years = new List<int>();
+        foreach (Match match in ReleaseYearRegex.Matches(releaseTitle))
+        {
+            if (int.TryParse(match.Groups["year"].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var year)
+                && year is >= 1900 and <= 2199)
+            {
+                years.Add(year);
+            }
+        }
+
+        return years;
+    }
+
+    /// <summary>
+    /// Movie-year compatibility for strict matching.
+    /// Unknown canonical year, or a candidate with no usable non-title year, stays compatible.
+    /// An explicit remaining year must fall within <paramref name="canonicalYear"/> ± 1.
+    /// Four-digit tokens already present in any canonical title are ignored so numeric
+    /// titles such as 1917 or Blade Runner 2049 are not treated as release years.
+    /// </summary>
+    public static bool YearCompatible(
+        int? canonicalYear,
+        string? releaseTitle,
+        IEnumerable<string>? canonicalNormalizedTitles = null)
+    {
+        if (canonicalYear is not { } expected) return true;
+
+        var titleYears = new HashSet<int>();
+        if (canonicalNormalizedTitles is not null)
+        {
+            foreach (var title in canonicalNormalizedTitles)
+            {
+                foreach (var year in ParseReleaseYears(title))
+                    titleYears.Add(year);
+            }
+        }
+
+        var remaining = ParseReleaseYears(releaseTitle)
+            .Where(year => !titleYears.Contains(year))
+            .ToList();
+        if (remaining.Count == 0) return true;
+        return remaining.Any(year => Math.Abs(year - expected) <= 1);
     }
 }

--- a/backend/Utils/FilenameMatcher.cs
+++ b/backend/Utils/FilenameMatcher.cs
@@ -170,17 +170,17 @@ public static class FilenameMatcher
     public static IReadOnlyList<int> ParseReleaseYears(string? releaseTitle)
     {
         if (string.IsNullOrWhiteSpace(releaseTitle)) return [];
-        var years = new List<int>();
-        foreach (Match match in ReleaseYearRegex.Matches(releaseTitle))
-        {
-            if (int.TryParse(match.Groups["year"].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var year)
-                && year is >= 1900 and <= 2199)
-            {
-                years.Add(year);
-            }
-        }
-
-        return years;
+        return ReleaseYearRegex.Matches(releaseTitle)
+            .Select(match => int.TryParse(
+                match.Groups["year"].Value,
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out var year)
+                    ? (int?)year
+                    : null)
+            .Where(year => year is >= 1900 and <= 2199)
+            .Select(year => year!.Value)
+            .ToList();
     }
 
     /// <summary>

--- a/backend/Utils/ProfileIdentityFilter.cs
+++ b/backend/Utils/ProfileIdentityFilter.cs
@@ -1,0 +1,63 @@
+namespace NzbWebDAV.Utils;
+
+public static class ProfileIdentityFilter
+{
+    public readonly record struct ExpectedIdentity(
+        IReadOnlySet<string> NormalizedTitles,
+        int? MovieYear);
+
+    public static bool HasCanonicalIdentity(ExpectedIdentity identity)
+        => identity.NormalizedTitles.Count > 0 || identity.MovieYear.HasValue;
+
+    public static List<T> ApplyStrictMatching<T>(
+        IReadOnlyList<T> items,
+        Func<T, string> indexerName,
+        Func<T, string?> title,
+        IReadOnlySet<string> strictIndexers,
+        ExpectedIdentity identity,
+        bool applyMovieYear)
+    {
+        if (strictIndexers.Count == 0) return items.ToList();
+
+        if (HasCanonicalIdentity(identity))
+        {
+            return items
+                .Where(item => !strictIndexers.Contains(indexerName(item))
+                               || MatchesCanonical(title(item), identity, applyMovieYear))
+                .ToList();
+        }
+
+        // Consensus fallback is only used when canonical metadata could not be resolved,
+        // and still requires at least two results before it will reject anything.
+        if (items.Count < 2) return items.ToList();
+
+        var withHead = items
+            .Select(item => (Entry: item, Head: FilenameMatcher.HeadTokens(title(item))))
+            .ToList();
+        var consensus = withHead
+            .Where(x => x.Head.Length > 0)
+            .GroupBy(x => string.Join(' ', x.Head))
+            .Select(g => new { g.First().Head, Count = g.Count() })
+            .OrderByDescending(x => x.Count)
+            .FirstOrDefault();
+        if (consensus is not { Count: >= 2 }) return items.ToList();
+
+        return withHead
+            .Where(x => !strictIndexers.Contains(indexerName(x.Entry))
+                        || FilenameMatcher.TokensEqual(x.Head, consensus.Head))
+            .Select(x => x.Entry)
+            .ToList();
+    }
+
+    private static bool MatchesCanonical(string? releaseTitle, ExpectedIdentity identity, bool applyMovieYear)
+    {
+        if (identity.NormalizedTitles.Count > 0
+            && !FilenameMatcher.TitleMatches(identity.NormalizedTitles, releaseTitle))
+        {
+            return false;
+        }
+
+        return !applyMovieYear
+               || FilenameMatcher.YearCompatible(identity.MovieYear, releaseTitle, identity.NormalizedTitles);
+    }
+}

--- a/backend/Utils/ProfileResultSorter.cs
+++ b/backend/Utils/ProfileResultSorter.cs
@@ -1,0 +1,51 @@
+using NzbWebDAV.Config;
+
+namespace NzbWebDAV.Utils;
+
+public static class ProfileResultSorter
+{
+    public static List<T> Sort<T>(
+        IEnumerable<T> items,
+        Func<T, string?> title,
+        Func<T, int?> grabs,
+        Func<T, long> size,
+        Func<T, DateTimeOffset?> posted,
+        ProfileConfig.QualitySortMode qualitySort,
+        bool preferDownloaded)
+    {
+        var ranked = items.Select(item =>
+        {
+            var quality = qualitySort == ProfileConfig.QualitySortMode.Off
+                ? ReleaseQualityRanks.Unknown
+                : ReleaseQuality.Parse(title(item));
+            return new Ranked<T>(
+                item,
+                qualitySort == ProfileConfig.QualitySortMode.Off ? 0 : quality.Resolution,
+                qualitySort == ProfileConfig.QualitySortMode.ResolutionAndSource ? quality.Source : 0,
+                grabs(item) ?? -1,
+                size(item),
+                posted(item) ?? DateTimeOffset.MinValue);
+        });
+
+        var ordered = qualitySort == ProfileConfig.QualitySortMode.Off
+            ? ranked.OrderByDescending(_ => 0)
+            : ranked.OrderByDescending(x => x.Resolution).ThenByDescending(x => x.Source);
+
+        if (preferDownloaded)
+            ordered = ordered.ThenByDescending(x => x.Grabs);
+
+        return ordered
+            .ThenByDescending(x => x.Size)
+            .ThenByDescending(x => x.Posted)
+            .Select(x => x.Item)
+            .ToList();
+    }
+
+    private sealed record Ranked<T>(
+        T Item,
+        int Resolution,
+        int Source,
+        int Grabs,
+        long Size,
+        DateTimeOffset Posted);
+}

--- a/backend/Utils/ReleaseQuality.cs
+++ b/backend/Utils/ReleaseQuality.cs
@@ -1,0 +1,69 @@
+using System.Text.RegularExpressions;
+
+namespace NzbWebDAV.Utils;
+
+public readonly record struct ReleaseQualityRanks(int Resolution, int Source)
+{
+    public static readonly ReleaseQualityRanks Unknown = new(ResolutionUnknown, SourceUnknown);
+
+    public const int Resolution4320 = 5;
+    public const int Resolution2160 = 4;
+    public const int Resolution1080 = 3;
+    public const int Resolution720 = 2;
+    public const int ResolutionSd = 1;
+    public const int ResolutionUnknown = 0;
+
+    public const int SourceRemux = 6;
+    public const int SourceBluRay = 5;
+    public const int SourceWebDl = 4;
+    public const int SourceWebRip = 3;
+    public const int SourceHdtv = 2;
+    public const int SourceDvd = 1;
+    public const int SourceUnknown = 0;
+    public const int SourceCam = -1;
+}
+
+public static class ReleaseQuality
+{
+    private static readonly Regex ResolutionRegex = new(
+        @"(?<![A-Za-z0-9])(?:(?<uhd8k>4320p|8k)|(?<uhd>2160p|4k|uhd)|(?<fhd>1080p|1080i)|(?<hd>720p)|(?<sd>576p|480p|sd))(?![A-Za-z0-9])",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex SourceRegex = new(
+        @"(?<![A-Za-z0-9])(?:(?<remux>remux)|(?<bluray>blu[-.]?ray|bdrip|brrip)|(?<webdl>web[-.]?dl)|(?<webrip>webrip)|(?<hdtv>hdtv)|(?<dvd>dvdrip|dvd)|(?<cam>telesync|cam|ts))(?![A-Za-z0-9])",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public static ReleaseQualityRanks Parse(string? title)
+    {
+        if (string.IsNullOrWhiteSpace(title)) return ReleaseQualityRanks.Unknown;
+
+        var normalized = title.Replace('_', '.');
+        return new ReleaseQualityRanks(ParseResolution(normalized), ParseSource(normalized));
+    }
+
+    private static int ParseResolution(string title)
+    {
+        var match = ResolutionRegex.Match(title);
+        if (!match.Success) return ReleaseQualityRanks.ResolutionUnknown;
+        if (match.Groups["uhd8k"].Success) return ReleaseQualityRanks.Resolution4320;
+        if (match.Groups["uhd"].Success) return ReleaseQualityRanks.Resolution2160;
+        if (match.Groups["fhd"].Success) return ReleaseQualityRanks.Resolution1080;
+        if (match.Groups["hd"].Success) return ReleaseQualityRanks.Resolution720;
+        if (match.Groups["sd"].Success) return ReleaseQualityRanks.ResolutionSd;
+        return ReleaseQualityRanks.ResolutionUnknown;
+    }
+
+    private static int ParseSource(string title)
+    {
+        var match = SourceRegex.Match(title);
+        if (!match.Success) return ReleaseQualityRanks.SourceUnknown;
+        if (match.Groups["remux"].Success) return ReleaseQualityRanks.SourceRemux;
+        if (match.Groups["bluray"].Success) return ReleaseQualityRanks.SourceBluRay;
+        if (match.Groups["webdl"].Success) return ReleaseQualityRanks.SourceWebDl;
+        if (match.Groups["webrip"].Success) return ReleaseQualityRanks.SourceWebRip;
+        if (match.Groups["hdtv"].Success) return ReleaseQualityRanks.SourceHdtv;
+        if (match.Groups["dvd"].Success) return ReleaseQualityRanks.SourceDvd;
+        if (match.Groups["cam"].Success) return ReleaseQualityRanks.SourceCam;
+        return ReleaseQualityRanks.SourceUnknown;
+    }
+}

--- a/docs/configuration/profiles.md
+++ b/docs/configuration/profiles.md
@@ -10,8 +10,27 @@ Named profiles select which indexers to query and which output adapters to expos
 | JSON Search API | Vendor-neutral JSON adapter | on if unset |
 | Newznab | For Prowlarr/Sonarr/Radarr | on if unset |
 | Addon | Manifest-based addon endpoint | on if unset |
+| Result ordering [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since } | Keep grabs/size/date order, or sort by resolution / resolution+source | Off |
 | Query fallback — Movies | Extra title searches when ID lookup is short | Off; threshold `3` |
 | Query fallback — TV | Off / Title+episode / Broad | Off; threshold `3` |
+
+## Result matching and ordering [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since }
+
+When an indexer has **Strict matching** enabled, Search Profiles reject movie releases whose explicit
+year is clearly wrong once a canonical title and year are known. A missing year is not treated as a
+mismatch. TV, season, and episode strict matching stay title- and `SxxExx`-based; a show premiere
+year is never applied to episode results.
+
+**Result ordering** is profile-scoped and defaults to **Off**, so existing profiles keep the previous
+grabs (when Prefer Downloaded is on), then size, then posted-date order. Choose:
+
+- **Resolution** to prefer 2160p, then 1080p, 720p, then SD, before those tie-breakers.
+- **Resolution + source** to keep that resolution order and then prefer Remux, BluRay, WEB-DL,
+  WEBRip, HDTV, DVD, unknown, and CAM/TS.
+
+Resolution always ranks above source. Watchtower-verified candidates can still be boosted above this
+ordinary indexer order. Settings → Indexers manual search does not use Search Profiles and is
+unchanged.
 
 Treat each generated **token** as a secret. Adapter URLs look like:
 

--- a/docs/features/indexer-search.md
+++ b/docs/features/indexer-search.md
@@ -14,6 +14,18 @@ Each profile selects indexers and optional adapters:
 
 Treat profile tokens as secrets. Play links in results have a configurable lifetime (**Watchdog → Search link lifetime**) [since 0.8.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.8.0){ .nzbdav-since }.
 
+## Ranking [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since }
+
+Search Profile adapters apply two independent controls:
+
+- **Strict matching** (per indexer) rejects an explicit wrong movie year when canonical metadata is
+  known. Lack of year evidence stays permissive. This is not a quality sort, and it does not apply
+  show-premiere years to TV/episode results.
+- **Result ordering** (per profile, default Off) can sort by resolution, or by resolution then
+  source, before the usual grabs/size/posted-date tie-breakers.
+
+Settings → Indexers manual search does not use Search Profiles and keeps its existing order.
+
 ## Filters
 
 Manual regex excludes plus synced remote lists (e.g. TRaSH-style JSON). Synced patterns refresh on a schedule; last-good cache survives temporary URL failures.

--- a/frontend/app/routes/settings/profiles/profiles.test.ts
+++ b/frontend/app/routes/settings/profiles/profiles.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+/* global HTMLSelectElement */
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createElement, type Dispatch, type SetStateAction, useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ProfilesSettings } from "./profiles";
+
+const existingProfileConfig = {
+  "indexers.instances": '{"Indexers":[]}',
+  "profiles.instances": JSON.stringify({
+    Profiles: [
+      {
+        Token: "existing-token",
+        Name: "Existing profile",
+        IndexerNames: [],
+      },
+    ],
+  }),
+};
+
+afterEach(cleanup);
+
+function ProfilesHarness({ onConfigChange }: { onConfigChange?: (config: Record<string, string>) => void }) {
+  const [config, setConfig] = useState<Record<string, string>>(existingProfileConfig);
+  const setNewConfig: Dispatch<SetStateAction<Record<string, string>>> = (update) => {
+    const next = typeof update === "function" ? update(config) : update;
+    onConfigChange?.(next);
+    setConfig(next);
+  };
+  return createElement(ProfilesSettings, { config, setNewConfig });
+}
+
+describe("ProfilesSettings result ordering", () => {
+  it("keeps existing profiles on Off until a quality mode is selected", async () => {
+    const onConfigChange = vi.fn();
+    const user = userEvent.setup();
+    render(createElement(ProfilesHarness, { onConfigChange }));
+
+    const ordering = screen.getByRole<HTMLSelectElement>("combobox", { name: "Result ordering" });
+    expect(ordering.value).toBe("Off");
+
+    await user.selectOptions(ordering, "ResolutionAndSource");
+
+    expect(onConfigChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        "profiles.instances": expect.stringContaining('"QualitySort":"ResolutionAndSource"'),
+      }),
+    );
+  });
+});

--- a/frontend/app/routes/settings/profiles/profiles.test.ts
+++ b/frontend/app/routes/settings/profiles/profiles.test.ts
@@ -21,7 +21,11 @@ const existingProfileConfig = {
 
 afterEach(cleanup);
 
-function ProfilesHarness({ onConfigChange }: { onConfigChange?: (config: Record<string, string>) => void }) {
+function ProfilesHarness({
+  onConfigChange,
+}: {
+  onConfigChange?: (config: Record<string, string>) => void;
+}) {
   const [config, setConfig] = useState<Record<string, string>>(existingProfileConfig);
   const setNewConfig: Dispatch<SetStateAction<Record<string, string>>> = (update) => {
     const next = typeof update === "function" ? update(config) : update;

--- a/frontend/app/routes/settings/profiles/profiles.test.ts
+++ b/frontend/app/routes/settings/profiles/profiles.test.ts
@@ -33,7 +33,7 @@ function ProfilesHarness({ onConfigChange }: { onConfigChange?: (config: Record<
 
 describe("ProfilesSettings result ordering", () => {
   it("keeps existing profiles on Off until a quality mode is selected", async () => {
-    const onConfigChange = vi.fn();
+    const onConfigChange = vi.fn<(config: Record<string, string>) => void>();
     const user = userEvent.setup();
     render(createElement(ProfilesHarness, { onConfigChange }));
 
@@ -42,10 +42,8 @@ describe("ProfilesSettings result ordering", () => {
 
     await user.selectOptions(ordering, "ResolutionAndSource");
 
-    expect(onConfigChange).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        "profiles.instances": expect.stringContaining('"QualitySort":"ResolutionAndSource"'),
-      }),
+    expect(onConfigChange.mock.lastCall?.[0]?.["profiles.instances"]).toContain(
+      '"QualitySort":"ResolutionAndSource"',
     );
   });
 });

--- a/frontend/app/routes/settings/profiles/profiles.tsx
+++ b/frontend/app/routes/settings/profiles/profiles.tsx
@@ -26,12 +26,14 @@ type ProfilesSettingsProps = {
 };
 
 type FallbackMode = "Off" | "Title" | "Broad";
+type QualitySortMode = "Off" | "Resolution" | "ResolutionAndSource";
 
 interface Profile {
   Token: string;
   Name: string;
   IndexerNames: string[];
   EnabledAdapters?: string[] | null;
+  QualitySort?: QualitySortMode;
   MovieFallback?: FallbackMode;
   TvFallback?: FallbackMode;
   MovieFallbackMinResults?: number;
@@ -137,6 +139,7 @@ export function ProfilesSettings({ config, setNewConfig }: ProfilesSettingsProps
           Name: "",
           IndexerNames: [],
           EnabledAdapters: [...ALL_ADAPTER_KEYS],
+          QualitySort: "Off",
           MovieFallback: "Off",
           TvFallback: "Off",
           MovieFallbackMinResults: 3,
@@ -419,6 +422,25 @@ function ProfileForm({ profile, index, availableIndexers, onChange, onRemove }: 
               />
             ))}
           </div>
+        </Field>
+        <Field>
+          <Label htmlFor={`profile-quality-sort-${profile.Token}`}>Result ordering</Label>
+          <Select
+            id={`profile-quality-sort-${profile.Token}`}
+            className="mb-2 w-full"
+            value={profile.QualitySort ?? "Off"}
+            onChange={(e) => onChange(index, { QualitySort: e.target.value as QualitySortMode })}
+          >
+            <option value="Off">Off — keep current grabs/size/date order</option>
+            <option value="Resolution">Resolution — prefer 2160p, then 1080p, 720p, SD</option>
+            <option value="ResolutionAndSource">
+              Resolution + source — resolution first, then Remux/BluRay/WEB-DL/...
+            </option>
+          </Select>
+          <p className="mb-0 mt-1 text-[11px] leading-relaxed text-base-content/45">
+            Quality sorting is opt-in. Existing profiles keep grabs, size, and posted-date order
+            until you enable a mode. Resolution always ranks above source.
+          </p>
         </Field>
         <Field>
           <Label>

--- a/tests/NzbWebDAV.Tests/Config/ProfileConfigFindByTokenTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/ProfileConfigFindByTokenTests.cs
@@ -1,4 +1,5 @@
 using NzbWebDAV.Config;
+using System.Text.Json;
 
 namespace NzbWebDAV.Tests.Config;
 
@@ -52,5 +53,42 @@ public class ProfileConfigFindByTokenTests
 
         Assert.NotNull(match);
         Assert.Equal("First", match.Name);
+    }
+
+    [Fact]
+    public void ExistingProfileWithoutQualitySort_UsesDefaultOrdering()
+    {
+        var config = JsonSerializer.Deserialize<ProfileConfig>(
+            """{"Profiles":[{"Token":"aaaaaaaaaaaaaaaaaaaaaaaa","Name":"Existing"}]}""");
+
+        Assert.NotNull(config);
+        Assert.Equal(ProfileConfig.QualitySortMode.Off, config.Profiles[0].QualitySort);
+    }
+
+    [Theory]
+    [InlineData(ProfileConfig.QualitySortMode.Off, "Off")]
+    [InlineData(ProfileConfig.QualitySortMode.Resolution, "Resolution")]
+    [InlineData(ProfileConfig.QualitySortMode.ResolutionAndSource, "ResolutionAndSource")]
+    public void QualitySort_RoundTripsAsString(ProfileConfig.QualitySortMode mode, string expected)
+    {
+        var config = new ProfileConfig
+        {
+            Profiles =
+            [
+                new ProfileConfig.Profile
+                {
+                    Token = "aaaaaaaaaaaaaaaaaaaaaaaa",
+                    Name = "A",
+                    QualitySort = mode,
+                },
+            ],
+        };
+
+        var json = JsonSerializer.Serialize(config);
+        Assert.Contains($"\"QualitySort\":\"{expected}\"", json, StringComparison.Ordinal);
+
+        var roundTrip = JsonSerializer.Deserialize<ProfileConfig>(json);
+        Assert.NotNull(roundTrip);
+        Assert.Equal(mode, roundTrip.Profiles[0].QualitySort);
     }
 }

--- a/tests/NzbWebDAV.Tests/Services/ImdbTitleResolverTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ImdbTitleResolverTests.cs
@@ -1,0 +1,94 @@
+using System.Text.Json;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class ImdbTitleResolverTests
+{
+    [Fact]
+    public void ParseTvmazeTitle_ReadsNameAndLeavesYearUnknown()
+    {
+        using var doc = JsonDocument.Parse("""{"name":"The Bear","premiered":"2022-06-23"}""");
+
+        var title = ImdbTitleResolver.ParseTvmazeTitle(doc.RootElement);
+
+        Assert.Equal("The Bear", title);
+    }
+
+    [Fact]
+    public void ParseWikidataMetadata_ReadsTitleAndSingleDate()
+    {
+        using var doc = JsonDocument.Parse(
+            """
+            {
+              "results": {
+                "bindings": [
+                  {
+                    "label": { "value": "Dune" },
+                    "date": { "value": "2021-10-22T00:00:00Z" }
+                  }
+                ]
+              }
+            }
+            """);
+
+        var metadata = ImdbTitleResolver.ParseWikidataMetadata(doc.RootElement);
+
+        Assert.NotNull(metadata);
+        Assert.Equal("Dune", metadata.Title);
+        Assert.Equal(2021, metadata.Year);
+    }
+
+    [Fact]
+    public void ParseWikidataMetadata_MultipleDates_ChoosesEarliestValidYear()
+    {
+        using var doc = JsonDocument.Parse(
+            """
+            {
+              "results": {
+                "bindings": [
+                  {
+                    "label": { "value": "Blade Runner 2049" },
+                    "date": { "value": "2017-10-06T00:00:00Z" }
+                  },
+                  {
+                    "label": { "value": "Blade Runner 2049" },
+                    "date": { "value": "2018-03-01T00:00:00Z" }
+                  },
+                  {
+                    "label": { "value": "Blade Runner 2049" },
+                    "year": { "value": "2016" }
+                  }
+                ]
+              }
+            }
+            """);
+
+        var metadata = ImdbTitleResolver.ParseWikidataMetadata(doc.RootElement);
+
+        Assert.NotNull(metadata);
+        Assert.Equal("Blade Runner 2049", metadata.Title);
+        Assert.Equal(2016, metadata.Year);
+    }
+
+    [Fact]
+    public void ParseWikidataMetadata_TitleWithoutDate_ReturnsNullYear()
+    {
+        using var doc = JsonDocument.Parse(
+            """
+            {
+              "results": {
+                "bindings": [
+                  { "label": { "value": "Mystery Film" } }
+                ]
+              }
+            }
+            """);
+
+        var metadata = ImdbTitleResolver.ParseWikidataMetadata(doc.RootElement);
+
+        Assert.NotNull(metadata);
+        Assert.Equal("Mystery Film", metadata.Title);
+        Assert.Null(metadata.Year);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Utils/FilenameMatcherTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/FilenameMatcherTests.cs
@@ -1,0 +1,79 @@
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public class FilenameMatcherTests
+{
+    [Fact]
+    public void YearCompatible_UnknownCanonicalYear_IsPermissive()
+    {
+        Assert.True(FilenameMatcher.YearCompatible(null, "Dune.1984.1080p.BluRay"));
+    }
+
+    [Fact]
+    public void YearCompatible_ExactYear_Matches()
+    {
+        Assert.True(FilenameMatcher.YearCompatible(2024, "Dune.Part.Two.2024.2160p.WEB-DL"));
+    }
+
+    [Theory]
+    [InlineData(2024, "Dune.Part.Two.2023.1080p")]
+    [InlineData(2024, "Dune.Part.Two.2025.1080p")]
+    public void YearCompatible_PlusOrMinusOne_Matches(int canonicalYear, string title)
+    {
+        Assert.True(FilenameMatcher.YearCompatible(canonicalYear, title));
+    }
+
+    [Fact]
+    public void YearCompatible_WrongRemakeYear_IsRejected()
+    {
+        Assert.False(FilenameMatcher.YearCompatible(2024, "Dune.1984.1080p.BluRay"));
+    }
+
+    [Fact]
+    public void YearCompatible_MissingReleaseYear_IsPermissive()
+    {
+        Assert.True(FilenameMatcher.YearCompatible(2024, "Dune.2160p.WEB-DL"));
+    }
+
+    [Fact]
+    public void ParseReleaseYears_DoesNotTreatResolutionAsYear()
+    {
+        Assert.Empty(FilenameMatcher.ParseReleaseYears("Dune.2160p.WEB-DL"));
+        Assert.Empty(FilenameMatcher.ParseReleaseYears("Movie.1080p.BluRay"));
+        Assert.Empty(FilenameMatcher.ParseReleaseYears("Movie.1920x1080.WEB-DL"));
+    }
+
+    [Fact]
+    public void YearCompatible_NumericTitle1917_UsesTheReleaseYear()
+    {
+        var titles = new[] { FilenameMatcher.NormalizeTitle("1917") };
+        Assert.True(FilenameMatcher.YearCompatible(2019, "1917.2019.1080p.BluRay", titles));
+        Assert.False(FilenameMatcher.YearCompatible(2019, "1917.2017.1080p.BluRay", titles));
+        Assert.Equal(new[] { 1917, 2019 }, FilenameMatcher.ParseReleaseYears("1917.2019.1080p.BluRay"));
+    }
+
+    [Fact]
+    public void YearCompatible_NumericTitle1984_UsesTheReleaseYear()
+    {
+        var titles = new[] { FilenameMatcher.NormalizeTitle("1984") };
+        Assert.True(FilenameMatcher.YearCompatible(1984, "1984.1984.1080p", titles));
+        Assert.False(FilenameMatcher.YearCompatible(1984, "1984.2023.1080p", titles));
+    }
+
+    [Fact]
+    public void YearCompatible_BladeRunner2049_DoesNotTreatTitleTokenAsYear()
+    {
+        var titles = new[] { FilenameMatcher.NormalizeTitle("Blade Runner 2049") };
+        Assert.True(FilenameMatcher.YearCompatible(2017, "Blade.Runner.2049.2017.1080p", titles));
+        Assert.False(FilenameMatcher.YearCompatible(2017, "Blade.Runner.2049.2015.1080p", titles));
+        Assert.True(FilenameMatcher.YearCompatible(2017, "Blade.Runner.2049.2160p.Remux", titles));
+    }
+
+    [Fact]
+    public void YearCompatible_SeriesStartYearInCanonicalTitle_IsIgnored()
+    {
+        var titles = new[] { FilenameMatcher.NormalizeTitle("Doctor Who 2005") };
+        Assert.True(FilenameMatcher.YearCompatible(2023, "Doctor.Who.2005.S01E01.720p", titles));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Utils/ProfileIdentityFilterTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/ProfileIdentityFilterTests.cs
@@ -1,0 +1,113 @@
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public class ProfileIdentityFilterTests
+{
+    private static readonly HashSet<string> Strict = new(StringComparer.Ordinal) { "strict" };
+
+    [Fact]
+    public void StrictIndexer_RemovesWrongYearMovie()
+    {
+        var identity = Identity("Dune", 2024);
+        var kept = Apply(
+            [
+                Result("strict", "Dune.2024.2160p.WEB-DL"),
+                Result("strict", "Dune.1984.1080p.BluRay"),
+            ],
+            identity,
+            applyMovieYear: true);
+
+        Assert.Equal(["Dune.2024.2160p.WEB-DL"], kept.Select(x => x.Title));
+    }
+
+    [Fact]
+    public void NonStrictIndexer_RetainsWrongYearMovie()
+    {
+        var identity = Identity("Dune", 2024);
+        var kept = Apply(
+            [Result("open", "Dune.1984.1080p.BluRay")],
+            identity,
+            applyMovieYear: true,
+            strictIndexers: Strict);
+
+        Assert.Single(kept);
+    }
+
+    [Fact]
+    public void SoleWrongYearStrictResult_IsRemovedWhenCanonicalYearExists()
+    {
+        var identity = Identity("Dune", 2024);
+        var kept = Apply(
+            [Result("strict", "Dune.1984.1080p.BluRay")],
+            identity,
+            applyMovieYear: true);
+
+        Assert.Empty(kept);
+    }
+
+    [Fact]
+    public void ResolverFailure_LeavesResultsIntact()
+    {
+        var empty = new ProfileIdentityFilter.ExpectedIdentity(
+            new HashSet<string>(StringComparer.Ordinal),
+            MovieYear: null);
+        var items = new[]
+        {
+            Result("strict", "Dune.1984.1080p.BluRay"),
+        };
+
+        var kept = Apply(items, empty, applyMovieYear: true);
+
+        Assert.Equal(items, kept);
+    }
+
+    [Fact]
+    public void TvResults_AreNotRejectedByShowPremiereYear()
+    {
+        var identity = new ProfileIdentityFilter.ExpectedIdentity(
+            new HashSet<string>(StringComparer.Ordinal) { FilenameMatcher.NormalizeTitle("The Bear") },
+            MovieYear: 2022);
+        var kept = Apply(
+            [Result("strict", "The.Bear.S03E01.2024.1080p.WEB-DL")],
+            identity,
+            applyMovieYear: false);
+
+        Assert.Single(kept);
+    }
+
+    [Fact]
+    public void NonStrictIndexer_PassesThroughUnchanged()
+    {
+        var identity = Identity("Dune", 2024);
+        var items = new[]
+        {
+            Result("open", "Completely.Different.1999.1080p"),
+            Result("strict", "Dune.2024.1080p"),
+        };
+
+        var kept = Apply(items, identity, applyMovieYear: true);
+
+        Assert.Equal(["Completely.Different.1999.1080p", "Dune.2024.1080p"], kept.Select(x => x.Title));
+    }
+
+    private static ProfileIdentityFilter.ExpectedIdentity Identity(string title, int? year) =>
+        new(new HashSet<string>(StringComparer.Ordinal) { FilenameMatcher.NormalizeTitle(title) }, year);
+
+    private static List<Hit> Apply(
+        IReadOnlyList<Hit> items,
+        ProfileIdentityFilter.ExpectedIdentity identity,
+        bool applyMovieYear,
+        IReadOnlySet<string>? strictIndexers = null) =>
+        ProfileIdentityFilter.ApplyStrictMatching(
+            items,
+            x => x.Indexer,
+            x => x.Title,
+            strictIndexers ?? Strict,
+            identity,
+            applyMovieYear);
+
+    private static Hit Result(string indexer, string title) => new(indexer, title);
+
+    private sealed record Hit(string Indexer, string Title);
+}

--- a/tests/NzbWebDAV.Tests/Utils/ProfileResultSorterTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/ProfileResultSorterTests.cs
@@ -1,0 +1,110 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public class ProfileResultSorterTests
+{
+    [Fact]
+    public void Sort_Off_ReproducesGrabsSizeDateOrder()
+    {
+        var items = new[]
+        {
+            new Release("Movie.2024.2160p.WEB-DL", Grabs: 1, Size: 10, Posted: DateTimeOffset.UnixEpoch),
+            new Release("Movie.2024.1080p.BluRay", Grabs: 50, Size: 20, Posted: DateTimeOffset.UnixEpoch.AddDays(1)),
+            new Release("Movie.2024.720p.WEB-DL", Grabs: 50, Size: 30, Posted: DateTimeOffset.UnixEpoch),
+        };
+
+        var sorted = Sort(items, ProfileConfig.QualitySortMode.Off, preferDownloaded: true);
+
+        Assert.Equal(
+            ["Movie.2024.720p.WEB-DL", "Movie.2024.1080p.BluRay", "Movie.2024.2160p.WEB-DL"],
+            sorted.Select(x => x.Title));
+    }
+
+    [Fact]
+    public void Sort_Resolution_IgnoresSourceRank()
+    {
+        var items = new[]
+        {
+            new Release("Movie.2024.1080p.REMUX", 100, 50, DateTimeOffset.UnixEpoch),
+            new Release("Movie.2024.2160p.HDTV", 1, 10, DateTimeOffset.UnixEpoch),
+            new Release("Movie.2024.1080p.WEB-DL", 500, 40, DateTimeOffset.UnixEpoch),
+        };
+
+        var sorted = Sort(items, ProfileConfig.QualitySortMode.Resolution, preferDownloaded: true);
+
+        Assert.Equal(
+            ["Movie.2024.2160p.HDTV", "Movie.2024.1080p.WEB-DL", "Movie.2024.1080p.REMUX"],
+            sorted.Select(x => x.Title));
+    }
+
+    [Fact]
+    public void Sort_ResolutionAndSource_AppliesSourceOnlyWithinResolution()
+    {
+        var items = new[]
+        {
+            new Release("Movie.2024.1080p.REMUX", 100, 50, DateTimeOffset.UnixEpoch),
+            new Release("Movie.2024.2160p.HDTV", 1, 10, DateTimeOffset.UnixEpoch),
+            new Release("Movie.2024.1080p.WEB-DL", 500, 40, DateTimeOffset.UnixEpoch),
+        };
+
+        var sorted = Sort(items, ProfileConfig.QualitySortMode.ResolutionAndSource);
+
+        Assert.Equal(
+            ["Movie.2024.2160p.HDTV", "Movie.2024.1080p.REMUX", "Movie.2024.1080p.WEB-DL"],
+            sorted.Select(x => x.Title));
+    }
+
+    [Fact]
+    public void Sort_FallbackMergedResults_UseTheSameOrdering()
+    {
+        var initial = new[]
+        {
+            new Release("Movie.2024.720p.WEB-DL", 1, 10, DateTimeOffset.UnixEpoch),
+        };
+        var fallback = new[]
+        {
+            new Release("Movie.2024.2160p.WEB-DL", 1, 10, DateTimeOffset.UnixEpoch),
+            new Release("Movie.2024.1080p.BluRay", 1, 20, DateTimeOffset.UnixEpoch),
+        };
+
+        var sorted = Sort(initial.Concat(fallback), ProfileConfig.QualitySortMode.ResolutionAndSource);
+
+        Assert.Equal(
+            ["Movie.2024.2160p.WEB-DL", "Movie.2024.1080p.BluRay", "Movie.2024.720p.WEB-DL"],
+            sorted.Select(x => x.Title));
+    }
+
+    [Fact]
+    public void Sort_DoesNotReorderAfterWatchtowerBoost()
+    {
+        var ordinary = Sort(
+            [
+                new Release("Movie.2024.1080p.WEB-DL", 1, 10, DateTimeOffset.UnixEpoch),
+                new Release("Movie.2024.2160p.WEB-DL", 1, 10, DateTimeOffset.UnixEpoch),
+            ],
+            ProfileConfig.QualitySortMode.Resolution);
+
+        var watchtowerFirst = new Release("Movie.2024.720p.HDTV", 1, 5, DateTimeOffset.UnixEpoch);
+        var merged = new[] { watchtowerFirst }.Concat(ordinary).ToList();
+
+        Assert.Equal("Movie.2024.720p.HDTV", merged[0].Title);
+        Assert.Equal("Movie.2024.2160p.WEB-DL", merged[1].Title);
+    }
+
+    private static List<Release> Sort(
+        IEnumerable<Release> items,
+        ProfileConfig.QualitySortMode mode,
+        bool preferDownloaded = false) =>
+        ProfileResultSorter.Sort(
+            items,
+            item => item.Title,
+            item => item.Grabs,
+            item => item.Size,
+            item => item.Posted,
+            mode,
+            preferDownloaded);
+
+    private sealed record Release(string Title, int Grabs, long Size, DateTimeOffset Posted);
+}

--- a/tests/NzbWebDAV.Tests/Utils/ReleaseQualityTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/ReleaseQualityTests.cs
@@ -1,0 +1,84 @@
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public class ReleaseQualityTests
+{
+    [Theory]
+    [InlineData("Movie.4320p.WEB-DL", ReleaseQualityRanks.Resolution4320)]
+    [InlineData("Movie.8K.WEB-DL", ReleaseQualityRanks.Resolution4320)]
+    [InlineData("Movie.2160p.WEB-DL", ReleaseQualityRanks.Resolution2160)]
+    [InlineData("Movie.4K.WEB-DL", ReleaseQualityRanks.Resolution2160)]
+    [InlineData("Movie.UHD.WEB-DL", ReleaseQualityRanks.Resolution2160)]
+    [InlineData("Movie.1080p.WEB-DL", ReleaseQualityRanks.Resolution1080)]
+    [InlineData("Movie.1080i.HDTV", ReleaseQualityRanks.Resolution1080)]
+    [InlineData("Movie.720p.WEB-DL", ReleaseQualityRanks.Resolution720)]
+    [InlineData("Movie.576p.DVD", ReleaseQualityRanks.ResolutionSd)]
+    [InlineData("Movie.480p.DVD", ReleaseQualityRanks.ResolutionSd)]
+    [InlineData("Movie.SD.WEB-DL", ReleaseQualityRanks.ResolutionSd)]
+    [InlineData("Movie.WEB-DL", ReleaseQualityRanks.ResolutionUnknown)]
+    public void Parse_RecognizesResolutionAliases(string title, int expected)
+    {
+        Assert.Equal(expected, ReleaseQuality.Parse(title).Resolution);
+    }
+
+    [Theory]
+    [InlineData("Movie.1080p.REMUX", ReleaseQualityRanks.SourceRemux)]
+    [InlineData("Movie.1080p.BluRay", ReleaseQualityRanks.SourceBluRay)]
+    [InlineData("Movie.1080p.Blu-Ray", ReleaseQualityRanks.SourceBluRay)]
+    [InlineData("Movie.1080p.BDRip", ReleaseQualityRanks.SourceBluRay)]
+    [InlineData("Movie.1080p.BRRip", ReleaseQualityRanks.SourceBluRay)]
+    [InlineData("Movie.1080p.WEB-DL", ReleaseQualityRanks.SourceWebDl)]
+    [InlineData("Movie.1080p.WEBDL", ReleaseQualityRanks.SourceWebDl)]
+    [InlineData("Movie.1080p.WEBRip", ReleaseQualityRanks.SourceWebRip)]
+    [InlineData("Movie.1080p.HDTV", ReleaseQualityRanks.SourceHdtv)]
+    [InlineData("Movie.480p.DVDRip", ReleaseQualityRanks.SourceDvd)]
+    [InlineData("Movie.480p.DVD", ReleaseQualityRanks.SourceDvd)]
+    [InlineData("Movie.1080p", ReleaseQualityRanks.SourceUnknown)]
+    [InlineData("Movie.1080p.CAM", ReleaseQualityRanks.SourceCam)]
+    [InlineData("Movie.1080p.TS", ReleaseQualityRanks.SourceCam)]
+    [InlineData("Movie.1080p.TELESYNC", ReleaseQualityRanks.SourceCam)]
+    public void Parse_RecognizesSourceAliases(string title, int expected)
+    {
+        Assert.Equal(expected, ReleaseQuality.Parse(title).Source);
+    }
+
+    [Fact]
+    public void Parse_IsCaseAndPunctuationInsensitive()
+    {
+        var dotted = ReleaseQuality.Parse("movie.2024.2160p.web-dl");
+        var underscored = ReleaseQuality.Parse("MOVIE_2024_2160P_WEB_DL");
+        Assert.Equal(ReleaseQualityRanks.Resolution2160, dotted.Resolution);
+        Assert.Equal(ReleaseQualityRanks.SourceWebDl, dotted.Source);
+        Assert.Equal(dotted, underscored);
+    }
+
+    [Fact]
+    public void Parse_UnknownQuality_ReturnsZeroRanks()
+    {
+        Assert.Equal(ReleaseQualityRanks.Unknown, ReleaseQuality.Parse("Some.Untitled.Release"));
+    }
+
+    [Fact]
+    public void Parse_CamRanksBelowUnknown()
+    {
+        Assert.True(ReleaseQuality.Parse("Movie.CAM").Source < ReleaseQualityRanks.SourceUnknown);
+    }
+
+    [Fact]
+    public void Parse_DoesNotClassifyOrdinaryTitleText()
+    {
+        var ranks = ReleaseQuality.Parse("The.Web.Of.Fear");
+        Assert.Equal(ReleaseQualityRanks.ResolutionUnknown, ranks.Resolution);
+        Assert.Equal(ReleaseQualityRanks.SourceUnknown, ranks.Source);
+    }
+
+    [Fact]
+    public void ResolutionDominatesSource()
+    {
+        var uhdHdtv = ReleaseQuality.Parse("Movie.2160p.HDTV");
+        var hdRemux = ReleaseQuality.Parse("Movie.1080p.REMUX");
+        Assert.True(uhdHdtv.Resolution > hdRemux.Resolution);
+        Assert.True(uhdHdtv.Source < hdRemux.Source);
+    }
+}


### PR DESCRIPTION
Fixes #260

## What this does

Search Profiles now reject clearly wrong-year **movie** releases on strict-matching indexers, and can opt into resolution / resolution+source ordering before the existing grabs, size, and posted-date tie-breakers.

- **Implemented:** movie year-aware strict matching and opt-in profile quality sorting.
- **Unchanged:** title and `SxxExx` matching. TV, season, and episode results are not gated by a show premiere year.
- **Not ported:** AIOStreams SEL/regex import and SeaDex. Those stay client-side for AIOStreams users via the dedicated InfiniDysk preset in #883. Direct Stremio / non-AIOStreams clients do **not** gain SEL, regex, or SeaDex support from this PR.

Quality sorting is profile-scoped and defaults to **Off**, so existing profiles keep their current order. Settings → Indexers manual search is unchanged. Watchtower verified candidates can still be boosted after ordinary indexer order.

No database migration. Back up `/config` before upgrading if you want a rollback copy of profile settings.

## Test plan

- [x] Backend: `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (3535 passed)
- [x] Frontend: `npm run typecheck && npm run build && npm test` (715 passed)
- [x] Docs: `zensical build --clean --strict`
- [ ] SharpCompress omitted: no archive-format paths were touched
- [ ] Live Usenet/indexer smoke not run (not required; no live providers in automation)

## Notes

Independent of #883. Do not merge from an agent.