### PR TITLE
feat(stremio): make Search Profiles work as a first-class AIOStreams addon

### DIFF
--- a/backend/Api/Controllers/Profiles/Adapters/NzbProxyController.cs
+++ b/backend/Api/Controllers/Profiles/Adapters/NzbProxyController.cs
@@ -89,14 +89,7 @@ public class NzbProxyController(
         }
 
         Response.Headers["Content-Disposition"] =
-            $"attachment; filename=\"{SanitizeFileName(candidate.Title)}.nzb\"";
+            $"attachment; filename=\"{ProfileReleaseName.ToNzbFileName(candidate.Title)}\"";
         return File(bytes, "application/x-nzb");
-    }
-
-    private static string SanitizeFileName(string name)
-    {
-        var invalid = Path.GetInvalidFileNameChars();
-        var clean = new string(name.Select(c => invalid.Contains(c) ? '_' : c).ToArray()).Trim();
-        return string.IsNullOrEmpty(clean) ? "untitled" : clean;
     }
 }

--- a/backend/Api/Controllers/Profiles/ProfileAddonContracts.cs
+++ b/backend/Api/Controllers/Profiles/ProfileAddonContracts.cs
@@ -198,8 +198,8 @@ public static class ProfileAddonFactory
             Url = $"{publicBaseUrl.TrimEnd('/')}/adapters/addon/{token}/play/{playToken}.mkv",
             BehaviorHints = new ProfileAddonStreamBehaviorHints
             {
-                Filename = candidate.Title,
-                VideoSize = candidate.Size,
+                Filename = ProfileReleaseName.SanitizeFileName(candidate.Title),
+                VideoSize = Math.Max(0, candidate.Size),
                 BingeGroup = $"nzbdav|{indexer}|{type}",
                 NotWebReady = true,
             },

--- a/backend/Api/Controllers/Profiles/ProfileAddonContracts.cs
+++ b/backend/Api/Controllers/Profiles/ProfileAddonContracts.cs
@@ -1,0 +1,270 @@
+using System.Text.Json.Serialization;
+using NzbWebDAV.Config;
+using NzbWebDAV.Services;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Api.Controllers.Profiles;
+
+public sealed class ProfileAddonManifest
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("version")]
+    public required string Version { get; init; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("description")]
+    public required string Description { get; init; }
+
+    [JsonPropertyName("logo")]
+    public required string Logo { get; init; }
+
+    [JsonPropertyName("resources")]
+    public required IReadOnlyList<string> Resources { get; init; }
+
+    [JsonPropertyName("types")]
+    public required IReadOnlyList<string> Types { get; init; }
+
+    [JsonPropertyName("idPrefixes")]
+    public required IReadOnlyList<string> IdPrefixes { get; init; }
+
+    [JsonPropertyName("behaviorHints")]
+    public required ProfileAddonManifestBehaviorHints BehaviorHints { get; init; }
+}
+
+public sealed class ProfileAddonManifestBehaviorHints
+{
+    [JsonPropertyName("configurable")]
+    public bool Configurable { get; init; }
+
+    [JsonPropertyName("configurationRequired")]
+    public bool ConfigurationRequired { get; init; }
+}
+
+public sealed class ProfileAddonStreamResponse
+{
+    [JsonPropertyName("streams")]
+    public required IReadOnlyList<ProfileAddonStream> Streams { get; init; }
+}
+
+public sealed class ProfileAddonStream
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("description")]
+    public required string Description { get; init; }
+
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+
+    [JsonPropertyName("url")]
+    public required string Url { get; init; }
+
+    [JsonPropertyName("behaviorHints")]
+    public required ProfileAddonStreamBehaviorHints BehaviorHints { get; init; }
+
+    [JsonPropertyName("meta")]
+    public required ProfileAddonStreamMeta Meta { get; init; }
+
+    [JsonPropertyName("failoverId")]
+    public required string FailoverId { get; init; }
+
+    [JsonPropertyName("extra")]
+    public required ProfileAddonStreamExtra Extra { get; init; }
+}
+
+public sealed class ProfileAddonStreamBehaviorHints
+{
+    [JsonPropertyName("filename")]
+    public required string Filename { get; init; }
+
+    [JsonPropertyName("videoSize")]
+    public long VideoSize { get; init; }
+
+    [JsonPropertyName("bingeGroup")]
+    public required string BingeGroup { get; init; }
+
+    [JsonPropertyName("notWebReady")]
+    public bool NotWebReady { get; init; }
+}
+
+public sealed class ProfileAddonStreamMeta
+{
+    [JsonPropertyName("indexer")]
+    public required string Indexer { get; init; }
+
+    [JsonPropertyName("inLibrary")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? InLibrary { get; init; }
+
+    [JsonPropertyName("availability")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Availability { get; init; }
+
+    [JsonPropertyName("languages")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? Languages { get; init; }
+
+    [JsonPropertyName("subtitleLanguages")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? SubtitleLanguages { get; init; }
+}
+
+public sealed class ProfileAddonStreamExtra
+{
+    [JsonPropertyName("failoverId")]
+    public required string FailoverId { get; init; }
+}
+
+public static class ProfileAddonFactory
+{
+    public const string LogoUrl =
+        "https://raw.githubusercontent.com/infinidysk/infinidysk/main/docs/assets/logo.png";
+
+    public static ProfileAddonManifest CreateManifest(ProfileConfig.Profile profile, string token)
+    {
+        return new ProfileAddonManifest
+        {
+            Id = $"nzbdav.profile.{token}",
+            Version = ConfigManager.AppVersion,
+            Name = string.IsNullOrWhiteSpace(profile.Name) ? "InfiniDysk Search Profile" : profile.Name,
+            Description =
+                "Playable Usenet streams from this InfiniDysk Search Profile's configured indexers.",
+            Logo = LogoUrl,
+            Resources = ["stream"],
+            Types = ["movie", "series"],
+            IdPrefixes = ["tt", "tmdb", "tvdb", "kitsu", "mal", "anilist"],
+            BehaviorHints = new ProfileAddonManifestBehaviorHints
+            {
+                Configurable = false,
+                ConfigurationRequired = false,
+            },
+        };
+    }
+
+    public static ProfileAddonStreamResponse CreateStreamResponse(
+        SearchProfileService.SearchResult result,
+        string publicBaseUrl,
+        IReadOnlySet<string> readyNzbFileNames,
+        Func<string, bool> isVerifiedAvailable)
+    {
+        if (result.Candidates.Count == 0)
+            return new ProfileAddonStreamResponse { Streams = [] };
+
+        var streams = result.Candidates
+            .Select((candidate, index) => CreateStream(
+                candidate,
+                result.Type,
+                result.ProfileToken,
+                result.PlayTokens[index],
+                publicBaseUrl,
+                readyNzbFileNames.Contains(ProfileReleaseName.ToNzbFileName(candidate.Title)),
+                isVerifiedAvailable(candidate.NzbUrl) || candidate.VerifiedAvailable))
+            .ToList();
+        return new ProfileAddonStreamResponse { Streams = streams };
+    }
+
+    public static ProfileAddonStream CreateStream(
+        NzbResolutionCache.Candidate candidate,
+        string type,
+        string token,
+        string playToken,
+        string publicBaseUrl,
+        bool inLibrary,
+        bool verifiedAvailable)
+    {
+        var indexer = string.IsNullOrWhiteSpace(candidate.SourceIndexerName)
+            ? candidate.IndexerName
+            : candidate.SourceIndexerName;
+        var audioLanguages = ProfileLanguageMetadata.NormalizeAudioLanguages(candidate.Language);
+        var subtitleLanguages = ProfileLanguageMetadata.NormalizeSubtitleLanguages(candidate.Subs);
+        var description = BuildDescription(
+            candidate,
+            indexer,
+            inLibrary,
+            verifiedAvailable,
+            audioLanguages,
+            subtitleLanguages);
+
+        return new ProfileAddonStream
+        {
+            Name = $"[NZB] {indexer}",
+            Description = description,
+            Title = description,
+            Url = $"{publicBaseUrl.TrimEnd('/')}/adapters/addon/{token}/play/{playToken}.mkv",
+            BehaviorHints = new ProfileAddonStreamBehaviorHints
+            {
+                Filename = candidate.Title,
+                VideoSize = candidate.Size,
+                BingeGroup = $"nzbdav|{indexer}|{type}",
+                NotWebReady = true,
+            },
+            Meta = new ProfileAddonStreamMeta
+            {
+                Indexer = indexer,
+                InLibrary = inLibrary ? true : null,
+                Availability = verifiedAvailable ? "available" : null,
+                Languages = audioLanguages.Count > 0 ? audioLanguages : null,
+                SubtitleLanguages = subtitleLanguages.Count > 0 ? subtitleLanguages : null,
+            },
+            FailoverId = playToken,
+            Extra = new ProfileAddonStreamExtra { FailoverId = playToken },
+        };
+    }
+
+    private static string BuildDescription(
+        NzbResolutionCache.Candidate candidate,
+        string indexer,
+        bool inLibrary,
+        bool verifiedAvailable,
+        List<string> audioLanguages,
+        List<string> subtitleLanguages)
+    {
+        var details = new List<string> { $"💾 {FormatBytes(candidate.Size)}" };
+        if (candidate.Posted is { } posted)
+            details.Add($"📅 {FormatAge(DateTimeOffset.UtcNow - posted)}");
+
+        var lines = new List<string>
+        {
+            candidate.Title,
+            string.Join(" | ", details),
+            $"🌐 {indexer}",
+        };
+        var markers = new List<string>();
+        if (inLibrary) markers.Add("⚡ Ready");
+        if (verifiedAvailable) markers.Add("✅ Verified");
+        markers.AddRange(ProfileLanguageMetadata.AudioFlagMarkers(audioLanguages));
+        if (markers.Count > 0)
+            lines.Add(string.Join(" ", markers));
+        if (subtitleLanguages.Count > 0)
+            lines.Add($"💬 Subs: {string.Join(", ", subtitleLanguages)}");
+        return string.Join('\n', lines);
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        if (bytes <= 0) return "?";
+        string[] suffixes = ["B", "KB", "MB", "GB", "TB"];
+        var index = 0;
+        double value = bytes;
+        while (value >= 1024 && index < suffixes.Length - 1)
+        {
+            value /= 1024;
+            index++;
+        }
+
+        return $"{value:0.##} {suffixes[index]}";
+    }
+
+    private static string FormatAge(TimeSpan age)
+    {
+        if (age.TotalDays >= 365) return $"{(int)(age.TotalDays / 365)}y";
+        if (age.TotalDays >= 1) return $"{(int)age.TotalDays}d";
+        if (age.TotalHours >= 1) return $"{(int)age.TotalHours}h";
+        return $"{Math.Max(1, (int)age.TotalMinutes)}m";
+    }
+}

--- a/backend/Api/Controllers/Profiles/ProfileManifestController.cs
+++ b/backend/Api/Controllers/Profiles/ProfileManifestController.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using NzbWebDAV.Config;
 using NzbWebDAV.Services;
 
 namespace NzbWebDAV.Api.Controllers.Profiles;
@@ -24,17 +23,7 @@ public class ProfileManifestController(SearchProfileService searchService) : Con
         if (profile is null) return NotFound();
         if (!searchService.IsAdapterEnabled(token, "addon")) return NotFound();
 
-        return new JsonResult(new
-        {
-            id = $"nzbdav.profile.{token}",
-            version = ConfigManager.AppVersion,
-            name = string.IsNullOrWhiteSpace(profile.Name) ? "NzbDav Search Profile" : profile.Name,
-            description = "Newznab search-API endpoint returning results from the user's configured indexers.",
-            resources = new[] { "stream" },
-            types = new[] { "movie", "series" },
-            idPrefixes = new[] { "tt", "tmdb", "tvdb", "kitsu", "mal", "anilist" },
-            behaviorHints = new { configurable = false, configurationRequired = false },
-        });
+        return new JsonResult(ProfileAddonFactory.CreateManifest(profile, token));
     }
 
     internal static void SetCors(HttpResponse response)

--- a/backend/Api/Controllers/Profiles/ProfilePlayController.cs
+++ b/backend/Api/Controllers/Profiles/ProfilePlayController.cs
@@ -265,7 +265,7 @@ public class ProfilePlayController(
                         providerHost: AllConfiguredProvidersDisplay());
                     continue;
                 }
-                var candidateFileName = $"{SanitizeFileName(c.Title)}.nzb";
+                var candidateFileName = ProfileReleaseName.ToNzbFileName(c.Title);
                 if (negativeCache.IsFileNameBroken(candidateFileName))
                 {
                     var skippedRank = displayRank++;
@@ -891,7 +891,7 @@ public class ProfilePlayController(
         var c = preVerify.Candidate;
         var commitTimer = Stopwatch.StartNew();
         var nzbBytes = preVerify.NzbBytes!;
-        var safeTitle = SanitizeFileName(c.Title);
+        var safeTitle = ProfileReleaseName.SanitizeFileName(c.Title);
         var fileName = $"{safeTitle}.nzb";
 
         var cacheEntry = cache.Get(nzbToken);
@@ -1108,7 +1108,7 @@ public class ProfilePlayController(
     private async Task<Guid?> FindInFlightQueueItemAsync(NzbResolutionCache.Entry entry, CancellationToken ct)
     {
         var fileNames = entry.Candidates
-            .Select(c => $"{SanitizeFileName(c.Title)}.nzb")
+            .Select(c => ProfileReleaseName.ToNzbFileName(c.Title))
             .Distinct()
             .ToList();
         var contentGroupKey = VariantResolver.BuildContentGroupKey(entry);
@@ -1128,7 +1128,7 @@ public class ProfilePlayController(
     private async Task<IActionResult?> TryResolveExistingAsync(NzbResolutionCache.Entry entry, CancellationToken ct)
     {
         var fileNames = entry.Candidates
-            .Select(c => $"{SanitizeFileName(c.Title)}.nzb")
+            .Select(c => ProfileReleaseName.ToNzbFileName(c.Title))
             .Distinct()
             .ToList();
         if (fileNames.Count == 0) return null;
@@ -1240,13 +1240,6 @@ public class ProfilePlayController(
         var parts = id.Split(':');
         if (parts.Length < 3) return false;
         return int.TryParse(parts[^2], out season) && int.TryParse(parts[^1], out episode);
-    }
-
-    private static string SanitizeFileName(string name)
-    {
-        var invalid = Path.GetInvalidFileNameChars();
-        var clean = new string(name.Select(c => invalid.Contains(c) ? '_' : c).ToArray()).Trim();
-        return string.IsNullOrEmpty(clean) ? "untitled" : clean;
     }
 
     private async Task<IActionResult> BuildRedirectAsync(Guid davItemId, string extension, CancellationToken ct)

--- a/backend/Api/Controllers/Profiles/ProfilePlayController.cs
+++ b/backend/Api/Controllers/Profiles/ProfilePlayController.cs
@@ -1247,14 +1247,8 @@ public class ProfilePlayController(
         var path = DatabaseStoreSymlinkFile.GetTargetPath(davItemId, "", '/').TrimStart('/');
         var dlKey = GetWebdavItemRequest.GenerateDownloadKey(configManager.GetStrmKey(), path);
         var relativeUrl = $"/view/{path}?downloadKey={dlKey}&extension={extension}";
-        var configuredBaseUrl = configManager.GetBaseUrl().TrimEnd('/');
-        if (!string.IsNullOrWhiteSpace(configuredBaseUrl) &&
-            configuredBaseUrl != "http://localhost:3000")
-        {
-            return Redirect($"{configuredBaseUrl}{relativeUrl}");
-        }
-
-        return LocalRedirect(relativeUrl);
+        var publicBaseUrl = HttpContext.GetPublicBaseUrl(configManager.GetBaseUrl());
+        return Redirect($"{publicBaseUrl}{relativeUrl}");
     }
 
     private readonly record struct PreVerifyResult(

--- a/backend/Api/Controllers/Profiles/ProfilePlayController.cs
+++ b/backend/Api/Controllers/Profiles/ProfilePlayController.cs
@@ -1247,8 +1247,8 @@ public class ProfilePlayController(
         var path = DatabaseStoreSymlinkFile.GetTargetPath(davItemId, "", '/').TrimStart('/');
         var dlKey = GetWebdavItemRequest.GenerateDownloadKey(configManager.GetStrmKey(), path);
         var relativeUrl = $"/view/{path}?downloadKey={dlKey}&extension={extension}";
-        var publicBaseUrl = HttpContext.GetPublicBaseUrl(configManager.GetBaseUrl());
-        return Redirect($"{publicBaseUrl}{relativeUrl}");
+        var publicPathPrefix = HttpContext.GetPublicPathPrefix(configManager.GetBaseUrl());
+        return LocalRedirect($"{publicPathPrefix}{relativeUrl}");
     }
 
     private readonly record struct PreVerifyResult(

--- a/backend/Api/Controllers/Profiles/ProfileReadController.cs
+++ b/backend/Api/Controllers/Profiles/ProfileReadController.cs
@@ -9,7 +9,9 @@ namespace NzbWebDAV.Api.Controllers.Profiles;
 [Route("adapters/addon/{token}/stream/{type}/{id}.json")]
 public class ProfileReadController(
     SearchProfileService searchService,
-    ConfigManager configManager
+    ConfigManager configManager,
+    ProfileStreamStateService streamState,
+    PreflightCache preflightCache
 ) : ControllerBase
 {
     [HttpOptions]
@@ -31,62 +33,13 @@ public class ProfileReadController(
         var ct = HttpContext.RequestAborted;
         var result = await searchService.SearchByImdbAsync(token, type, id, ct).ConfigureAwait(false);
         if (result is null) return NotFound();
-        if (result.Candidates.Count == 0) return new JsonResult(new { streams = Array.Empty<object>() });
 
+        var readyNames = await streamState.GetReadyNzbFileNamesAsync(result.Candidates, ct).ConfigureAwait(false);
         var baseUrl = HttpContext.GetPublicBaseUrl(configManager.GetBaseUrl());
-        var items = result.Candidates
-            .Select((c, i) =>
-            {
-                var displayIndexer = !string.IsNullOrWhiteSpace(c.SourceIndexerName)
-                    ? c.SourceIndexerName!
-                    : c.IndexerName;
-                var description = BuildDescription(c, displayIndexer);
-                var failoverId = result.PlayTokens[i];
-                return new
-                {
-                    name = $"[NZB] {displayIndexer}",
-                    description,
-                    title = description,
-                    url = $"{baseUrl}/adapters/addon/{token}/play/{failoverId}.mkv",
-                    behaviorHints = new
-                    {
-                        filename = c.Title,
-                        videoSize = c.Size,
-                        bingeGroup = $"nzbdav|{displayIndexer}|{type}",
-                        notWebReady = true,
-                    },
-                    meta = new { indexer = displayIndexer },
-                    failoverId,
-                    extra = new { failoverId },
-                };
-            })
-            .ToList();
-
-        return new JsonResult(new { streams = items });
-    }
-
-    private static string FormatBytes(long bytes)
-    {
-        if (bytes <= 0) return "?";
-        string[] s = ["B", "KB", "MB", "GB", "TB"];
-        var i = 0;
-        double v = bytes;
-        while (v >= 1024 && i < s.Length - 1) { v /= 1024; i++; }
-        return $"{v:0.##} {s[i]}";
-    }
-
-    private static string BuildDescription(NzbResolutionCache.Candidate c, string indexerName)
-    {
-        var meta = new List<string> { $"💾 {FormatBytes(c.Size)}" };
-        if (c.Posted is { } p) meta.Add($"📅 {FormatAge(DateTimeOffset.UtcNow - p)}");
-        return $"{c.Title}\n{string.Join(" | ", meta)}\n🌐 {indexerName}";
-    }
-
-    private static string FormatAge(TimeSpan a)
-    {
-        if (a.TotalDays >= 365) return $"{(int)(a.TotalDays / 365)}y";
-        if (a.TotalDays >= 1) return $"{(int)a.TotalDays}d";
-        if (a.TotalHours >= 1) return $"{(int)a.TotalHours}h";
-        return $"{Math.Max(1, (int)a.TotalMinutes)}m";
+        return new JsonResult(ProfileAddonFactory.CreateStreamResponse(
+            result,
+            baseUrl,
+            readyNames,
+            nzbUrl => preflightCache.Get(nzbUrl)?.Verdict == PlaybackFastVerifier.Verdict.Available));
     }
 }

--- a/backend/Database/Migrations/20260822140000_Add-Profile-Stream-State-Index.cs
+++ b/backend/Database/Migrations/20260822140000_Add-Profile-Stream-State-Index.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.Migrations
+{
+    /// <summary>
+    /// Adds a case-insensitive partial lookup index for completed NZB history
+    /// rows used to annotate Search Profile streams with local ready state.
+    /// </summary>
+    [DbContext(typeof(DavDatabaseContext))]
+    [Migration("20260822140000_Add-Profile-Stream-State-Index")]
+    public partial class AddProfileStreamStateIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+                CREATE INDEX IF NOT EXISTS "IX_HistoryItems_FileNameLower_Completed"
+                ON "HistoryItems" (LOWER("FileName"))
+                WHERE "DownloadStatus" = 1;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""DROP INDEX IF EXISTS "IX_HistoryItems_FileNameLower_Completed";""");
+        }
+    }
+}

--- a/backend/Database/PostgresMigrations/20260822140000_Add-Profile-Stream-State-Index.cs
+++ b/backend/Database/PostgresMigrations/20260822140000_Add-Profile-Stream-State-Index.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.PostgresMigrations
+{
+    /// <summary>
+    /// Adds a case-insensitive partial lookup index for completed NZB history
+    /// rows used to annotate Search Profile streams with local ready state.
+    /// </summary>
+    [DbContext(typeof(PostgresDavDatabaseContext))]
+    [Migration("20260822140000_Add-Profile-Stream-State-Index")]
+    public partial class AddProfileStreamStateIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+                CREATE INDEX IF NOT EXISTS "IX_HistoryItems_FileNameLower_Completed"
+                ON "HistoryItems" (LOWER("FileName"))
+                WHERE "DownloadStatus" = 1;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""DROP INDEX IF EXISTS "IX_HistoryItems_FileNameLower_Completed";""");
+        }
+    }
+}

--- a/backend/Extensions/HttpContextExtensions.cs
+++ b/backend/Extensions/HttpContextExtensions.cs
@@ -39,13 +39,29 @@ public static class HttpContextExtensions
     public static string GetPublicBaseUrl(this HttpContext httpContext, string configuredBaseUrl)
     {
         var trimmed = configuredBaseUrl.TrimEnd('/');
-        if (!string.IsNullOrWhiteSpace(trimmed) && trimmed != "http://localhost:3000")
-            return trimmed;
+        var baseUrl = !string.IsNullOrWhiteSpace(trimmed) && trimmed != "http://localhost:3000"
+            ? trimmed
+            : $"{httpContext.Request.Scheme}://{httpContext.Request.Host.Value}";
 
-        // Prefer Scheme/Host as populated by ForwardedHeadersMiddleware from a
-        // trusted proxy — never read raw X-Forwarded-* (spoofable).
-        var scheme = httpContext.Request.Scheme;
-        var host = httpContext.Request.Host.Value;
-        return $"{scheme}://{host}";
+        // The frontend proxy supplies its validated URL_BASE as this prefix, so URLs copied
+        // from profile adapters remain routable when the application is mounted at a sub-path.
+        var prefix = NormalizePathPrefix(httpContext.Request.Headers["X-Forwarded-Prefix"].FirstOrDefault());
+        if (prefix is null || baseUrl.EndsWith(prefix, StringComparison.Ordinal))
+            return baseUrl;
+        return baseUrl + prefix;
+    }
+
+    private static string? NormalizePathPrefix(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        var trimmed = raw.Trim().TrimEnd('/');
+        if (trimmed.Length == 0 || trimmed == "/") return null;
+        if (!trimmed.StartsWith('/')
+            || trimmed.Any(c => !(char.IsAsciiLetterOrDigit(c) || c is '.' or '_' or '~' or '-' or '/')))
+        {
+            return null;
+        }
+
+        return trimmed;
     }
 }

--- a/backend/Extensions/HttpContextExtensions.cs
+++ b/backend/Extensions/HttpContextExtensions.cs
@@ -51,12 +51,26 @@ public static class HttpContextExtensions
         return baseUrl + prefix;
     }
 
+    public static string GetPublicPathPrefix(this HttpContext httpContext, string configuredBaseUrl)
+    {
+        var configuredPrefix = Uri.TryCreate(configuredBaseUrl, UriKind.Absolute, out var configuredUri)
+            ? NormalizePathPrefix(configuredUri.AbsolutePath)
+            : null;
+        var forwardedPrefix = NormalizePathPrefix(
+            httpContext.Request.Headers["X-Forwarded-Prefix"].FirstOrDefault());
+
+        if (forwardedPrefix is null || configuredPrefix?.EndsWith(forwardedPrefix, StringComparison.Ordinal) == true)
+            return configuredPrefix ?? string.Empty;
+        return (configuredPrefix ?? string.Empty) + forwardedPrefix;
+    }
+
     private static string? NormalizePathPrefix(string? raw)
     {
         if (string.IsNullOrWhiteSpace(raw)) return null;
         var trimmed = raw.Trim().TrimEnd('/');
         if (trimmed.Length == 0 || trimmed == "/") return null;
         if (!trimmed.StartsWith('/')
+            || trimmed.Contains("//", StringComparison.Ordinal)
             || trimmed.Any(c => !(char.IsAsciiLetterOrDigit(c) || c is '.' or '_' or '~' or '-' or '/')))
         {
             return null;

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -419,6 +419,7 @@ public partial class Program
                 .AddScoped(sp =>
                     sp.GetRequiredService<IDbContextFactory<DavDatabaseContext>>().CreateDbContext())
                 .AddScoped<DavDatabaseClient>()
+                .AddScoped<ProfileStreamStateService>()
                 .AddScoped<NzbWebDAV.Services.Benchmark.BenchmarkCorpusProvider>()
                 .AddScoped<NzbWebDAV.Services.Benchmark.UsenetBenchmarkService>()
                 .AddScoped<DatabaseStore>()

--- a/backend/Services/NzbResolutionCache.cs
+++ b/backend/Services/NzbResolutionCache.cs
@@ -166,6 +166,7 @@ public class NzbResolutionCache(Func<DavDatabaseContext> contextFactory)
         public string? Language { get; init; }
         public string? Subs { get; init; }
         public string? InfoHash { get; init; }
+        public bool VerifiedAvailable { get; set; }
     }
 
     public class Entry

--- a/backend/Services/PreflightOrchestrator.cs
+++ b/backend/Services/PreflightOrchestrator.cs
@@ -188,7 +188,7 @@ public class PreflightOrchestrator(
     {
         try
         {
-            var fileName = $"{SanitizeFileName(candidate.Title)}.nzb";
+            var fileName = ProfileReleaseName.ToNzbFileName(candidate.Title);
             await using var ctx = new DavDatabaseContext();
 
             var historyId = await ctx.HistoryItems.AsNoTracking()
@@ -225,10 +225,4 @@ public class PreflightOrchestrator(
         }
     }
 
-    private static string SanitizeFileName(string name)
-    {
-        var invalid = Path.GetInvalidFileNameChars();
-        var clean = new string(name.Select(c => invalid.Contains(c) ? '_' : c).ToArray()).Trim();
-        return string.IsNullOrEmpty(clean) ? "untitled" : clean;
-    }
 }

--- a/backend/Services/ProfileStreamStateService.cs
+++ b/backend/Services/ProfileStreamStateService.cs
@@ -45,15 +45,12 @@ public class ProfileStreamStateService(
                 .ToListAsync(ct)
                 .ConfigureAwait(false);
 
-            var ready = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var group in rows.GroupBy(row => row.FileName, StringComparer.OrdinalIgnoreCase))
-            {
-                if (group.Any(row => ContentTypeUtil.GetContentType(row.Name)
+            var ready = new HashSet<string>(
+                rows.GroupBy(row => row.FileName, StringComparer.OrdinalIgnoreCase)
+                    .Where(group => group.Any(row => ContentTypeUtil.GetContentType(row.Name)
                         .StartsWith("video/", StringComparison.OrdinalIgnoreCase)))
-                {
-                    ready.Add(group.Key);
-                }
-            }
+                    .Select(group => group.Key),
+                StringComparer.OrdinalIgnoreCase);
 
             return ready;
         }
@@ -61,7 +58,7 @@ public class ProfileStreamStateService(
             e is DbUpdateException
                 or InvalidOperationException
                 or SqliteException
-                or PostgresException)
+                or NpgsqlException)
         {
             Log.Debug(e, "Profile stream ready-state lookup failed");
             return new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/backend/Services/ProfileStreamStateService.cs
+++ b/backend/Services/ProfileStreamStateService.cs
@@ -1,0 +1,70 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Utils;
+using Serilog;
+
+namespace NzbWebDAV.Services;
+
+public class ProfileStreamStateService(
+    DavDatabaseClient dbClient,
+    CandidateNegativeCache negativeCache)
+{
+    public async Task<IReadOnlySet<string>> GetReadyNzbFileNamesAsync(
+        IReadOnlyList<NzbResolutionCache.Candidate> candidates,
+        CancellationToken ct)
+    {
+        var names = candidates
+            .Select(candidate => ProfileReleaseName.ToNzbFileName(candidate.Title))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (names.Count == 0)
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        try
+        {
+            var brokenIds = negativeCache.SnapshotBrokenHistoryItems();
+            var loweredNames = names.Select(name => name.ToLowerInvariant()).ToList();
+            var historyQuery = dbClient.Ctx.HistoryItems.AsNoTracking()
+                .Where(history =>
+#pragma warning disable CA1311 // EF translates ToLower() to SQL LOWER(); ToLowerInvariant is not translatable.
+                    loweredNames.Contains(history.FileName.ToLower())
+#pragma warning restore CA1311
+                    && history.DownloadStatus == HistoryItem.DownloadStatusOption.Completed);
+            if (brokenIds.Count > 0)
+                historyQuery = historyQuery.Where(history => !brokenIds.Contains(history.Id));
+
+            var rows = await (
+                    from history in historyQuery
+                    join item in dbClient.Ctx.Items.AsNoTracking()
+                        on history.Id equals item.HistoryItemId
+                    where item.Type == DavItem.ItemType.UsenetFile
+                    select new { history.FileName, item.Name })
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+
+            var ready = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var group in rows.GroupBy(row => row.FileName, StringComparer.OrdinalIgnoreCase))
+            {
+                if (group.Any(row => ContentTypeUtil.GetContentType(row.Name)
+                        .StartsWith("video/", StringComparison.OrdinalIgnoreCase)))
+                {
+                    ready.Add(group.Key);
+                }
+            }
+
+            return ready;
+        }
+        catch (Exception e) when (
+            e is DbUpdateException
+                or InvalidOperationException
+                or SqliteException
+                or PostgresException)
+        {
+            Log.Debug(e, "Profile stream ready-state lookup failed");
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/backend/Services/SearchProfileService.cs
+++ b/backend/Services/SearchProfileService.cs
@@ -529,18 +529,27 @@ public class SearchProfileService(
             {
                 if (!seen.Add(p.NzbUrl)) continue;
                 var existing = candidates.FirstOrDefault(c => c.NzbUrl == p.NzbUrl);
-                ordered.Add(existing ?? new NzbResolutionCache.Candidate
+                if (existing is not null)
                 {
-                    IndexerName = p.IndexerName,
-                    IndexerUserAgent = p.IndexerUserAgent,
-                    NzbUrl = p.NzbUrl,
-                    Title = p.Title,
-                    Size = p.Size,
-                    Grabs = p.Grabs,
-                    Poster = p.Poster,
-                    UsenetDate = p.UsenetDate,
-                    ProxyUrl = p.ProxyUrl,
-                });
+                    existing.VerifiedAvailable = true;
+                    ordered.Add(existing);
+                }
+                else
+                {
+                    ordered.Add(new NzbResolutionCache.Candidate
+                    {
+                        IndexerName = p.IndexerName,
+                        IndexerUserAgent = p.IndexerUserAgent,
+                        NzbUrl = p.NzbUrl,
+                        Title = p.Title,
+                        Size = p.Size,
+                        Grabs = p.Grabs,
+                        Poster = p.Poster,
+                        UsenetDate = p.UsenetDate,
+                        ProxyUrl = p.ProxyUrl,
+                        VerifiedAvailable = true,
+                    });
+                }
             }
 
             foreach (var c in candidates)
@@ -579,7 +588,13 @@ public class SearchProfileService(
             foreach (var p in WtJson.ReadPointers(seasonRow.Shortlist))
             {
                 if (p.Verdict != "available") continue;
-                if (candidates.Any(c => c.NzbUrl == p.NzbUrl)) continue;
+                var existing = candidates.FirstOrDefault(c => c.NzbUrl == p.NzbUrl);
+                if (existing is not null)
+                {
+                    existing.VerifiedAvailable = true;
+                    continue;
+                }
+
                 candidates.Add(new NzbResolutionCache.Candidate
                 {
                     IndexerName = p.IndexerName,
@@ -591,6 +606,7 @@ public class SearchProfileService(
                     Poster = p.Poster,
                     UsenetDate = p.UsenetDate,
                     ProxyUrl = p.ProxyUrl,
+                    VerifiedAvailable = true,
                 });
             }
         }

--- a/backend/Utils/ProfileLanguageMetadata.cs
+++ b/backend/Utils/ProfileLanguageMetadata.cs
@@ -33,15 +33,11 @@ public static class ProfileLanguageMetadata
 
     public static List<string> AudioFlagMarkers(IEnumerable<string> codes)
     {
-        var flags = new List<string>();
-        var seen = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var code in codes)
-        {
-            if (AudioFlags.TryGetValue(code, out var flag) && seen.Add(flag))
-                flags.Add(flag);
-        }
-
-        return flags;
+        return codes
+            .Where(AudioFlags.ContainsKey)
+            .Select(code => AudioFlags[code])
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
     }
 
     private static List<string> Normalize(string? value)

--- a/backend/Utils/ProfileLanguageMetadata.cs
+++ b/backend/Utils/ProfileLanguageMetadata.cs
@@ -1,0 +1,51 @@
+namespace NzbWebDAV.Utils;
+
+public static class ProfileLanguageMetadata
+{
+    private static readonly Dictionary<string, string> AudioFlags = new(StringComparer.Ordinal)
+    {
+        ["en"] = "🇬🇧",
+        ["es"] = "🇪🇸",
+        ["fr"] = "🇫🇷",
+        ["de"] = "🇩🇪",
+        ["it"] = "🇮🇹",
+        ["pt"] = "🇵🇹",
+        ["nl"] = "🇳🇱",
+        ["ru"] = "🇷🇺",
+        ["ja"] = "🇯🇵",
+        ["ko"] = "🇰🇷",
+        ["zh"] = "🇨🇳",
+        ["ar"] = "🇸🇦",
+        ["hi"] = "🇮🇳",
+        ["swe"] = "🇸🇪",
+        ["nor"] = "🇳🇴",
+        ["dan"] = "🇩🇰",
+        ["fin"] = "🇫🇮",
+        ["pol"] = "🇵🇱",
+        ["tur"] = "🇹🇷",
+    };
+
+    public static List<string> NormalizeAudioLanguages(string? value)
+        => Normalize(value);
+
+    public static List<string> NormalizeSubtitleLanguages(string? value)
+        => Normalize(value);
+
+    public static List<string> AudioFlagMarkers(IEnumerable<string> codes)
+    {
+        var flags = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var code in codes)
+        {
+            if (AudioFlags.TryGetValue(code, out var flag) && seen.Add(flag))
+                flags.Add(flag);
+        }
+
+        return flags;
+    }
+
+    private static List<string> Normalize(string? value)
+        => SubtitlePreference.ParseLanguages(value)
+            .OrderBy(code => code, StringComparer.Ordinal)
+            .ToList();
+}

--- a/backend/Utils/ProfileReleaseName.cs
+++ b/backend/Utils/ProfileReleaseName.cs
@@ -1,0 +1,14 @@
+namespace NzbWebDAV.Utils;
+
+public static class ProfileReleaseName
+{
+    public static string SanitizeFileName(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return "untitled";
+        var invalid = Path.GetInvalidFileNameChars();
+        var clean = new string(name.Select(c => invalid.Contains(c) ? '_' : c).ToArray()).Trim();
+        return string.IsNullOrEmpty(clean) ? "untitled" : clean;
+    }
+
+    public static string ToNzbFileName(string? title) => $"{SanitizeFileName(title)}.nzb";
+}

--- a/contracts/stremio/v1/profile-manifest.schema.json
+++ b/contracts/stremio/v1/profile-manifest.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://infinidysk.local/contracts/stremio/v1/profile-manifest.schema.json",
+  "title": "InfiniDysk Stremio profile manifest",
+  "description": "Reviewed against the Stremio addon manifest contract and AIOStreams Custom Addon / davex preset parsing. Schemas are not fetched during CI.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "id",
+    "version",
+    "name",
+    "description",
+    "logo",
+    "resources",
+    "types",
+    "idPrefixes",
+    "behaviorHints"
+  ],
+  "properties": {
+    "id": { "type": "string", "pattern": "^nzbdav\\.profile\\." },
+    "version": { "type": "string", "minLength": 1 },
+    "name": { "type": "string", "minLength": 1 },
+    "description": { "type": "string", "minLength": 1 },
+    "logo": { "type": "string", "pattern": "^https?://" },
+    "resources": {
+      "type": "array",
+      "const": ["stream"]
+    },
+    "types": {
+      "type": "array",
+      "const": ["movie", "series"]
+    },
+    "idPrefixes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "behaviorHints": {
+      "type": "object",
+      "required": ["configurable", "configurationRequired"],
+      "properties": {
+        "configurable": { "const": false },
+        "configurationRequired": { "const": false }
+      }
+    }
+  }
+}

--- a/contracts/stremio/v1/profile-stream-response.schema.json
+++ b/contracts/stremio/v1/profile-stream-response.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://infinidysk.local/contracts/stremio/v1/profile-stream-response.schema.json",
+  "title": "InfiniDysk Stremio profile stream response",
+  "description": "Reviewed against the Stremio stream resource and AIOStreams davex/Custom Addon parsing. Additive meta fields are optional.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["streams"],
+  "properties": {
+    "streams": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "name",
+          "description",
+          "title",
+          "url",
+          "behaviorHints",
+          "meta",
+          "failoverId",
+          "extra"
+        ],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "description": { "type": "string", "minLength": 1 },
+          "title": { "type": "string", "minLength": 1 },
+          "url": {
+            "type": "string",
+            "pattern": "^https?://.+/play/.+\\.mkv$"
+          },
+          "behaviorHints": {
+            "type": "object",
+            "required": ["filename", "videoSize", "notWebReady"],
+            "properties": {
+              "filename": { "type": "string", "minLength": 1 },
+              "videoSize": { "type": "integer", "minimum": 0 },
+              "bingeGroup": { "type": "string", "minLength": 1 },
+              "notWebReady": { "const": true }
+            }
+          },
+          "meta": {
+            "type": "object",
+            "required": ["indexer"],
+            "properties": {
+              "indexer": { "type": "string", "minLength": 1 },
+              "inLibrary": { "type": "boolean" },
+              "availability": { "const": "available" },
+              "languages": {
+                "type": "array",
+                "items": { "type": "string", "minLength": 1 }
+              },
+              "subtitleLanguages": {
+                "type": "array",
+                "items": { "type": "string", "minLength": 1 }
+              }
+            }
+          },
+          "failoverId": { "type": "string", "minLength": 1 },
+          "extra": {
+            "type": "object",
+            "required": ["failoverId"],
+            "properties": {
+              "failoverId": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/configuration/profiles.md
+++ b/docs/configuration/profiles.md
@@ -13,6 +13,10 @@ Named profiles select which indexers to query and which output adapters to expos
 | Query fallback — Movies | Extra title searches when ID lookup is short | Off; threshold `3` |
 | Query fallback — TV | Off / Title+episode / Broad | Off; threshold `3` |
 
+The Addon adapter is a Stremio manifest. Paste it into AIOStreams as the dedicated **InfiniDysk** preset when available, or as **Custom Addon** until that preset ships. See [Stremio](../guides/stremio.md).
+
+Addon streams can include best-effort `inLibrary`, `availability`, audio language, and subtitle language metadata [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since }. Those markers are optional and are omitted when unknown. Copied adapter URLs include any configured URL base.
+
 Treat each generated **token** as a secret. Adapter URLs look like:
 
 - Newznab: `http://nzbdav:3000/adapters/newznab/{token}`

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -47,8 +47,18 @@ flowchart TB
 
 ### On-demand (Stremio)
 
-1. AIOStreams finds a release via Newznab.
-2. NZB is mounted through InfiniDysk's API.
+There are two Stremio paths:
+
+**Direct Search Profile preset** [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since }
+
+1. InfiniDysk searches the profile's Newznab indexers and returns playable stream objects.
+2. AIOStreams or Stremio lists those streams. The dedicated InfiniDysk preset can report the final order back to `/failover_order`.
+3. Playback hits `/play/{token}.mkv`, which resolves/queues the NZB and redirects to `/view`.
+
+**AIOStreams-managed search**
+
+1. AIOStreams finds a release via its own Newznab addons.
+2. The NZB is mounted through InfiniDysk's service/API.
 3. Playback URL (often proxied by AIOStreams) streams from WebDAV.
 
 ## Processes and ports

--- a/docs/guides/stremio.md
+++ b/docs/guides/stremio.md
@@ -2,7 +2,31 @@
 
 Stream Usenet on demand in Stremio using [AIOStreams](https://github.com/Viren070/AIOStreams). Upstream guide: [AIOStreams Usenet docs](https://docs.aiostreams.viren070.me/guides/usenet/).
 
-## Configure the InfiniDysk service
+There are two supported setups. Choose one. Do not combine them for the same indexers.
+
+## Path A — InfiniDysk owns search (recommended)
+
+Use this when InfiniDysk should search your Newznab indexers and return playable streams. AIOStreams only filters, sorts, and formats those streams.
+
+1. Configure Usenet providers and Newznab indexers in InfiniDysk.
+2. Set a public base URL / reverse proxy so AIOStreams and the playback client can reach InfiniDysk over HTTPS.
+3. Create a **Search Profile**, choose indexers, enable **Addon**, and configure query fallback if you want it.
+4. Copy the Addon **manifest URL**. Treat the full URL as a secret: it contains the profile token.
+5. In AIOStreams Marketplace:
+   - After a release that includes the dedicated **InfiniDysk** preset, add that preset and paste the manifest URL. No InfiniDysk/NzbDAV service credentials are required.
+   - Until that preset is released, add **Custom Addon** and paste the same manifest URL. Custom Addon fetches streams but does **not** report AIOStreams' final order to `/failover_order`.
+6. Do **not** also add the InfiniDysk/NzbDAV service, and do **not** duplicate those indexers as AIOStreams Newznab addons.
+7. Save and install the combined AIOStreams addon in Stremio.
+
+If InfiniDysk is mounted under a path such as `/nzbdav`, the copied manifest URL already includes that prefix.
+
+Give AIOStreams enough timeout for indexer search. Play links expire; search again after the Watchdog search-link lifetime. The first play of a new release may take time because `notWebReady` is intentional: InfiniDysk resolves and queues the NZB before redirecting to `/view`. Ready and verified markers are best-effort and do not guarantee the provider still has the articles.
+
+AIOStreams proxying is optional on this path. Direct play URLs work when the player can reach InfiniDysk.
+
+## Path B — AIOStreams owns search
+
+Use this when AIOStreams should search Newznab addons itself and hand NZBs to InfiniDysk only for playback.
 
 In AIOStreams → **Services** → **InfiniDysk**:
 
@@ -16,18 +40,16 @@ In AIOStreams → **Services** → **InfiniDysk**:
 
 Providing the auth token lets AIOStreams proxy streams — keeps InfiniDysk private and avoids protocol mismatches.
 
-## Newznab addon
-
-**Addons → Marketplace → Usenet → Newznab**: add each indexer (URL, API key). Search mode **Both** when your API budget allows.
-
-## Install to Stremio
+Then in **Addons → Marketplace → Usenet → Newznab**, add each indexer (URL, API key). Search mode **Both** when your API budget allows.
 
 **Save & Install** in AIOStreams, then install the addon in Stremio.
 
-## Search profiles (optional)
+## Security and reachability
 
-Expose InfiniDysk indexers as Newznab/Addon/JSON adapters — [Search profiles](../configuration/profiles.md) and [Indexer search](../features/indexer-search.md).
+- The profile token in the Path A manifest URL is a capability credential. Do not paste it into public chats or commit it.
+- Players and AIOStreams must be able to reach the public InfiniDysk URL, including any URL-base prefix.
+- HTTPS and a reverse proxy in front of the container are the usual production setup.
 
 ## Related
 
-[Streaming-only use case](../use-cases/streaming-only.md) · [Watchtower](../features/watchtower.md)
+[Search profiles](../configuration/profiles.md) · [Indexer search](../features/indexer-search.md) · [Streaming-only use case](../use-cases/streaming-only.md) · [Watchtower](../features/watchtower.md)

--- a/frontend/app/routes/settings/profiles/profile-adapter-urls.test.ts
+++ b/frontend/app/routes/settings/profiles/profile-adapter-urls.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { buildProfileAdapterUrl } from "./profile-adapter-urls";
+
+describe("buildProfileAdapterUrl", () => {
+  const origin = "https://stream.example";
+  const token = "profile-token";
+  const urlBase = "/infinidysk";
+
+  it.each([
+    [
+      "json",
+      "https://stream.example/infinidysk/api/search/profile-token/lookup?type=movie&id=tt0111161",
+    ],
+    ["newznab", "https://stream.example/infinidysk/adapters/newznab/profile-token/api"],
+    ["addon", "https://stream.example/infinidysk/adapters/addon/profile-token/manifest.json"],
+  ] as const)("includes URL_BASE for the %s adapter", (adapter, expected) => {
+    expect(buildProfileAdapterUrl(origin, adapter, token, urlBase)).toBe(expected);
+  });
+
+  it("keeps root-mounted adapter URLs unchanged", () => {
+    expect(buildProfileAdapterUrl(origin, "addon", token, "")).toBe(
+      "https://stream.example/adapters/addon/profile-token/manifest.json",
+    );
+  });
+});

--- a/frontend/app/routes/settings/profiles/profile-adapter-urls.ts
+++ b/frontend/app/routes/settings/profiles/profile-adapter-urls.ts
@@ -1,0 +1,18 @@
+import { URL_BASE } from "~/utils/url-base";
+
+export type ProfileAdapterKey = "json" | "addon" | "newznab";
+
+const paths: Record<ProfileAdapterKey, (token: string) => string> = {
+  json: (token) => `/api/search/${token}/lookup?type=movie&id=tt0111161`,
+  newznab: (token) => `/adapters/newznab/${token}/api`,
+  addon: (token) => `/adapters/addon/${token}/manifest.json`,
+};
+
+export function buildProfileAdapterUrl(
+  origin: string,
+  adapter: ProfileAdapterKey,
+  token: string,
+  urlBase = URL_BASE,
+): string {
+  return `${origin}${urlBase}${paths[adapter](token)}`;
+}

--- a/frontend/app/routes/settings/profiles/profiles.tsx
+++ b/frontend/app/routes/settings/profiles/profiles.tsx
@@ -19,6 +19,7 @@ import {
   Toggle,
   Tooltip,
 } from "~/components/ui";
+import { buildProfileAdapterUrl, type ProfileAdapterKey } from "./profile-adapter-urls";
 
 type ProfilesSettingsProps = {
   config: Record<string, string>;
@@ -50,7 +51,7 @@ interface IndexerSummary {
   Enabled: boolean;
 }
 
-type AdapterKey = "json" | "addon" | "newznab";
+type AdapterKey = ProfileAdapterKey;
 
 const ADAPTERS: {
   key: AdapterKey;
@@ -62,20 +63,20 @@ const ADAPTERS: {
     key: "json",
     name: "JSON Search API",
     description: "Vendor-neutral JSON results. Use from custom clients or scripts.",
-    buildUrl: (origin, token) => `${origin}/api/search/${token}/lookup?type=movie&id=tt0111161`,
+    buildUrl: (origin, token) => buildProfileAdapterUrl(origin, "json", token),
   },
   {
     key: "newznab",
     name: "Newznab",
     description: "Newznab-protocol meta-indexer endpoint. Add to Prowlarr / Sonarr / Radarr.",
-    buildUrl: (origin, token) => `${origin}/adapters/newznab/${token}/api`,
+    buildUrl: (origin, token) => buildProfileAdapterUrl(origin, "newznab", token),
   },
   {
     key: "addon",
     name: "Addon",
     description:
       "Manifest-based addon endpoint. Install the URL in a compatible client to query this Search Profile.",
-    buildUrl: (origin, token) => `${origin}/adapters/addon/${token}/manifest.json`,
+    buildUrl: (origin, token) => buildProfileAdapterUrl(origin, "addon", token),
   },
 ];
 

--- a/tests/NzbWebDAV.Tests/Api/ProfileAddonContractTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/ProfileAddonContractTests.cs
@@ -1,9 +1,11 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using NzbWebDAV.Api.Controllers.Profiles;
 using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
 using NzbWebDAV.Services;
 using NzbWebDAV.Tests.TestUtils;
 using NzbWebDAV.Utils;
@@ -77,9 +79,10 @@ public sealed class ProfileAddonContractTests
     {
         await using var factory = new NzbDavWebApplicationFactory();
         using var client = factory.CreateClient();
-        using var response = await client.SendAsync(new HttpRequestMessage(
+        using var request = new HttpRequestMessage(
             HttpMethod.Options,
-            $"/adapters/addon/{Token}/manifest.json"));
+            $"/adapters/addon/{Token}/manifest.json");
+        using var response = await client.SendAsync(request);
 
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         Assert.Equal("*", Assert.Single(response.Headers.GetValues("Access-Control-Allow-Origin")));
@@ -206,6 +209,52 @@ public sealed class ProfileAddonContractTests
     }
 
     [Fact]
+    public async Task Play_ExistingVideoWithForwardedPrefix_RedirectsToPrefixedView()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        using var admin = factory.CreateAuthenticatedClient();
+        await ConfigureAddonProfileAsync(admin, Token, "Redirect Profile");
+
+        const string title = "Movie.2024.1080p";
+        var historyId = Guid.NewGuid();
+        await factory.SeedHistoryItemAsync(
+            historyId,
+            HistoryItem.DownloadStatusOption.Completed,
+            $"{title}.nzb");
+        await factory.AddDavItemsAsync(UsenetFile($"{title}.mkv", historyId));
+
+        var cache = factory.Services.GetRequiredService<NzbResolutionCache>();
+        var playToken = (await cache.AddGroupAsync(
+            [
+                new NzbResolutionCache.Candidate
+                {
+                    IndexerName = "Primary",
+                    IndexerUserAgent = "test-agent",
+                    NzbUrl = "https://indexer.example/get/123",
+                    Title = title,
+                    Size = 1_500_000_000,
+                },
+            ],
+            "movie",
+            Token,
+            "tt0111161"))[0];
+
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+        });
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/adapters/addon/{Token}/play/{playToken}.mkv");
+        request.Headers.Add("X-Forwarded-Prefix", "/infinidysk");
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        Assert.NotNull(response.Headers.Location);
+        Assert.StartsWith("/infinidysk/view/", response.Headers.Location.PathAndQuery);
+    }
+
+    [Fact]
     public async Task FailoverOrder_ReportsMatchedTokensForSameProfile()
     {
         await using var factory = new NzbDavWebApplicationFactory();
@@ -296,9 +345,10 @@ public sealed class ProfileAddonContractTests
         Assert.Equal(0, crossJson.RootElement.GetProperty("matched").GetInt32());
         Assert.Equal(1, crossJson.RootElement.GetProperty("unmatched").GetInt32());
 
-        using var options = await client.SendAsync(new HttpRequestMessage(
+        using var optionsRequest = new HttpRequestMessage(
             HttpMethod.Options,
-            $"/adapters/addon/{Token}/failover_order"));
+            $"/adapters/addon/{Token}/failover_order");
+        using var options = await client.SendAsync(optionsRequest);
         Assert.Equal(HttpStatusCode.NoContent, options.StatusCode);
         Assert.Equal("*", Assert.Single(options.Headers.GetValues("Access-Control-Allow-Origin")));
     }
@@ -326,6 +376,18 @@ public sealed class ProfileAddonContractTests
             Name = name,
             EnabledAdapters = enabledAdapters?.ToList() ?? ["addon"],
         });
+
+    private static DavItem UsenetFile(string name, Guid historyItemId) => DavItem.New(
+        Guid.NewGuid(),
+        DavItem.ContentFolder,
+        name,
+        fileSize: 100,
+        DavItem.ItemType.UsenetFile,
+        DavItem.ItemSubType.NzbFile,
+        releaseDate: DateTimeOffset.UtcNow.AddDays(-1),
+        lastHealthCheck: null,
+        historyItemId: historyItemId,
+        fileBlobId: null);
 
     private static async Task ConfigureAddonProfilesAsync(
         HttpClient client,

--- a/tests/NzbWebDAV.Tests/Api/ProfileAddonContractTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/ProfileAddonContractTests.cs
@@ -209,6 +209,26 @@ public sealed class ProfileAddonContractTests
     }
 
     [Fact]
+    public void StreamFactory_SanitizesFilenameAndClampsNegativeVideoSize()
+    {
+        var candidate = new NzbResolutionCache.Candidate
+        {
+            IndexerName = "Primary",
+            IndexerUserAgent = "test-agent",
+            NzbUrl = "https://indexer.example/get/123",
+            Title = "",
+            Size = -1,
+        };
+
+        var stream = ProfileAddonFactory.CreateStream(
+            candidate, "movie", Token, "play-token", "https://host.example",
+            inLibrary: false, verifiedAvailable: false);
+
+        Assert.Equal("untitled", stream.BehaviorHints.Filename);
+        Assert.Equal(0, stream.BehaviorHints.VideoSize);
+    }
+
+    [Fact]
     public async Task Play_ExistingVideoWithForwardedPrefix_RedirectsToPrefixedView()
     {
         await using var factory = new NzbDavWebApplicationFactory();
@@ -251,7 +271,7 @@ public sealed class ProfileAddonContractTests
 
         Assert.Equal(HttpStatusCode.Found, response.StatusCode);
         Assert.NotNull(response.Headers.Location);
-        Assert.StartsWith("/infinidysk/view/", response.Headers.Location.PathAndQuery);
+        Assert.StartsWith("/infinidysk/view/", response.Headers.Location.OriginalString);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Api/ProfileAddonContractTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/ProfileAddonContractTests.cs
@@ -1,0 +1,340 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using NzbWebDAV.Api.Controllers.Profiles;
+using NzbWebDAV.Config;
+using NzbWebDAV.Services;
+using NzbWebDAV.Tests.TestUtils;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Api;
+
+[Collection(nameof(HttpIntegrationCollection))]
+public sealed class ProfileAddonContractTests
+{
+    private const string Token = "aaaaaaaaaaaaaaaaaaaaaaaa";
+
+    [Fact]
+    public async Task Manifest_ValidEnabledProfile_ReturnsContract()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        using var admin = factory.CreateAuthenticatedClient();
+        using var client = factory.CreateClient();
+        await ConfigureAddonProfileAsync(admin, Token, "Contract Profile");
+
+        using var response = await client.GetAsync($"/adapters/addon/{Token}/manifest.json");
+        using var json = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("*", Assert.Single(response.Headers.GetValues("Access-Control-Allow-Origin")));
+        Assert.True(response.Headers.CacheControl?.NoStore);
+        JsonContractValidator.AssertMatchesSchema(json.RootElement, "stremio/v1/profile-manifest.schema.json");
+        Assert.Equal($"nzbdav.profile.{Token}", json.RootElement.GetProperty("id").GetString());
+        Assert.Equal("Contract Profile", json.RootElement.GetProperty("name").GetString());
+        Assert.Equal(ProfileAddonFactory.LogoUrl, json.RootElement.GetProperty("logo").GetString());
+        Assert.Equal("0.0.0", json.RootElement.GetProperty("version").GetString());
+        Assert.Contains("indexers", json.RootElement.GetProperty("description").GetString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Manifest_FallbackName_UsesInfiniDyskBranding()
+    {
+        var manifest = ProfileAddonFactory.CreateManifest(
+            new ProfileConfig.Profile { Token = Token, Name = "  " },
+            Token);
+
+        Assert.Equal("InfiniDysk Search Profile", manifest.Name);
+        Assert.False(manifest.BehaviorHints.Configurable);
+        Assert.False(manifest.BehaviorHints.ConfigurationRequired);
+        Assert.Equal(["stream"], manifest.Resources);
+        Assert.Equal(["movie", "series"], manifest.Types);
+    }
+
+    [Fact]
+    public async Task Manifest_InvalidToken_Returns404()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        using var client = factory.CreateClient();
+        using var response = await client.GetAsync("/adapters/addon/missing-token/manifest.json");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Manifest_DisabledAddon_Returns404()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        using var admin = factory.CreateAuthenticatedClient();
+        using var client = factory.CreateClient();
+        await ConfigureAddonProfileAsync(admin, Token, "Disabled", enabledAdapters: ["json"]);
+
+        using var response = await client.GetAsync($"/adapters/addon/{Token}/manifest.json");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Manifest_Options_ReturnsCors()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        using var client = factory.CreateClient();
+        using var response = await client.SendAsync(new HttpRequestMessage(
+            HttpMethod.Options,
+            $"/adapters/addon/{Token}/manifest.json"));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.Equal("*", Assert.Single(response.Headers.GetValues("Access-Control-Allow-Origin")));
+    }
+
+    [Fact]
+    public void StreamFactory_EmptyCandidates_ProduceEmptyArray()
+    {
+        var response = ProfileAddonFactory.CreateStreamResponse(
+            new SearchProfileService.SearchResult
+            {
+                ProfileToken = Token,
+                Type = "movie",
+                Id = "tt0111161",
+                Candidates = [],
+                PlayTokens = [],
+            },
+            "https://host.example",
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            _ => false);
+
+        Assert.Empty(response.Streams);
+        JsonContractValidator.AssertMatchesSchema(
+            JsonSerializer.SerializeToElement(response),
+            "stremio/v1/profile-stream-response.schema.json");
+    }
+
+    [Fact]
+    public void StreamFactory_MapsPlayUrlHintsAndOptionalMetadata()
+    {
+        var candidate = new NzbResolutionCache.Candidate
+        {
+            IndexerName = "Primary",
+            SourceIndexerName = "Indexer Proxy",
+            IndexerUserAgent = "test-agent",
+            NzbUrl = "https://indexer.example/get/123",
+            Title = "Example.Movie.2026.1080p",
+            Size = 1_500_000_000,
+            Posted = DateTimeOffset.UtcNow.AddDays(-2),
+            Language = "English",
+            Subs = "English, Spanish",
+            VerifiedAvailable = true,
+        };
+
+        var stream = ProfileAddonFactory.CreateStream(
+            candidate,
+            "movie",
+            Token,
+            "play-token",
+            "https://host.example/nzbdav",
+            inLibrary: true,
+            verifiedAvailable: true);
+        var json = JsonSerializer.SerializeToElement(new ProfileAddonStreamResponse { Streams = [stream] });
+
+        JsonContractValidator.AssertMatchesSchema(json, "stremio/v1/profile-stream-response.schema.json");
+        Assert.Equal("[NZB] Indexer Proxy", stream.Name);
+        Assert.Equal("https://host.example/nzbdav/adapters/addon/aaaaaaaaaaaaaaaaaaaaaaaa/play/play-token.mkv", stream.Url);
+        Assert.Equal("play-token", stream.FailoverId);
+        Assert.Equal("play-token", stream.Extra.FailoverId);
+        Assert.Equal("Example.Movie.2026.1080p", stream.BehaviorHints.Filename);
+        Assert.Equal(1_500_000_000, stream.BehaviorHints.VideoSize);
+        Assert.True(stream.BehaviorHints.NotWebReady);
+        Assert.Equal("Indexer Proxy", stream.Meta.Indexer);
+        Assert.True(stream.Meta.InLibrary);
+        Assert.Equal("available", stream.Meta.Availability);
+        Assert.Equal(["en"], stream.Meta.Languages);
+        Assert.Equal(["en", "es"], stream.Meta.SubtitleLanguages);
+        Assert.Contains("⚡ Ready", stream.Description, StringComparison.Ordinal);
+        Assert.Contains("✅ Verified", stream.Description, StringComparison.Ordinal);
+        Assert.Contains("🇬🇧", stream.Description, StringComparison.Ordinal);
+        Assert.Contains("💬 Subs: en, es", stream.Description, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StreamFactory_MarksPreflightAvailableWithoutGuessingTimeout()
+    {
+        var candidate = new NzbResolutionCache.Candidate
+        {
+            IndexerName = "Primary",
+            IndexerUserAgent = "ua",
+            NzbUrl = "https://indexer.example/available",
+            Title = "Example.Movie.2026.1080p",
+            Size = 100,
+        };
+
+        var available = ProfileAddonFactory.CreateStreamResponse(
+            Result([candidate], ["play-token"]),
+            "https://host.example",
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            nzbUrl => nzbUrl == "https://indexer.example/available");
+        var timeout = ProfileAddonFactory.CreateStreamResponse(
+            Result([candidate], ["play-token"]),
+            "https://host.example",
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            _ => false);
+
+        Assert.Equal("available", available.Streams[0].Meta.Availability);
+        Assert.Null(timeout.Streams[0].Meta.Availability);
+    }
+
+    [Fact]
+    public void StreamFactory_OmitsUnknownOptionalMetadata()
+    {
+        var candidate = new NzbResolutionCache.Candidate
+        {
+            IndexerName = "Primary",
+            IndexerUserAgent = "test-agent",
+            NzbUrl = "https://indexer.example/get/123",
+            Title = "Example.Movie.2026.1080p",
+            Size = 100,
+        };
+
+        var stream = ProfileAddonFactory.CreateStream(
+            candidate, "movie", Token, "play-token", "https://host.example",
+            inLibrary: false, verifiedAvailable: false);
+
+        Assert.Null(stream.Meta.InLibrary);
+        Assert.Null(stream.Meta.Availability);
+        Assert.Null(stream.Meta.Languages);
+        Assert.Null(stream.Meta.SubtitleLanguages);
+        Assert.DoesNotContain("⚡ Ready", stream.Description, StringComparison.Ordinal);
+        Assert.DoesNotContain("✅ Verified", stream.Description, StringComparison.Ordinal);
+        Assert.DoesNotContain("💬 Subs:", stream.Description, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task FailoverOrder_ReportsMatchedTokensForSameProfile()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        using var admin = factory.CreateAuthenticatedClient();
+        using var client = factory.CreateClient();
+        await ConfigureAddonProfileAsync(admin, Token, "Order Profile");
+
+        var cache = factory.Services.GetRequiredService<NzbResolutionCache>();
+        var tokens = await cache.AddGroupAsync(
+            [
+                new NzbResolutionCache.Candidate
+                {
+                    IndexerName = "A",
+                    IndexerUserAgent = "ua",
+                    NzbUrl = "https://indexer.example/a",
+                    Title = "A",
+                    Size = 1,
+                },
+                new NzbResolutionCache.Candidate
+                {
+                    IndexerName = "B",
+                    IndexerUserAgent = "ua",
+                    NzbUrl = "https://indexer.example/b",
+                    Title = "B",
+                    Size = 2,
+                },
+            ],
+            "movie",
+            Token,
+            "tt0111161");
+
+        using var response = await client.PostAsJsonAsync(
+            $"/adapters/addon/{Token}/failover_order",
+            new { streams = new[] { new { failoverId = tokens[1] }, new { failoverId = tokens[0] } } });
+        using var json = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(json.RootElement.GetProperty("ok").GetBoolean());
+        Assert.Equal(2, json.RootElement.GetProperty("matched").GetInt32());
+        Assert.Equal(0, json.RootElement.GetProperty("unmatched").GetInt32());
+
+        var store = factory.Services.GetRequiredService<PreferredOrderStore>();
+        Assert.Equal(2, store.GetOrder(Token, "movie", "tt0111161")!.Count);
+    }
+
+    [Fact]
+    public async Task FailoverOrder_RejectsUnknownProfileEmptyBodyAndCrossProfileTokens()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        using var admin = factory.CreateAuthenticatedClient();
+        using var client = factory.CreateClient();
+        const string otherToken = "bbbbbbbbbbbbbbbbbbbbbbbb";
+        await ConfigureAddonProfilesAsync(admin,
+            new ProfileConfig.Profile { Token = Token, Name = "Order Profile", EnabledAdapters = ["addon"] },
+            new ProfileConfig.Profile { Token = otherToken, Name = "Other", EnabledAdapters = ["addon"] });
+
+        var cache = factory.Services.GetRequiredService<NzbResolutionCache>();
+        var otherTokens = await cache.AddGroupAsync(
+            [
+                new NzbResolutionCache.Candidate
+                {
+                    IndexerName = "A",
+                    IndexerUserAgent = "ua",
+                    NzbUrl = "https://indexer.example/other",
+                    Title = "Other",
+                    Size = 1,
+                },
+            ],
+            "movie",
+            otherToken,
+            "tt0111161");
+
+        using var missing = await client.PostAsJsonAsync(
+            "/adapters/addon/missing-token/failover_order",
+            new { streams = new[] { new { failoverId = "x" } } });
+        Assert.Equal(HttpStatusCode.NotFound, missing.StatusCode);
+
+        using var empty = await client.PostAsJsonAsync(
+            $"/adapters/addon/{Token}/failover_order",
+            new { streams = Array.Empty<object>() });
+        Assert.Equal(HttpStatusCode.BadRequest, empty.StatusCode);
+
+        using var cross = await client.PostAsJsonAsync(
+            $"/adapters/addon/{Token}/failover_order",
+            new { streams = new[] { new { failoverId = otherTokens[0] } } });
+        using var crossJson = await JsonDocument.ParseAsync(await cross.Content.ReadAsStreamAsync());
+        Assert.Equal(HttpStatusCode.OK, cross.StatusCode);
+        Assert.Equal(0, crossJson.RootElement.GetProperty("matched").GetInt32());
+        Assert.Equal(1, crossJson.RootElement.GetProperty("unmatched").GetInt32());
+
+        using var options = await client.SendAsync(new HttpRequestMessage(
+            HttpMethod.Options,
+            $"/adapters/addon/{Token}/failover_order"));
+        Assert.Equal(HttpStatusCode.NoContent, options.StatusCode);
+        Assert.Equal("*", Assert.Single(options.Headers.GetValues("Access-Control-Allow-Origin")));
+    }
+
+    private static SearchProfileService.SearchResult Result(
+        IReadOnlyList<NzbResolutionCache.Candidate> candidates,
+        string[] playTokens) =>
+        new()
+        {
+            ProfileToken = Token,
+            Type = "movie",
+            Id = "tt0111161",
+            Candidates = candidates,
+            PlayTokens = playTokens,
+        };
+
+    private static Task ConfigureAddonProfileAsync(
+        HttpClient client,
+        string token,
+        string name,
+        IReadOnlyList<string>? enabledAdapters = null) =>
+        ConfigureAddonProfilesAsync(client, new ProfileConfig.Profile
+        {
+            Token = token,
+            Name = name,
+            EnabledAdapters = enabledAdapters?.ToList() ?? ["addon"],
+        });
+
+    private static async Task ConfigureAddonProfilesAsync(
+        HttpClient client,
+        params ProfileConfig.Profile[] profiles)
+    {
+        var payload = JsonSerializer.Serialize(new ProfileConfig { Profiles = [.. profiles] });
+        using var form = new MultipartFormDataContent();
+        form.Add(new StringContent(payload), ConfigKeys.ProfilesInstances);
+        using var response = await client.PostAsync("/api/update-config", form);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Extensions/GetPublicBaseUrlTests.cs
+++ b/tests/NzbWebDAV.Tests/Extensions/GetPublicBaseUrlTests.cs
@@ -71,6 +71,17 @@ public class GetPublicBaseUrlTests
     }
 
     [Fact]
+    public void BuildsLocalPathPrefixFromConfiguredAndForwardedBases()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers["X-Forwarded-Prefix"] = "/infinidysk";
+
+        var result = context.GetPublicPathPrefix("https://nzbdav.example/app");
+
+        Assert.Equal("/app/infinidysk", result);
+    }
+
+    [Fact]
     public void IgnoresUnsafeForwardedPrefix()
     {
         var context = new DefaultHttpContext();

--- a/tests/NzbWebDAV.Tests/Extensions/GetPublicBaseUrlTests.cs
+++ b/tests/NzbWebDAV.Tests/Extensions/GetPublicBaseUrlTests.cs
@@ -45,4 +45,41 @@ public class GetPublicBaseUrlTests
 
         Assert.Equal("http://localhost:8080", result);
     }
+
+    [Fact]
+    public void AddsFrontendUrlBaseToCopiedPublicUrls()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("nzbdav.example");
+        context.Request.Headers["X-Forwarded-Prefix"] = "/infinidysk";
+
+        var result = context.GetPublicBaseUrl("http://localhost:3000");
+
+        Assert.Equal("https://nzbdav.example/infinidysk", result);
+    }
+
+    [Fact]
+    public void DoesNotDuplicateConfiguredUrlBase()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers["X-Forwarded-Prefix"] = "/infinidysk";
+
+        var result = context.GetPublicBaseUrl("https://nzbdav.example/infinidysk");
+
+        Assert.Equal("https://nzbdav.example/infinidysk", result);
+    }
+
+    [Fact]
+    public void IgnoresUnsafeForwardedPrefix()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("nzbdav.example");
+        context.Request.Headers["X-Forwarded-Prefix"] = "https://evil.example";
+
+        var result = context.GetPublicBaseUrl("http://localhost:3000");
+
+        Assert.Equal("https://nzbdav.example", result);
+    }
 }

--- a/tests/NzbWebDAV.Tests/Services/NzbResolutionCachePersistenceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/NzbResolutionCachePersistenceTests.cs
@@ -125,6 +125,34 @@ public sealed class NzbResolutionCachePersistenceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Hydrate_MissingVerifiedAvailable_DefaultsToFalse()
+    {
+        var token = "cafebabedeadbeef";
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            ctx.NzbResolutionGroups.Add(new NzbResolutionGroup
+            {
+                Id = Guid.NewGuid(),
+                Type = "movie",
+                ProfileToken = "p",
+                SearchId = "legacy",
+                CandidatesJson =
+                    """[{"IndexerName":"idx","IndexerUserAgent":"ua","NzbUrl":"https://example.com/nzb/0","Title":"Title 0","Size":1000}]""",
+                TokensJson = System.Text.Json.JsonSerializer.Serialize(new[] { token }),
+                CreatedAtUnix = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var cache = NewCache();
+        await cache.HydrateAsync(TimeSpan.FromDays(7), CancellationToken.None);
+
+        var entry = cache.Get(token);
+        Assert.NotNull(entry);
+        Assert.False(entry.Primary.VerifiedAvailable);
+    }
+
+    [Fact]
     public async Task AddGroupAsync_PersistenceFailure_StillReturnsTokens()
     {
         var cache = new NzbResolutionCache(() => throw new InvalidOperationException("db down"));

--- a/tests/NzbWebDAV.Tests/Services/ProfileStreamStateServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ProfileStreamStateServiceTests.cs
@@ -1,0 +1,124 @@
+using Microsoft.Extensions.DependencyInjection;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services;
+using NzbWebDAV.Tests.TestUtils;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Services;
+
+[Collection(nameof(HttpIntegrationCollection))]
+public sealed class ProfileStreamStateServiceTests
+{
+    [Fact]
+    public async Task MarksExactCompletedVideoReleaseReady()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        var historyId = Guid.NewGuid();
+        await factory.SeedHistoryItemAsync(
+            historyId,
+            HistoryItem.DownloadStatusOption.Completed,
+            "Movie.2024.1080p.nzb");
+        await factory.AddDavItemsAsync(UsenetFile("Movie.2024.1080p.mkv", historyId));
+
+        var ready = await GetReadyAsync(factory, Title: "Movie.2024.1080p");
+
+        Assert.Contains("Movie.2024.1080p.nzb", ready);
+    }
+
+    [Fact]
+    public async Task CompletedHistoryWithOnlySubtitles_IsNotReady()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        var historyId = Guid.NewGuid();
+        await factory.SeedHistoryItemAsync(
+            historyId,
+            HistoryItem.DownloadStatusOption.Completed,
+            "Movie.2024.1080p.nzb");
+        await factory.AddDavItemsAsync(UsenetFile("Movie.2024.1080p.srt", historyId));
+
+        var ready = await GetReadyAsync(factory, Title: "Movie.2024.1080p");
+
+        Assert.Empty(ready);
+    }
+
+    [Fact]
+    public async Task BrokenHistoryIds_AreExcluded()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        var historyId = Guid.NewGuid();
+        await factory.SeedHistoryItemAsync(
+            historyId,
+            HistoryItem.DownloadStatusOption.Completed,
+            "Movie.2024.1080p.nzb");
+        await factory.AddDavItemsAsync(UsenetFile("Movie.2024.1080p.mkv", historyId));
+        factory.Services.GetRequiredService<CandidateNegativeCache>().MarkHistoryItemBroken(historyId);
+
+        var ready = await GetReadyAsync(factory, Title: "Movie.2024.1080p");
+
+        Assert.Empty(ready);
+    }
+
+    [Fact]
+    public async Task FilenameMatching_IsCaseInsensitive()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        var historyId = Guid.NewGuid();
+        await factory.SeedHistoryItemAsync(
+            historyId,
+            HistoryItem.DownloadStatusOption.Completed,
+            "movie.2024.1080p.nzb");
+        await factory.AddDavItemsAsync(UsenetFile("movie.2024.1080p.mkv", historyId));
+
+        var ready = await GetReadyAsync(factory, Title: "Movie.2024.1080p");
+
+        Assert.Contains("movie.2024.1080p.nzb", ready, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task DoesNotMarkSiblingReleaseReady()
+    {
+        await using var factory = new NzbDavWebApplicationFactory();
+        var historyId = Guid.NewGuid();
+        await factory.SeedHistoryItemAsync(
+            historyId,
+            HistoryItem.DownloadStatusOption.Completed,
+            "Movie.2024.2160p.nzb");
+        await factory.AddDavItemsAsync(UsenetFile("Movie.2024.2160p.mkv", historyId));
+
+        var ready = await GetReadyAsync(factory, Title: "Movie.2024.1080p");
+
+        Assert.Empty(ready);
+    }
+
+    private static async Task<IReadOnlySet<string>> GetReadyAsync(
+        NzbDavWebApplicationFactory factory,
+        string Title)
+    {
+        using var scope = factory.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<ProfileStreamStateService>();
+        return await service.GetReadyNzbFileNamesAsync(
+            [
+                new NzbResolutionCache.Candidate
+                {
+                    IndexerName = "idx",
+                    IndexerUserAgent = "ua",
+                    NzbUrl = "https://indexer.example/nzb",
+                    Title = Title,
+                    Size = 1,
+                },
+            ],
+            CancellationToken.None);
+    }
+
+    private static DavItem UsenetFile(string name, Guid historyItemId) => DavItem.New(
+        Guid.NewGuid(),
+        DavItem.ContentFolder,
+        name,
+        fileSize: 100,
+        DavItem.ItemType.UsenetFile,
+        DavItem.ItemSubType.NzbFile,
+        releaseDate: DateTimeOffset.UtcNow.AddDays(-1),
+        lastHealthCheck: null,
+        historyItemId: historyItemId,
+        fileBlobId: null);
+}

--- a/tests/NzbWebDAV.Tests/Utils/ProfileLanguageMetadataTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/ProfileLanguageMetadataTests.cs
@@ -1,0 +1,28 @@
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public class ProfileLanguageMetadataTests
+{
+    [Fact]
+    public void NormalizeAudioLanguages_MapsAliasesAndKeepsUnknownTokens()
+    {
+        Assert.Equal(["de", "en"], ProfileLanguageMetadata.NormalizeAudioLanguages("English, German"));
+        Assert.Equal(["klingon"], ProfileLanguageMetadata.NormalizeAudioLanguages("Klingon"));
+    }
+
+    [Fact]
+    public void NormalizeSubtitleLanguages_StaysSeparateFromAudioFlags()
+    {
+        var subs = ProfileLanguageMetadata.NormalizeSubtitleLanguages("English, Spanish");
+        Assert.Equal(["en", "es"], subs);
+        Assert.Empty(ProfileLanguageMetadata.AudioFlagMarkers(subs).Except(["🇬🇧", "🇪🇸"]));
+    }
+
+    [Fact]
+    public void AudioFlagMarkers_OnlyMapKnownAudioCodes()
+    {
+        Assert.Equal(["🇬🇧"], ProfileLanguageMetadata.AudioFlagMarkers(["en"]));
+        Assert.Empty(ProfileLanguageMetadata.AudioFlagMarkers(["klingon"]));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Utils/ProfileReleaseNameTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/ProfileReleaseNameTests.cs
@@ -1,0 +1,25 @@
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public class ProfileReleaseNameTests
+{
+    [Theory]
+    [InlineData("Movie.2024.1080p", "Movie.2024.1080p")]
+    [InlineData("Movie/Name", "Movie_Name")]
+    [InlineData("  padded  ", "padded")]
+    [InlineData("", "untitled")]
+    [InlineData("   ", "untitled")]
+    [InlineData(null, "untitled")]
+    public void SanitizeFileName_ReplacesInvalidCharactersAndFallsBack(string? name, string expected)
+    {
+        Assert.Equal(expected, ProfileReleaseName.SanitizeFileName(name));
+    }
+
+    [Fact]
+    public void ToNzbFileName_AppendsNzbExtension()
+    {
+        Assert.Equal("Movie.2024.1080p.nzb", ProfileReleaseName.ToNzbFileName("Movie.2024.1080p"));
+        Assert.Equal("untitled.nzb", ProfileReleaseName.ToNzbFileName(""));
+    }
+}


### PR DESCRIPTION
Fixes #883

## What this does

Search Profile Addon manifests are now a stable, documented Stremio contract that AIOStreams can consume directly.

- Typed manifest/stream contracts, JSON schemas, and InfiniDysk branding (manifest ID is unchanged).
- Best-effort `inLibrary`, `availability`, audio, and subtitle metadata from local history and in-memory Preflight state. No extra network calls and no per-result Warden queries.
- Copied adapter URLs honor `NZBDAV_URL_BASE`; public play URLs append a safe `X-Forwarded-Prefix`.
- Docs cover Path A (direct InfiniDysk preset / Custom Addon fallback) and Path B (AIOStreams-managed search).

This PR does **not** include issue #260 ranking controls and does not depend on that branch.

Until the upstream AIOStreams InfiniDysk preset is released, use **Custom Addon** with the same manifest URL. Custom Addon fetches streams but does not report final order to `/failover_order`.

Companion upstream PR: https://github.com/Viren070/AIOStreams/pull/1231

The additive ready-state lookup index migration auto-applies on startup. Back up `/config` before upgrading if you want a rollback copy.

## Test plan

- [x] Focused backend: `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~ProfileAddonContractTests|FullyQualifiedName~ProfileStreamStateServiceTests|FullyQualifiedName~ProfileLanguageMetadataTests"` (20 passed)
- [x] Backend: `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (3503 passed before review follow-up)
- [x] Frontend: `npm run typecheck && npm run build && npm test` (718 passed before review follow-up)
- [x] Docs: `zensical build --clean --strict`
- [ ] SharpCompress omitted: no archive-format paths were touched
- [ ] Cross-project live InfiniDysk + AIOStreams smoke test was not run

## Notes

Do not merge from an agent.