### PR TITLE
fix(streams): Article RAM waits no longer inflate during playback

### DIFF
--- a/backend/Services/Observability/PrometheusMetrics.cs
+++ b/backend/Services/Observability/PrometheusMetrics.cs
@@ -74,7 +74,9 @@ public sealed class PrometheusMetrics
         _inFlightSegmentFetches = metrics.CreateGauge("nzbdav_concurrent_in_flight_segment_fetches", "Current in-flight segment fetches.");
         _articleBudgetBytes = metrics.CreateGauge("nzbdav_inflight_article_bytes", "Article bytes currently leased.");
         _articleBudgetCapBytes = metrics.CreateGauge("nzbdav_inflight_article_budget_bytes", "Configured in-flight article byte budget.");
-        _articleBudgetThrottleEvents = metrics.CreateCounter("nzbdav_inflight_article_throttle_events_total", "Article budget throttle events.");
+        _articleBudgetThrottleEvents = metrics.CreateCounter(
+            "nzbdav_inflight_article_throttle_events_total",
+            "Article RAM lease requests that encountered budget backpressure.");
         _metricsQueueLength = metrics.CreateGauge("nzbdav_metrics_queue_length", "Queued internal metric rows.", new GaugeConfiguration { LabelNames = ["queue"] });
         _metricsDropped = metrics.CreateCounter("nzbdav_metrics_dropped_total", "Dropped internal metric rows.", new CounterConfiguration { LabelNames = ["queue"] });
         _poolConnections = metrics.CreateGauge("nzbdav_nntp_pool_connections", "NNTP pool connection state.", new GaugeConfiguration { LabelNames = ["provider_key", "state"] });

--- a/backend/Streams/InFlightArticleBudget.cs
+++ b/backend/Streams/InFlightArticleBudget.cs
@@ -38,6 +38,7 @@ public sealed class InFlightArticleBudget
 
     public long LeasedBytes => Interlocked.Read(ref _leased);
     public long CapBytes => Interlocked.Read(ref _capBytes);
+    /// <summary>Number of leases that encountered Article RAM backpressure.</summary>
     public long ThrottleEvents => Interlocked.Read(ref _throttleEvents);
 
     /// <summary>
@@ -93,9 +94,12 @@ public sealed class InFlightArticleBudget
                     return new ArticleByteLease(this, bytes);
                 }
 
-                Interlocked.Increment(ref _throttleEvents);
                 MaybeWarn(bytes);
-                waitTimer ??= Stopwatch.StartNew();
+                if (waitTimer is null)
+                {
+                    waitTimer = Stopwatch.StartNew();
+                    Interlocked.Increment(ref _throttleEvents);
+                }
 
                 waiter ??= new Waiter(bytes);
                 lock (_gate)

--- a/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
@@ -778,7 +778,14 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
         {
             gate2.Set();
             await cts.CancelAsync();
-            await loop.WaitAsync(TimeSpan.FromSeconds(5));
+            try
+            {
+                await loop.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            catch (OperationCanceledException) when (cts.IsCancellationRequested)
+            {
+                // Expected when shutdown cancels GetTopQueueItem.
+            }
         }
     }
 

--- a/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
@@ -727,7 +727,7 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
         DateTime item1CompleteAt = default;
         DateTime item2ClaimedAt = default;
         using var gate1 = new ManualResetEventSlim(true);
-        using var gate2 = new ManualResetEventSlim(true);
+        using var gate2 = new ManualResetEventSlim(false);
 
         _queueManager.GetTopQueueItemOverride = async (exclude, ct) =>
         {
@@ -766,6 +766,11 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
         Assert.True(
             gap < TimeSpan.FromMilliseconds(500),
             $"Second item claimed {gap.TotalMilliseconds:F0}ms after first completed; expected prompt claim");
+
+        var item2InProgress = await WaitForInProgress(item2.Id, TimeSpan.FromSeconds(5));
+        Assert.NotNull(item2InProgress);
+        gate2.Set();
+        await GetProcessingTask(item2InProgress!).WaitAsync(TimeSpan.FromSeconds(5));
 
         await cts.CancelAsync();
         await loop.WaitAsync(TimeSpan.FromSeconds(5));

--- a/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
@@ -759,21 +759,27 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
         var loop = _queueManager.ProcessQueueAsync(cts.Token);
 
-        await item1CompleteTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        await item2ClaimedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        try
+        {
+            await item1CompleteTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await item2ClaimedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-        var gap = item2ClaimedAt - item1CompleteAt;
-        Assert.True(
-            gap < TimeSpan.FromMilliseconds(500),
-            $"Second item claimed {gap.TotalMilliseconds:F0}ms after first completed; expected prompt claim");
+            var gap = item2ClaimedAt - item1CompleteAt;
+            Assert.True(
+                gap < TimeSpan.FromMilliseconds(500),
+                $"Second item claimed {gap.TotalMilliseconds:F0}ms after first completed; expected prompt claim");
 
-        var item2InProgress = await WaitForInProgress(item2.Id, TimeSpan.FromSeconds(5));
-        Assert.NotNull(item2InProgress);
-        gate2.Set();
-        await GetProcessingTask(item2InProgress!).WaitAsync(TimeSpan.FromSeconds(5));
-
-        await cts.CancelAsync();
-        await loop.WaitAsync(TimeSpan.FromSeconds(5));
+            var item2InProgress = await WaitForInProgress(item2.Id, TimeSpan.FromSeconds(5));
+            Assert.NotNull(item2InProgress);
+            gate2.Set();
+            await GetProcessingTask(item2InProgress!).WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            gate2.Set();
+            await cts.CancelAsync();
+            await loop.WaitAsync(TimeSpan.FromSeconds(5));
+        }
     }
 
     private object? FindInProgressItem(Guid queueItemId, QueueManager? manager = null)

--- a/tests/NzbWebDAV.Tests/Streams/InFlightArticleBudgetTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/InFlightArticleBudgetTests.cs
@@ -64,6 +64,35 @@ public class InFlightArticleBudgetTests
     }
 
     [Fact]
+    public async Task LeaseAsync_RepeatedPartialWakes_CountsOneThrottleEvent()
+    {
+        const long cap = 1_000;
+        var budget = new InFlightArticleBudget(cap);
+        budget.AccountBufferedPipeBytes(cap);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var waiter = budget.LeaseAsync(500, cts.Token).AsTask();
+        await WaitUntil(() => budget.ThrottleEvents == 1);
+
+        for (var i = 0; i < 10; i++)
+        {
+            budget.AccountBufferedPipeBytes(-10);
+            await Task.Delay(10);
+            Assert.False(waiter.IsCompleted);
+        }
+
+        Assert.Equal(1, budget.ThrottleEvents);
+
+        budget.AccountBufferedPipeBytes(-500);
+        using var lease = await waiter.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(900, budget.LeasedBytes);
+
+        lease.Dispose();
+        budget.AccountBufferedPipeBytes(-400);
+        Assert.Equal(0, budget.LeasedBytes);
+    }
+
+    [Fact]
     public async Task LeaseAsync_QueuedHead_NewcomerDoesNotBargeReleasedCapacity()
     {
         const long cap = 1_000;


### PR DESCRIPTION
## Summary
- Count each Article RAM admission wait once, even when partial pipe releases wake the same request repeatedly.
- Clarify the Prometheus throttle metric as the number of requests that encountered backpressure.
- Cover repeated partial wake-ups with a regression test.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~InFlightArticleBudgetTests"`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved article memory-budget throttling when capacity is released in partial amounts.
  * Prevented duplicate throttle events and ensured queued operations wait until sufficient capacity is available.
  * Improved queue processing so healthy items can continue promptly once progress is confirmed.
  * Clarified throttling metrics and documentation for more accurate monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->