### PR TITLE
feat(usenet): make provider circuit-breaker cooldowns configurable

### DIFF
--- a/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
+++ b/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
@@ -60,7 +60,12 @@ public class ProviderCircuitBreaker
         _providerName = providerName;
         _onTransition = onTransition;
         _coalesceFailureBursts = coalesceFailureBursts;
-        _initialCooldown = initialCooldown ?? DefaultInitialCooldown;
+        // A non-positive initial cooldown would trip straight into half-open and the
+        // doubling ladder would never grow, silently disabling the breaker.
+        var configuredInitial = initialCooldown ?? DefaultInitialCooldown;
+        _initialCooldown = configuredInitial > TimeSpan.Zero
+            ? configuredInitial
+            : DefaultInitialCooldown;
         // A ceiling under the initial cooldown would shorten the first trip instead of
         // bounding the ladder, so keep it at or above the value it caps.
         var ceiling = maxCooldown ?? DefaultMaxCooldown;

--- a/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
+++ b/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
@@ -27,20 +27,22 @@ public class ProviderCircuitBreaker
     private const int MinFailuresToTrip = 3;
     private const double TripFailureRate = 0.5;
 
-    private static readonly TimeSpan InitialCooldown = TimeSpan.FromSeconds(60);
-    private static readonly TimeSpan MaxCooldown = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan DefaultInitialCooldown = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan DefaultMaxCooldown = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan FailureBurstCoalesceWindow = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan DefaultProbeAbandonTimeout = TimeSpan.FromSeconds(60);
 
     private readonly string _providerName;
     private readonly Action<ProviderCircuitTransition>? _onTransition;
     private readonly bool _coalesceFailureBursts;
+    private readonly TimeSpan _initialCooldown;
+    private readonly TimeSpan _maxCooldown;
     private readonly object _lock = new();
     private readonly Queue<(long AtMs, bool Failed)> _window = new();
 
     private long _trippedUntilMs;
     private long _failureBurstStartedAtMs = long.MinValue;
-    private TimeSpan _currentCooldown = InitialCooldown;
+    private TimeSpan _currentCooldown;
     private int _halfOpenProbeInFlight; // 0/1
     private long _probeStartedMs;
     private string? _lastFailureReason;
@@ -51,11 +53,19 @@ public class ProviderCircuitBreaker
     public ProviderCircuitBreaker(
         string providerName,
         Action<ProviderCircuitTransition>? onTransition = null,
-        bool coalesceFailureBursts = false)
+        bool coalesceFailureBursts = false,
+        TimeSpan? initialCooldown = null,
+        TimeSpan? maxCooldown = null)
     {
         _providerName = providerName;
         _onTransition = onTransition;
         _coalesceFailureBursts = coalesceFailureBursts;
+        _initialCooldown = initialCooldown ?? DefaultInitialCooldown;
+        // A ceiling under the initial cooldown would shorten the first trip instead of
+        // bounding the ladder, so keep it at or above the value it caps.
+        var ceiling = maxCooldown ?? DefaultMaxCooldown;
+        _maxCooldown = ceiling < _initialCooldown ? _initialCooldown : ceiling;
+        _currentCooldown = _initialCooldown;
     }
 
     /// <summary>How long an unanswered half-open probe may hold the slot. For tests.</summary>
@@ -163,7 +173,7 @@ public class ProviderCircuitBreaker
             _failureBurstStartedAtMs = long.MinValue;
             _trippedUntilMs = 0;
             if (resetsCooldownLadder)
-                _currentCooldown = InitialCooldown;
+                _currentCooldown = _initialCooldown;
             _lastFailureReason = null;
             Volatile.Write(ref _halfOpenProbeInFlight, 0);
             Volatile.Write(ref _probeStartedMs, 0);
@@ -347,7 +357,7 @@ public class ProviderCircuitBreaker
         _window.Clear();
         _failureBurstStartedAtMs = long.MinValue;
         _currentCooldown = TimeSpan.FromMilliseconds(
-            Math.Min(_currentCooldown.TotalMilliseconds * 2, MaxCooldown.TotalMilliseconds));
+            Math.Min(_currentCooldown.TotalMilliseconds * 2, _maxCooldown.TotalMilliseconds));
     }
 
     private void NotifyTransition(

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -202,6 +202,8 @@ public class UsenetStreamingClient : WrappingNntpClient
         var connectionPoolStats = new ConnectionPoolStats(providerConfig, websocketManager);
         var idleTimeoutSeconds = configManager.GetIdleConnectionTimeoutSeconds();
         var streamingPriority = configManager.GetStreamingPriority();
+        var circuitInitialCooldown = configManager.GetCircuitBreakerInitialCooldown();
+        var circuitMaxCooldown = configManager.GetCircuitBreakerMaxCooldown();
         var tripDetector = new CorrelatedTripDetector();
         var providerClients = providerConfig.Providers
             .Select((provider, index) => CreateProviderClient(
@@ -212,6 +214,8 @@ public class UsenetStreamingClient : WrappingNntpClient
                     ? configManager.GetWarmConnectionsFloor(provider.MaxConnections)
                     : 0,
                 metricsWriter,
+                circuitInitialCooldown,
+                circuitMaxCooldown,
                 streamingPriority,
                 latencyTracker,
                 tripDetector
@@ -235,6 +239,8 @@ public class UsenetStreamingClient : WrappingNntpClient
         int idleTimeoutSeconds,
         int warmConnectionFloor,
         MetricsWriter metricsWriter,
+        TimeSpan circuitInitialCooldown,
+        TimeSpan circuitMaxCooldown,
         SemaphorePriorityOdds? streamingPriority = null,
         ProviderLatencyTracker? latencyTracker = null,
         CorrelatedTripDetector? tripDetector = null
@@ -318,7 +324,9 @@ public class UsenetStreamingClient : WrappingNntpClient
                 });
                 tripDetector?.OnTransition(metricsKey, transition);
             },
-            coalesceFailureBursts: true);
+            coalesceFailureBursts: true,
+            initialCooldown: circuitInitialCooldown,
+            maxCooldown: circuitMaxCooldown);
         // Only providers that can carry traffic participate in correlation; a Disabled
         // provider never trips and would wedge the "all tripped" condition forever.
         if (connectionDetails.Type != ProviderType.Disabled)

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -44,6 +44,8 @@ public static class ConfigKeys
     public const string UsenetIdleConnectionTimeoutSeconds = "usenet.idle-connection-timeout-seconds";
     public const string UsenetWarmConnectionsEnabled = "usenet.warm-connections.enabled";
     public const string UsenetWarmConnectionsFloor = "usenet.warm-connections.floor";
+    public const string UsenetCircuitBreakerInitialCooldownSeconds = "usenet.circuit-breaker.initial-cooldown-seconds";
+    public const string UsenetCircuitBreakerMaxCooldownSeconds = "usenet.circuit-breaker.max-cooldown-seconds";
     public const string UsenetMaxDownloadConnections = "usenet.max-download-connections";
     public const string UsenetMaxDownloadConnectionsPerStream = "usenet.max-download-connections-per-stream";
     public const string UsenetMaxDownloadConnectionsPerStreamPreset = "usenet.max-download-connections-per-stream-preset";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1051,9 +1051,9 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
     public TimeSpan GetCircuitBreakerInitialCooldown()
     {
         var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetCircuitBreakerInitialCooldownSeconds));
-        if (configured is null || !int.TryParse(configured, out var seconds))
+        if (configured is null || !long.TryParse(configured, out var seconds))
             return TimeSpan.FromSeconds(60);
-        return TimeSpan.FromSeconds(Math.Clamp(seconds, 5, 300));
+        return TimeSpan.FromSeconds(Math.Clamp(seconds, 5L, 300L));
     }
 
     /// <summary>
@@ -1065,9 +1065,9 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
     public TimeSpan GetCircuitBreakerMaxCooldown()
     {
         var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetCircuitBreakerMaxCooldownSeconds));
-        if (configured is null || !int.TryParse(configured, out var seconds))
+        if (configured is null || !long.TryParse(configured, out var seconds))
             return TimeSpan.FromSeconds(300);
-        return TimeSpan.FromSeconds(Math.Clamp(seconds, 5, 3600));
+        return TimeSpan.FromSeconds(Math.Clamp(seconds, 5L, 3600L));
     }
 
     /// <summary>

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -359,6 +359,8 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
                 case ConfigKeys.UsenetInFlightArticleBudgetMb:
                 case ConfigKeys.UsenetIdleConnectionTimeoutSeconds:
                 case ConfigKeys.UsenetWarmConnectionsFloor:
+                case ConfigKeys.UsenetCircuitBreakerInitialCooldownSeconds:
+                case ConfigKeys.UsenetCircuitBreakerMaxCooldownSeconds:
                 case ConfigKeys.UsenetArticleMissCacheTtlSeconds:
                 case ConfigKeys.UsenetArticleMissCacheMaxEntries:
                 case ConfigKeys.UsenetSegmentCacheMaxGb:
@@ -1038,6 +1040,34 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
         if (configured is null || !int.TryParse(configured, out var value))
             return Math.Clamp(maxConnections / 6, 1, 8);
         return Math.Clamp(value, 1, maxConnections);
+    }
+
+    /// <summary>
+    /// Cooldown applied the first time a provider's circuit trips. Each consecutive trip
+    /// doubles it up to the ceiling, and a successful body fetch resets it back to this
+    /// value. Defaults to 60s and is clamped to 5 through 300. The connection pools read
+    /// it when they are built, so a change applies on the next restart or provider save.
+    /// </summary>
+    public TimeSpan GetCircuitBreakerInitialCooldown()
+    {
+        var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetCircuitBreakerInitialCooldownSeconds));
+        if (configured is null || !int.TryParse(configured, out var seconds))
+            return TimeSpan.FromSeconds(60);
+        return TimeSpan.FromSeconds(Math.Clamp(seconds, 5, 300));
+    }
+
+    /// <summary>
+    /// Ceiling the doubling cooldown stops at, so a provider that stays down is re-probed
+    /// on a bounded interval instead of an ever-growing one. Defaults to 300s and is
+    /// clamped to 5 through 3600. The connection pools read it when they are built, so a
+    /// change applies on the next restart or provider save.
+    /// </summary>
+    public TimeSpan GetCircuitBreakerMaxCooldown()
+    {
+        var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetCircuitBreakerMaxCooldownSeconds));
+        if (configured is null || !int.TryParse(configured, out var seconds))
+            return TimeSpan.FromSeconds(300);
+        return TimeSpan.FromSeconds(Math.Clamp(seconds, 5, 3600));
     }
 
     /// <summary>

--- a/docs/configuration/usenet.md
+++ b/docs/configuration/usenet.md
@@ -85,7 +85,7 @@ re-probing the same provider for the same article until the TTL expires. Transie
 
 The cache clears automatically when Usenet providers are reconfigured.
 
-## Provider circuit-breaker cooldown
+## Provider circuit-breaker cooldown [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since }
 
 When a provider's circuit trips, that provider is skipped for a cooldown and traffic goes to
 the remaining providers. Each consecutive trip doubles the cooldown up to a ceiling. A

--- a/docs/configuration/usenet.md
+++ b/docs/configuration/usenet.md
@@ -84,3 +84,25 @@ re-probing the same provider for the same article until the TTL expires. Transie
 | Miss-cache max entries | `usenet.article-miss-cache-max-entries` | `10000` | Cap before oldest entries are evicted (clamped 100–1000000) |
 
 The cache clears automatically when Usenet providers are reconfigured.
+
+## Provider circuit-breaker cooldown
+
+When a provider's circuit trips, that provider is skipped for a cooldown and traffic goes to
+the remaining providers. Each consecutive trip doubles the cooldown up to a ceiling. A
+successful article body resets it to the initial value.
+
+| Control | Config key | Default | Effect |
+|---------|------------|---------|--------|
+| Initial cooldown (seconds) | `usenet.circuit-breaker.initial-cooldown-seconds` | `60` | Cooldown applied on the first trip (clamped 5 to 300) |
+| Maximum cooldown (seconds) | `usenet.circuit-breaker.max-cooldown-seconds` | `300` | Ceiling the doubling stops at (clamped 5 to 3600) |
+
+Lower the initial cooldown when a single pool provider carries the traffic and the backups are
+metered blocks. A brief wobble then spends fewer backup bytes before the primary is re-probed.
+A maximum below the initial value is raised to it. The connection pools read both values when
+they are built, so a change applies on the next restart or provider save. Neither has a
+Settings control. Set them through config or the environment.
+
+Once the cooldown lapses, one request is admitted as a half-open probe. If that request is
+abandoned before it returns an outcome, the probe slot stays claimed for up to 60 seconds
+before another request can retake it. A cooldown shorter than that will not always re-probe as
+quickly as the number suggests.

--- a/docs/features/multi-provider.md
+++ b/docs/features/multi-provider.md
@@ -13,7 +13,7 @@ Each provider has type (pool / backup-only / disabled), SSL, connection limits, 
 
 ## Circuit breakers and storage groups
 
-Failing providers are skipped temporarily. **Storage group** labels mark resellers that share the same upstream storage — after a clean article miss on one, siblings in the group are skipped for that request (connection errors never trigger this).
+Failing providers are skipped temporarily, for a cooldown that doubles on each consecutive trip up to a ceiling. Both bounds default to 60s and 5 minutes and are set with the `usenet.circuit-breaker.*` config keys. See [Usenet configuration](../configuration/usenet.md). **Storage group** labels mark resellers that share the same upstream storage — after a clean article miss on one, siblings in the group are skipped for that request (connection errors never trigger this).
 
 Across requests, a bounded TTL **article-miss negative cache** [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since } remembers definitive misses per provider or storage group so streaming retries are not spent re-probing known-missing articles. Tune TTL and max entries under **Settings → Usenet → Global settings**.
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerCooldownTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerCooldownTests.cs
@@ -1,0 +1,104 @@
+using NzbWebDAV.Clients.Usenet.Connections;
+using NzbWebDAV.Clients.Usenet.Models;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class ProviderCircuitBreakerCooldownTests
+{
+    [Fact]
+    public void ConfiguredInitialCooldown_AppliesToTheFirstTrip()
+    {
+        var clock = new TestClock();
+        var breaker = CreateBreaker(clock, initial: TimeSpan.FromSeconds(15));
+
+        breaker.RecordConnectionFailure();
+
+        var snapshot = breaker.GetSnapshot();
+        Assert.Equal(ProviderCircuitState.Open, snapshot.State);
+        Assert.InRange(snapshot.CooldownRemainingSeconds ?? 0, 14, 15);
+    }
+
+    [Fact]
+    public void LadderDoublesFromTheConfiguredInitialCooldown()
+    {
+        var clock = new TestClock();
+        var breaker = CreateBreaker(clock, initial: TimeSpan.FromSeconds(15));
+
+        breaker.RecordConnectionFailure();
+
+        Assert.Equal(TimeSpan.FromSeconds(30), breaker.CurrentCooldown);
+    }
+
+    [Fact]
+    public void LadderStopsAtTheConfiguredCeiling()
+    {
+        var clock = new TestClock();
+        var breaker = CreateBreaker(
+            clock,
+            initial: TimeSpan.FromSeconds(15),
+            max: TimeSpan.FromSeconds(45));
+
+        for (var trip = 0; trip < 5; trip++)
+        {
+            breaker.RecordConnectionFailure();
+            clock.Advance(milliseconds: 60_000);
+        }
+
+        Assert.Equal(TimeSpan.FromSeconds(45), breaker.CurrentCooldown);
+    }
+
+    [Fact]
+    public void BodySuccess_ResetsTheLadderToTheConfiguredInitialCooldown()
+    {
+        var clock = new TestClock();
+        var breaker = CreateBreaker(clock, initial: TimeSpan.FromSeconds(15));
+
+        breaker.RecordConnectionFailure();
+        clock.Advance(milliseconds: 15_000);
+        breaker.RecordSuccess();
+
+        Assert.Equal(TimeSpan.FromSeconds(15), breaker.CurrentCooldown);
+    }
+
+    [Fact]
+    public void CeilingBelowTheInitialCooldown_IsRaisedToIt()
+    {
+        var clock = new TestClock();
+        var breaker = CreateBreaker(
+            clock,
+            initial: TimeSpan.FromSeconds(120),
+            max: TimeSpan.FromSeconds(30));
+
+        breaker.RecordConnectionFailure();
+
+        var snapshot = breaker.GetSnapshot();
+        Assert.InRange(snapshot.CooldownRemainingSeconds ?? 0, 119, 120);
+        Assert.Equal(TimeSpan.FromSeconds(120), breaker.CurrentCooldown);
+    }
+
+    [Fact]
+    public void UnconfiguredBreaker_KeepsTheShippedLadder()
+    {
+        var clock = new TestClock();
+        var breaker = new ProviderCircuitBreaker("cooldown-test") { Clock = () => clock.Now };
+
+        breaker.RecordConnectionFailure();
+
+        var snapshot = breaker.GetSnapshot();
+        Assert.InRange(snapshot.CooldownRemainingSeconds ?? 0, 59, 60);
+        Assert.Equal(TimeSpan.FromSeconds(120), breaker.CurrentCooldown);
+    }
+
+    private static ProviderCircuitBreaker CreateBreaker(
+        TestClock clock,
+        TimeSpan? initial = null,
+        TimeSpan? max = null) =>
+        new("cooldown-test", initialCooldown: initial, maxCooldown: max) { Clock = () => clock.Now };
+
+    private sealed class TestClock
+    {
+        public long Now { get; private set; }
+
+        public void Advance(long milliseconds) => Now += milliseconds;
+    }
+}

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerCooldownTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ProviderCircuitBreakerCooldownTests.cs
@@ -76,6 +76,21 @@ public class ProviderCircuitBreakerCooldownTests
         Assert.Equal(TimeSpan.FromSeconds(120), breaker.CurrentCooldown);
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-30)]
+    public void NonPositiveInitialCooldown_FallsBackToTheDefault(int seconds)
+    {
+        var clock = new TestClock();
+        var breaker = CreateBreaker(clock, initial: TimeSpan.FromSeconds(seconds));
+
+        breaker.RecordConnectionFailure();
+
+        var snapshot = breaker.GetSnapshot();
+        Assert.InRange(snapshot.CooldownRemainingSeconds ?? 0, 59, 60);
+        Assert.Equal(TimeSpan.FromSeconds(120), breaker.CurrentCooldown);
+    }
+
     [Fact]
     public void UnconfiguredBreaker_KeepsTheShippedLadder()
     {

--- a/tests/NzbWebDAV.Tests/Config/CircuitBreakerCooldownConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/CircuitBreakerCooldownConfigTests.cs
@@ -1,0 +1,53 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+public sealed class CircuitBreakerCooldownConfigTests
+{
+    [Fact]
+    public void InitialCooldown_DefaultsToSixtySeconds()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(60), new ConfigManager().GetCircuitBreakerInitialCooldown());
+    }
+
+    [Theory]
+    [InlineData("15", 15)]
+    [InlineData("300", 300)]
+    [InlineData("1", 5)]
+    [InlineData("-30", 5)]
+    [InlineData("3600", 300)]
+    [InlineData("abc", 60)]
+    [InlineData("", 60)]
+    public void InitialCooldown_IsParsedAndClamped(string configured, int expectedSeconds)
+    {
+        var config = new ConfigManager();
+        config.UpdateValues([Item(ConfigKeys.UsenetCircuitBreakerInitialCooldownSeconds, configured)]);
+
+        Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), config.GetCircuitBreakerInitialCooldown());
+    }
+
+    [Fact]
+    public void MaxCooldown_DefaultsToFiveMinutes()
+    {
+        Assert.Equal(TimeSpan.FromMinutes(5), new ConfigManager().GetCircuitBreakerMaxCooldown());
+    }
+
+    [Theory]
+    [InlineData("60", 60)]
+    [InlineData("3600", 3600)]
+    [InlineData("1", 5)]
+    [InlineData("7200", 3600)]
+    [InlineData("abc", 300)]
+    [InlineData("", 300)]
+    public void MaxCooldown_IsParsedAndClamped(string configured, int expectedSeconds)
+    {
+        var config = new ConfigManager();
+        config.UpdateValues([Item(ConfigKeys.UsenetCircuitBreakerMaxCooldownSeconds, configured)]);
+
+        Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), config.GetCircuitBreakerMaxCooldown());
+    }
+
+    private static ConfigItem Item(string name, string value) =>
+        new() { ConfigName = name, ConfigValue = value };
+}

--- a/tests/NzbWebDAV.Tests/Config/CircuitBreakerCooldownConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/CircuitBreakerCooldownConfigTests.cs
@@ -52,6 +52,29 @@ public sealed class CircuitBreakerCooldownConfigTests
         Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), config.GetCircuitBreakerMaxCooldown());
     }
 
+    [Theory]
+    [InlineData("2147483648")]
+    [InlineData("-2147483649")]
+    public void ValidateConfigItems_AcceptsValuesOutsideInt32(string configured)
+    {
+        ConfigManager.ValidateConfigItems(
+        [
+            Item(ConfigKeys.UsenetCircuitBreakerInitialCooldownSeconds, configured),
+            Item(ConfigKeys.UsenetCircuitBreakerMaxCooldownSeconds, configured),
+        ]);
+    }
+
+    [Theory]
+    [InlineData("abc")]
+    [InlineData("1.5")]
+    public void ValidateConfigItems_RejectsValuesThatAreNotWholeNumbers(string configured)
+    {
+        Assert.Throws<ArgumentException>(() => ConfigManager.ValidateConfigItems(
+        [
+            Item(ConfigKeys.UsenetCircuitBreakerInitialCooldownSeconds, configured),
+        ]));
+    }
+
     private static ConfigItem Item(string name, string value) =>
         new() { ConfigName = name, ConfigValue = value };
 }

--- a/tests/NzbWebDAV.Tests/Config/CircuitBreakerCooldownConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/CircuitBreakerCooldownConfigTests.cs
@@ -17,6 +17,8 @@ public sealed class CircuitBreakerCooldownConfigTests
     [InlineData("1", 5)]
     [InlineData("-30", 5)]
     [InlineData("3600", 300)]
+    [InlineData("2147483648", 300)]
+    [InlineData("-2147483649", 5)]
     [InlineData("abc", 60)]
     [InlineData("", 60)]
     public void InitialCooldown_IsParsedAndClamped(string configured, int expectedSeconds)
@@ -38,6 +40,8 @@ public sealed class CircuitBreakerCooldownConfigTests
     [InlineData("3600", 3600)]
     [InlineData("1", 5)]
     [InlineData("7200", 3600)]
+    [InlineData("2147483648", 3600)]
+    [InlineData("-2147483649", 5)]
     [InlineData("abc", 300)]
     [InlineData("", 300)]
     public void MaxCooldown_IsParsedAndClamped(string configured, int expectedSeconds)


### PR DESCRIPTION
Make circuit breaker cooldown settings configurable, matching existing defaults. On systems with only 1 primary this prevents the backup block providers from being drained too fast.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable initial and maximum cooldown durations for provider circuit breakers.
  * Cooldowns now increase exponentially after repeated failures and reset after successful recovery.
  * Invalid settings are validated and safely clamped to supported ranges.

* **Documentation**
  * Documented cooldown configuration, backoff behavior, limits, persistence, and recovery probes.

* **Tests**
  * Added coverage for cooldown escalation, resets, defaults, parsing, and boundary handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->