### PR TITLE
fix(ui): show Right now at the top of Overview on mobile

### DIFF
--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -504,7 +504,8 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
             </SortableContext>
           </DndContext>
         </div>
-        <aside className="flex w-full shrink-0 xl:w-80 xl:self-stretch">
+        {/* Pin above widgets when stacked; restore document order for the xl right rail. */}
+        <aside className="order-first flex w-full shrink-0 xl:order-none xl:w-80 xl:self-stretch">
           <LiveReadsPanel paused={editMode} />
         </aside>
       </div>


### PR DESCRIPTION
## Summary
- On phones and other stacked Overview layouts, the Right now panel now appears above the widgets instead of after every card.
- Desktop still shows Right now as the right-column rail.

## Test plan
- [ ] Open Overview on a narrow viewport (< 1280px) and confirm Right now is the first card under the header.
- [ ] Confirm the page title, Edit layout, and window tabs stay above Right now.
- [ ] Open Overview on a wide viewport and confirm Right now is still the right rail.
- [ ] With active reads, confirm the panel still updates live.