### PR TITLE
fix(usenet): retain context for unclassified fetch failures

### DIFF
--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -1249,8 +1249,11 @@ public class MultiProviderNntpClient(
             var parameterName = argumentException?.ParamName;
             var segmentHash = HashSegmentId(segmentId);
             var innermostException = exception.GetBaseException();
+            var reason = RedactSegmentId(exception.Message, segmentId);
+            var innermostReason = RedactSegmentId(innermostException.Message, segmentId);
             var warningKey = string.Join(
                 '\n',
+                metricsKey,
                 exceptionType,
                 parameterName ?? "",
                 operationName);
@@ -1267,29 +1270,30 @@ public class MultiProviderNntpClient(
                     metricsKey,
                     operationName,
                     exceptionType,
-                    exception.Message,
+                    reason,
                     parameterName,
                     segmentHash,
                     retries,
                     innermostException.GetType().FullName,
-                    innermostException.Message))
+                    innermostReason))
             {
                 Log.Error(
-                    exception,
                     "Unclassified Usenet segment fetch failure stack. " +
                     "ProviderKey={ProviderKey} Operation={Operation} " +
                     "ExceptionType={ExceptionType} Reason={Reason} ParameterName={ParameterName} " +
                     "SegmentHash={SegmentHash} AttemptIndex={AttemptIndex} " +
-                    "InnermostExceptionType={InnermostExceptionType} InnermostReason={InnermostReason}",
+                    "InnermostExceptionType={InnermostExceptionType} InnermostReason={InnermostReason} " +
+                    "Stack={Stack}",
                     metricsKey,
                     operationName,
                     exceptionType,
-                    exception.Message,
+                    reason,
                     parameterName,
                     segmentHash,
                     retries,
                     innermostException.GetType().FullName,
-                    innermostException.Message);
+                    innermostReason,
+                    RedactSegmentId(exception.ToString(), segmentId));
             }
         }
         return status;
@@ -1301,6 +1305,16 @@ public class MultiProviderNntpClient(
         if (string.IsNullOrEmpty(value)) return null;
 
         return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value)))[..12];
+    }
+
+    private static string RedactSegmentId(string value, SegmentId? segmentId)
+    {
+        var segment = segmentId?.ToString();
+        return string.IsNullOrEmpty(segment)
+            ? value
+            : value
+                .Replace($"<{segment}>", "[segment]", StringComparison.Ordinal)
+                .Replace(segment, "[segment]", StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -1,6 +1,8 @@
 ﻿using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
+using System.Security.Cryptography;
+using System.Text;
 using NzbWebDAV.Clients.Usenet.Concurrency;
 using NzbWebDAV.Clients.Usenet.Connections;
 using NzbWebDAV.Clients.Usenet.Contexts;
@@ -504,7 +506,7 @@ public class MultiProviderNntpClient(
                 walk.NoteException(e);
                 var reason = ClassifyAndRecordFailure(
                     primaryProvider.MetricsKey, e, primaryStopwatch.ElapsedMilliseconds, 0,
-                    primaryTraceRange);
+                    primaryTraceRange, NntpOperation.PipelinedBody, segmentId);
                 (priorMisses ??= []).Add((primaryProvider.MetricsKey, reason));
                 lastException = ExceptionDispatchInfo.Capture(e);
             }
@@ -673,7 +675,8 @@ public class MultiProviderNntpClient(
                         walk.NoteException(e);
                         var reason = ClassifyAndRecordFailure(
                             provider.MetricsKey, e, stopwatch.ElapsedMilliseconds,
-                            priorMisses?.Count ?? 0, traceRange);
+                            priorMisses?.Count ?? 0, traceRange,
+                            NntpOperation.PipelinedBody, segmentId);
                         (priorMisses ??= []).Add((provider.MetricsKey, reason));
                         deferredCallback.Discard();
                         coordinator.CompleteAttempt();
@@ -904,7 +907,7 @@ public class MultiProviderNntpClient(
                 walk.NoteException(e);
                 var reason = ClassifyAndRecordFailure(
                     provider.MetricsKey, e, stopwatch.ElapsedMilliseconds, attemptIndex,
-                    traceRange);
+                    traceRange, operation, segmentId);
                 (priorMisses ??= []).Add((provider.MetricsKey, reason));
                 deferredCallback.Discard();
                 lastException = ExceptionDispatchInfo.Capture(e);
@@ -1054,7 +1057,7 @@ public class MultiProviderNntpClient(
                 walk.NoteException(e);
                 var reason = ClassifyAndRecordFailure(
                     provider.MetricsKey, e, stopwatch.ElapsedMilliseconds, attemptIndex,
-                    traceRange);
+                    traceRange, operation, articleId);
                 (priorMisses ??= new()).Add((provider.MetricsKey, reason));
                 lastException = ExceptionDispatchInfo.Capture(e);
                 lastOutcomeWasException = ClassifyException(e) != SegmentFetch.FetchStatus.Missing;
@@ -1229,29 +1232,75 @@ public class MultiProviderNntpClient(
 
     /// <summary>
     /// Classifies <paramref name="exception"/>, records the SegmentFetch row, and for residual
-    /// <see cref="SegmentFetch.FetchStatus.Other"/> logs the concrete exception type so support
-    /// packs stay diagnosable without a schema change.
+    /// <see cref="SegmentFetch.FetchStatus.Other"/> records sufficient request context for a
+    /// warning-level support pack to identify the unexpected throw site without exposing article IDs.
     /// </summary>
     private SegmentFetch.FetchStatus ClassifyAndRecordFailure(
         string metricsKey, Exception exception, long durationMs, int retries,
-        StreamTraceRangeContext? traceRange)
+        StreamTraceRangeContext? traceRange, NntpOperation operation, SegmentId? segmentId)
     {
         var status = ClassifyException(exception);
         RecordFetch(metricsKey, status, durationMs, retries, traceRange);
         if (status == SegmentFetch.FetchStatus.Other)
         {
-            // Keyed by exception type so a storm of the same novel failure logs once per
-            // minute and still names the type in support packs; the stack stays at Debug.
-            ThrottledSegmentWarning.Write(
-                exception.GetType().FullName ?? "unknown",
-                "Unclassified Usenet segment fetch failure. Host={Host} ExceptionType={ExceptionType}",
-                metricsKey, exception.GetType().FullName);
-            Log.Debug(
-                exception,
-                "Unclassified Usenet segment fetch failure stack. Host={Host}",
-                metricsKey);
+            exception.TryGetCausingException<ArgumentException>(out var argumentException);
+            var exceptionType = exception.GetType().FullName ?? "unknown";
+            var operationName = operation.ToString().ToLowerInvariant();
+            var parameterName = argumentException?.ParamName;
+            var segmentHash = HashSegmentId(segmentId);
+            var innermostException = exception.GetBaseException();
+            var warningKey = string.Join(
+                '\n',
+                exceptionType,
+                parameterName ?? "",
+                operationName);
+
+            // Coalesce only identical unexpected failures. The first event carries all the
+            // request context and the stack at Error so warning-level support packs retain it.
+            if (ThrottledSegmentWarning.Write(
+                    warningKey,
+                    "Unclassified Usenet segment fetch failure. " +
+                    "ProviderKey={ProviderKey} Operation={Operation} " +
+                    "ExceptionType={ExceptionType} Reason={Reason} ParameterName={ParameterName} " +
+                    "SegmentHash={SegmentHash} AttemptIndex={AttemptIndex} " +
+                    "InnermostExceptionType={InnermostExceptionType} InnermostReason={InnermostReason}",
+                    metricsKey,
+                    operationName,
+                    exceptionType,
+                    exception.Message,
+                    parameterName,
+                    segmentHash,
+                    retries,
+                    innermostException.GetType().FullName,
+                    innermostException.Message))
+            {
+                Log.Error(
+                    exception,
+                    "Unclassified Usenet segment fetch failure stack. " +
+                    "ProviderKey={ProviderKey} Operation={Operation} " +
+                    "ExceptionType={ExceptionType} Reason={Reason} ParameterName={ParameterName} " +
+                    "SegmentHash={SegmentHash} AttemptIndex={AttemptIndex} " +
+                    "InnermostExceptionType={InnermostExceptionType} InnermostReason={InnermostReason}",
+                    metricsKey,
+                    operationName,
+                    exceptionType,
+                    exception.Message,
+                    parameterName,
+                    segmentHash,
+                    retries,
+                    innermostException.GetType().FullName,
+                    innermostException.Message);
+            }
         }
         return status;
+    }
+
+    private static string? HashSegmentId(SegmentId? segmentId)
+    {
+        var value = segmentId?.ToString();
+        if (string.IsNullOrEmpty(value)) return null;
+
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value)))[..12];
     }
 
     /// <summary>

--- a/backend/Streams/ThrottledSegmentWarning.cs
+++ b/backend/Streams/ThrottledSegmentWarning.cs
@@ -16,7 +16,7 @@ internal static class ThrottledSegmentWarning
     private static readonly TimeSpan CleanupThreshold = TimeSpan.FromMinutes(5);
     private static int _callCount;
 
-    public static void Write(
+    public static bool Write(
         string key,
         string messageTemplate,
         params object?[] propertyValues)
@@ -42,7 +42,7 @@ internal static class ThrottledSegmentWarning
             }
         }
 
-        if (!shouldLog) return;
+        if (!shouldLog) return false;
 
         if (suppressed > 0)
         {
@@ -56,6 +56,8 @@ internal static class ThrottledSegmentWarning
 
         if (Interlocked.Increment(ref _callCount) % 256 == 0)
             Cleanup(now);
+
+        return true;
     }
 
     private static void Cleanup(DateTime now)

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -9,12 +9,17 @@ using NzbWebDAV.Exceptions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Services.StreamTrace;
+using NzbWebDAV.Tests.TestUtils;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
 using UsenetSharp.Exceptions;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Tests.Clients.Usenet;
 
+[Collection(nameof(GlobalLoggerCollection))]
 public class MultiProviderNntpClientTests
 {
     [Fact]
@@ -351,6 +356,137 @@ public class MultiProviderNntpClientTests
         var response = await client.StatAsync("segment", CancellationToken.None);
         Assert.True(response.ArticleExists);
         Assert.Equal(0, writer.Stats.QueuedFetches);
+    }
+
+    [Fact]
+    public async Task StatAsync_ArgumentException_LogsDiagnosticContextAndFallsBack()
+    {
+        const string segmentId = "<diagnostic-context@example>";
+        const string parameterName = "segmentId-context";
+        var events = await CaptureLogsAsync(async () =>
+        {
+            var primary = new ScriptedNntpClient
+            {
+                BatchResponseCode = 222,
+                SingularException = _ => new ArgumentException("Segment ID was invalid.", parameterName),
+            };
+            var backup = new ScriptedNntpClient
+            {
+                BatchResponseCode = 222,
+                SingularResponseCode = (int)UsenetResponseType.ArticleExists,
+            };
+            using var client = new MultiProviderNntpClient(
+            [
+                CreateProvider(primary, host: "primary.example"),
+                CreateProvider(backup, host: "backup.example", providerType: ProviderType.BackupOnly),
+            ]);
+
+            var response = await client.StatAsync(segmentId, CancellationToken.None);
+            Assert.True(response.ArticleExists);
+        });
+
+        var warning = Assert.Single(events, IsUnclassifiedFetchWarning);
+        Assert.Equal("primary.example", PropertyText(warning, "ProviderKey"));
+        Assert.Equal("stat", PropertyText(warning, "Operation"));
+        Assert.Equal(typeof(ArgumentException).FullName, PropertyText(warning, "ExceptionType"));
+        Assert.Equal("Segment ID was invalid. (Parameter 'segmentId-context')", PropertyText(warning, "Reason"));
+        Assert.Equal(parameterName, PropertyText(warning, "ParameterName"));
+        Assert.Equal("0", PropertyText(warning, "AttemptIndex"));
+        Assert.Matches("^[0-9A-F]{12}$", PropertyText(warning, "SegmentHash"));
+        Assert.Equal(typeof(ArgumentException).FullName, PropertyText(warning, "InnermostExceptionType"));
+        Assert.Equal(PropertyText(warning, "Reason"), PropertyText(warning, "InnermostReason"));
+
+        var stack = Assert.Single(events, e =>
+            e.Level == LogEventLevel.Error &&
+            e.MessageTemplate.Text.StartsWith("Unclassified Usenet segment fetch failure stack", StringComparison.Ordinal));
+        Assert.NotNull(stack.Exception);
+        Assert.Equal("stat", PropertyText(stack, "Operation"));
+    }
+
+    [Fact]
+    public async Task StatAsync_RepeatedUnclassifiedFailure_IsThrottled()
+    {
+        const string parameterName = "segmentId-repeat";
+        var events = await CaptureLogsAsync(async () =>
+        {
+            var primary = new ScriptedNntpClient
+            {
+                BatchResponseCode = 222,
+                SingularException = _ => new ArgumentException("Repeated failure.", parameterName),
+            };
+            var backup = new ScriptedNntpClient
+            {
+                BatchResponseCode = 222,
+                SingularResponseCode = (int)UsenetResponseType.ArticleExists,
+            };
+            using var client = new MultiProviderNntpClient(
+            [
+                CreateProvider(primary, host: "primary.example"),
+                CreateProvider(backup, host: "backup.example", providerType: ProviderType.BackupOnly),
+            ]);
+
+            await client.StatAsync("<repeat-one@example>", CancellationToken.None);
+            await client.StatAsync("<repeat-two@example>", CancellationToken.None);
+        });
+
+        Assert.Single(events, IsUnclassifiedFetchWarning);
+        Assert.Single(events, e =>
+            e.Level == LogEventLevel.Error &&
+            e.MessageTemplate.Text.StartsWith("Unclassified Usenet segment fetch failure stack", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task UnclassifiedFailures_WithDifferentOperationsOrParameters_AreNotCoalesced()
+    {
+        var events = await CaptureLogsAsync(async () =>
+        {
+            await RunFailingRequestAsync("segmentId-operation", body: false);
+            await RunFailingRequestAsync("segmentId-operation", body: true);
+            await RunFailingRequestAsync("otherParameter", body: false);
+        });
+
+        var warnings = events.Where(IsUnclassifiedFetchWarning).ToArray();
+        Assert.Equal(3, warnings.Length);
+        Assert.Contains(warnings, e =>
+            PropertyText(e, "Operation") == "stat" &&
+            PropertyText(e, "ParameterName") == "segmentId-operation");
+        Assert.Contains(warnings, e =>
+            PropertyText(e, "Operation") == "body" &&
+            PropertyText(e, "ParameterName") == "segmentId-operation");
+        Assert.Contains(warnings, e =>
+            PropertyText(e, "Operation") == "stat" &&
+            PropertyText(e, "ParameterName") == "otherParameter");
+
+        static async Task RunFailingRequestAsync(string parameterName, bool body)
+        {
+            var primary = new ScriptedNntpClient
+            {
+                BatchResponseCode = 222,
+                SingularException = _ => new ArgumentException("Failure for throttling key.", parameterName),
+            };
+            var backup = new ScriptedNntpClient
+            {
+                BatchResponseCode = 222,
+                SingularResponseCode = body
+                    ? (int)UsenetResponseType.ArticleRetrievedBodyFollows
+                    : (int)UsenetResponseType.ArticleExists,
+            };
+            using var client = new MultiProviderNntpClient(
+            [
+                CreateProvider(primary, host: "primary.example"),
+                CreateProvider(backup, host: "backup.example", providerType: ProviderType.BackupOnly),
+            ]);
+
+            if (body)
+            {
+                var response = await client.DecodedBodyAsync("<operation@example>", CancellationToken.None);
+                await response.Stream!.DisposeAsync();
+            }
+            else
+            {
+                await client.StatAsync("<parameter@example>", CancellationToken.None);
+            }
+        }
     }
 
     [Fact]
@@ -1926,6 +2062,58 @@ public class MultiProviderNntpClientTests
         var aggregate = new AggregateException("one or more errors", inner);
         var status = MultiProviderNntpClient.ClassifyException(aggregate);
         Assert.Equal(SegmentFetch.FetchStatus.Corrupt, status);
+    }
+
+    private static bool IsUnclassifiedFetchWarning(LogEvent logEvent) =>
+        logEvent.Level == LogEventLevel.Warning
+        && logEvent.MessageTemplate.Text.StartsWith(
+            "Unclassified Usenet segment fetch failure.", StringComparison.Ordinal);
+
+    private static string PropertyText(LogEvent logEvent, string name)
+    {
+        if (!logEvent.Properties.TryGetValue(name, out var value))
+            return "";
+        return value is ScalarValue { Value: { } raw }
+            ? raw.ToString() ?? ""
+            : value.ToString();
+    }
+
+    private static async Task<IReadOnlyList<LogEvent>> CaptureLogsAsync(Func<Task> act)
+    {
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        try
+        {
+            await act().ConfigureAwait(false);
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+
+        return sink.Events;
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events) return _events.ToArray();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events) _events.Add(logEvent);
+        }
     }
 
     internal static MultiConnectionNntpClient CreateProvider(

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -368,7 +368,8 @@ public class MultiProviderNntpClientTests
             var primary = new ScriptedNntpClient
             {
                 BatchResponseCode = 222,
-                SingularException = _ => new ArgumentException("Segment ID was invalid.", parameterName),
+                SingularException = _ => new ArgumentException(
+                    $"Segment {segmentId} was invalid.", parameterName),
             };
             var backup = new ScriptedNntpClient
             {
@@ -389,7 +390,7 @@ public class MultiProviderNntpClientTests
         Assert.Equal("primary.example", PropertyText(warning, "ProviderKey"));
         Assert.Equal("stat", PropertyText(warning, "Operation"));
         Assert.Equal(typeof(ArgumentException).FullName, PropertyText(warning, "ExceptionType"));
-        Assert.Equal("Segment ID was invalid. (Parameter 'segmentId-context')", PropertyText(warning, "Reason"));
+        Assert.Equal("Segment [segment] was invalid. (Parameter 'segmentId-context')", PropertyText(warning, "Reason"));
         Assert.Equal(parameterName, PropertyText(warning, "ParameterName"));
         Assert.Equal("0", PropertyText(warning, "AttemptIndex"));
         Assert.Matches("^[0-9A-F]{12}$", PropertyText(warning, "SegmentHash"));
@@ -399,8 +400,10 @@ public class MultiProviderNntpClientTests
         var stack = Assert.Single(events, e =>
             e.Level == LogEventLevel.Error &&
             e.MessageTemplate.Text.StartsWith("Unclassified Usenet segment fetch failure stack", StringComparison.Ordinal));
-        Assert.NotNull(stack.Exception);
+        Assert.Null(stack.Exception);
         Assert.Equal("stat", PropertyText(stack, "Operation"));
+        Assert.Contains(typeof(ArgumentException).FullName!, PropertyText(stack, "Stack"), StringComparison.Ordinal);
+        Assert.DoesNotContain(segmentId, PropertyText(stack, "Stack"), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -443,10 +446,14 @@ public class MultiProviderNntpClientTests
             await RunFailingRequestAsync("segmentId-operation", body: false);
             await RunFailingRequestAsync("segmentId-operation", body: true);
             await RunFailingRequestAsync("otherParameter", body: false);
+            await RunFailingRequestAsync(
+                "segmentId-operation",
+                body: false,
+                providerKey: "alternate-primary.example");
         });
 
         var warnings = events.Where(IsUnclassifiedFetchWarning).ToArray();
-        Assert.Equal(3, warnings.Length);
+        Assert.Equal(4, warnings.Length);
         Assert.Contains(warnings, e =>
             PropertyText(e, "Operation") == "stat" &&
             PropertyText(e, "ParameterName") == "segmentId-operation");
@@ -456,8 +463,15 @@ public class MultiProviderNntpClientTests
         Assert.Contains(warnings, e =>
             PropertyText(e, "Operation") == "stat" &&
             PropertyText(e, "ParameterName") == "otherParameter");
+        Assert.Contains(warnings, e =>
+            PropertyText(e, "ProviderKey") == "alternate-primary.example" &&
+            PropertyText(e, "Operation") == "stat" &&
+            PropertyText(e, "ParameterName") == "segmentId-operation");
 
-        static async Task RunFailingRequestAsync(string parameterName, bool body)
+        static async Task RunFailingRequestAsync(
+            string parameterName,
+            bool body,
+            string providerKey = "primary.example")
         {
             var primary = new ScriptedNntpClient
             {
@@ -473,7 +487,7 @@ public class MultiProviderNntpClientTests
             };
             using var client = new MultiProviderNntpClient(
             [
-                CreateProvider(primary, host: "primary.example"),
+                CreateProvider(primary, host: providerKey),
                 CreateProvider(backup, host: "backup.example", providerType: ProviderType.BackupOnly),
             ]);
 
@@ -2082,10 +2096,11 @@ public class MultiProviderNntpClientTests
     {
         var sink = new CollectingSink();
         var previous = Log.Logger;
-        Log.Logger = new LoggerConfiguration()
+        var logger = new LoggerConfiguration()
             .MinimumLevel.Debug()
             .WriteTo.Sink(sink)
             .CreateLogger();
+        Log.Logger = logger;
         try
         {
             await act().ConfigureAwait(false);
@@ -2093,6 +2108,7 @@ public class MultiProviderNntpClientTests
         finally
         {
             Log.Logger = previous;
+            logger.Dispose();
         }
 
         return sink.Events;


### PR DESCRIPTION
## Summary
- include provider, operation, a privacy-preserving segment hash, attempt, exception reason, parameter, and inner-cause context in unclassified Usenet fetch diagnostics
- emit one throttled Error-level stack per unexpected failure key so warning-level support packs keep the stack
- cover STAT fallback diagnostics and operation/parameter-aware throttling

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter \"FullyQualifiedName~MultiProviderNntpClientTests\"`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`