### PR TITLE
fix: prevent intermittent backend CI failures

### DIFF
--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -521,6 +521,15 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
         if (remaining.Length > 0)
         {
             try { await Task.WhenAll(remaining).ConfigureAwait(false); }
+            catch (OperationCanceledException)
+            {
+                // Workers are cancelled deliberately during shutdown.
+            }
+            catch (AggregateException e) when (
+                e.Flatten().InnerExceptions.All(exception => exception.IsCancellationException()))
+            {
+                // Task.WhenAll may retain multiple expected worker cancellations.
+            }
 #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
             catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
 #pragma warning restore CA2016

--- a/backend/Utils/StreamingResponseWriteWatchdog.cs
+++ b/backend/Utils/StreamingResponseWriteWatchdog.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Streams;
 
@@ -15,7 +14,8 @@ namespace NzbWebDAV.Utils;
 internal sealed class StreamingResponseWriteWatchdog(
     TimeSpan timeout,
     CancellationTokenSource readCts,
-    InFlightArticleBudget? budget)
+    InFlightArticleBudget? budget,
+    TimeProvider? timeProvider = null)
 {
     /// <summary>
     /// Size of the WebDAV/`/view` copy buffer. Aggregate reclaim fires when a
@@ -26,16 +26,18 @@ internal sealed class StreamingResponseWriteWatchdog(
 
     private long _windowWriteTicks;
     private long _windowBytes;
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
 
     public async ValueTask WriteAsync(
         Stream dest,
         Memory<byte> chunk,
         CancellationToken cancellationToken)
     {
-        var writeStarted = Stopwatch.GetTimestamp();
+        var writeStarted = _timeProvider.GetTimestamp();
         await WriteWithProgressTimeoutAsync(dest, chunk, timeout, readCts, cancellationToken)
             .ConfigureAwait(false);
-        if (ObserveWrite(chunk.Length, Stopwatch.GetElapsedTime(writeStarted)))
+        if (ObserveWrite(chunk.Length, _timeProvider.GetElapsedTime(
+            writeStarted, _timeProvider.GetTimestamp())))
         {
             await readCts.CancelAsync().ConfigureAwait(false);
             throw new StreamingWriteTimeoutException(

--- a/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
@@ -174,6 +174,7 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
             return (claimed, stall);
         };
 
+        var pauseWindowStarted = DateTime.Now;
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
         var loop = _queueManager.ProcessQueueAsync(cts.Token);
 
@@ -187,9 +188,15 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
         }
 
         Assert.NotNull(inProgress);
-        stall.BindWorker(GetWorkerCts(inProgress!));
+        var workerCts = GetWorkerCts(inProgress!);
+        stall.BindWorker(workerCts);
 
         deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline && !workerCts.IsCancellationRequested)
+            await Task.Delay(20);
+
+        Assert.True(workerCts.IsCancellationRequested);
+
         DateTime? pauseUntil = null;
         while (DateTime.UtcNow < deadline)
         {
@@ -203,8 +210,10 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
         }
 
         Assert.NotNull(pauseUntil);
-        var now = DateTime.Now;
-        Assert.InRange(pauseUntil!.Value, now + TimeSpan.FromMinutes(14), now + TimeSpan.FromMinutes(21));
+        Assert.InRange(
+            pauseUntil!.Value,
+            pauseWindowStarted + TimeSpan.FromMinutes(14),
+            pauseWindowStarted + TimeSpan.FromMinutes(21));
 
         await using (var ctx = new DavDatabaseContext(_options))
         {
@@ -212,10 +221,16 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
             Assert.Equal(1, await ctx.QueueItems.CountAsync());
         }
 
-        Assert.True(GetWorkerCts(inProgress!).IsCancellationRequested);
-
         await cts.CancelAsync();
-        await loop.WaitAsync(TimeSpan.FromSeconds(5));
+        try
+        {
+            await loop.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        catch (OperationCanceledException)
+        {
+            // ProcessQueueAsync may still be inside GetTopQueueItem when the loop token
+            // is cancelled; shutdown cancellation is expected once assertions pass.
+        }
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Utils/StreamingResponseWriteWatchdogTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/StreamingResponseWriteWatchdogTests.cs
@@ -103,13 +103,22 @@ public class StreamingResponseWriteWatchdogTests
         await WaitUntil(() => budget.HasWaiters);
 
         using var readCts = new CancellationTokenSource();
-        using var dest = new DelayedCompletingWriteStream(TimeSpan.FromMilliseconds(400));
+        using var dest = new BlockingWriteStream(writeCount: 2);
+        var timeProvider = new ManualTimeProvider();
         var watchdog = new StreamingResponseWriteWatchdog(
-            TimeSpan.FromMilliseconds(700), readCts, budget);
+            TimeSpan.FromMilliseconds(700), readCts, budget, timeProvider);
 
-        await watchdog.WriteAsync(dest, new byte[100], CancellationToken.None);
-        var ex = await Assert.ThrowsAsync<StreamingWriteTimeoutException>(async () =>
-            await watchdog.WriteAsync(dest, new byte[100], CancellationToken.None));
+        var firstWrite = watchdog.WriteAsync(dest, new byte[100], CancellationToken.None).AsTask();
+        await dest.WaitForWriteAsync(0);
+        timeProvider.Advance(TimeSpan.FromMilliseconds(400));
+        dest.ReleaseWrite(0);
+        await firstWrite;
+
+        var secondWrite = watchdog.WriteAsync(dest, new byte[100], CancellationToken.None).AsTask();
+        await dest.WaitForWriteAsync(1);
+        timeProvider.Advance(TimeSpan.FromMilliseconds(400));
+        dest.ReleaseWrite(1);
+        var ex = await Assert.ThrowsAsync<StreamingWriteTimeoutException>(() => secondWrite);
 
         Assert.True(readCts.IsCancellationRequested);
         Assert.Equal(StreamingWriteTimeoutException.AggregateReclaimReason, ex.Reason);
@@ -147,8 +156,13 @@ public class StreamingResponseWriteWatchdogTests
         }
     }
 
-    private sealed class DelayedCompletingWriteStream(TimeSpan delay) : Stream
+    private sealed class BlockingWriteStream(int writeCount) : Stream
     {
+        private readonly WriteGate[] _gates = Enumerable.Range(0, writeCount)
+            .Select(_ => new WriteGate())
+            .ToArray();
+        private int _nextWrite;
+
         public override bool CanWrite => true;
         public override bool CanRead => false;
         public override bool CanSeek => false;
@@ -160,10 +174,35 @@ public class StreamingResponseWriteWatchdogTests
         public override void SetLength(long value) { }
         public override void Write(byte[] buffer, int offset, int count) { }
 
+        public Task WaitForWriteAsync(int index) => _gates[index].Started.Task;
+
+        public void ReleaseWrite(int index) => _gates[index].Release.TrySetResult();
+
         public override async ValueTask WriteAsync(
             ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
-            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            var gate = _gates[Interlocked.Increment(ref _nextWrite) - 1];
+            gate.Started.TrySetResult();
+            await gate.Release.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
+
+        private sealed class WriteGate
+        {
+            public TaskCompletionSource Started { get; } =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            public TaskCompletionSource Release { get; } =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+    }
+
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => Interlocked.Read(ref _timestamp);
+
+        public void Advance(TimeSpan elapsed) => Interlocked.Add(ref _timestamp, elapsed.Ticks);
     }
 }


### PR DESCRIPTION
## Summary
- make streaming write-watchdog timing deterministic under CI load
- remove the queue watchdog test race between persisting the pause and cancelling the worker
- treat intentionally cancelled queue workers as clean shutdowns

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore`
- [x] Ran `StreamingResponseWriteWatchdogTests` 50 times
- [x] Ran `StuckProgress_CancelsWorkerAndSetsPauseUntil` 20 times

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queue shutdown handling so expected worker cancellations no longer produce unnecessary errors.
  * Improved streaming write timeout measurement for more reliable behavior under stalled or concurrent writes.
  * Preserved timeout enforcement and resource-reclaim behavior when writes exceed allowed durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->