### PR TITLE
fix(ui): show the Connections warm-pool hint

### DIFF
--- a/frontend/app/routes/_index/components/live-usenet-connections/live-usenet-connections.tsx
+++ b/frontend/app/routes/_index/components/live-usenet-connections/live-usenet-connections.tsx
@@ -73,7 +73,7 @@ export function LiveUsenetConnections({ hasUsenetProviders }: LiveUsenetConnecti
 
   return (
     <div
-      className="stats hidden h-10 overflow-hidden border border-base-content/10 bg-base-200 sm:inline-grid"
+      className="stats hidden h-10 border border-base-content/10 bg-base-200 sm:inline-grid"
       aria-label="Usenet connections"
     >
       <div className="stat flex items-center gap-3 px-3 py-1">


### PR DESCRIPTION
## Summary
- allow the Connections tooltip to render outside its compact status card
- keep the existing connection summary layout unchanged

## Test plan
- [x] `npx eslint app/routes/_index/components/live-usenet-connections/live-usenet-connections.tsx --max-warnings 0`
- [x] `npx prettier --check app/routes/_index/components/live-usenet-connections/live-usenet-connections.tsx`
- [x] Confirmed no IDE diagnostics for the edited component