### PR TITLE
fix(usenet): auto article memory scales on large-memory hosts

### DIFF
--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -986,7 +986,7 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
 
     /// <summary>
     /// Host-wide cap on decoded article bytes retained in RAM across concurrent WebDAV
-    /// streams. When unset, derived from the process heap limit (25%, clamped [64, 512]).
+    /// streams. When unset, derived from the process heap limit (25%, clamped [64, 8192]).
     /// Explicit values keep the existing [64, 8192] clamp. Distinct from
     /// <see cref="GetArticleBufferSize"/>, which bounds per-stream segment count.
     /// </summary>

--- a/backend/Utils/MemoryBudget.cs
+++ b/backend/Utils/MemoryBudget.cs
@@ -17,7 +17,7 @@ public static class MemoryBudget
     private const double InFlightBudgetShare = 0.25;
 
     private const int MinInFlightArticleBudgetMb = 64;
-    private const int MaxDefaultInFlightArticleBudgetMb = 512;
+    private const int MaxDefaultInFlightArticleBudgetMb = 8192;
 
     private static readonly Lazy<long> LazyHeapLimit = new(DetectHeapLimitBytes);
 
@@ -26,8 +26,8 @@ public static class MemoryBudget
 
     /// <summary>
     /// Default for <c>usenet.in-flight-article-budget-mb</c> when unset: 25% of the
-    /// detected heap limit, clamped to [64, 512] so large hosts keep today's ceiling
-    /// and small hosts do not dedicate half their RAM to decoded articles.
+    /// detected managed-heap ceiling, clamped to [64, 8192]. The budget gates
+    /// decoded-article admission; it does not reserve that memory eagerly.
     /// </summary>
     public static int DefaultInFlightArticleBudgetMb() =>
         DefaultInFlightArticleBudgetMb(HeapLimitBytes);

--- a/docs/configuration/streaming.md
+++ b/docs/configuration/streaming.md
@@ -41,7 +41,7 @@ is saturated.
 | Streaming Write Timeout | `usenet.streaming-write-timeout-seconds` | `60` | Per-write deadline, 0–600 seconds (0 disables); also cancels a stream that transfers less than 64 KB per timeout window while other streams wait on Article RAM |
 | Streaming Segment Retries | `usenet.streaming-segment-retries` | `3` | Fresh-connection retries after timeout, 0–5 |
 | Article Buffer Size | `usenet.article-buffer-size` | `40` | Articles buffered ahead per stream |
-| In-flight article budget (MiB) [since 0.8.2](https://github.com/infinidysk/infinidysk/releases/tag/v0.8.2){ .nzbdav-since } | `usenet.in-flight-article-budget-mb` | auto | Host-wide decoded-byte cap, 64–8192 MiB |
+| In-flight article budget (MiB) [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since } | `usenet.in-flight-article-budget-mb` | auto | Host-wide decoded-byte cap. Auto uses 25% of the detected managed-heap ceiling, clamped to 64–8192 MiB; explicit values also range from 64–8192 MiB |
 | Idle connection timeout | `usenet.idle-connection-timeout-seconds` | `60` | Close unused connections after 15–300 seconds |
 | Batched article downloads | `usenet.pipelined-body-requests` | on | Fetch WebDAV BODY requests in small batches |
 | Streaming batch width [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since } | `usenet.streaming-body-batch-width` | `4` | Maximum articles per BODY batch (1–8) |

--- a/docs/features/nntp-pipelining.md
+++ b/docs/features/nntp-pipelining.md
@@ -47,7 +47,7 @@ During WebDAV playback with batched BODY requests enabled:
 
 - Connections engaged per stream ≈ outstanding segment window ÷ batch width.
 - At stream construction, InfiniDysk sizes the segment task window and prefetch byte ceiling from the configured batch width and article buffer. Those ceilings stay fixed for the life of the stream; adaptive narrowing only shrinks future batch sizes, not the retained window.
-- Decoded bytes retained across all streams are capped host-wide by `usenet.in-flight-article-budget-mb` (≤512 MiB by default when heap-derived). One stream with a wide batch width can consume most of that budget and starve other concurrent viewers.
+- Decoded bytes retained across all streams are capped host-wide by `usenet.in-flight-article-budget-mb` (25% of the detected managed-heap ceiling by default, clamped to 64–8192 MiB). One stream with a wide batch width can consume most of that budget and starve other concurrent viewers.
 
 Provider behavior varies: some throttle per connection (wider batches can help), others per account (more connections / narrower batches). If Auto-tune reports queue pipelining is unsafe for a provider, treat wide streaming batch widths cautiously too — both use the same NNTP pipelining mechanism.
 

--- a/tests/NzbWebDAV.Tests/Utils/MemoryBudgetTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/MemoryBudgetTests.cs
@@ -7,15 +7,26 @@ public class MemoryBudgetTests
     private const long Mb = 1024 * 1024;
 
     [Theory]
+    [InlineData(64 * Mb, 64)]    // floored
     [InlineData(256 * Mb, 64)]   // 25% of 256 = 64, at floor
     [InlineData(512 * Mb, 128)]  // 25% of 512
     [InlineData(1024 * Mb, 256)]
-    [InlineData(2048 * Mb, 512)] // 25% would be 512, at ceiling
-    [InlineData(4096 * Mb, 512)] // capped at previous fixed default
-    [InlineData(64 * Mb, 64)]    // floored
+    [InlineData(2048 * Mb, 512)]
+    [InlineData(4096 * Mb, 1024)]
+    [InlineData(16384 * Mb, 4096)]
+    [InlineData(32768 * Mb, 8192)]
+    [InlineData(65536 * Mb, 8192)]
     public void DefaultInFlightArticleBudgetMb_ScalesWithHeap(long heap, int expected)
     {
         Assert.Equal(expected, MemoryBudget.DefaultInFlightArticleBudgetMb(heap));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void DefaultInFlightArticleBudgetMb_UsesFallbackForInvalidHeapLimit(long heap)
+    {
+        Assert.Equal(128, MemoryBudget.DefaultInFlightArticleBudgetMb(heap));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Scale the automatic in-flight article budget to 25% of the detected managed-heap ceiling, capped at 8192 MiB.
- Cover floor, fallback, scaling, and clamp boundaries, including the 4 GiB regression.
- Correct the streaming documentation and setting release marker.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter \"FullyQualifiedName~NzbWebDAV.Tests.Utils.MemoryBudgetTests\"`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [x] `zensical build --clean --strict`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Increased the automatic in-flight article budget limit to 8192 MiB.
  * Automatic sizing now uses 25% of the detected managed-heap limit, within a 64–8192 MiB range.
  * Explicit budget values continue to be constrained to the same range.
* **Documentation**
  * Updated configuration and streaming documentation to reflect the new limits and behavior.
* **Tests**
  * Expanded coverage for larger heap sizes and invalid-limit fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->