### PR TITLE
fix(nntp): recover faster from shared Usenet provider failures

### DIFF
--- a/backend/Clients/Usenet/Connections/CorrelatedTripDetector.cs
+++ b/backend/Clients/Usenet/Connections/CorrelatedTripDetector.cs
@@ -14,13 +14,14 @@ namespace NzbWebDAV.Clients.Usenet.Connections;
 /// rebuild creates a new detector for the new provider set; any in-flight trip state from
 /// the old generation is intentionally lost. This means a trip on provider A under the old
 /// client followed by a trip on provider B under the new client will not correlate — an
-/// acceptable gap since config changes are rare and the correlation window is short (10s).
+/// acceptable gap since config changes are rare and the correlation window is short.
 /// </para>
 /// </summary>
 public sealed class CorrelatedTripDetector
 {
-    private static readonly TimeSpan DefaultWindow = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan DefaultWindow = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan DefaultThrottle = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan DefaultEpisodeIdleTimeout = TimeSpan.FromMinutes(5);
 
     private readonly object _lock = new();
     private readonly Dictionary<string, string> _providers = new(StringComparer.Ordinal); // key -> host
@@ -28,12 +29,19 @@ public sealed class CorrelatedTripDetector
     private readonly Dictionary<string, long> _openSinceMs = new(StringComparer.Ordinal);
     private readonly TimeSpan _window;
     private readonly TimeSpan _throttle;
+    private readonly TimeSpan _episodeIdleTimeout;
     private long? _lastWarningAtMs;
+    private bool _correlatedEpisodeActive;
+    private long _correlatedEpisodeLastActivityAtMs;
 
-    public CorrelatedTripDetector(TimeSpan? window = null, TimeSpan? throttle = null)
+    public CorrelatedTripDetector(
+        TimeSpan? window = null,
+        TimeSpan? throttle = null,
+        TimeSpan? episodeIdleTimeout = null)
     {
         _window = window ?? DefaultWindow;
         _throttle = throttle ?? DefaultThrottle;
+        _episodeIdleTimeout = episodeIdleTimeout ?? DefaultEpisodeIdleTimeout;
     }
 
     /// <summary>Wall clock, injectable for tests.</summary>
@@ -63,6 +71,8 @@ public sealed class CorrelatedTripDetector
             _providers.Remove(providerKey);
             _onCorrelatedTrip.Remove(providerKey);
             _openSinceMs.Remove(providerKey);
+            if (_openSinceMs.Count == 0)
+                _correlatedEpisodeActive = false;
         }
     }
 
@@ -74,29 +84,52 @@ public sealed class CorrelatedTripDetector
         var shouldWarn = false;
         lock (_lock)
         {
+            var now = Clock();
+            ExpireCorrelatedEpisodeIfInactive(now);
+
             if (transition.State == ProviderCircuitTransitionState.Open)
                 _openSinceMs[providerKey] = transition.AtUnixMilliseconds;
             else
                 _openSinceMs.Remove(providerKey);
 
-            if (transition.State != ProviderCircuitTransitionState.Open) return;
-            if (_providers.Count < 2) return;
-            if (!_providers.Keys.All(_openSinceMs.ContainsKey)) return;
+            if (_correlatedEpisodeActive)
+                _correlatedEpisodeLastActivityAtMs = now;
 
-            // All providers are open; only correlated if the trips cluster in time.
-            var opens = _providers.Keys.Select(p => _openSinceMs[p]).ToList();
-            if (opens.Max() - opens.Min() > (long)_window.TotalMilliseconds) return;
-
-            callbacks = _onCorrelatedTrip.Values.ToList();
-            providers = string.Join(", ", _providers.Values);
-            providerCount = _providers.Count;
-            var now = Clock();
-            if (_lastWarningAtMs is not { } lastWarning
-                || now - lastWarning >= (long)_throttle.TotalMilliseconds)
+            if (_openSinceMs.Count == 0)
             {
-                _lastWarningAtMs = now;
-                shouldWarn = true;
+                _correlatedEpisodeActive = false;
+                return;
             }
+
+            if (transition.State != ProviderCircuitTransitionState.Open ||
+                _providers.Count < 2 ||
+                !_providers.Keys.All(_openSinceMs.ContainsKey))
+            {
+                return;
+            }
+
+            var opens = _providers.Keys.Select(p => _openSinceMs[p]).ToList();
+            var clustered = opens.Max() - opens.Min() <= (long)_window.TotalMilliseconds;
+            if (clustered)
+            {
+                _correlatedEpisodeActive = true;
+                _correlatedEpisodeLastActivityAtMs = now;
+                providers = string.Join(", ", _providers.Values);
+                providerCount = _providers.Count;
+                if (_lastWarningAtMs is not { } lastWarning
+                    || now - lastWarning >= (long)_throttle.TotalMilliseconds)
+                {
+                    _lastWarningAtMs = now;
+                    shouldWarn = true;
+                }
+            }
+
+            // The original clustered all-open event starts the episode. While it is
+            // active, later re-trips are still part of the same shared-path outage even
+            // when their independent cooldowns have drifted apart.
+            if (!_correlatedEpisodeActive)
+                return;
+            callbacks = _onCorrelatedTrip.Values.ToList();
         }
 
         if (shouldWarn)
@@ -120,5 +153,16 @@ public sealed class CorrelatedTripDetector
                 Log.Warning(exception, "Correlated NNTP provider trip callback failed");
             }
         }
+    }
+
+    private void ExpireCorrelatedEpisodeIfInactive(long now)
+    {
+        if (!_correlatedEpisodeActive ||
+            now - _correlatedEpisodeLastActivityAtMs < (long)_episodeIdleTimeout.TotalMilliseconds)
+        {
+            return;
+        }
+
+        _correlatedEpisodeActive = false;
     }
 }

--- a/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
+++ b/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
@@ -238,7 +238,9 @@ public class ProviderCircuitBreaker
     /// connect is enough to trip because concurrent retries would otherwise consume the
     /// provider's connection capacity while it is unreachable.
     /// </summary>
-    public void RecordConnectionFailure(string? reason = null)
+    public void RecordConnectionFailure(
+        string? reason = null,
+        ProviderCircuitPoolDiagnostics? pool = null)
     {
         lock (_lock)
         {
@@ -259,11 +261,13 @@ public class ProviderCircuitBreaker
                 : "connection failure";
             Trip(now, reason is null
                 ? failureReason
-                : $"{failureReason} ({reason})");
+                : $"{failureReason} ({reason})", pool);
         }
     }
 
-    public void RecordFailure(string? reason = null)
+    public void RecordFailure(
+        string? reason = null,
+        ProviderCircuitPoolDiagnostics? pool = null)
     {
         lock (_lock)
         {
@@ -285,7 +289,7 @@ public class ProviderCircuitBreaker
                 Interlocked.Increment(ref _failureCount);
                 Trip(now, reason is null
                     ? "half-open failure"
-                    : $"half-open failure ({reason})");
+                    : $"half-open failure ({reason})", pool);
                 return;
             }
 
@@ -314,21 +318,31 @@ public class ProviderCircuitBreaker
                 var tripReason = reason is null
                     ? $"{failures} failures in {_window.Count}-sample window"
                     : $"{failures} failures in {_window.Count}-sample window ({reason})";
-                Trip(now, tripReason);
+                Trip(now, tripReason, pool);
             }
         }
     }
 
-    private void Trip(long nowMs, string reason)
+    private void Trip(long nowMs, string reason, ProviderCircuitPoolDiagnostics? pool = null)
     {
         var appliedCooldown = _currentCooldown;
         _lastFailureReason = reason;
         Interlocked.Increment(ref _tripCount);
         _trippedUntilMs = nowMs + (long)appliedCooldown.TotalMilliseconds;
-        Log.Warning(
-            "Provider {Provider} tripped ({Reason}). Skipping for {Cooldown}s.",
-            _providerName, reason, appliedCooldown.TotalSeconds);
-        NotifyTransition(ProviderCircuitTransitionState.Open, appliedCooldown);
+        if (pool is null)
+        {
+            Log.Warning(
+                "Provider {Provider} tripped ({Reason}). Skipping for {Cooldown}s.",
+                _providerName, reason, appliedCooldown.TotalSeconds);
+        }
+        else
+        {
+            Log.Warning(
+                "Provider {Provider} tripped ({Reason}). Pool live={LiveConnections}, idle={IdleConnections}, active={ActiveConnections}. Skipping for {Cooldown}s.",
+                _providerName, reason, pool.LiveConnections, pool.IdleConnections,
+                pool.ActiveConnections, appliedCooldown.TotalSeconds);
+        }
+        NotifyTransition(ProviderCircuitTransitionState.Open, appliedCooldown, reason, pool);
 
         _window.Clear();
         _failureBurstStartedAtMs = long.MinValue;
@@ -338,7 +352,9 @@ public class ProviderCircuitBreaker
 
     private void NotifyTransition(
         ProviderCircuitTransitionState state,
-        TimeSpan? cooldown)
+        TimeSpan? cooldown,
+        string? failureReason = null,
+        ProviderCircuitPoolDiagnostics? pool = null)
     {
         if (_onTransition is null)
             return;
@@ -348,7 +364,9 @@ public class ProviderCircuitBreaker
             _onTransition(new ProviderCircuitTransition(
                 state,
                 DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                cooldown));
+                cooldown,
+                failureReason,
+                pool));
         }
         catch (Exception exception) when (exception is not OutOfMemoryException)
         {

--- a/backend/Clients/Usenet/Models/ProviderCircuitTransition.cs
+++ b/backend/Clients/Usenet/Models/ProviderCircuitTransition.cs
@@ -6,7 +6,15 @@ public enum ProviderCircuitTransitionState
     Closed,
 }
 
+/// <summary>Connection-pool state observed when a circuit transition was recorded.</summary>
+public sealed record ProviderCircuitPoolDiagnostics(
+    int LiveConnections,
+    int IdleConnections,
+    int ActiveConnections);
+
 public sealed record ProviderCircuitTransition(
     ProviderCircuitTransitionState State,
     long AtUnixMilliseconds,
-    TimeSpan? Cooldown);
+    TimeSpan? Cooldown,
+    string? FailureReason = null,
+    ProviderCircuitPoolDiagnostics? Pool = null);

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -294,12 +294,12 @@ public class MultiConnectionNntpClient(
                             // client cancellation as provider health failure.
                             LogException(connectionLock.Replace);
                             if (!ct.IsCancellationRequested)
-                                circuitBreaker.RecordFailure(failureReason is null
+                                RecordProviderFailure(failureReason is null
                                     ? $"pipeline-callback-{result}"
                                     : $"pipeline-callback-{result} ({failureReason})");
                             break;
                         default:
-                            circuitBreaker.RecordFailure(failureReason is null
+                            RecordProviderFailure(failureReason is null
                                 ? $"pipeline-callback-{result}"
                                 : $"pipeline-callback-{result} ({failureReason})");
                             LogException(connectionLock.Replace);
@@ -332,7 +332,7 @@ public class MultiConnectionNntpClient(
                     continue;
                 }
 
-                circuitBreaker.RecordFailure("streaming-timeout-pipelined-BODY");
+                RecordProviderFailure("streaming-timeout-pipelined-BODY");
                 Log.Warning(
                     "Streaming timeout executing pipelined nntp BODY commands for provider {Provider} after {Timeout}s. No retries left.",
                     Host, streamingTimeout.PerSegmentTimeout.TotalSeconds);
@@ -374,18 +374,11 @@ public class MultiConnectionNntpClient(
                 var wasReused = connectionLock?.WasReused ?? false;
                 if (connectionLock is null)
                 {
-                    // The failure happened while establishing a connection. Trip
-                    // immediately (mirrors RunWithConnection) so an unreachable
-                    // provider hit through streaming fails over without burning
-                    // connect timeouts until the sampling window fills. A client
-                    // abort mid-connect can surface as an IOException rather than
-                    // a cancellation exception, so it is filtered here too.
-                    if (!ct.IsCancellationRequested)
-                        circuitBreaker.RecordConnectionFailure($"pipeline-get-connection-{e.GetType().Name}");
+                    RecordConnectionAcquisitionFailure(e, "pipeline-get-connection", ct);
                 }
                 else if (!wasReused)
                 {
-                    circuitBreaker.RecordFailure($"pipeline-setup-{e.GetType().Name}");
+                    RecordProviderFailure($"pipeline-setup-{e.GetType().Name}");
                 }
                 LogException(() => connectionLock?.Replace());
                 LogException(() => connectionLock?.Dispose());
@@ -475,11 +468,7 @@ public class MultiConnectionNntpClient(
             }
             catch (Exception e) when (e is not OutOfMemoryException)
             {
-                // A client abort (seek/stop) mid-connect can surface as an
-                // IOException/SocketException rather than a cancellation
-                // exception; it must not trip a healthy provider.
-                if (!ct.IsCancellationRequested)
-                    circuitBreaker.RecordConnectionFailure($"get-connection-{e.GetType().Name}");
+                RecordConnectionAcquisitionFailure(e, "get-connection", ct);
                 LogException(() => connectionLock?.Replace());
                 LogException(() => connectionLock?.Dispose());
                 if (retryCount > 0)
@@ -552,7 +541,7 @@ public class MultiConnectionNntpClient(
                 // Exhausted the streaming-timeout retry budget — count toward the
                 // breaker once per segment (not per attempt) so chronically-slow
                 // providers still trip without over-counting a single segment.
-                circuitBreaker.RecordFailure($"streaming-timeout-{name}");
+                RecordProviderFailure($"streaming-timeout-{name}");
                 Log.Warning(
                     "Streaming timeout executing nntp {Command} command for provider {Provider} after {Timeout}s. No retries left.",
                     name, Host, streamingTimeout.PerSegmentTimeout.TotalSeconds);
@@ -585,7 +574,7 @@ public class MultiConnectionNntpClient(
                 // on the wire) and propagate so the outer provider loop moves on.
                 IncrementTimeoutCount(Host);
                 deferredCallback.Discard();
-                circuitBreaker.RecordFailure($"read-timeout-{name}");
+                RecordProviderFailure($"read-timeout-{name}");
                 LogException(() => connectionLock?.Replace());
                 LogException(() => connectionLock?.Dispose());
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
@@ -598,7 +587,7 @@ public class MultiConnectionNntpClient(
                 // STAT, HEAD, and DATE failures do not feed a closed circuit because their
                 // successes intentionally do not reset its BODY failure sampling window.
                 if (!wasReused && IsBodyCommand(name))
-                    circuitBreaker.RecordFailure($"cmd-setup-{name}-{e.GetType().Name}");
+                    RecordProviderFailure($"cmd-setup-{name}-{e.GetType().Name}");
                 LogException(() => connectionLock?.Replace());
                 LogException(() => connectionLock?.Dispose());
 
@@ -621,7 +610,7 @@ public class MultiConnectionNntpClient(
                 // recovery probe. Once its retries are exhausted, release the probe slot
                 // and reopen the circuit instead of leaving it claimed until timeout.
                 if (!IsBodyCommand(name) && circuitBreaker.IsLatched)
-                    circuitBreaker.RecordFailure($"cmd-{name}-{e.GetType().Name}");
+                    RecordProviderFailure($"cmd-{name}-{e.GetType().Name}");
 
                 e.LogWarningKnownOrStack(
                     "Error executing nntp {Command} command for provider {Provider}.", name, Host);
@@ -670,7 +659,7 @@ public class MultiConnectionNntpClient(
                         LogException(() => connectionLock?.Replace());
                         // Client abort (seek) must not trip the provider circuit breaker.
                         if (!ct.IsCancellationRequested)
-                            circuitBreaker.RecordFailure(failureReason is null
+                            RecordProviderFailure(failureReason is null
                                 ? $"body-callback-{name}-NotRetrieved"
                                 : $"body-callback-{name}-NotRetrieved ({failureReason})");
                     }
@@ -813,7 +802,7 @@ public class MultiConnectionNntpClient(
                 catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
 #pragma warning restore CA2016
                 {
-                    circuitBreaker.RecordFailure($"pipelined-enum-{e.GetType().Name}");
+                    RecordProviderFailure($"pipelined-enum-{e.GetType().Name}");
                     connectionLock.Replace();
                     throw;
                 }
@@ -889,13 +878,47 @@ public class MultiConnectionNntpClient(
         catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
 #pragma warning restore CA2016
         {
-            // A client abort mid-connect can surface as an IOException rather than
-            // a cancellation exception; it must not trip a healthy provider.
-            if (!ct.IsCancellationRequested)
-                circuitBreaker.RecordConnectionFailure($"pipelined-get-connection-{e.GetType().Name}");
+            RecordConnectionAcquisitionFailure(e, "pipelined-get-connection", ct);
             throw;
         }
     }
+
+    /// <summary>
+    /// Records a failed pool expansion. A cold pool cannot serve traffic, so it is
+    /// still benched immediately. Once a provider has established sockets, one failed
+    /// replacement does not prove the provider is unreachable; corroborate it through
+    /// the normal failure window instead. A latched breaker always re-trips immediately
+    /// so its half-open probe cannot return a still-failing provider to rotation.
+    /// </summary>
+    private void RecordConnectionAcquisitionFailure(
+        Exception exception,
+        string operation,
+        CancellationToken ct)
+    {
+        // A client abort (seek/stop) mid-connect can surface as an IOException or
+        // SocketException rather than a cancellation exception; it must not affect
+        // provider health.
+        if (ct.IsCancellationRequested)
+            return;
+
+        var reason = $"{operation}-{exception.GetType().Name}";
+        if (exception.TryGetKnownErrorMessage(out var knownReason))
+            reason = $"{reason}: {knownReason}";
+
+        if (circuitBreaker.IsLatched || connectionPool.LiveConnections == 0)
+            RecordProviderConnectionFailure(reason);
+        else
+            RecordProviderFailure(reason);
+    }
+
+    private void RecordProviderConnectionFailure(string reason) =>
+        circuitBreaker.RecordConnectionFailure(reason, GetPoolDiagnostics());
+
+    private void RecordProviderFailure(string reason) =>
+        circuitBreaker.RecordFailure(reason, GetPoolDiagnostics());
+
+    private ProviderCircuitPoolDiagnostics GetPoolDiagnostics() =>
+        new(connectionPool.LiveConnections, connectionPool.IdleConnections, connectionPool.ActiveConnections);
 
     /// <summary>
     /// Pool disposal (client retirement / shutdown) is not a provider-health failure.

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -1,4 +1,5 @@
-﻿using NzbWebDAV.Clients.Usenet.Concurrency;
+﻿using System.Text.Json;
+using NzbWebDAV.Clients.Usenet.Concurrency;
 using NzbWebDAV.Clients.Usenet.Connections;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Config;
@@ -313,6 +314,7 @@ public class UsenetStreamingClient : WrappingNntpClient
                     Num = transition.Cooldown is { } cooldown
                         ? (long)cooldown.TotalMilliseconds
                         : null,
+                    Note = BuildCircuitTransitionNote(transition),
                 });
                 tripDetector?.OnTransition(metricsKey, transition);
             },
@@ -339,6 +341,25 @@ public class UsenetStreamingClient : WrappingNntpClient
             metricsKey,
             latencyTracker
         );
+    }
+
+    private static string? BuildCircuitTransitionNote(ProviderCircuitTransition transition)
+    {
+        if (transition.FailureReason is null && transition.Pool is null)
+            return null;
+
+        return JsonSerializer.Serialize(new
+        {
+            failureReason = transition.FailureReason,
+            pool = transition.Pool is { } pool
+                ? new
+                {
+                    liveConnections = pool.LiveConnections,
+                    idleConnections = pool.IdleConnections,
+                    activeConnections = pool.ActiveConnections,
+                }
+                : null,
+        });
     }
 
     private static ConnectionPool<INntpClient> CreateNewConnectionPool

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -844,7 +844,7 @@ public sealed class SupportPackService(
             .ToListAsync(cancellationToken).ConfigureAwait(false);
         var circuitTransitions = await metricsDb.MetricEvents
             .Where(row => row.Kind == "circuit" && row.At >= since7Days)
-            .Select(row => new { row.At, row.Tag1, row.Tag2, row.Num })
+            .Select(row => new { row.At, row.Tag1, row.Tag2, row.Num, row.Note })
             .ToListAsync(cancellationToken).ConfigureAwait(false);
         var failover = await metricsDb.FailoverHourly
             .Where(row => row.Hour >= since7Days)
@@ -939,6 +939,7 @@ public sealed class SupportPackService(
                         nickname = nicknames.GetValueOrDefault(row.Tag1!),
                         state = row.Tag2,
                         cooldownMs = row.Num,
+                        diagnostics = TryParseCircuitTransitionDiagnostics(row.Note),
                     }),
             },
             failoverReasons = failover,
@@ -959,6 +960,25 @@ public sealed class SupportPackService(
                 latencyDroppedObservations = latencyTracker.DroppedObservations,
             },
         };
+    }
+
+    private static JsonElement? TryParseCircuitTransitionDiagnostics(string? note)
+    {
+        if (string.IsNullOrWhiteSpace(note))
+            return null;
+
+        try
+        {
+            using var document = JsonDocument.Parse(note);
+            return document.RootElement.ValueKind == JsonValueKind.Object
+                ? document.RootElement.Clone()
+                : null;
+        }
+        catch (JsonException)
+        {
+            // A malformed diagnostic note must not prevent generating the support pack.
+            return null;
+        }
     }
 
     private async Task<object> BuildManifestAsync(

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/CorrelatedTripDetectorTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/CorrelatedTripDetectorTests.cs
@@ -10,7 +10,7 @@ namespace NzbWebDAV.Tests.Clients.Usenet;
 [Collection(nameof(GlobalLoggerCollection))]
 public class CorrelatedTripDetectorTests
 {
-    private static readonly TimeSpan Window = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan Window = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan Throttle = TimeSpan.FromMinutes(5);
 
     [Fact]
@@ -55,6 +55,23 @@ public class CorrelatedTripDetectorTests
     }
 
     [Fact]
+    public void DefaultWindow_CorrelatesTripsSeparatedByAConnectDeadline()
+    {
+        var callbacks = 0;
+        var detector = new CorrelatedTripDetector()
+        {
+            Clock = () => 16_000,
+        };
+        detector.Register("a", "a.example.com", () => callbacks++);
+        detector.Register("b", "b.example.com", () => callbacks++);
+
+        detector.OnTransition("a", Open(atMs: 0));
+        detector.OnTransition("b", Open(atMs: 16_000));
+
+        Assert.Equal(2, callbacks);
+    }
+
+    [Fact]
     public void CorrelationsWithinTheWarningThrottle_StillInvokeCallbacks()
     {
         var callbacks = 0;
@@ -73,6 +90,56 @@ public class CorrelatedTripDetectorTests
         detector.OnTransition("b", Open(atMs: 5_000));
 
         Assert.Equal(4, callbacks);
+    }
+
+    [Fact]
+    public void CorrelatedEpisode_DesynchronizedRetripAfterPartialRecovery_StillInvokesCallbacks()
+    {
+        var callbacks = new List<string>();
+        var detector = new CorrelatedTripDetector(window: Window, throttle: Throttle)
+        {
+            Clock = () => 0,
+        };
+        detector.Register("a", "a.example.com", () => callbacks.Add("a"));
+        detector.Register("b", "b.example.com", () => callbacks.Add("b"));
+
+        detector.OnTransition("a", Open(atMs: 0));
+        detector.OnTransition("b", Open(atMs: 15_000));
+        detector.OnTransition("a", Closed(atMs: 20_000));
+
+        // A later re-trip is outside the initial correlation window, but it is
+        // still part of the active correlated episode while b remains latched.
+        detector.OnTransition("a", Open(atMs: 150_000));
+
+        Assert.Equal(["a", "b", "a", "b"], callbacks);
+    }
+
+    [Fact]
+    public void CorrelatedEpisode_ExpiresAfterInactivity()
+    {
+        var callbacks = new List<string>();
+        var clock = 0L;
+        var detector = new CorrelatedTripDetector(
+            window: Window,
+            throttle: Throttle,
+            episodeIdleTimeout: TimeSpan.FromMinutes(1))
+        {
+            Clock = () => clock,
+        };
+        detector.Register("a", "a.example.com", () => callbacks.Add("a"));
+        detector.Register("b", "b.example.com", () => callbacks.Add("b"));
+
+        detector.OnTransition("a", Open(atMs: 0));
+        clock = 1_000;
+        detector.OnTransition("b", Open(atMs: 1_000));
+        detector.OnTransition("a", Closed(atMs: 2_000));
+
+        // The remaining open b must not cause an unrelated a trip after the
+        // idle timeout to inherit the earlier correlated episode.
+        clock = 62_000;
+        detector.OnTransition("a", Open(atMs: 62_000));
+
+        Assert.Equal(["a", "b"], callbacks);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerConnectionFailureTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerConnectionFailureTests.cs
@@ -1,4 +1,5 @@
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Concurrency;
 using NzbWebDAV.Clients.Usenet.Connections;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Models;
@@ -75,6 +76,75 @@ public class ProviderCircuitBreakerConnectionFailureTests
 
         Assert.Equal(ProviderCircuitState.Closed, breaker.GetSnapshot().State);
         Assert.Equal(0, breaker.GetSnapshot().TripCount);
+    }
+
+    [Fact]
+    public async Task RunWithConnection_FailedExpansionWithLiveConnections_UsesFailureWindow()
+    {
+        var clock = 0L;
+        var factoryCalls = 0;
+        var breaker = new ProviderCircuitBreaker("partially-healthy", coalesceFailureBursts: true)
+        {
+            Clock = () => clock,
+        };
+        using var pool = new ConnectionPool<INntpClient>(
+            maxConnections: 2,
+            _ => Interlocked.Increment(ref factoryCalls) == 1
+                ? ValueTask.FromResult<INntpClient>(new SuccessfulStatClient())
+                : throw new IOException("New connection failed."));
+        using var retainedConnection = await pool.GetConnectionLockAsync(
+            SemaphorePriority.High, CancellationToken.None);
+        using var client = new MultiConnectionNntpClient(
+            pool, ProviderType.Pooled, breaker, "partially-healthy");
+
+        await Assert.ThrowsAsync<IOException>(
+            () => client.StatAsync("first", CancellationToken.None));
+
+        Assert.Equal(ProviderCircuitState.Closed, breaker.GetSnapshot().State);
+        Assert.Equal(2, breaker.GetSnapshot().FailureCount);
+
+        clock += 2_000;
+        await Assert.ThrowsAsync<IOException>(
+            () => client.StatAsync("second", CancellationToken.None));
+        Assert.Equal(ProviderCircuitState.Closed, breaker.GetSnapshot().State);
+
+        clock += 2_000;
+        await Assert.ThrowsAsync<IOException>(
+            () => client.StatAsync("third", CancellationToken.None));
+
+        Assert.Equal(ProviderCircuitState.Open, breaker.GetSnapshot().State);
+        Assert.Equal(1, breaker.GetSnapshot().TripCount);
+    }
+
+    [Fact]
+    public async Task RunWithConnection_HalfOpenFailedExpansion_RetripsImmediately()
+    {
+        var clock = 0L;
+        var factoryCalls = 0;
+        var breaker = new ProviderCircuitBreaker("half-open-live")
+        {
+            Clock = () => clock,
+        };
+        breaker.RecordConnectionFailure("initial");
+        clock += 60_000;
+        breaker.ExpireCooldownForTests();
+
+        using var pool = new ConnectionPool<INntpClient>(
+            maxConnections: 2,
+            _ => Interlocked.Increment(ref factoryCalls) == 1
+                ? ValueTask.FromResult<INntpClient>(new SuccessfulStatClient())
+                : throw new IOException("Half-open connection failed."));
+        using var retainedConnection = await pool.GetConnectionLockAsync(
+            SemaphorePriority.High, CancellationToken.None);
+        using var client = new MultiConnectionNntpClient(
+            pool, ProviderType.Pooled, breaker, "half-open-live");
+
+        await Assert.ThrowsAsync<IOException>(
+            () => client.StatAsync("segment", CancellationToken.None));
+
+        Assert.Equal(ProviderCircuitState.Open, breaker.GetSnapshot().State);
+        Assert.Equal(2, breaker.GetSnapshot().TripCount);
+        Assert.Equal(TimeSpan.FromSeconds(240), breaker.CurrentCooldown);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerLoggingTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerLoggingTests.cs
@@ -1,4 +1,5 @@
 using NzbWebDAV.Clients.Usenet.Connections;
+using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Tests.TestUtils;
 using Serilog;
 using Serilog.Core;
@@ -55,6 +56,20 @@ public class ProviderCircuitBreakerLoggingTests
         });
 
         Assert.DoesNotContain(events, RecoveryWasAnnounced);
+    }
+
+    [Fact]
+    public void RecordConnectionFailure_WithPoolDiagnostics_IncludesThemInTripWarning()
+    {
+        var events = CaptureLogs(breaker => breaker.RecordConnectionFailure(
+            "connect-timeout",
+            new ProviderCircuitPoolDiagnostics(
+                LiveConnections: 25,
+                IdleConnections: 23,
+                ActiveConnections: 2)));
+
+        Assert.Contains(events, logEvent =>
+            logEvent.MessageTemplate.Text.Contains("Pool live={LiveConnections}", StringComparison.Ordinal));
     }
 
     private static bool RecoveryWasAnnounced(LogEvent logEvent) =>

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -627,6 +627,54 @@ public sealed class SupportPackContentsTests : IDisposable
         }
     }
 
+    [Fact]
+    public async Task Pack_IncludesCircuitTransitionDiagnostics()
+    {
+        MetricsDbContext.ResetOptionsForTests();
+        try
+        {
+            await using (var metricsDb = new MetricsDbContext())
+            {
+                await metricsDb.Database.MigrateAsync();
+                metricsDb.MetricEvents.Add(new MetricEvent
+                {
+                    At = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    Kind = "circuit",
+                    Tag1 = "provider-a",
+                    Tag2 = "open",
+                    Num = 60_000,
+                    Note = """
+                    {"failureReason":"connection failure (get-connection-CouldNotConnectToUsenetException)","pool":{"liveConnections":25,"idleConnections":23,"activeConnections":2}}
+                    """,
+                });
+                await metricsDb.SaveChangesAsync();
+            }
+
+            var entries = await ReadPackEntriesAsync(
+                new LogBufferSink(10),
+                new WarningLogBuffer(new LogBufferSink(50)));
+
+            using var metrics = JsonDocument.Parse(entries["metrics/recent.json"]);
+            var transition = metrics.RootElement
+                .GetProperty("circuits")
+                .GetProperty("transitions")
+                .EnumerateArray()
+                .Single(item => item.GetProperty("providerKey").GetString() == "provider-a");
+            var diagnostics = transition.GetProperty("diagnostics");
+
+            Assert.Equal(
+                "connection failure (get-connection-CouldNotConnectToUsenetException)",
+                diagnostics.GetProperty("failureReason").GetString());
+            Assert.Equal(25, diagnostics.GetProperty("pool").GetProperty("liveConnections").GetInt32());
+            Assert.Equal(23, diagnostics.GetProperty("pool").GetProperty("idleConnections").GetInt32());
+            Assert.Equal(2, diagnostics.GetProperty("pool").GetProperty("activeConnections").GetInt32());
+        }
+        finally
+        {
+            MetricsDbContext.ResetOptionsForTests();
+        }
+    }
+
     private static void CollectNonCamelCaseNames(JsonElement element, string path, List<string> offenders)
     {
         switch (element.ValueKind)


### PR DESCRIPTION
## Summary
- Avoid benching providers that still have established NNTP connections after a single failed pool expansion.
- Keep short recovery cooldowns active through a correlated provider outage even when re-trips drift apart.
- Include sanitized trip causes and connection-pool state in circuit metrics and support packs.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [x] Focused breaker, correlation, logging, and support-pack tests