### PR TITLE
fix(health): prevent health checks crashing on oversized metadata

### DIFF
--- a/backend/Services/Diagnostics/OomDiagnostics.cs
+++ b/backend/Services/Diagnostics/OomDiagnostics.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using NzbWebDAV.Streams;
+using NzbWebDAV.Utils;
 using Serilog;
 
 namespace NzbWebDAV.Services.Diagnostics;
@@ -17,18 +18,24 @@ internal static class OomDiagnostics
         try
         {
             var info = GC.GetGCMemoryInfo();
+            var addressSpace = AddressSpaceDiagnostics.Capture();
             Log.Warning(
-                exception,
                 "OutOfMemoryException during {Context}. Heap={Heap:N0} Committed={Committed:N0} " +
                 "Available={Available:N0} Fragmentation={Fragmentation:N0} " +
-                "InFlight={InFlight:N0} Cap={Cap:N0}",
+                "InFlight={InFlight:N0} Cap={Cap:N0} Virtual={Virtual:N0} RLIMIT_AS={AddressSpaceLimit:N0} " +
+                "RegionRange={RegionRange:N0} HeapHardLimit={HeapHardLimit:N0}",
                 context,
                 info.HeapSizeBytes,
                 info.TotalCommittedBytes,
                 info.TotalAvailableMemoryBytes,
                 info.FragmentedBytes,
                 InFlightArticleBudget.Current?.LeasedBytes ?? -1,
-                InFlightArticleBudget.Current?.CapBytes ?? -1);
+                InFlightArticleBudget.Current?.CapBytes ?? -1,
+                addressSpace.VirtualMemoryBytes ?? -1,
+                addressSpace.AddressSpaceLimitBytes ?? -1,
+                addressSpace.GcRegionRangeBytes ?? -1,
+                addressSpace.GcHeapHardLimitBytes ?? -1);
+            Log.Debug(exception, "OutOfMemoryException stack during {Context}", context);
         }
         catch
         {

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -1115,33 +1115,10 @@ public class HealthCheckService : BackgroundService
         HealthCheckDepth depth = ConfigManager.DefaultHealthCheckDepth,
         TimeSpan? age = null)
     {
-        var count = segments.Count;
-        var target = SampleTarget(count, depth, age);
-        if (count <= target) return segments;
+        if (segments.Count <= SampleTarget(segments.Count, depth, age))
+            return segments;
 
-        const int headCount = 100;
-        const int tailCount = 100;
-
-        var result = new HashSet<int>();
-
-        for (var i = 0; i < Math.Min(headCount, count); i++)
-            result.Add(i);
-
-        for (var i = Math.Max(0, count - tailCount); i < count; i++)
-            result.Add(i);
-
-        // Spread `target` picks across the file with a running remainder, so the sample lands
-        // on the target instead of on the nearest whole number stride.
-        var carry = 0L;
-        for (var i = 0; i < count; i++)
-        {
-            carry += target;
-            if (carry < count) continue;
-            carry -= count;
-            result.Add(i);
-        }
-
-        return result.OrderBy(i => i).Select(i => segments[i]).ToList();
+        return SampleSegmentsIndexed(segments, depth, age).ToList();
     }
 
     private static SegmentIndexView SampleSegmentsIndexed(
@@ -1338,19 +1315,19 @@ public class HealthCheckService : BackgroundService
     /// Presents archive parts as one indexable sequence without copying every Message-ID
     /// into a temporary flattened list.
     /// </summary>
-    private sealed class ConcatenatedSegmentView : IReadOnlyList<string>
+    internal sealed class ConcatenatedSegmentView : IReadOnlyList<string>
     {
         private readonly string[][] _parts;
         private readonly int[] _partEnds;
 
         public ConcatenatedSegmentView(string[][] parts)
         {
-            _parts = parts;
-            _partEnds = new int[parts.Length];
+            _parts = parts.Where(part => part.Length > 0).ToArray();
+            _partEnds = new int[_parts.Length];
             var count = 0;
-            for (var index = 0; index < parts.Length; index++)
+            for (var index = 0; index < _parts.Length; index++)
             {
-                count = checked(count + parts[index].Length);
+                count = checked(count + _parts[index].Length);
                 _partEnds[index] = count;
             }
         }

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -13,6 +13,7 @@ using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Queue.PostProcessors;
+using NzbWebDAV.Services.Diagnostics;
 using NzbWebDAV.Services.Repair;
 using NzbWebDAV.Streams;
 using NzbWebDAV.Utils;
@@ -328,29 +329,59 @@ public class HealthCheckService : BackgroundService
                 // Validate the local payload before Repair: missing metadata is
                 // local data loss, not a bad release, and must not reach the
                 // Arr remove-and-blocklist path. Routine checks get the same
-                // guarantee from GetAllSegments below.
-                await EnsurePayloadExistsAsync(davItem, dbClient, ct).ConfigureAwait(false);
+                // guarantee from LoadHealthCheckPayloadAsync below.
+                try
+                {
+                    await EnsurePayloadExistsAsync(davItem, dbClient, ct).ConfigureAwait(false);
+                }
+                catch (OutOfMemoryException oom)
+                {
+                    await DeferPayloadOutOfMemoryAsync(davItem, dbClient, oom, ct).ConfigureAwait(false);
+                    return;
+                }
                 Log.Information("Performing urgent dynamic repair for {FilePath}", davItem.Path);
                 await HandleUrgentRepair(davItem, dbClient, ct).ConfigureAwait(false);
                 return;
             }
 
+            HealthCheckPayload payload;
+            try
+            {
+                payload = await LoadHealthCheckPayloadAsync(davItem, dbClient, ct).ConfigureAwait(false);
+            }
+            catch (OutOfMemoryException oom)
+            {
+                await DeferPayloadOutOfMemoryAsync(davItem, dbClient, oom, ct).ConfigureAwait(false);
+                return;
+            }
+
+            var segments = payload.Segments;
+            var nzbFile = payload.NzbFile;
+
             // update the release date, if null
-            var segments = await GetAllSegments(davItem, dbClient, ct).ConfigureAwait(false);
             if (davItem.ReleaseDate == null) await UpdateReleaseDate(davItem, segments, ct).ConfigureAwait(false);
 
-            // sample large files to reduce NNTP load while keeping head/tail/stride coverage
+            // Sample large files to reduce NNTP load while keeping head/tail/stride coverage.
+            // SegmentIndexView retains source indices, so later repair logic does not need to
+            // build a dictionary over the full payload just to recover an index.
             var totalSegments = segments.Count;
             var age = _configManager.IsHealthCheckAgingEnabled() && davItem.ReleaseDate is { } posted
                 ? DateTimeOffset.UtcNow - posted
                 : (TimeSpan?)null;
-            var sampled = SampleSegments(segments, _configManager.GetHealthCheckDepth(), age);
-            var nzbFile = davItem.SubType == DavItem.ItemSubType.NzbFile
-                ? await dbClient.GetDavNzbFileAsync(davItem, ct).ConfigureAwait(false)
-                : null;
-            var statSegments = nzbFile != null
-                ? FilterSegmentsForStat(sampled, segments, nzbFile, _repairPatchStore)
-                : sampled;
+            SegmentIndexView sampled;
+            SegmentIndexView statSegments;
+            try
+            {
+                sampled = SampleSegmentsIndexed(segments, _configManager.GetHealthCheckDepth(), age);
+                statSegments = nzbFile != null
+                    ? FilterSegmentsForStat(sampled, nzbFile, _repairPatchStore)
+                    : sampled;
+            }
+            catch (OutOfMemoryException oom)
+            {
+                await DeferPayloadOutOfMemoryAsync(davItem, dbClient, oom, ct).ConfigureAwait(false);
+                return;
+            }
 
             // A damaged-but-tolerable video file can only be told apart from a failed one by a
             // full-coverage sweep of an eligible container with recorded segment sizes (#461).
@@ -403,7 +434,7 @@ public class HealthCheckService : BackgroundService
                             statSegments, depth: 0, concurrency, progress, statCts.Token)
                         .ConfigureAwait(false);
                     confirmedHoles = await ConfirmHolesThroughFallbacksAsync(
-                            missingIds, segments, nzbFile!, concurrency, statCts)
+                            missingIds, statSegments, nzbFile!, concurrency, statCts)
                         .ConfigureAwait(false);
                 }
             }
@@ -584,7 +615,7 @@ public class HealthCheckService : BackgroundService
         DavItem davItem,
         DavDatabaseClient dbClient,
         DavNzbFile nzbFile,
-        List<string> segments,
+        IReadOnlyList<string> segments,
         LongRange[] segmentRanges,
         List<int> missingIndices,
         List<int> corruptIndices,
@@ -697,7 +728,7 @@ public class HealthCheckService : BackgroundService
         ResolveContainerClassAsync(
             DavItem davItem,
             DavNzbFile nzbFile,
-            List<string> segments,
+            IReadOnlyList<string> segments,
             List<int> holeIndices,
             CancellationToken ct)
     {
@@ -743,23 +774,25 @@ public class HealthCheckService : BackgroundService
     /// </summary>
     private async Task<List<int>> ConfirmHolesThroughFallbacksAsync(
         IReadOnlyList<string> primaryMissIds,
-        List<string> segments,
+        SegmentIndexView statSegments,
         DavNzbFile nzbFile,
         int concurrency,
         ContextualCancellationTokenSource statCts)
     {
         if (primaryMissIds.Count == 0) return [];
 
-        var indexById = segments
-            .Select((id, index) => (id, index))
-            .ToDictionary(x => x.id, x => x.index, StringComparer.Ordinal);
+        var primaryMisses = new HashSet<string>(primaryMissIds, StringComparer.Ordinal);
+        var missingIndices = new List<int>(primaryMisses.Count);
+        for (var index = 0; index < statSegments.Count; index++)
+        {
+            if (primaryMisses.Contains(statSegments[index]))
+                missingIndices.Add(statSegments.SourceIndexAt(index));
+        }
 
-        var checks = primaryMissIds
-            .Select(missId => (Id: missId, Index: indexById.GetValueOrDefault(missId, -1)))
-            .Where(miss => miss.Index >= 0)
-            .Select(async miss => (
-                miss.Index,
-                IsHole: await IsConfirmedHoleAsync(miss.Index, nzbFile, statCts.Token).ConfigureAwait(false)))
+        var checks = missingIndices
+            .Select(async index => (
+                Index: index,
+                IsHole: await IsConfirmedHoleAsync(index, nzbFile, statCts.Token).ConfigureAwait(false)))
             .WithConcurrencyAsync(concurrency, statCts.Token);
 
         var holes = new List<int>();
@@ -911,6 +944,28 @@ public class HealthCheckService : BackgroundService
     {
         _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItemId}|100");
         _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItemId}|done");
+    }
+
+    private async Task DeferPayloadOutOfMemoryAsync(
+        DavItem davItem,
+        DavDatabaseClient dbClient,
+        OutOfMemoryException exception,
+        CancellationToken ct)
+    {
+        CompleteHealthProgress(davItem.Id);
+        OomDiagnostics.LogHeapStateOnOom(exception, $"health-check payload preparation for {davItem.Path}");
+
+        var utcNow = DateTimeOffset.UtcNow;
+        davItem.LastHealthCheck = utcNow;
+        davItem.NextHealthCheck = utcNow + TimeSpan.FromDays(1);
+        await RecordHealthResult(
+            dbClient,
+            davItem,
+            HealthCheckResult.HealthResult.Unhealthy,
+            HealthCheckResult.RepairAction.ActionNeeded,
+            "Health check deferred: the file's segment metadata exceeded the process memory limit. " +
+            "Increase the address-space limit or reduce the release size before retrying.",
+            ct).ConfigureAwait(false);
     }
 
     private async Task DeferHealthCheck(
@@ -1089,6 +1144,37 @@ public class HealthCheckService : BackgroundService
         return result.OrderBy(i => i).Select(i => segments[i]).ToList();
     }
 
+    private static SegmentIndexView SampleSegmentsIndexed(
+        IReadOnlyList<string> segments,
+        HealthCheckDepth depth,
+        TimeSpan? age)
+    {
+        var count = segments.Count;
+        var target = SampleTarget(count, depth, age);
+        if (count <= target) return new SegmentIndexView(segments);
+
+        const int headCount = 100;
+        const int tailCount = 100;
+        var indexes = new HashSet<int>();
+
+        for (var i = 0; i < Math.Min(headCount, count); i++)
+            indexes.Add(i);
+
+        for (var i = Math.Max(0, count - tailCount); i < count; i++)
+            indexes.Add(i);
+
+        var carry = 0L;
+        for (var i = 0; i < count; i++)
+        {
+            carry += target;
+            if (carry < count) continue;
+            carry -= count;
+            indexes.Add(i);
+        }
+
+        return new SegmentIndexView(segments, indexes.OrderBy(i => i).ToArray());
+    }
+
     internal static List<string> FilterSegmentsForStat(
         List<string> sampledSegmentIds,
         List<string> allSegmentIds,
@@ -1097,22 +1183,58 @@ public class HealthCheckService : BackgroundService
     {
         if (!patchStore.IsCatalogReady) return sampledSegmentIds;
 
-        var indexById = allSegmentIds
-            .Select((id, index) => (id, index))
-            .ToDictionary(x => x.id, x => x.index, StringComparer.Ordinal);
         var ranges = nzbFile.SegmentByteRanges;
+        var filtered = new List<string>(sampledSegmentIds.Count);
+        foreach (var segmentId in sampledSegmentIds)
+        {
+            var index = allSegmentIds.IndexOf(segmentId);
+            if (index < 0
+                || ranges == null
+                || index >= ranges.Length
+                || !patchStore.IsRepaired(segmentId, ranges[index].Count))
+                filtered.Add(segmentId);
+        }
 
-        return sampledSegmentIds
-            .Where(segmentId => !indexById.TryGetValue(segmentId, out var index)
-                                || ranges == null
-                                || index >= ranges.Length
-                                || !patchStore.IsRepaired(segmentId, ranges[index].Count))
-            .ToList();
+        return filtered;
     }
 
-    private async Task UpdateReleaseDate(DavItem davItem, List<string> segments, CancellationToken ct)
+    private static SegmentIndexView FilterSegmentsForStat(
+        SegmentIndexView sampledSegments,
+        DavNzbFile nzbFile,
+        RepairPatchStore patchStore)
     {
-        var firstSegmentId = StringUtil.EmptyToNull(segments.FirstOrDefault());
+        if (!patchStore.IsCatalogReady || patchStore.EntryCount == 0) return sampledSegments;
+
+        var ranges = nzbFile.SegmentByteRanges;
+        List<int>? filteredIndexes = null;
+        for (var index = 0; index < sampledSegments.Count; index++)
+        {
+            var sourceIndex = sampledSegments.SourceIndexAt(index);
+            var segmentId = sampledSegments[index];
+            var isRepaired = ranges != null
+                             && sourceIndex < ranges.Length
+                             && patchStore.IsRepaired(segmentId, ranges[sourceIndex].Count);
+            if (!isRepaired)
+            {
+                filteredIndexes?.Add(sourceIndex);
+                continue;
+            }
+
+            if (filteredIndexes != null) continue;
+
+            filteredIndexes = new List<int>(sampledSegments.Count - 1);
+            for (var prior = 0; prior < index; prior++)
+                filteredIndexes.Add(sampledSegments.SourceIndexAt(prior));
+        }
+
+        return filteredIndexes is null
+            ? sampledSegments
+            : new SegmentIndexView(sampledSegments.Source, filteredIndexes.ToArray());
+    }
+
+    private async Task UpdateReleaseDate(DavItem davItem, IReadOnlyList<string> segments, CancellationToken ct)
+    {
+        var firstSegmentId = segments.Count == 0 ? null : StringUtil.EmptyToNull(segments[0]);
         if (firstSegmentId == null) return;
         var articleHeadersResponse = await _usenetClient.HeadAsync(firstSegmentId, ct).ConfigureAwait(false);
         if (articleHeadersResponse.ArticleHeaders is not { } articleHeaders)
@@ -1139,30 +1261,124 @@ public class HealthCheckService : BackgroundService
         if (!exists) throw new MissingFilePayloadException(davItem, davItem.SubType);
     }
 
-    private async Task<List<string>> GetAllSegments(DavItem davItem, DavDatabaseClient dbClient, CancellationToken ct)
+    private async Task<HealthCheckPayload> LoadHealthCheckPayloadAsync(
+        DavItem davItem,
+        DavDatabaseClient dbClient,
+        CancellationToken ct)
     {
         if (davItem.SubType == DavItem.ItemSubType.NzbFile)
         {
             var nzbFile = await dbClient.GetDavNzbFileAsync(davItem, ct).ConfigureAwait(false);
-            return nzbFile?.SegmentIds?.ToList()
-                ?? throw new MissingFilePayloadException(davItem, DavItem.ItemSubType.NzbFile);
+            return nzbFile is null
+                ? throw new MissingFilePayloadException(davItem, DavItem.ItemSubType.NzbFile)
+                : new HealthCheckPayload(nzbFile.SegmentIds, nzbFile);
         }
 
         if (davItem.SubType == DavItem.ItemSubType.RarFile)
         {
             var rarFile = await dbClient.GetDavRarFileAsync(davItem, ct).ConfigureAwait(false);
-            return rarFile?.RarParts?.SelectMany(x => x.SegmentIds)?.ToList()
-                ?? throw new MissingFilePayloadException(davItem, DavItem.ItemSubType.RarFile);
+            return rarFile is null
+                ? throw new MissingFilePayloadException(davItem, DavItem.ItemSubType.RarFile)
+                : new HealthCheckPayload(
+                    new ConcatenatedSegmentView(rarFile.RarParts.Select(part => part.SegmentIds).ToArray()),
+                    null);
         }
 
         if (davItem.SubType == DavItem.ItemSubType.MultipartFile)
         {
             var multipartFile = await dbClient.GetDavMultipartFileAsync(davItem, ct).ConfigureAwait(false);
-            return multipartFile?.Metadata?.FileParts?.SelectMany(x => x.SegmentIds)?.ToList()
-                ?? throw new MissingFilePayloadException(davItem, DavItem.ItemSubType.MultipartFile);
+            return multipartFile is null
+                ? throw new MissingFilePayloadException(davItem, DavItem.ItemSubType.MultipartFile)
+                : new HealthCheckPayload(
+                    new ConcatenatedSegmentView(multipartFile.Metadata.FileParts.Select(part => part.SegmentIds).ToArray()),
+                    null);
         }
 
-        return [];
+        return new HealthCheckPayload(Array.Empty<string>(), null);
+    }
+
+    private readonly record struct HealthCheckPayload(
+        IReadOnlyList<string> Segments,
+        DavNzbFile? NzbFile);
+
+    /// <summary>
+    /// A sampled projection that retains its original segment indexes. The projection only
+    /// stores indexes when it is actually sampled; full checks use the source directly.
+    /// </summary>
+    private sealed class SegmentIndexView : IReadOnlyList<string>
+    {
+        private readonly int[]? _sourceIndexes;
+
+        public SegmentIndexView(IReadOnlyList<string> source, int[]? sourceIndexes = null)
+        {
+            Source = source;
+            _sourceIndexes = sourceIndexes;
+        }
+
+        public IReadOnlyList<string> Source { get; }
+        public int Count => _sourceIndexes?.Length ?? Source.Count;
+        public string this[int index] => Source[SourceIndexAt(index)];
+
+        public int SourceIndexAt(int index)
+        {
+            if ((uint)index >= (uint)Count) throw new ArgumentOutOfRangeException(nameof(index));
+            return _sourceIndexes?[index] ?? index;
+        }
+
+        public IEnumerator<string> GetEnumerator()
+        {
+            for (var index = 0; index < Count; index++)
+                yield return this[index];
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    /// <summary>
+    /// Presents archive parts as one indexable sequence without copying every Message-ID
+    /// into a temporary flattened list.
+    /// </summary>
+    private sealed class ConcatenatedSegmentView : IReadOnlyList<string>
+    {
+        private readonly string[][] _parts;
+        private readonly int[] _partEnds;
+
+        public ConcatenatedSegmentView(string[][] parts)
+        {
+            _parts = parts;
+            _partEnds = new int[parts.Length];
+            var count = 0;
+            for (var index = 0; index < parts.Length; index++)
+            {
+                count = checked(count + parts[index].Length);
+                _partEnds[index] = count;
+            }
+        }
+
+        public int Count => _partEnds.Length == 0 ? 0 : _partEnds[^1];
+
+        public string this[int index]
+        {
+            get
+            {
+                if ((uint)index >= (uint)Count) throw new ArgumentOutOfRangeException(nameof(index));
+                var partIndex = Array.BinarySearch(_partEnds, index + 1);
+                if (partIndex < 0) partIndex = ~partIndex;
+                var partStart = partIndex == 0 ? 0 : _partEnds[partIndex - 1];
+                return _parts[partIndex][index - partStart];
+            }
+        }
+
+        public IEnumerator<string> GetEnumerator()
+        {
+            foreach (var part in _parts)
+            {
+                foreach (var segmentId in part)
+                    yield return segmentId;
+            }
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     /// <summary>
@@ -1804,8 +2020,14 @@ public class HealthCheckService : BackgroundService
     {
         try
         {
-            var segments = await GetAllSegments(davItem, dbClient, ct).ConfigureAwait(false);
-            AddMissingSegmentIds(SelectRejectedReleaseSeedSegments(segments));
+            var payload = await LoadHealthCheckPayloadAsync(davItem, dbClient, ct).ConfigureAwait(false);
+            AddMissingSegmentIds(EnumerateRejectedReleaseSeedSegments(payload.Segments));
+        }
+        catch (OutOfMemoryException oom)
+        {
+            // Cache seeding is an optimization after Arr has already rejected the release.
+            // Do not let a huge payload turn that completed repair into a process-fatal OOM.
+            OomDiagnostics.LogHeapStateOnOom(oom, "rejected-release cache seeding");
         }
         catch (Exception e) when (!e.IsCancellationException(ct) && e is not OutOfMemoryException)
         {
@@ -1826,6 +2048,12 @@ public class HealthCheckService : BackgroundService
         segments.Count <= RejectedReleaseSeedSegments
             ? segments
             : segments.Take(RejectedReleaseSeedSegments).ToList();
+
+    private static IEnumerable<string> EnumerateRejectedReleaseSeedSegments(IReadOnlyList<string> segments)
+    {
+        for (var index = 0; index < Math.Min(segments.Count, RejectedReleaseSeedSegments); index++)
+            yield return segments[index];
+    }
 
     public static void AddMissingSegmentIds(IEnumerable<string> segmentIds)
     {

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -15,6 +15,7 @@ using NzbWebDAV.Services.Diagnostics;
 using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Streams;
+using NzbWebDAV.Utils;
 using Serilog;
 
 namespace NzbWebDAV.Services.SupportPack;
@@ -322,6 +323,7 @@ public sealed class SupportPackService(
         var concurrentReads = concurrentReadTracker?.Snapshot() ?? default;
         var bufferPool = BufferPoolDiagnostics.Shared.Snapshot();
         var segmentPool = (PooledBufferStream.DefaultPool as SegmentBufferPool)?.Snapshot();
+        var addressSpace = AddressSpaceDiagnostics.Capture();
         var cpu = await BuildCpuDiagnosticsAsync(usage, uptime, cancellationToken).ConfigureAwait(false);
 
         return new
@@ -345,6 +347,8 @@ public sealed class SupportPackService(
                 processorCount = Environment.ProcessorCount,
                 workingSetBytes = Environment.WorkingSet,
                 gcTotalMemoryBytes = GC.GetTotalMemory(forceFullCollection: false),
+                virtualMemoryBytes = addressSpace.VirtualMemoryBytes,
+                addressSpaceLimitBytes = addressSpace.AddressSpaceLimitBytes,
                 inFlightArticleBytes = inFlightArticleBudget.LeasedBytes,
                 inFlightArticleBudgetBytes = inFlightArticleBudget.CapBytes,
                 inFlightArticleThrottleEvents = inFlightArticleBudget.ThrottleEvents,
@@ -425,7 +429,7 @@ public sealed class SupportPackService(
             },
             runtimeSampler = BuildRuntimeSamplerDiagnostics(usage),
             cpu,
-            gc = BuildGcDiagnostics(usage),
+            gc = BuildGcDiagnostics(usage, addressSpace),
             gcDiagnostics = gcDiagnosticsStore.LastResult,
             threadPool = new
             {
@@ -567,7 +571,9 @@ public sealed class SupportPackService(
     /// collection. Pause percentages are of wall clock, not of core time, because a pause
     /// stops the whole process.
     /// </summary>
-    private static object BuildGcDiagnostics(RuntimeUsageSnapshot usage)
+    private static object BuildGcDiagnostics(
+        RuntimeUsageSnapshot usage,
+        AddressSpaceDiagnostics.Snapshot addressSpace)
     {
         var rolling = new
         {
@@ -603,6 +609,11 @@ public sealed class SupportPackService(
                 totalAllocatedBytes = GC.GetTotalAllocatedBytes(precise: false),
                 totalPauseDurationMs = (long)GC.GetTotalPauseDuration().TotalMilliseconds,
                 pauseTimePercentage = info.PauseTimePercentage,
+                heapLimitBytes = MemoryBudget.HeapLimitBytes,
+                heapHardLimitBytes = addressSpace.GcHeapHardLimitBytes,
+                heapHardLimitPercent = addressSpace.GcHeapHardLimitPercent,
+                regionRangeBytes = addressSpace.GcRegionRangeBytes,
+                regionSizeBytes = addressSpace.GcRegionSizeBytes,
                 heapSizeBytes = info.HeapSizeBytes,
                 committedBytes = info.TotalCommittedBytes,
                 generations,

--- a/backend/Utils/AddressSpaceDiagnostics.cs
+++ b/backend/Utils/AddressSpaceDiagnostics.cs
@@ -1,0 +1,108 @@
+using System.Diagnostics;
+using System.Globalization;
+
+namespace NzbWebDAV.Utils;
+
+/// <summary>
+/// Captures the virtual-address-space constraints that matter when a host uses
+/// <c>RLIMIT_AS</c> instead of a cgroup memory limit.
+/// </summary>
+internal static class AddressSpaceDiagnostics
+{
+    internal readonly record struct Snapshot(
+        long? AddressSpaceLimitBytes,
+        long? VirtualMemoryBytes,
+        long? GcRegionRangeBytes,
+        long? GcRegionSizeBytes,
+        long? GcHeapHardLimitBytes,
+        long? GcHeapHardLimitPercent,
+        long? GcCommittedBytes);
+
+    internal static Snapshot Capture()
+    {
+        long? virtualMemoryBytes = null;
+        try
+        {
+            using var process = Process.GetCurrentProcess();
+            virtualMemoryBytes = process.VirtualMemorySize64;
+        }
+        catch (Exception e) when (e is InvalidOperationException or PlatformNotSupportedException)
+        {
+            // Process diagnostics are optional and must not prevent startup or support-pack collection.
+        }
+
+        IReadOnlyDictionary<string, object>? config = null;
+        long? committedBytes = null;
+        try
+        {
+            config = GC.GetConfigurationVariables();
+            committedBytes = GC.GetGCMemoryInfo().TotalCommittedBytes;
+        }
+        catch (Exception e) when (e is InvalidOperationException or NotSupportedException)
+        {
+            // GC diagnostics are optional on unsupported runtimes.
+        }
+
+        return new Snapshot(
+            ReadLinuxAddressSpaceLimit(),
+            virtualMemoryBytes,
+            GetConfigurationValue(config, "GCRegionRange"),
+            GetConfigurationValue(config, "GCRegionSize"),
+            GetConfigurationValue(config, "GCHeapHardLimit"),
+            GetConfigurationValue(config, "GCHeapHardLimitPercent"),
+            committedBytes);
+    }
+
+    internal static long? ParseLinuxAddressSpaceLimit(string limits)
+    {
+        foreach (var line in limits.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (!line.StartsWith("Max address space", StringComparison.Ordinal)) continue;
+
+            var columns = line["Max address space".Length..]
+                .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+            if (columns.Length == 0 || columns[0].Equals("unlimited", StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            return long.TryParse(columns[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+                ? value
+                : null;
+        }
+
+        return null;
+    }
+
+    private static long? ReadLinuxAddressSpaceLimit()
+    {
+        const string limitsPath = "/proc/self/limits";
+        if (!OperatingSystem.IsLinux() || !File.Exists(limitsPath)) return null;
+
+        try
+        {
+            return ParseLinuxAddressSpaceLimit(File.ReadAllText(limitsPath));
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    private static long? GetConfigurationValue(
+        IReadOnlyDictionary<string, object>? config,
+        string name)
+    {
+        if (config is null || !config.TryGetValue(name, out var value)) return null;
+        var bytes = ToInt64(value);
+        return bytes > 0 ? bytes : null;
+    }
+
+    private static long ToInt64(object value) => value switch
+    {
+        long l => l,
+        ulong ul => ul > long.MaxValue ? long.MaxValue : (long)ul,
+        int i => i,
+        uint ui => ui,
+        string s when long.TryParse(s, CultureInfo.InvariantCulture, out var parsed) => parsed,
+        _ => 0,
+    };
+}

--- a/backend/Utils/MemoryBudget.cs
+++ b/backend/Utils/MemoryBudget.cs
@@ -88,9 +88,21 @@ public static class MemoryBudget
     /// <summary>One startup line saying what unset defaults the box affords.</summary>
     public static void LogInFlightBudget(int effectiveBudgetMb)
     {
+        var addressSpace = AddressSpaceDiagnostics.Capture();
         Log.Information(
-            "[MemoryBudget] Heap limit {HeapMB}MB -> in-flight article budget {BudgetMB}MB (derived when unset; explicit usenet.in-flight-article-budget-mb still wins).",
+            "[MemoryBudget] Heap limit {HeapMB}MB, GC hard limit {GcHardLimitMB}MB, region range {RegionRangeMB}MB, " +
+            "region size {RegionSizeMB}MB, committed heap {CommittedMB}MB, virtual memory {VirtualMemoryMB}MB, " +
+            "RLIMIT_AS {AddressSpaceLimitMB}MB -> in-flight article budget {BudgetMB}MB " +
+            "(derived when unset; explicit usenet.in-flight-article-budget-mb still wins).",
             HeapLimitBytes / Mb,
+            ToMegabytes(addressSpace.GcHeapHardLimitBytes),
+            ToMegabytes(addressSpace.GcRegionRangeBytes),
+            ToMegabytes(addressSpace.GcRegionSizeBytes),
+            ToMegabytes(addressSpace.GcCommittedBytes),
+            ToMegabytes(addressSpace.VirtualMemoryBytes),
+            ToMegabytes(addressSpace.AddressSpaceLimitBytes),
             effectiveBudgetMb);
     }
+
+    private static long? ToMegabytes(long? bytes) => bytes / Mb;
 }

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -97,6 +97,12 @@ or restrict backend capabilities when enforcement is required.
 | `USENET_DISABLE_CRC_VALIDATION` [since 0.8.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.8.0){ .nzbdav-since } | unset | `1` skips yEnc CRC checks (emergency) |
 | `THREADPOOL_MIN_THREADS` | `max(2×CPU, 50)` | Override min worker/IOCP threads |
 | `THREADPOOL_MAX_THREADS` | `max(50×CPU, 1000)` | Override max threads |
+| `DOTNET_GCHeapHardLimit` | runtime default | .NET managed-heap ceiling; hexadecimal bytes |
+| `DOTNET_GCHeapHardLimitPercent` | runtime/container default | .NET managed-heap ceiling as a hexadecimal percentage |
+| `DOTNET_GCRegionRange` | runtime default | .NET regions-GC virtual reservation; hexadecimal bytes |
+| `DOTNET_GCRegionSize` | runtime default | .NET SOH region size; hexadecimal bytes |
+| `DOTNET_GCConserveMemory` | `0` | .NET heap-conservation level (0–9) |
+| `DOTNET_gcServer` | image default (`1`) | Enables (`1`) or disables (`0`) server GC |
 | `MAX_REQUEST_BODY_SIZE` | 100 MiB | Max request body bytes |
 | `QUEUE_ITEM_STUCK_MINUTES` [since 1.1.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0){ .nzbdav-since } | `5` | Minutes without queue progress before the stuck-item watchdog pauses and cancels the worker |
 | `NZBDAV_VERSION` | `0.0.0` | Reported app version |
@@ -107,6 +113,12 @@ change Docker's published host port. For normal Compose deployments, leave the
 internal ports unchanged and use a `HOST_PORT:CONTAINER_PORT` mapping. See
 [Change the published port](../getting-started/docker.md#change-the-published-port)
 for bridge networking, host networking, healthcheck, and DUMB examples.
+
+`DOTNET_*` variables are .NET runtime settings rather than InfiniDysk
+configuration. Environment-variable numeric values are hexadecimal where the
+.NET runtime requires it. See [Memory-constrained hosts](../operations/memory-constrained-hosts.md)
+before setting heap or region limits, especially on a host that enforces
+`ulimit -v`.
 
 ## Settings fallbacks (when UI empty)
 

--- a/docs/operations/memory-constrained-hosts.md
+++ b/docs/operations/memory-constrained-hosts.md
@@ -1,0 +1,83 @@
+# Memory-constrained hosts
+
+InfiniDysk has a .NET backend and a Node frontend. Size the limit for both
+processes, plus sockets, TLS, SQLite, and native allocations—not only the
+managed .NET heap.
+
+## Container memory limits
+
+Prefer a real container memory limit (`docker run --memory` or the equivalent
+Compose/Kubernetes setting). .NET detects a cgroup limit and uses it when it
+derives its available-memory and unset streaming-budget defaults.
+
+Set an explicit **In-flight article budget** in Settings → Streaming on small
+hosts. Also cap provider connections and the streaming/queue connection
+settings to the throughput the host can sustain.
+
+## Hosts with `ulimit -v` / `RLIMIT_AS`
+
+`ulimit -v` caps *virtual address space*, not resident memory. A process can
+hit it while its RSS is comparatively small.
+
+On 64-bit Linux, the .NET regions GC reserves virtual address space up front.
+When only `DOTNET_GCHeapHardLimit` is configured, the default region range is
+five times that limit. Set `DOTNET_GCRegionRange` explicitly if that reservation
+does not fit alongside the rest of the process.
+
+Environment-variable byte values for these .NET GC settings are hexadecimal:
+
+```yaml
+environment:
+  # 512 MiB managed heap ceiling
+  DOTNET_GCHeapHardLimit: "20000000"
+  # 1 GiB regions reservation (2× the heap ceiling)
+  DOTNET_GCRegionRange: "40000000"
+  DOTNET_GCConserveMemory: "9"
+  # Bound worker growth separately from the GC heap.
+  THREADPOOL_MAX_THREADS: "200"
+```
+
+Treat a 2× region range as a starting point, not a universal value. Workloads
+that frequently make large object allocations can need a larger range; a range
+that is too small trades virtual address space for more full compacting GCs.
+`DOTNET_GCHeapHardLimitPercent` is usually unsuitable for a host that has only
+an address-space limit, because its percentage is based on physical/cgroup
+memory rather than `RLIMIT_AS`.
+
+Set these values before the backend starts. Confirm the active values in
+Settings → Support → downloaded `environment.json`: `runtime.addressSpaceLimitBytes`
+is the finite `RLIMIT_AS` when Linux exposes one, and the `gc` section reports
+the region range, size, hard limit, committed heap, and detected heap limit.
+
+## Repeated 64 MiB `PROT_NONE` mappings
+
+On a **glibc** host, a repeated pair of anonymous RW and `PROT_NONE` mappings
+whose combined size is 64 MiB commonly identifies glibc malloc arenas. It is
+not evidence that each NNTP socket has allocated 64 MiB.
+
+After verifying that map shape, try a conservative arena cap:
+
+```yaml
+environment:
+  MALLOC_ARENA_MAX: "2"
+```
+
+Fewer arenas can add allocator lock contention under highly concurrent TLS or
+download workloads, so measure throughput after changing it. This tuning is
+glibc-specific; the shipped Alpine image uses musl and does not use
+`MALLOC_ARENA_MAX`.
+
+## Additional safeguards
+
+- Lower provider **Max connections** and explicit download/queue connection
+  limits before reducing buffers. NNTP I/O is asynchronous; it does not create
+  a dedicated OS thread per socket.
+- Disable warm connections or shorten the idle timeout if many pooled sockets
+  are unnecessary.
+- Lower **Streaming body batch width** and set an explicit **In-flight article
+  budget** to reduce active decoded-pipe retention.
+- `DOTNET_GCRetainVM=0` is already the .NET default; setting it does not shrink
+  the initial regions-GC reservation.
+
+See [.NET runtime GC configuration](https://learn.microsoft.com/dotnet/core/runtime-config/garbage-collector)
+for the complete runtime-setting semantics.

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
@@ -647,6 +647,30 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
         Assert.Null(blob.CorruptSegmentIndices);
     }
 
+    [Fact]
+    public async Task PayloadOutOfMemory_IsDeferredWithoutStartingRepair()
+    {
+        var segments = NewSegmentIds(4);
+        var (item, _) = await AddVideoFileAsync("movie.mkv", segments, [10_000, 10_000, 10_000, 10_000]);
+        var (service, _) = await NewServiceAsync(NewFakeClient(segments, missing: []), par2Outcome: false);
+        var previousStore = BlobStore.Current;
+        BlobStore.Use(new OutOfMemoryBlobStore());
+        try
+        {
+            await service.PerformHealthCheck(item, _dbClient, concurrency: 4, CancellationToken.None);
+        }
+        finally
+        {
+            BlobStore.Use(previousStore);
+        }
+
+        var row = Assert.Single(GetHealthRows(item.Id));
+        Assert.Equal(HealthCheckResult.HealthResult.Unhealthy, row.Result);
+        Assert.Equal(HealthCheckResult.RepairAction.ActionNeeded, row.RepairStatus);
+        Assert.Contains("segment metadata exceeded", row.Message);
+        Assert.True(ReloadItem(item.Id).NextHealthCheck > DateTimeOffset.UtcNow.AddHours(23));
+    }
+
     private static string[] NewSegmentIds(int count) =>
         Enumerable.Range(0, count).Select(i => $"seg{i}-{Guid.NewGuid():N}@test").ToArray();
 
@@ -683,6 +707,22 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
             Memory<byte> buffer,
             CancellationToken cancellationToken = default) =>
             ValueTask.FromException<int>(CreateException());
+    }
+
+    private sealed class OutOfMemoryBlobStore : IBlobStore
+    {
+        public Task WriteBlob(Guid id, Stream stream, CancellationToken cancellationToken = default) =>
+            Task.FromException(new NotSupportedException());
+
+        public Task WriteBlob<T>(Guid id, T blob) =>
+            Task.FromException(new NotSupportedException());
+
+        public Stream? ReadBlob(Guid id) => null;
+
+        public Task<T?> ReadBlob<T>(Guid id) =>
+            Task.FromException<T?>(new OutOfMemoryException("simulated payload allocation failure"));
+
+        public void Delete(Guid id) => throw new NotSupportedException();
     }
 
     private async Task<(HealthCheckService Service, ScriptedPar2RepairService Par2)> NewServiceAsync(

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
@@ -652,7 +652,7 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
     {
         var segments = NewSegmentIds(4);
         var (item, _) = await AddVideoFileAsync("movie.mkv", segments, [10_000, 10_000, 10_000, 10_000]);
-        var (service, _) = await NewServiceAsync(NewFakeClient(segments, missing: []), par2Outcome: false);
+        var (service, par2) = await NewServiceAsync(NewFakeClient(segments, missing: []), par2Outcome: false);
         var previousStore = BlobStore.Current;
         BlobStore.Use(new OutOfMemoryBlobStore());
         try
@@ -668,7 +668,10 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
         Assert.Equal(HealthCheckResult.HealthResult.Unhealthy, row.Result);
         Assert.Equal(HealthCheckResult.RepairAction.ActionNeeded, row.RepairStatus);
         Assert.Contains("segment metadata exceeded", row.Message);
-        Assert.True(ReloadItem(item.Id).NextHealthCheck > DateTimeOffset.UtcNow.AddHours(23));
+        Assert.Empty(par2.Requests);
+        var persisted = ReloadItem(item.Id);
+        Assert.Equal(item.Id, persisted.Id);
+        Assert.True(persisted.NextHealthCheck > DateTimeOffset.UtcNow.AddHours(23));
     }
 
     private static string[] NewSegmentIds(int count) =>

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckSampleSegmentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckSampleSegmentsTests.cs
@@ -73,6 +73,21 @@ public class HealthCheckSampleSegmentsTests
     }
 
     [Fact]
+    public void ConcatenatedSegmentView_SkipsEmptyPartsWhilePreservingIndexes()
+    {
+        var segments = new HealthCheckService.ConcatenatedSegmentView(
+        [
+            ["first"],
+            [],
+            ["second", "third"],
+        ]);
+
+        Assert.Equal(["first", "second", "third"], segments);
+        Assert.Equal("second", segments[1]);
+        Assert.Equal("third", segments[2]);
+    }
+
+    [Fact]
     public void SampleSegments_CoverageTapersInsteadOfSteppingDown()
     {
         double Coverage(int count) =>

--- a/tests/NzbWebDAV.Tests/Services/OomDiagnosticsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/OomDiagnosticsTests.cs
@@ -20,6 +20,11 @@ public sealed class OomDiagnosticsTests
             e => e.MessageTemplate.Text.Contains("OutOfMemoryException during"));
         Assert.Equal(LogEventLevel.Warning, entry.Level);
         Assert.Contains("OutOfMemoryException during", entry.MessageTemplate.Text);
+        Assert.Null(entry.Exception);
+        Assert.Contains(events, e =>
+            e.Level == LogEventLevel.Debug &&
+            e.MessageTemplate.Text.Contains("OutOfMemoryException stack") &&
+            e.Exception is OutOfMemoryException);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -143,6 +143,9 @@ public sealed class SupportPackContentsTests : IDisposable
         Assert.True(gc.GetProperty("totalAllocatedBytes").GetInt64() > 0);
         Assert.True(gc.GetProperty("totalPauseDurationMs").GetInt64() >= 0);
         Assert.True(gc.TryGetProperty("isServerGc", out _));
+        Assert.True(gc.GetProperty("heapLimitBytes").GetInt64() > 0);
+        Assert.True(gc.TryGetProperty("regionRangeBytes", out _));
+        Assert.True(gc.TryGetProperty("regionSizeBytes", out _));
         // Article buffers land on the large-object heap, so its size must be visible.
         var generations = gc.GetProperty("generations").EnumerateArray()
             .Select(entry => entry.GetProperty("name").GetString())
@@ -153,6 +156,10 @@ public sealed class SupportPackContentsTests : IDisposable
         Assert.True(threadPool.GetProperty("threadCount").GetInt32() >= 0);
         Assert.True(threadPool.GetProperty("pendingWorkItems").GetInt64() >= 0);
         Assert.True(threadPool.GetProperty("completedWorkItems").GetInt64() >= 0);
+
+        var runtime = root.GetProperty("runtime");
+        Assert.True(runtime.TryGetProperty("virtualMemoryBytes", out _));
+        Assert.True(runtime.TryGetProperty("addressSpaceLimitBytes", out _));
 
         // No providers are configured in this fixture, so the section is present but empty.
         Assert.Equal(JsonValueKind.Array, root.GetProperty("connections").ValueKind);

--- a/tests/NzbWebDAV.Tests/Utils/AddressSpaceDiagnosticsTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/AddressSpaceDiagnosticsTests.cs
@@ -1,0 +1,38 @@
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public sealed class AddressSpaceDiagnosticsTests
+{
+    [Fact]
+    public void ParseLinuxAddressSpaceLimit_ReturnsFiniteSoftLimit()
+    {
+        const string limits = """
+            Limit                     Soft Limit           Hard Limit           Units
+            Max address space         10000000000          unlimited            bytes
+            """;
+
+        Assert.Equal(10_000_000_000, AddressSpaceDiagnostics.ParseLinuxAddressSpaceLimit(limits));
+    }
+
+    [Fact]
+    public void ParseLinuxAddressSpaceLimit_ReturnsNullForUnlimitedOrMissingLimit()
+    {
+        const string unlimited = """
+            Limit                     Soft Limit           Hard Limit           Units
+            Max address space         unlimited            unlimited            bytes
+            """;
+
+        Assert.Null(AddressSpaceDiagnostics.ParseLinuxAddressSpaceLimit(unlimited));
+        Assert.Null(AddressSpaceDiagnostics.ParseLinuxAddressSpaceLimit("Max open files            1024                 4096                 files"));
+    }
+
+    [Fact]
+    public void Capture_ReturnsNonNegativeVirtualMemoryWhenAvailable()
+    {
+        var snapshot = AddressSpaceDiagnostics.Capture();
+
+        Assert.True(snapshot.VirtualMemoryBytes is null or >= 0);
+        Assert.True(snapshot.GcCommittedBytes is null or >= 0);
+    }
+}

--- a/zensical.toml
+++ b/zensical.toml
@@ -82,6 +82,7 @@ nav = [
   { "Operations" = [
     { "Health and repairs" = "operations/health-repairs.md" },
     { "Prometheus metrics" = "operations/prometheus.md" },
+    { "Memory-constrained hosts" = "operations/memory-constrained-hosts.md" },
     { "Retention and cleanup" = "operations/retention-cleanup.md" },
     { "Logs and crash dumps" = "operations/logs-crash-dumps.md" },
     { "Deletion audit" = "operations/deletion-audit.md" },


### PR DESCRIPTION
## Summary
- defer health checks when a file payload cannot fit in the process address space, instead of faulting the service
- avoid duplicating complete segment-ID collections and report GC region/RLIMIT_AS diagnostics in support packs and startup logs
- document shared-host runtime tuning and add regression coverage

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [x] `zensical build --clean --strict`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Health checks now handle memory allocation failures safely, defer checks, and avoid starting repairs prematurely.
  * Payload sampling and repair classification remain accurate when segments are filtered or rearranged.
  * Missing payload metadata is reported more clearly.
  * Out-of-memory diagnostics now provide more actionable memory and address-space details.

* **Documentation**
  * Added guidance for configuring and operating the application on memory-constrained hosts.
  * Documented relevant .NET GC environment variables and linked the new guidance in Operations navigation.

* **Diagnostics**
  * Support packs and budget warnings now include expanded virtual-memory, heap, and address-space metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->