### PR TITLE
fix(ui): hide Stable/Dev label in the version dropdown on mobile

### DIFF
--- a/frontend/app/routes/_index/components/top-navigation/top-navigation.test.tsx
+++ b/frontend/app/routes/_index/components/top-navigation/top-navigation.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { TopNavigation } from "./top-navigation";
+
+vi.mock("../live-usenet-connections/live-usenet-connections", () => ({
+  LiveUsenetConnections: () => null,
+}));
+
+afterEach(cleanup);
+
+function renderTopNavigation(version = "0.8.0") {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "*",
+        element: (
+          <TopNavigation
+            isHamburgerMenuOpen={false}
+            onHamburgerMenuClick={() => undefined}
+            drawerToggleId="drawer"
+            version={version}
+          />
+        ),
+      },
+    ],
+    { initialEntries: ["/"] },
+  );
+
+  return render(<RouterProvider router={router} />);
+}
+
+describe("TopNavigation version summary", () => {
+  it("hides the channel label and separator below the sm breakpoint", () => {
+    renderTopNavigation();
+
+    const channelLabel = screen.getByText("Stable");
+    expect(channelLabel.className).toContain("hidden");
+    expect(channelLabel.className).toContain("sm:inline");
+
+    const separator = channelLabel.nextElementSibling;
+    expect(separator).toBeInstanceOf(HTMLSpanElement);
+    expect(separator?.getAttribute("aria-hidden")).toBe("true");
+    expect(separator?.className).toContain("hidden");
+    expect(separator?.className).toContain("sm:block");
+
+    expect(screen.getAllByText("0.8.0")).toHaveLength(2);
+    expect(screen.getByText("InfiniDysk Stable")).toBeTruthy();
+  });
+});

--- a/frontend/app/routes/_index/components/top-navigation/top-navigation.tsx
+++ b/frontend/app/routes/_index/components/top-navigation/top-navigation.tsx
@@ -111,7 +111,10 @@ export const TopNavigation = memo(function TopNavigation(props: TopNavigationPro
                   <span className="hidden text-[10px] font-semibold uppercase tracking-[0.14em] text-base-content/40 sm:inline">
                     {channelLabel}
                   </span>
-                  <span className="hidden h-3 w-px bg-base-content/15 sm:block" aria-hidden="true" />
+                  <span
+                    className="hidden h-3 w-px bg-base-content/15 sm:block"
+                    aria-hidden="true"
+                  />
                   <span className="font-mono text-sm tracking-tight text-base-content/80">
                     {displayVersion}
                   </span>

--- a/frontend/app/routes/_index/components/top-navigation/top-navigation.tsx
+++ b/frontend/app/routes/_index/components/top-navigation/top-navigation.tsx
@@ -108,10 +108,10 @@ export const TopNavigation = memo(function TopNavigation(props: TopNavigationPro
             ) : (
               <span className="btn btn-ghost h-10 min-h-10 shrink-0 gap-2 rounded-[calc(var(--radius-box)-1px)] border-0 bg-base-200 px-4 whitespace-nowrap hover:bg-base-200 pointer-events-none">
                 <span className="inline-flex items-center gap-2 whitespace-nowrap">
-                  <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-base-content/40">
+                  <span className="hidden text-[10px] font-semibold uppercase tracking-[0.14em] text-base-content/40 sm:inline">
                     {channelLabel}
                   </span>
-                  <span className="h-3 w-px bg-base-content/15" aria-hidden="true" />
+                  <span className="hidden h-3 w-px bg-base-content/15 sm:block" aria-hidden="true" />
                   <span className="font-mono text-sm tracking-tight text-base-content/80">
                     {displayVersion}
                   </span>


### PR DESCRIPTION
## Summary
- Hide the top-nav `Stable`/`Dev` channel label and its separator below the `sm` breakpoint so the version block takes less horizontal room on mobile.
- Keep the version number and dropdown chevron visible, and leave the opened menu title unchanged so the channel is still available there.

## Test plan
- [x] `npx vitest run app/routes/_index/components/top-navigation/top-navigation.test.tsx` from `frontend/`
- [x] `npm run typecheck` from `frontend/`
- [ ] On a narrow mobile viewport, confirm the version dropdown shows only the version (no `Stable`/`Dev` or divider) and still opens.
- [ ] At `sm` and above, confirm `Stable`/`Dev` plus the divider still appear next to the version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive navigation by hiding the version channel label and separator on smaller screens.
  * Preserved channel information on larger screens.

* **Tests**
  * Added coverage for responsive visibility and version label rendering in the top navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->