### PR TITLE
fix(queue): delete STRM files with removed history items

### DIFF
--- a/backend/Queue/PostProcessors/CreateStrmFilesPostProcessor.cs
+++ b/backend/Queue/PostProcessors/CreateStrmFilesPostProcessor.cs
@@ -89,8 +89,76 @@ public class CreateStrmFilesPostProcessor(
         return Path.Join(configManager.GetStrmCompletedDownloadDir(), relativePath);
     }
 
+    /// <summary>
+    /// Removes a generated STRM sidecar only when its target belongs to <paramref name="davItem"/>.
+    /// </summary>
+    internal static void DeleteStrmFile(ConfigManager configManager, DavItem davItem)
+    {
+        if (!IsStrmCandidate(davItem))
+            return;
+
+        var completedDownloadsRoot = Path.GetFullPath(configManager.GetStrmCompletedDownloadDir());
+        var strmFilePath = Path.GetFullPath(GetStrmFilePath(configManager, davItem));
+        if (!IsPathWithinRoot(strmFilePath, completedDownloadsRoot))
+            return;
+
+        SymlinkAndStrmUtil.ISymlinkOrStrmInfo? strmOrSymlink;
+        try
+        {
+            strmOrSymlink = SymlinkAndStrmUtil.GetSymlinkOrStrmInfo(new FileInfo(strmFilePath));
+        }
+        catch (FileNotFoundException)
+        {
+            return;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return;
+        }
+
+        if (strmOrSymlink is not SymlinkAndStrmUtil.StrmInfo strmInfo)
+            return;
+
+        var link = OrganizedLinksUtil.GetDavItemLink(strmInfo);
+        if (link?.DavItemId != davItem.Id)
+            return;
+
+        File.Delete(strmFilePath);
+        try
+        {
+            DeleteEmptyParentDirectories(Path.GetDirectoryName(strmFilePath), completedDownloadsRoot);
+        }
+        catch (DirectoryNotFoundException)
+        {
+            // A concurrent cleanup already pruned the empty parent directory.
+        }
+    }
+
     internal string GetStrmFilePath(DavItem davItem) =>
         GetStrmFilePath(configManager, davItem);
+
+    private static bool IsPathWithinRoot(string path, string root)
+    {
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        var rootWithSeparator = root.EndsWith(Path.DirectorySeparatorChar)
+            ? root
+            : root + Path.DirectorySeparatorChar;
+        return path.StartsWith(rootWithSeparator, comparison);
+    }
+
+    private static void DeleteEmptyParentDirectories(string? directoryPath, string root)
+    {
+        while (directoryPath != null && IsPathWithinRoot(directoryPath, root))
+        {
+            if (Directory.EnumerateFileSystemEntries(directoryPath).Any())
+                return;
+
+            Directory.Delete(directoryPath);
+            directoryPath = Path.GetDirectoryName(directoryPath);
+        }
+    }
 
     internal static string GetPathRelativeToContentRoot(string davPath)
     {

--- a/backend/Queue/PostProcessors/CreateStrmFilesPostProcessor.cs
+++ b/backend/Queue/PostProcessors/CreateStrmFilesPostProcessor.cs
@@ -102,6 +102,9 @@ public class CreateStrmFilesPostProcessor(
         if (!IsPathWithinRoot(strmFilePath, completedDownloadsRoot))
             return;
 
+        if (HasSymlinkedAncestor(strmFilePath, completedDownloadsRoot))
+            return;
+
         SymlinkAndStrmUtil.ISymlinkOrStrmInfo? strmOrSymlink;
         try
         {
@@ -146,6 +149,26 @@ public class CreateStrmFilesPostProcessor(
             ? root
             : root + Path.DirectorySeparatorChar;
         return path.StartsWith(rootWithSeparator, comparison);
+    }
+
+    private static bool HasSymlinkedAncestor(string path, string root)
+    {
+        var directoryPath = Path.GetDirectoryName(path);
+        while (directoryPath is not null)
+        {
+            if (new DirectoryInfo(directoryPath).LinkTarget is not null)
+                return true;
+
+            if (string.Equals(
+                    directoryPath.TrimEnd(Path.DirectorySeparatorChar),
+                    root.TrimEnd(Path.DirectorySeparatorChar),
+                    OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+                return false;
+
+            directoryPath = Path.GetDirectoryName(directoryPath);
+        }
+
+        return true;
     }
 
     private static void DeleteEmptyParentDirectories(string? directoryPath, string root)

--- a/backend/Services/HistoryCleanupService.cs
+++ b/backend/Services/HistoryCleanupService.cs
@@ -1,12 +1,16 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue.PostProcessors;
 using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Services;
 
-public class HistoryCleanupService(IDbContextFactory<DavDatabaseContext> dbContextFactory) : BackgroundService
+public class HistoryCleanupService(
+    IDbContextFactory<DavDatabaseContext> dbContextFactory,
+    ConfigManager configManager) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -16,65 +20,12 @@ public class HistoryCleanupService(IDbContextFactory<DavDatabaseContext> dbConte
             {
                 await using var dbContext = dbContextFactory.CreateDbContext();
 
-                // Get the first item from the queue
-                var cleanupItem = await dbContext.HistoryCleanupItems
-                    .OrderBy(item => item.Id)
-                    .FirstOrDefaultAsync(stoppingToken)
-                    .ConfigureAwait(false);
-
                 // If no items in queue, wait 10 seconds before checking again
-                if (cleanupItem == null)
+                if (!await ProcessNextItemAsync(dbContext, configManager, stoppingToken).ConfigureAwait(false))
                 {
                     await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken).ConfigureAwait(false);
                     continue;
                 }
-
-                if (cleanupItem.DeleteMountedFiles)
-                {
-                    // Collect items to delete for vfs/forget
-                    var deletedItems = await dbContext.Items
-                        .Where(x => x.HistoryItemId == cleanupItem.Id)
-                        .Select(x => new DavItem { Id = x.Id, Type = x.Type, Path = x.Path })
-                        .ToListAsync(stoppingToken).ConfigureAwait(false);
-
-                    // Loud warning for large deletes; does not block (SAB semantics unchanged).
-                    DeletionAuditLog.WarnBulkDelete(
-                        "history-cleanup",
-                        deletedItems.Count,
-                        $"DeleteMountedFiles=true historyItemId={cleanupItem.Id}");
-
-                    foreach (var deletedItem in deletedItems)
-                    {
-                        DeletionAuditLog.Record(
-                            "history-cleanup",
-                            deletedItem,
-                            $"DeleteMountedFiles=true historyItemId={cleanupItem.Id}");
-                    }
-
-                    // Delete the corresponding dav-items
-                    await dbContext.Items
-                        .Where(x => x.HistoryItemId == cleanupItem.Id)
-                        .ExecuteDeleteAsync(stoppingToken).ConfigureAwait(false);
-
-                    // Trigger rclone vfs/forget for deleted items
-                    _ = DavDatabaseContext.RcloneVfsForget(deletedItems, stoppingToken);
-                }
-                else
-                {
-                    // Mark the corresponding dav-items as no longer in History
-                    await dbContext.Items
-                        .Where(x => x.HistoryItemId == cleanupItem.Id)
-                        .ExecuteUpdateAsync(
-                            x => x.SetProperty(p => p.HistoryItemId, (Guid?)null),
-                            stoppingToken
-                        ).ConfigureAwait(false);
-                }
-
-                // Remove the cleanup item from the database
-                dbContext.HistoryCleanupItems.Remove(cleanupItem);
-                await dbContext.SaveChangesAsync(stoppingToken).ConfigureAwait(false);
-
-                // Continue immediately to next iteration to process more items
             }
             catch (OperationCanceledException) when (SigtermUtil.IsSigtermTriggered())
             {
@@ -90,5 +41,65 @@ public class HistoryCleanupService(IDbContextFactory<DavDatabaseContext> dbConte
                 await Task.Delay(retryDelay, stoppingToken).ConfigureAwait(false);
             }
         }
+    }
+
+    internal static async Task<bool> ProcessNextItemAsync(
+        DavDatabaseContext dbContext,
+        ConfigManager configManager,
+        CancellationToken cancellationToken = default)
+    {
+        var cleanupItem = await dbContext.HistoryCleanupItems
+            .OrderBy(item => item.Id)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (cleanupItem == null)
+            return false;
+
+        if (cleanupItem.DeleteMountedFiles)
+        {
+            // Collect items to delete for vfs/forget and STRM ownership checks.
+            var deletedItems = await dbContext.Items
+                .Where(x => x.HistoryItemId == cleanupItem.Id)
+                .Select(x => new DavItem { Id = x.Id, Name = x.Name, Type = x.Type, Path = x.Path })
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            // Loud warning for large deletes; does not block (SAB semantics unchanged).
+            DeletionAuditLog.WarnBulkDelete(
+                "history-cleanup",
+                deletedItems.Count,
+                $"DeleteMountedFiles=true historyItemId={cleanupItem.Id}");
+
+            foreach (var deletedItem in deletedItems)
+            {
+                DeletionAuditLog.Record(
+                    "history-cleanup",
+                    deletedItem,
+                    $"DeleteMountedFiles=true historyItemId={cleanupItem.Id}");
+                CreateStrmFilesPostProcessor.DeleteStrmFile(configManager, deletedItem);
+            }
+
+            // Delete the corresponding dav-items.
+            await dbContext.Items
+                .Where(x => x.HistoryItemId == cleanupItem.Id)
+                .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+
+            // Trigger rclone vfs/forget for deleted items.
+            _ = DavDatabaseContext.RcloneVfsForget(deletedItems, cancellationToken);
+        }
+        else
+        {
+            // Mark the corresponding dav-items as no longer in History.
+            await dbContext.Items
+                .Where(x => x.HistoryItemId == cleanupItem.Id)
+                .ExecuteUpdateAsync(
+                    x => x.SetProperty(p => p.HistoryItemId, (Guid?)null),
+                    cancellationToken
+                ).ConfigureAwait(false);
+        }
+
+        // Remove the cleanup item from the database.
+        dbContext.HistoryCleanupItems.Remove(cleanupItem);
+        await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return true;
     }
 }

--- a/tests/NzbWebDAV.Tests/Queue/CreateStrmFilesPostProcessorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/CreateStrmFilesPostProcessorTests.cs
@@ -167,7 +167,7 @@ public class CreateStrmFilesPostProcessorTests : IDisposable
             Id = Guid.NewGuid(),
             Name = $"escape-{Guid.NewGuid():N}.mkv",
             Type = DavItem.ItemType.UsenetFile,
-            Path = $"/content/../../escape-{Guid.NewGuid():N}.mkv",
+            Path = $"/content/../escape-{Guid.NewGuid():N}.mkv",
         };
         var strmPath = Path.GetFullPath(CreateStrmFilesPostProcessor.GetStrmFilePath(_config, davItem));
         try
@@ -183,6 +183,37 @@ public class CreateStrmFilesPostProcessorTests : IDisposable
         finally
         {
             try { File.Delete(strmPath); } catch (IOException) { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task DeleteStrmFile_PreservesSidecarBehindSymlinkedDirectory()
+    {
+        var davItem = new DavItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "episode.mkv",
+            Type = DavItem.ItemType.UsenetFile,
+            Path = "/content/tv/Show/episode.mkv",
+        };
+        var outsideDirectory = Path.Join(Path.GetTempPath(), $"strm-outside-{Guid.NewGuid():N}");
+        var symlinkPath = Path.Join(_strmDir, "tv");
+        var strmPath = CreateStrmFilesPostProcessor.GetStrmFilePath(_config, davItem);
+        try
+        {
+            Directory.CreateDirectory(Path.Join(outsideDirectory, "Show"));
+            Directory.CreateSymbolicLink(symlinkPath, outsideDirectory);
+            await File.WriteAllTextAsync(
+                strmPath,
+                CreateStrmFilesPostProcessor.GetStrmTargetUrl(_config, davItem));
+
+            CreateStrmFilesPostProcessor.DeleteStrmFile(_config, davItem);
+
+            Assert.True(File.Exists(strmPath));
+        }
+        finally
+        {
+            try { Directory.Delete(outsideDirectory, recursive: true); } catch (IOException) { /* best effort */ }
         }
     }
 

--- a/tests/NzbWebDAV.Tests/Queue/CreateStrmFilesPostProcessorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/CreateStrmFilesPostProcessorTests.cs
@@ -111,6 +111,81 @@ public class CreateStrmFilesPostProcessorTests : IDisposable
         Assert.Equal(mtime1, mtime2);
     }
 
+    [Fact]
+    public async Task DeleteStrmFile_RemovesOwnedSidecarAndEmptyDirectories()
+    {
+        var davItem = new DavItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "episode.mkv",
+            Type = DavItem.ItemType.UsenetFile,
+            Path = "/content/tv/Show/Season 01/episode.mkv",
+        };
+        var strmPath = CreateStrmFilesPostProcessor.GetStrmFilePath(_config, davItem);
+        await CreateStrmFilesPostProcessor.WriteStrmFileAsync(_config, davItem, forceRewrite: false);
+
+        CreateStrmFilesPostProcessor.DeleteStrmFile(_config, davItem);
+
+        Assert.False(File.Exists(strmPath));
+        Assert.False(Directory.Exists(Path.GetDirectoryName(strmPath)));
+    }
+
+    [Fact]
+    public async Task DeleteStrmFile_PreservesUnrelatedOrMissingSidecars()
+    {
+        var davItem = new DavItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "movie.mkv",
+            Type = DavItem.ItemType.UsenetFile,
+            Path = "/content/movies/Movie/movie.mkv",
+        };
+        var strmPath = CreateStrmFilesPostProcessor.GetStrmFilePath(_config, davItem);
+        Directory.CreateDirectory(Path.GetDirectoryName(strmPath)!);
+        var otherItem = new DavItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "other.mkv",
+            Type = DavItem.ItemType.UsenetFile,
+            Path = "/content/movies/Other/other.mkv",
+        };
+        await File.WriteAllTextAsync(
+            strmPath,
+            CreateStrmFilesPostProcessor.GetStrmTargetUrl(_config, otherItem));
+
+        CreateStrmFilesPostProcessor.DeleteStrmFile(_config, davItem);
+        CreateStrmFilesPostProcessor.DeleteStrmFile(_config, davItem);
+
+        Assert.True(File.Exists(strmPath));
+    }
+
+    [Fact]
+    public async Task DeleteStrmFile_PreservesSidecarOutsideCompletedDownloadsDirectory()
+    {
+        var davItem = new DavItem
+        {
+            Id = Guid.NewGuid(),
+            Name = $"escape-{Guid.NewGuid():N}.mkv",
+            Type = DavItem.ItemType.UsenetFile,
+            Path = $"/content/../../escape-{Guid.NewGuid():N}.mkv",
+        };
+        var strmPath = Path.GetFullPath(CreateStrmFilesPostProcessor.GetStrmFilePath(_config, davItem));
+        try
+        {
+            await File.WriteAllTextAsync(
+                strmPath,
+                CreateStrmFilesPostProcessor.GetStrmTargetUrl(_config, davItem));
+
+            CreateStrmFilesPostProcessor.DeleteStrmFile(_config, davItem);
+
+            Assert.True(File.Exists(strmPath));
+        }
+        finally
+        {
+            try { File.Delete(strmPath); } catch (IOException) { /* best effort */ }
+        }
+    }
+
     private DavItem SeedDirectory(DavItem parent, string name, Guid? historyItemId = null)
     {
         var item = DavItem.New(

--- a/tests/NzbWebDAV.Tests/Services/HistoryCleanupServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HistoryCleanupServiceTests.cs
@@ -1,0 +1,111 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue.PostProcessors;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public sealed class HistoryCleanupServiceTests : IDisposable
+{
+    private readonly string _databasePath =
+        Path.Join(Path.GetTempPath(), $"nzbdav-history-cleanup-{Guid.NewGuid():N}.sqlite");
+    private readonly string _strmDirectory =
+        Path.Join(Path.GetTempPath(), $"nzbdav-history-cleanup-strm-{Guid.NewGuid():N}");
+    private readonly DavDatabaseContext _context;
+    private readonly ConfigManager _config;
+
+    public HistoryCleanupServiceTests()
+    {
+        _context = new DavDatabaseContext(new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_databasePath}")
+            .Options);
+        _context.Database.EnsureCreated();
+        Directory.CreateDirectory(_strmDirectory);
+
+        _config = new ConfigManager();
+        _config.UpdateValues(
+        [
+            new() { ConfigName = ConfigKeys.ApiCompletedDownloadsDir, ConfigValue = _strmDirectory },
+            new() { ConfigName = ConfigKeys.GeneralBaseUrl, ConfigValue = "http://localhost:3000" },
+            new() { ConfigName = ConfigKeys.ApiStrmKey, ConfigValue = "test-strm-key" },
+        ]);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        try { File.Delete(_databasePath); } catch (IOException) { /* best effort */ }
+        try { Directory.Delete(_strmDirectory, recursive: true); } catch (IOException) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task ProcessNextItemAsync_DeleteMountedFilesRemovesOwnedStrmSidecars()
+    {
+        var historyItemId = Guid.NewGuid();
+        var firstVideo = NewVideo(historyItemId, "tv/Show/S01E01.mkv");
+        var secondVideo = NewVideo(historyItemId, "tv/Show/S01E02.mkv");
+        _context.Items.AddRange(firstVideo, secondVideo);
+        _context.HistoryCleanupItems.Add(new HistoryCleanupItem
+        {
+            Id = historyItemId,
+            DeleteMountedFiles = true,
+        });
+        await _context.SaveChangesAsync();
+
+        await CreateStrmFilesPostProcessor.WriteStrmFileAsync(_config, firstVideo, forceRewrite: false);
+        await CreateStrmFilesPostProcessor.WriteStrmFileAsync(_config, secondVideo, forceRewrite: false);
+        var firstStrmPath = CreateStrmFilesPostProcessor.GetStrmFilePath(_config, firstVideo);
+        var secondStrmPath = CreateStrmFilesPostProcessor.GetStrmFilePath(_config, secondVideo);
+
+        var processed = await HistoryCleanupService.ProcessNextItemAsync(_context, _config);
+
+        Assert.True(processed);
+        Assert.False(File.Exists(firstStrmPath));
+        Assert.False(File.Exists(secondStrmPath));
+        Assert.False(await _context.Items.AsNoTracking().AnyAsync(x => x.HistoryItemId == historyItemId));
+        Assert.False(await _context.HistoryCleanupItems.AsNoTracking().AnyAsync(x => x.Id == historyItemId));
+    }
+
+    [Fact]
+    public async Task ProcessNextItemAsync_KeepMountedFilesPreservesStrmSidecars()
+    {
+        var historyItemId = Guid.NewGuid();
+        var video = NewVideo(historyItemId, "movies/Movie/movie.mkv");
+        _context.Items.Add(video);
+        _context.HistoryCleanupItems.Add(new HistoryCleanupItem
+        {
+            Id = historyItemId,
+            DeleteMountedFiles = false,
+        });
+        await _context.SaveChangesAsync();
+
+        await CreateStrmFilesPostProcessor.WriteStrmFileAsync(_config, video, forceRewrite: false);
+        var strmPath = CreateStrmFilesPostProcessor.GetStrmFilePath(_config, video);
+
+        var processed = await HistoryCleanupService.ProcessNextItemAsync(_context, _config);
+
+        Assert.True(processed);
+        Assert.True(File.Exists(strmPath));
+        var retainedItem = await _context.Items.AsNoTracking().SingleAsync(x => x.Id == video.Id);
+        Assert.Null(retainedItem.HistoryItemId);
+        Assert.False(await _context.HistoryCleanupItems.AsNoTracking().AnyAsync(x => x.Id == historyItemId));
+    }
+
+    private static DavItem NewVideo(Guid historyItemId, string relativePath)
+    {
+        var id = Guid.NewGuid();
+        var name = Path.GetFileName(relativePath);
+        return new DavItem
+        {
+            Id = id,
+            IdPrefix = id.ToString("N")[..DavItem.IdPrefixLength],
+            Name = name,
+            Type = DavItem.ItemType.UsenetFile,
+            SubType = DavItem.ItemSubType.NzbFile,
+            Path = $"/content/{relativePath}",
+            HistoryItemId = historyItemId,
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- remove generated completed-download STRM sidecars when deleting history items with **Delete mounted files**
- verify sidecar ownership before deletion and preserve unrelated or out-of-root files
- cover sidecar cleanup, keep-files behavior, and filesystem safety cases

Fixes #1119

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter \"FullyQualifiedName~CreateStrmFilesPostProcessorTests|FullyQualifiedName~HistoryCleanupServiceTests\"`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically removes associated STRM sidecar files when completed downloads are deleted.
  * Preserves unrelated, missing, externally located, or symlink-protected sidecar files.
  * Removes empty directories left behind after cleanup.
  * Improves cleanup handling when files or directories are already missing or being removed concurrently.
  * Keeps history records and mounted-file cleanup in sync.

* **Tests**
  * Added coverage for safe sidecar deletion and history cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->