### PR TITLE
fix(ui): remove scrollbar from header connection status

### DIFF
--- a/frontend/app/routes/_index/components/live-usenet-connections/live-usenet-connections.tsx
+++ b/frontend/app/routes/_index/components/live-usenet-connections/live-usenet-connections.tsx
@@ -73,7 +73,7 @@ export function LiveUsenetConnections({ hasUsenetProviders }: LiveUsenetConnecti
 
   return (
     <div
-      className="stats hidden h-10 overflow-hidden border border-base-content/10 bg-base-200 sm:inline-grid"
+      className="stats hidden h-10 overflow-visible border border-base-content/10 bg-base-200 sm:inline-grid"
       aria-label="Usenet connections"
     >
       <div className="stat flex items-center gap-3 px-3 py-1">

--- a/frontend/app/routes/_index/components/live-usenet-connections/live-usenet-connections.tsx
+++ b/frontend/app/routes/_index/components/live-usenet-connections/live-usenet-connections.tsx
@@ -73,7 +73,7 @@ export function LiveUsenetConnections({ hasUsenetProviders }: LiveUsenetConnecti
 
   return (
     <div
-      className="stats hidden h-10 border border-base-content/10 bg-base-200 sm:inline-grid"
+      className="stats hidden h-10 overflow-hidden border border-base-content/10 bg-base-200 sm:inline-grid"
       aria-label="Usenet connections"
     >
       <div className="stat flex items-center gap-3 px-3 py-1">


### PR DESCRIPTION
## Summary
- override daisyUI's scrollable stats overflow so the compact header metric has no scrollbar
- keep overflow visible so the warm-pool tooltip can render outside the connection card

## Test plan
- [x] Run `npm run typecheck`
- [x] Run `npm run build`
- [x] Compare rendered `auto`, `hidden`, and `visible` overflow behavior
- [x] Verify `visible` removes the scrollbar without clipping the tooltip