### PR TITLE
fix(ui): Mount button on Search page now adds releases

### DIFF
--- a/frontend/app/clients/backend-client.server.test.ts
+++ b/frontend/app/clients/backend-client.server.test.ts
@@ -213,6 +213,29 @@ describe("BackendClient", () => {
     expect(form.get("limit")).toBe("25");
   });
 
+  it("adds an NZB URL using the configured manual category", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          configItems: [{ configName: "api.manual-category", configValue: "movies" }],
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ nzo_ids: ["SABnzbd_nzo_1"] }));
+
+    await expect(
+      backendClient.addNzbFromUrl("https://indexer.example/nzb/123", "Example Release"),
+    ).resolves.toBe("SABnzbd_nzo_1");
+
+    const [url, init] = fetchMock.mock.calls[1]!;
+    expect(url).toBe(
+      "http://backend/api?mode=addurl&cat=movies&priority=0&pp=0&name=https%3A%2F%2Findexer.example%2Fnzb%2F123&nzbname=Example+Release",
+    );
+    expect(init).toEqual({
+      method: "POST",
+      headers: { "x-api-key": "test-api-key" },
+    });
+  });
+
   it("queries and mutates watchtower state", async () => {
     const data = { items: [], total: 0 };
     fetchMock

--- a/frontend/app/routes/search/route.component.test.tsx
+++ b/frontend/app/routes/search/route.component.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+import { createRoutesStub } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import Search from "./route";
+
+vi.mock("~/auth/authorization", () => ({
+  useIsReadOnly: () => false,
+}));
+
+afterEach(cleanup);
+
+const loaderData = {
+  q: "example",
+  data: {
+    indexers: [],
+    results: [
+      {
+        indexer: "Example Indexer",
+        title: "Example Release",
+        nzbUrl: "https://indexer.example/nzb/123",
+        size: 1024,
+        posted: null,
+      },
+    ],
+  },
+};
+
+describe("Search Mount", () => {
+  it("posts the selected NZB URL and name to the route action", async () => {
+    let submittedFormData: FormData | undefined;
+    const action = vi.fn(async ({ request }: { request: Request }) => {
+      submittedFormData = await request.formData();
+      return { ok: true, nzoId: "SABnzbd_nzo_1" };
+    });
+    const Stub = createRoutesStub([
+      {
+        path: "/search",
+        Component: () => (
+          <Search {...({ loaderData } as unknown as ComponentProps<typeof Search>)} />
+        ),
+        action,
+      },
+    ]);
+
+    render(<Stub initialEntries={["/search?q=example"]} />);
+
+    await userEvent.setup().click(screen.getByRole("button", { name: "Mount" }));
+
+    await waitFor(() => expect(action).toHaveBeenCalledTimes(1));
+    const [{ request }] = action.mock.calls[0]!;
+    expect(request.method).toBe("POST");
+    expect(Object.fromEntries(submittedFormData!)).toEqual({
+      nzbUrl: "https://indexer.example/nzb/123",
+      nzbName: "Example Release",
+    });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Mounted" })).toBeTruthy());
+  });
+});

--- a/frontend/app/routes/search/route.test.ts
+++ b/frontend/app/routes/search/route.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { action, shouldRevalidate } from "./route";
+
+const { addNzbFromUrlMock } = vi.hoisted(() => ({
+  addNzbFromUrlMock: vi.fn(),
+}));
+
+vi.mock("~/clients/backend-client.server", () => ({
+  backendClient: {
+    addNzbFromUrl: addNzbFromUrlMock,
+  },
+}));
+
+function mountRequest(nzbUrl?: string, nzbName?: string): Request {
+  const formData = new FormData();
+  if (nzbUrl !== undefined) formData.set("nzbUrl", nzbUrl);
+  if (nzbName !== undefined) formData.set("nzbName", nzbName);
+  return new Request("http://localhost/search", { method: "POST", body: formData });
+}
+
+describe("Search route action", () => {
+  beforeEach(() => {
+    addNzbFromUrlMock.mockReset();
+  });
+
+  it("adds the submitted NZB URL", async () => {
+    addNzbFromUrlMock.mockResolvedValueOnce("SABnzbd_nzo_1");
+
+    await expect(
+      action({ request: mountRequest("https://indexer.example/nzb/123", "Example Release") } as Parameters<
+        typeof action
+      >[0]),
+    ).resolves.toEqual({ ok: true, nzoId: "SABnzbd_nzo_1" });
+
+    expect(addNzbFromUrlMock).toHaveBeenCalledWith(
+      "https://indexer.example/nzb/123",
+      "Example Release",
+    );
+  });
+
+  it("rejects a submission without both NZB fields", async () => {
+    await expect(
+      action({ request: mountRequest("https://indexer.example/nzb/123") } as Parameters<typeof action>[0]),
+    ).resolves.toEqual({ ok: false, error: "Missing nzbUrl or nzbName" });
+
+    expect(addNzbFromUrlMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a backend add failure", async () => {
+    addNzbFromUrlMock.mockRejectedValueOnce(new Error("provider unavailable"));
+
+    await expect(
+      action({ request: mountRequest("https://indexer.example/nzb/123", "Example Release") } as Parameters<
+        typeof action
+      >[0]),
+    ).resolves.toEqual({ ok: false, error: "provider unavailable" });
+  });
+});
+
+describe("Search route revalidation", () => {
+  it("skips revalidation after mounting an NZB", () => {
+    const formData = new FormData();
+    formData.set("nzbUrl", "https://indexer.example/nzb/123");
+
+    expect(
+      shouldRevalidate({
+        formData,
+        formMethod: "POST",
+        defaultShouldRevalidate: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("revalidates normal search navigations", () => {
+    expect(
+      shouldRevalidate({
+        formData: new FormData(),
+        formMethod: "GET",
+        defaultShouldRevalidate: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/frontend/app/routes/search/route.test.ts
+++ b/frontend/app/routes/search/route.test.ts
@@ -27,9 +27,9 @@ describe("Search route action", () => {
     addNzbFromUrlMock.mockResolvedValueOnce("SABnzbd_nzo_1");
 
     await expect(
-      action({ request: mountRequest("https://indexer.example/nzb/123", "Example Release") } as Parameters<
-        typeof action
-      >[0]),
+      action({
+        request: mountRequest("https://indexer.example/nzb/123", "Example Release"),
+      } as Parameters<typeof action>[0]),
     ).resolves.toEqual({ ok: true, nzoId: "SABnzbd_nzo_1" });
 
     expect(addNzbFromUrlMock).toHaveBeenCalledWith(
@@ -40,7 +40,9 @@ describe("Search route action", () => {
 
   it("rejects a submission without both NZB fields", async () => {
     await expect(
-      action({ request: mountRequest("https://indexer.example/nzb/123") } as Parameters<typeof action>[0]),
+      action({ request: mountRequest("https://indexer.example/nzb/123") } as Parameters<
+        typeof action
+      >[0]),
     ).resolves.toEqual({ ok: false, error: "Missing nzbUrl or nzbName" });
 
     expect(addNzbFromUrlMock).not.toHaveBeenCalled();
@@ -50,9 +52,9 @@ describe("Search route action", () => {
     addNzbFromUrlMock.mockRejectedValueOnce(new Error("provider unavailable"));
 
     await expect(
-      action({ request: mountRequest("https://indexer.example/nzb/123", "Example Release") } as Parameters<
-        typeof action
-      >[0]),
+      action({
+        request: mountRequest("https://indexer.example/nzb/123", "Example Release"),
+      } as Parameters<typeof action>[0]),
     ).resolves.toEqual({ ok: false, error: "provider unavailable" });
   });
 });

--- a/frontend/app/routes/search/route.tsx
+++ b/frontend/app/routes/search/route.tsx
@@ -30,6 +30,19 @@ export async function action({ request }: Route.ActionArgs): Promise<SearchActio
   }
 }
 
+export function shouldRevalidate({
+  formData,
+  formMethod,
+  defaultShouldRevalidate,
+}: {
+  formData?: FormData;
+  formMethod?: string;
+  defaultShouldRevalidate: boolean;
+}) {
+  if (formMethod?.toUpperCase() === "POST" && formData?.get("nzbUrl")) return false;
+  return defaultShouldRevalidate;
+}
+
 export default function Search({ loaderData }: Route.ComponentProps) {
   const navigation = useNavigation();
   const isSearching = navigation.state === "loading" && navigation.location?.pathname === "/search";
@@ -84,8 +97,8 @@ export default function Search({ loaderData }: Route.ComponentProps) {
 
       {data && data.results.length > 0 && (
         <ul className="list rounded-box border border-base-content/10 bg-base-200">
-          {data.results.map((r, idx) => (
-            <ResultRow key={`${r.nzbUrl}-${idx}`} result={r} />
+          {data.results.map((r) => (
+            <ResultRow key={r.nzbUrl} result={r} />
           ))}
         </ul>
       )}
@@ -114,20 +127,21 @@ function ResultRow({
         </div>
       </div>
       {!isReadOnly && (
-        <fetcher.Form method="post">
-          <input type="hidden" name="nzbUrl" value={result.nzbUrl} />
-          <input type="hidden" name="nzbName" value={result.title} />
-          <Button
-            type="submit"
-            size="xsmall"
-            variant={done ? "success" : failed ? "danger" : "primary"}
-            disabled={submitting || done}
-            className="whitespace-nowrap"
-            title={fetcher.data && !fetcher.data.ok ? fetcher.data.error : undefined}
-          >
-            {submitting ? <Spinner size="sm" /> : done ? "Mounted" : failed ? "Failed" : "Mount"}
-          </Button>
-        </fetcher.Form>
+        <Button
+          size="xsmall"
+          variant={done ? "success" : failed ? "danger" : "primary"}
+          disabled={submitting || done}
+          className="whitespace-nowrap"
+          title={fetcher.data && !fetcher.data.ok ? fetcher.data.error : undefined}
+          onClick={() => {
+            void fetcher.submit(
+              { nzbUrl: result.nzbUrl, nzbName: result.title },
+              { method: "post" },
+            );
+          }}
+        >
+          {submitting ? <Spinner size="sm" /> : done ? "Mounted" : failed ? "Failed" : "Mount"}
+        </Button>
       )}
     </li>
   );

--- a/frontend/coverage-thresholds.json
+++ b/frontend/coverage-thresholds.json
@@ -7,7 +7,7 @@
   },
   "globs": {
     "app/clients/**": {
-      "lines": 83
+      "lines": 86
     },
     "app/auth/**": {
       "lines": 85


### PR DESCRIPTION
## Summary
- submit Search-page Mount actions through an explicit fetcher POST and retain the result without re-running indexers
- keep Mount state stable when results are re-rendered
- cover the route action, fetcher submission, revalidation guard, and SAB addurl request contract

Closes #1111

## Test plan
- [x] `cd frontend && npm test`
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run build`