### PR TITLE
fix(arr): prevent automatic replacement search loops

### DIFF
--- a/backend/Clients/RadarrSonarr/ArrClient.cs
+++ b/backend/Clients/RadarrSonarr/ArrClient.cs
@@ -23,9 +23,15 @@ public class ArrClient(string host, string apiKey)
     public Task<ArrApiInfoResponse> GetApiInfo(CancellationToken ct = default) =>
         GetRoot<ArrApiInfoResponse>($"/api", ct);
 
+    /// <param name="shouldRequestSearch">
+    /// Consulted with the media identity (e.g. "movie:42") right before the
+    /// replacement-search command. Returning false withholds only the search;
+    /// the file removal, history-failed mark, and blocklist still happen.
+    /// </param>
     public virtual Task<ArrRepairOutcome> RemoveAndBlocklist(
         string symlinkOrStrmPath,
         Guid downloadId,
+        Func<string, bool>? shouldRequestSearch = null,
         CancellationToken ct = default) =>
         throw new InvalidOperationException();
 

--- a/backend/Clients/RadarrSonarr/ArrClient.cs
+++ b/backend/Clients/RadarrSonarr/ArrClient.cs
@@ -24,14 +24,16 @@ public class ArrClient(string host, string apiKey)
         GetRoot<ArrApiInfoResponse>($"/api", ct);
 
     /// <param name="shouldRequestSearch">
-    /// Consulted with the media identity (e.g. "movie:42") right before the
-    /// replacement-search command. Returning false withholds only the search;
-    /// the file removal, history-failed mark, and blocklist still happen.
+    /// Consulted with every media identity the replacement-search command would
+    /// cover (for example <c>movie:42</c> or a season pack of <c>episode:301</c>,
+    /// <c>episode:302</c>) right before that command. Returning false withholds
+    /// only the search; the file removal, history-failed mark, and blocklist
+    /// still happen.
     /// </param>
     public virtual Task<ArrRepairOutcome> RemoveAndBlocklist(
         string symlinkOrStrmPath,
         Guid downloadId,
-        Func<string, bool>? shouldRequestSearch = null,
+        Func<IReadOnlyList<string>, bool>? shouldRequestSearch = null,
         CancellationToken ct = default) =>
         throw new InvalidOperationException();
 

--- a/backend/Clients/RadarrSonarr/BaseModels/ArrQueueRecord.cs
+++ b/backend/Clients/RadarrSonarr/BaseModels/ArrQueueRecord.cs
@@ -47,8 +47,27 @@ public class ArrQueueRecord
 
     public bool HasStatusMessage(string message)
     {
+        return GetMatchingStatusMessages([message]).Count > 0;
+    }
+
+    /// <summary>
+    /// Returns the original Arr status text, rather than the configured substring
+    /// that matched it, so callers can give operators the actionable import reason.
+    /// </summary>
+    public IReadOnlyList<string> GetMatchingStatusMessages(IEnumerable<string> messages)
+    {
+        var configuredMessages = messages
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .ToArray();
+        if (configuredMessages.Length == 0) return [];
+
         return StatusMessages
             .SelectMany(x => x.Messages)
-            .Any(x => x.Contains(message, StringComparison.Ordinal));
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Where(status => configuredMessages.Any(message => status.Contains(message, StringComparison.Ordinal)))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
     }
+
+    public virtual string? GetMediaIdentity() => null;
 }

--- a/backend/Clients/RadarrSonarr/BaseModels/ArrRepairOutcome.cs
+++ b/backend/Clients/RadarrSonarr/BaseModels/ArrRepairOutcome.cs
@@ -3,6 +3,7 @@ namespace NzbWebDAV.Clients.RadarrSonarr.BaseModels;
 public enum ArrRepairOutcome
 {
     RemoveAndBlocklistSucceeded,
+    RemoveAndBlocklistSucceededSearchWithheld,
     MediaItemNotFound,
     DownloadHistoryNotFound,
 }

--- a/backend/Clients/RadarrSonarr/RadarrClient.cs
+++ b/backend/Clients/RadarrSonarr/RadarrClient.cs
@@ -20,8 +20,11 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
     public Task<List<RadarrMovie>> GetMoviesAsync(CancellationToken ct = default) =>
         Get<List<RadarrMovie>>($"/movie", ct);
 
-    public Task<RadarrQueue> GetRadarrQueueAsync() =>
-        Get<RadarrQueue>($"/queue?protocol=usenet&pageSize=5000");
+    public Task<RadarrQueue> GetRadarrQueueAsync(CancellationToken ct = default) =>
+        Get<RadarrQueue>($"/queue?protocol=usenet&pageSize=5000", ct);
+
+    public override async Task<ArrQueue<ArrQueueRecord>> GetQueueAsync(CancellationToken ct = default) =>
+        (await GetRadarrQueueAsync(ct).ConfigureAwait(false)).ToGeneric();
 
     public Task<HttpStatusCode> DeleteMovieFile(int id, CancellationToken ct = default) =>
         Delete($"/moviefile/{id}", ct: ct);

--- a/backend/Clients/RadarrSonarr/RadarrClient.cs
+++ b/backend/Clients/RadarrSonarr/RadarrClient.cs
@@ -32,7 +32,7 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
     public override async Task<ArrRepairOutcome> RemoveAndBlocklist(
         string symlinkOrStrmPath,
         Guid downloadId,
-        Func<string, bool>? shouldRequestSearch = null,
+        Func<IReadOnlyList<string>, bool>? shouldRequestSearch = null,
         CancellationToken ct = default)
     {
         var movieIds = await GetMovieFileIds(symlinkOrStrmPath, ct).ConfigureAwait(false);
@@ -46,14 +46,14 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
 
         await MarkHistoryFailed(historyId.Value, ct).ConfigureAwait(false);
 
-        if (shouldRequestSearch is not null && !shouldRequestSearch($"movie:{movieIds.MovieId}"))
+        if (shouldRequestSearch is not null && !shouldRequestSearch([$"movie:{movieIds.MovieId}"]))
         {
             Log.Warning(
                 "Radarr repair on {Host}: automatic replacement-search limit reached for movie {MovieId}; " +
                 "the file was removed and its download blocklisted without starting another search.",
                 Host,
                 movieIds.MovieId);
-            return ArrRepairOutcome.RemoveAndBlocklistSucceeded;
+            return ArrRepairOutcome.RemoveAndBlocklistSucceededSearchWithheld;
         }
 
         try

--- a/backend/Clients/RadarrSonarr/RadarrClient.cs
+++ b/backend/Clients/RadarrSonarr/RadarrClient.cs
@@ -32,6 +32,7 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
     public override async Task<ArrRepairOutcome> RemoveAndBlocklist(
         string symlinkOrStrmPath,
         Guid downloadId,
+        Func<string, bool>? shouldRequestSearch = null,
         CancellationToken ct = default)
     {
         var movieIds = await GetMovieFileIds(symlinkOrStrmPath, ct).ConfigureAwait(false);
@@ -44,6 +45,16 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
             throw new InvalidOperationException($"Failed to delete movie file `{symlinkOrStrmPath}` from radarr instance `{Host}`.");
 
         await MarkHistoryFailed(historyId.Value, ct).ConfigureAwait(false);
+
+        if (shouldRequestSearch is not null && !shouldRequestSearch($"movie:{movieIds.MovieId}"))
+        {
+            Log.Warning(
+                "Radarr repair on {Host}: automatic replacement-search limit reached for movie {MovieId}; " +
+                "the file was removed and its download blocklisted without starting another search.",
+                Host,
+                movieIds.MovieId);
+            return ArrRepairOutcome.RemoveAndBlocklistSucceeded;
+        }
 
         try
         {

--- a/backend/Clients/RadarrSonarr/RadarrModels/RadarrQueueRecord.cs
+++ b/backend/Clients/RadarrSonarr/RadarrModels/RadarrQueueRecord.cs
@@ -7,4 +7,6 @@ public class RadarrQueueRecord : ArrQueueRecord
 {
     [JsonPropertyName("movieId")]
     public int MovieId { get; set; }
+
+    public override string? GetMediaIdentity() => MovieId > 0 ? $"movie:{MovieId}" : null;
 }

--- a/backend/Clients/RadarrSonarr/SonarrClient.cs
+++ b/backend/Clients/RadarrSonarr/SonarrClient.cs
@@ -49,6 +49,7 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
     public override async Task<ArrRepairOutcome> RemoveAndBlocklist(
         string symlinkOrStrmPath,
         Guid downloadId,
+        Func<string, bool>? shouldRequestSearch = null,
         CancellationToken ct = default)
     {
         var episodeFileId = await GetEpisodeFileId(symlinkOrStrmPath, ct).ConfigureAwait(false);
@@ -86,6 +87,14 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
             {
                 Log.Warning(
                     "Sonarr repair on {Host}: no episodes linked to episode file {EpisodeFileId}; skipping EpisodeSearch",
+                    Host,
+                    episodeFileId.Value);
+            }
+            else if (shouldRequestSearch is not null && !shouldRequestSearch($"episode:{episodeIds[0]}"))
+            {
+                Log.Warning(
+                    "Sonarr repair on {Host}: automatic replacement-search limit reached for episode file {EpisodeFileId}; " +
+                    "the file was removed and its download blocklisted without starting another search.",
                     Host,
                     episodeFileId.Value);
             }

--- a/backend/Clients/RadarrSonarr/SonarrClient.cs
+++ b/backend/Clients/RadarrSonarr/SonarrClient.cs
@@ -14,8 +14,11 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
     private static readonly ConcurrentDictionary<(string Host, string Path), int>
         SymlinkOrStrmToEpisodeFileIdCache = new();
 
-    public Task<SonarrQueue> GetSonarrQueueAsync() =>
-        Get<SonarrQueue>($"/queue?protocol=usenet&pageSize=5000");
+    public Task<SonarrQueue> GetSonarrQueueAsync(CancellationToken ct = default) =>
+        Get<SonarrQueue>($"/queue?protocol=usenet&pageSize=5000", ct);
+
+    public override async Task<ArrQueue<ArrQueueRecord>> GetQueueAsync(CancellationToken ct = default) =>
+        (await GetSonarrQueueAsync(ct).ConfigureAwait(false)).ToGeneric();
 
     public Task<List<SonarrSeries>> GetAllSeries(CancellationToken ct = default) =>
         Get<List<SonarrSeries>>($"/series", ct);

--- a/backend/Clients/RadarrSonarr/SonarrClient.cs
+++ b/backend/Clients/RadarrSonarr/SonarrClient.cs
@@ -49,7 +49,7 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
     public override async Task<ArrRepairOutcome> RemoveAndBlocklist(
         string symlinkOrStrmPath,
         Guid downloadId,
-        Func<string, bool>? shouldRequestSearch = null,
+        Func<IReadOnlyList<string>, bool>? shouldRequestSearch = null,
         CancellationToken ct = default)
     {
         var episodeFileId = await GetEpisodeFileId(symlinkOrStrmPath, ct).ConfigureAwait(false);
@@ -90,13 +90,15 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
                     Host,
                     episodeFileId.Value);
             }
-            else if (shouldRequestSearch is not null && !shouldRequestSearch($"episode:{episodeIds[0]}"))
+            else if (shouldRequestSearch is not null &&
+                     !shouldRequestSearch(episodeIds.Select(id => $"episode:{id}").ToArray()))
             {
                 Log.Warning(
                     "Sonarr repair on {Host}: automatic replacement-search limit reached for episode file {EpisodeFileId}; " +
                     "the file was removed and its download blocklisted without starting another search.",
                     Host,
                     episodeFileId.Value);
+                return ArrRepairOutcome.RemoveAndBlocklistSucceededSearchWithheld;
             }
             else
             {

--- a/backend/Clients/RadarrSonarr/SonarrModels/SonarrQueue.cs
+++ b/backend/Clients/RadarrSonarr/SonarrModels/SonarrQueue.cs
@@ -1,5 +1,17 @@
-﻿namespace NzbWebDAV.Clients.RadarrSonarr.SonarrModels;
+﻿using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
 
-public class SonarrQueue : Queue<SonarrQueueRecord>
+namespace NzbWebDAV.Clients.RadarrSonarr.SonarrModels;
+
+public class SonarrQueue : ArrQueue<SonarrQueueRecord>
 {
+    public ArrQueue<ArrQueueRecord> ToGeneric()
+    {
+        return new ArrQueue<ArrQueueRecord>()
+        {
+            Page = Page,
+            PageSize = PageSize,
+            TotalRecords = TotalRecords,
+            Records = Records.Select(x => (ArrQueueRecord)x).ToList()
+        };
+    }
 }

--- a/backend/Clients/RadarrSonarr/SonarrModels/SonarrQueueRecord.cs
+++ b/backend/Clients/RadarrSonarr/SonarrModels/SonarrQueueRecord.cs
@@ -13,4 +13,6 @@ public class SonarrQueueRecord : ArrQueueRecord
 
     [JsonPropertyName("seasonNumber")]
     public int SeasonNumber { get; set; }
+
+    public override string? GetMediaIdentity() => EpisodeId > 0 ? $"episode:{EpisodeId}" : null;
 }

--- a/backend/Config/ArrConfig.cs
+++ b/backend/Config/ArrConfig.cs
@@ -4,9 +4,14 @@ namespace NzbWebDAV.Config;
 
 public class ArrConfig
 {
+    public const int DefaultQueueReplacementSearchLimit = 3;
+    public const int DefaultQueueReplacementSearchWindowMinutes = 30;
+
     public List<ConnectionDetails> RadarrInstances { get; set; } = [];
     public List<ConnectionDetails> SonarrInstances { get; set; } = [];
     public List<QueueRule> QueueRules { get; set; } = [];
+    public int QueueReplacementSearchLimit { get; set; } = DefaultQueueReplacementSearchLimit;
+    public int QueueReplacementSearchWindowMinutes { get; set; } = DefaultQueueReplacementSearchWindowMinutes;
 
     /// <summary>
     /// Clients for enabled instances only. Disabling an instance opts it out of
@@ -26,6 +31,11 @@ public class ArrConfig
 
     public int GetInstanceCount() =>
         RadarrInstances.Count + SonarrInstances.Count;
+
+    public int EffectiveQueueReplacementSearchLimit() => Math.Clamp(QueueReplacementSearchLimit, 1, 10);
+
+    public TimeSpan EffectiveQueueReplacementSearchWindow() =>
+        TimeSpan.FromMinutes(Math.Clamp(QueueReplacementSearchWindowMinutes, 1, 1440));
 
     public static string MakeInstanceKey(string appType, string host) =>
         $"{appType}|{host.TrimEnd('/').ToLowerInvariant()}";

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -392,6 +392,7 @@ public partial class Program
                 .AddHostedService<SqliteMaintenanceService>()
                 .AddSingleton<LiveStatsBroadcaster>()
                 .AddHostedService(sp => sp.GetRequiredService<LiveStatsBroadcaster>())
+                .AddSingleton<ArrReplacementSearchBudget>()
                 .AddHostedService<HealthCheckService>()
                 .AddHostedService<HealthCheckRetentionService>()
                 .AddHostedService<ArrMonitoringService>()

--- a/backend/Services/ArrMonitoringService.cs
+++ b/backend/Services/ArrMonitoringService.cs
@@ -138,6 +138,8 @@ public class ArrMonitoringService : BackgroundService
             mediaKey,
             arrConfig,
             _replacementSearchBudget);
+        var searchReserved = requestedAction is ArrConfig.QueueAction.RemoveAndBlocklistAndSearch &&
+                             action is ArrConfig.QueueAction.RemoveAndBlocklistAndSearch;
         if (requestedAction is ArrConfig.QueueAction.RemoveAndBlocklistAndSearch &&
             action is ArrConfig.QueueAction.RemoveAndBlocklist)
         {
@@ -147,7 +149,22 @@ public class ArrMonitoringService : BackgroundService
                      "the release was removed and blocklisted without starting another search.";
         }
 
-        await client.DeleteQueueRecord(item.Id, action, ct).ConfigureAwait(false);
+        // A transport exception below is ambiguous — Arr may have already processed the
+        // removal and started the search — so the reservation stays consumed and ambiguity
+        // can only under-search, never exceed the cap.
+        var status = await client.DeleteQueueRecord(item.Id, action, ct).ConfigureAwait(false);
+        if ((int)status is < 200 or >= 300)
+        {
+            // Arr definitively rejected the removal (commonly 404 when the record is already
+            // gone), so no replacement search occurred; refund the reservation.
+            if (searchReserved) _replacementSearchBudget.ReleaseLastReservation(mediaKey);
+            Log.Debug(
+                "Arr instance {Host} rejected removal of queue record {QueueRecordId} ({QueueItemTitle}) " +
+                "with status {StatusCode}",
+                client.Host, item.Id, item.Title, status);
+            return null;
+        }
+
         Log.Debug(
             "Resolved stuck queue record {QueueRecordId} ({QueueItemTitle}) from {Host} with action {Action}. " +
             "Reason: {Reason}. Media identity source: {IdentitySource}",

--- a/backend/Services/ArrMonitoringService.cs
+++ b/backend/Services/ArrMonitoringService.cs
@@ -19,10 +19,10 @@ public class ArrMonitoringService : BackgroundService
     private readonly ConfigManager _configManager;
     private readonly ArrReplacementSearchBudget _replacementSearchBudget;
 
-    public ArrMonitoringService(ConfigManager configManager, TimeProvider? timeProvider = null)
+    public ArrMonitoringService(ConfigManager configManager, ArrReplacementSearchBudget replacementSearchBudget)
     {
         _configManager = configManager;
-        _replacementSearchBudget = new ArrReplacementSearchBudget(timeProvider);
+        _replacementSearchBudget = replacementSearchBudget;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -61,10 +61,10 @@ public class ArrMonitoringService : BackgroundService
         // the buffer support packs are built from, so detail goes to Debug and the pass
         // reports one Warning per release and action.
         var resolutions = new List<(string? Title, ArrConfig.QueueAction Action, string Reason, string IdentitySource)>();
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeout.CancelAfter(TimeSpan.FromSeconds(20));
         try
         {
-            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            timeout.CancelAfter(TimeSpan.FromSeconds(20));
             var queueStatus = await client.GetQueueStatusAsync(timeout.Token).ConfigureAwait(false);
             if (queueStatus is { Warnings: false, UnknownWarnings: false }) return;
             var queue = await client.GetQueueAsync(timeout.Token).ConfigureAwait(false);
@@ -80,6 +80,10 @@ public class ArrMonitoringService : BackgroundService
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
             // Monitoring pass aborted on shutdown.
+        }
+        catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+        {
+            Log.Warning("Arr queue monitoring timed out after 20 seconds for {Host}", client.Host);
         }
         catch (Exception e) when (e is HttpRequestException { InnerException: System.Net.Sockets.SocketException })
         {

--- a/backend/Services/ArrMonitoringService.cs
+++ b/backend/Services/ArrMonitoringService.cs
@@ -17,10 +17,12 @@ namespace NzbWebDAV.Services;
 public class ArrMonitoringService : BackgroundService
 {
     private readonly ConfigManager _configManager;
+    private readonly ArrReplacementSearchBudget _replacementSearchBudget;
 
-    public ArrMonitoringService(ConfigManager configManager)
+    public ArrMonitoringService(ConfigManager configManager, TimeProvider? timeProvider = null)
     {
         _configManager = configManager;
+        _replacementSearchBudget = new ArrReplacementSearchBudget(timeProvider);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -58,7 +60,7 @@ public class ArrMonitoringService : BackgroundService
         // hundreds of removals. Logging each at Warning evicted every other warning from
         // the buffer support packs are built from, so detail goes to Debug and the pass
         // reports one Warning per release and action.
-        var resolutions = new List<(string? Title, ArrConfig.QueueAction Action)>();
+        var resolutions = new List<(string? Title, ArrConfig.QueueAction Action, string Reason, string IdentitySource)>();
         try
         {
             using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
@@ -66,14 +68,13 @@ public class ArrMonitoringService : BackgroundService
             var queueStatus = await client.GetQueueStatusAsync(timeout.Token).ConfigureAwait(false);
             if (queueStatus is { Warnings: false, UnknownWarnings: false }) return;
             var queue = await client.GetQueueAsync(timeout.Token).ConfigureAwait(false);
-            var actionableStatuses = arrConfig.QueueRules.Select(x => x.Message);
-            var stuckRecords = queue.Records.Where(x => actionableStatuses.Any(x.HasStatusMessage));
+            var stuckRecords = GetActionableStuckRecords(queue, arrConfig.QueueRules);
             foreach (var record in stuckRecords)
             {
-                var action = await HandleStuckQueueItem(record, arrConfig, client, timeout.Token)
+                var resolution = await HandleStuckQueueItem(record, arrConfig, client, timeout.Token)
                     .ConfigureAwait(false);
-                if (action is null) continue;
-                resolutions.Add((record.Title, action.Value));
+                if (resolution is null) continue;
+                resolutions.Add(resolution.Value);
             }
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -96,24 +97,119 @@ public class ArrMonitoringService : BackgroundService
         }
     }
 
-    private async Task<ArrConfig.QueueAction?> HandleStuckQueueItem(
+    internal static IReadOnlyList<ArrQueueRecord> GetActionableStuckRecords(
+        ArrQueue<ArrQueueRecord> queue,
+        IEnumerable<ArrConfig.QueueRule> queueRules)
+    {
+        var actionableStatuses = queueRules
+            .Where(x => x.Action is not ArrConfig.QueueAction.DoNothing)
+            .Select(x => x.Message)
+            .ToArray();
+
+        return queue.Records
+            .Where(x => x.IsAwaitingImport)
+            .Where(x => actionableStatuses.Any(x.HasStatusMessage))
+            .ToList();
+    }
+
+    private async Task<(string? Title, ArrConfig.QueueAction Action, string Reason, string IdentitySource)?>
+        HandleStuckQueueItem(
         ArrQueueRecord item, ArrConfig arrConfig, ArrClient client, CancellationToken ct)
     {
         // since there may be multiple status messages, multiple actions may apply.
         // in such case, always perform the strongest action.
-        var action = arrConfig.QueueRules
+        var matchingRules = arrConfig.QueueRules
             .Where(x => item.HasStatusMessage(x.Message))
+            .ToList();
+        var action = matchingRules
             .Select(x => x.Action)
             .DefaultIfEmpty(ArrConfig.QueueAction.DoNothing)
             .Max();
 
         if (action is ArrConfig.QueueAction.DoNothing) return null;
+        var reason = SummarizeReason(
+            item.GetMatchingStatusMessages(matchingRules.Where(x => x.Action == action).Select(x => x.Message)),
+            matchingRules.Where(x => x.Action == action).Select(x => x.Message));
+        var (mediaKey, identitySource) = GetMediaKey(client, item);
+
+        var requestedAction = action;
+        action = ApplyReplacementSearchBudget(
+            requestedAction,
+            mediaKey,
+            arrConfig,
+            _replacementSearchBudget);
+        if (requestedAction is ArrConfig.QueueAction.RemoveAndBlocklistAndSearch &&
+            action is ArrConfig.QueueAction.RemoveAndBlocklist)
+        {
+            reason = $"{reason} Automatic replacement-search limit reached " +
+                     $"({arrConfig.EffectiveQueueReplacementSearchLimit()} in " +
+                     $"{arrConfig.EffectiveQueueReplacementSearchWindow().TotalMinutes:0} minutes); " +
+                     "the release was removed and blocklisted without starting another search.";
+        }
+
         await client.DeleteQueueRecord(item.Id, action, ct).ConfigureAwait(false);
         Log.Debug(
-            "Resolved stuck queue record {QueueRecordId} ({QueueItemTitle}) from {Host} with action {Action}",
-            item.Id, item.Title, client.Host, action);
-        return action;
+            "Resolved stuck queue record {QueueRecordId} ({QueueItemTitle}) from {Host} with action {Action}. " +
+            "Reason: {Reason}. Media identity source: {IdentitySource}",
+            item.Id, item.Title, client.Host, action, reason, identitySource);
+        return (item.Title, action, reason, identitySource);
     }
+
+    internal static ArrConfig.QueueAction ApplyReplacementSearchBudget(
+        ArrConfig.QueueAction requestedAction,
+        string mediaKey,
+        ArrConfig arrConfig,
+        ArrReplacementSearchBudget replacementSearchBudget)
+    {
+        if (requestedAction is not ArrConfig.QueueAction.RemoveAndBlocklistAndSearch)
+            return requestedAction;
+
+        return replacementSearchBudget.TryReserve(
+            mediaKey,
+            arrConfig.EffectiveQueueReplacementSearchLimit(),
+            arrConfig.EffectiveQueueReplacementSearchWindow())
+            ? requestedAction
+            : ArrConfig.QueueAction.RemoveAndBlocklist;
+    }
+
+    private static (string Key, string Source) GetMediaKey(ArrClient client, ArrQueueRecord item)
+    {
+        var host = client.Host.TrimEnd('/').ToLowerInvariant();
+        var mediaIdentity = item.GetMediaIdentity();
+        if (mediaIdentity is not null) return ($"{host}|{mediaIdentity}", "Arr media ID");
+
+        if (!string.IsNullOrWhiteSpace(item.DownloadId))
+            return ($"{host}|download:{item.DownloadId}", "download ID fallback");
+
+        return ($"{host}|queue:{item.Id}", "queue record ID fallback");
+    }
+
+    internal static string SummarizeReason(
+        IEnumerable<string> matchingStatusMessages,
+        IEnumerable<string> configuredMessages)
+    {
+        const int maxLength = 512;
+        var reasons = matchingStatusMessages
+            .Select(FlattenReason)
+            .Where(x => x.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        if (reasons.Count == 0)
+        {
+            reasons = configuredMessages
+                .Select(FlattenReason)
+                .Where(x => x.Length > 0)
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+        }
+
+        var reason = string.Join("; ", reasons);
+        return reason.Length <= maxLength ? reason : $"{reason[..(maxLength - 1)]}…";
+    }
+
+    private static string FlattenReason(string value) =>
+        string.Join(' ', value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
 
     internal static IReadOnlyList<((string Title, ArrConfig.QueueAction Action) Key, int Count)>
         GroupResolutions(IEnumerable<(string? Title, ArrConfig.QueueAction Action)> resolutions) =>
@@ -134,6 +230,26 @@ public class ArrMonitoringService : BackgroundService
                 entry.Key.Title,
                 host,
                 entry.Key.Action);
+        }
+    }
+
+    internal static void LogResolutionSummary(
+        IEnumerable<(string? Title, ArrConfig.QueueAction Action, string Reason, string IdentitySource)> resolutions,
+        string host)
+    {
+        foreach (var entry in resolutions
+                     .GroupBy(x => (x.Title ?? "(untitled)", x.Action, x.Reason, x.IdentitySource))
+                     .Select(g => (g.Key, g.Count())))
+        {
+            Log.Warning(
+                "Resolved {Count} stuck queue item(s) for {QueueItemTitle} from {Host} with action {Action}. " +
+                "Reason: {Reason}. Media identity source: {IdentitySource}",
+                entry.Item2,
+                entry.Key.Item1,
+                host,
+                entry.Key.Action,
+                entry.Key.Reason,
+                entry.Key.IdentitySource);
         }
     }
 }

--- a/backend/Services/ArrReplacementSearchBudget.cs
+++ b/backend/Services/ArrReplacementSearchBudget.cs
@@ -1,0 +1,64 @@
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Bounds automatic Arr replacement searches for one media item. Queue removals
+/// and blocklisting still happen after the limit; only the next search is withheld.
+/// </summary>
+public sealed class ArrReplacementSearchBudget
+{
+    private const int MaxTrackedMediaItems = 4096;
+
+    private readonly object _gate = new();
+    private readonly TimeProvider _timeProvider;
+    private readonly Dictionary<string, List<DateTimeOffset>> _searches = new(StringComparer.Ordinal);
+
+    public ArrReplacementSearchBudget(TimeProvider? timeProvider = null)
+    {
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public bool TryReserve(string mediaKey, int limit, TimeSpan window)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(mediaKey);
+        ArgumentOutOfRangeException.ThrowIfLessThan(limit, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(window, TimeSpan.Zero);
+
+        lock (_gate)
+        {
+            var now = _timeProvider.GetUtcNow();
+            var cutoff = now - window;
+            Prune(cutoff);
+
+            if (!_searches.TryGetValue(mediaKey, out var reservations))
+            {
+                MakeRoom();
+                reservations = [];
+                _searches[mediaKey] = reservations;
+            }
+
+            if (reservations.Count >= limit) return false;
+
+            reservations.Add(now);
+            return true;
+        }
+    }
+
+    private void Prune(DateTimeOffset cutoff)
+    {
+        foreach (var (key, reservations) in _searches.ToArray())
+        {
+            reservations.RemoveAll(x => x < cutoff);
+            if (reservations.Count == 0) _searches.Remove(key);
+        }
+    }
+
+    private void MakeRoom()
+    {
+        if (_searches.Count < MaxTrackedMediaItems) return;
+
+        var oldest = _searches
+            .OrderBy(x => x.Value[0])
+            .First();
+        _searches.Remove(oldest.Key);
+    }
+}

--- a/backend/Services/ArrReplacementSearchBudget.cs
+++ b/backend/Services/ArrReplacementSearchBudget.cs
@@ -31,7 +31,10 @@ public sealed class ArrReplacementSearchBudget
 
             if (!_searches.TryGetValue(mediaKey, out var reservations))
             {
-                MakeRoom();
+                // Fail closed at capacity: evicting an active key would forget its
+                // reservations and let that media item exceed the configured cap.
+                // Denying the new key only withholds a search until entries expire.
+                if (_searches.Count >= MaxTrackedMediaItems) return false;
                 reservations = [];
                 _searches[mediaKey] = reservations;
             }
@@ -43,6 +46,20 @@ public sealed class ArrReplacementSearchBudget
         }
     }
 
+    /// <summary>
+    /// Refunds the most recent reservation after the Arr action it was reserved for
+    /// was definitively rejected, so a failed request cannot consume the budget.
+    /// </summary>
+    public void ReleaseLastReservation(string mediaKey)
+    {
+        lock (_gate)
+        {
+            if (!_searches.TryGetValue(mediaKey, out var reservations)) return;
+            if (reservations.Count > 0) reservations.RemoveAt(reservations.Count - 1);
+            if (reservations.Count == 0) _searches.Remove(mediaKey);
+        }
+    }
+
     private void Prune(DateTimeOffset cutoff)
     {
         foreach (var (key, reservations) in _searches.ToArray())
@@ -50,15 +67,5 @@ public sealed class ArrReplacementSearchBudget
             reservations.RemoveAll(x => x < cutoff);
             if (reservations.Count == 0) _searches.Remove(key);
         }
-    }
-
-    private void MakeRoom()
-    {
-        if (_searches.Count < MaxTrackedMediaItems) return;
-
-        var oldest = _searches
-            .OrderBy(x => x.Value[0])
-            .First();
-        _searches.Remove(oldest.Key);
     }
 }

--- a/backend/Services/ArrReplacementSearchBudget.cs
+++ b/backend/Services/ArrReplacementSearchBudget.cs
@@ -17,31 +17,61 @@ public sealed class ArrReplacementSearchBudget
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
-    public bool TryReserve(string mediaKey, int limit, TimeSpan window)
+    public bool TryReserve(string mediaKey, int limit, TimeSpan window) =>
+        TryReserveAll([mediaKey], limit, window);
+
+    /// <summary>
+    /// Reserves every media key or none of them. A season-pack <c>EpisodeSearch</c>
+    /// must not start when any linked episode is already at its limit.
+    /// </summary>
+    public bool TryReserveAll(IReadOnlyList<string> mediaKeys, int limit, TimeSpan window)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(mediaKey);
+        ArgumentNullException.ThrowIfNull(mediaKeys);
         ArgumentOutOfRangeException.ThrowIfLessThan(limit, 1);
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(window, TimeSpan.Zero);
+
+        var uniqueKeys = new List<string>(mediaKeys.Count);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var mediaKey in mediaKeys)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(mediaKey);
+            if (seen.Add(mediaKey)) uniqueKeys.Add(mediaKey);
+        }
+
+        if (uniqueKeys.Count == 0) return true;
 
         lock (_gate)
         {
             var now = _timeProvider.GetUtcNow();
-            var cutoff = now - window;
-            Prune(cutoff);
+            Prune(now - window);
 
-            if (!_searches.TryGetValue(mediaKey, out var reservations))
+            var newKeyCount = 0;
+            foreach (var mediaKey in uniqueKeys)
             {
-                // Fail closed at capacity: evicting an active key would forget its
-                // reservations and let that media item exceed the configured cap.
-                // Denying the new key only withholds a search until entries expire.
-                if (_searches.Count >= MaxTrackedMediaItems) return false;
-                reservations = [];
-                _searches[mediaKey] = reservations;
+                if (_searches.TryGetValue(mediaKey, out var reservations))
+                {
+                    if (reservations.Count >= limit) return false;
+                    continue;
+                }
+
+                newKeyCount++;
             }
 
-            if (reservations.Count >= limit) return false;
+            // Fail closed at capacity: evicting an active key would forget its
+            // reservations and let that media item exceed the configured cap.
+            if (_searches.Count + newKeyCount > MaxTrackedMediaItems) return false;
 
-            reservations.Add(now);
+            foreach (var mediaKey in uniqueKeys)
+            {
+                if (!_searches.TryGetValue(mediaKey, out var reservations))
+                {
+                    reservations = [];
+                    _searches[mediaKey] = reservations;
+                }
+
+                reservations.Add(now);
+            }
+
             return true;
         }
     }

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -64,7 +64,7 @@ public class HealthCheckService : BackgroundService
     private const double MinDepthDays = 3650;
 
     private readonly ConfigManager _configManager;
-    private readonly ArrReplacementSearchBudget _replacementSearchBudget = new();
+    private readonly ArrReplacementSearchBudget _replacementSearchBudget;
     private readonly UsenetStreamingClient _usenetClient;
     private readonly WebsocketManager _websocketManager;
     private readonly BenchmarkGate _benchmarkGate;
@@ -89,10 +89,12 @@ public class HealthCheckService : BackgroundService
         QueueManager queueManager,
         Par2RepairService par2RepairService,
         RepairPatchStore repairPatchStore,
+        ArrReplacementSearchBudget replacementSearchBudget,
         IDbContextFactory<DavDatabaseContext>? dbContextFactory = null
     )
     {
         _configManager = configManager;
+        _replacementSearchBudget = replacementSearchBudget;
         _usenetClient = usenetClient;
         _websocketManager = websocketManager;
         _benchmarkGate = benchmarkGate;
@@ -1473,6 +1475,11 @@ public class HealthCheckService : BackgroundService
         /// <summary>An Arr instance owned the file and remove-and-blocklist succeeded.</summary>
         RemoveAndBlocklistSucceeded,
         /// <summary>
+        /// An Arr instance owned the file and remove-and-blocklist succeeded, but the
+        /// replacement search was withheld by the per-media search budget.
+        /// </summary>
+        RemoveAndBlocklistSucceededSearchWithheld,
+        /// <summary>
         /// At least one Arr instance was unreachable/unusable and no instance completed repair —
         /// leave the DavItem in place.
         /// </summary>
@@ -1496,7 +1503,7 @@ public class HealthCheckService : BackgroundService
         string symlinkOrStrmPath,
         Guid? downloadId,
         CancellationToken ct,
-        Func<ArrClient, string, bool>? shouldRequestSearch = null)
+        Func<ArrClient, IReadOnlyList<string>, bool>? shouldRequestSearch = null)
     {
         // Track whether a no-owner result is authoritative enough to explain to the operator.
         // Neither outcome permits deletion: a successful-but-incomplete library/Arr view is
@@ -1556,6 +1563,9 @@ public class HealthCheckService : BackgroundService
 
             if (repairOutcome == ArrRepairOutcome.RemoveAndBlocklistSucceeded)
                 return ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded;
+
+            if (repairOutcome == ArrRepairOutcome.RemoveAndBlocklistSucceededSearchWithheld)
+                return ArrLinkedRepairDecision.RemoveAndBlocklistSucceededSearchWithheld;
 
             if (repairOutcome == ArrRepairOutcome.DownloadHistoryNotFound)
                 return ArrLinkedRepairDecision.DeferMissingDownloadHistory;
@@ -1786,15 +1796,18 @@ public class HealthCheckService : BackgroundService
                 linkedPath,
                 davItem.HistoryItemId ?? davItem.NzbBlobId,
                 ct,
-                (arrClient, mediaIdentity) => _replacementSearchBudget.TryReserve(
-                    $"{arrClient.Host.TrimEnd('/').ToLowerInvariant()}|{mediaIdentity}",
+                (arrClient, mediaIdentities) => _replacementSearchBudget.TryReserveAll(
+                    mediaIdentities
+                        .Select(identity => $"{arrClient.Host.TrimEnd('/').ToLowerInvariant()}|{identity}")
+                        .ToArray(),
                     arrConfig.EffectiveQueueReplacementSearchLimit(),
                     arrConfig.EffectiveQueueReplacementSearchWindow())).ConfigureAwait(false);
 
             if (arrDecision != ArrLinkedRepairDecision.DeferNoMatchingMediaItem)
                 _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);
 
-            if (arrDecision == ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded)
+            if (arrDecision is ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded
+                or ArrLinkedRepairDecision.RemoveAndBlocklistSucceededSearchWithheld)
             {
                 RecordRepairRemoval(linkedPath, DateTimeOffset.UtcNow);
                 await SeedRejectedReleaseSegmentsAsync(davItem, dbClient, ct).ConfigureAwait(false);
@@ -1804,6 +1817,9 @@ public class HealthCheckService : BackgroundService
                     "health validation failed; Arr media removed and original download blocklisted");
                 dbClient.Ctx.Items.Remove(davItem);
                 _failureTracker.ClearFailure(davItem.Id);
+                var searchClause = arrDecision is ArrLinkedRepairDecision.RemoveAndBlocklistSucceededSearchWithheld
+                    ? "The automatic replacement search was withheld because the per-media search limit was reached."
+                    : "Arr was notified to search for a replacement.";
                 await RecordHealthResult(
                     dbClient, davItem,
                     HealthCheckResult.HealthResult.Unhealthy,
@@ -1812,7 +1828,7 @@ public class HealthCheckService : BackgroundService
                         "File failed health validation.",
                         $"Corresponding {linkType} found within Library Dir.",
                         "Removed the Arr media file and blocklisted its original download.",
-                        "Arr was notified to search for a replacement."
+                        searchClause
                     ]), ct).ConfigureAwait(false);
                 return;
             }

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -64,6 +64,7 @@ public class HealthCheckService : BackgroundService
     private const double MinDepthDays = 3650;
 
     private readonly ConfigManager _configManager;
+    private readonly ArrReplacementSearchBudget _replacementSearchBudget = new();
     private readonly UsenetStreamingClient _usenetClient;
     private readonly WebsocketManager _websocketManager;
     private readonly BenchmarkGate _benchmarkGate;
@@ -1494,7 +1495,8 @@ public class HealthCheckService : BackgroundService
         IEnumerable<ArrClient> arrClients,
         string symlinkOrStrmPath,
         Guid? downloadId,
-        CancellationToken ct)
+        CancellationToken ct,
+        Func<ArrClient, string, bool>? shouldRequestSearch = null)
     {
         // Track whether a no-owner result is authoritative enough to explain to the operator.
         // Neither outcome permits deletion: a successful-but-incomplete library/Arr view is
@@ -1539,6 +1541,7 @@ public class HealthCheckService : BackgroundService
                 repairOutcome = await arrClient.RemoveAndBlocklist(
                     symlinkOrStrmPath,
                     downloadId.Value,
+                    shouldRequestSearch is null ? null : identity => shouldRequestSearch(arrClient, identity),
                     ct).ConfigureAwait(false);
             }
             catch (Exception e) when (e is HttpRequestException or TaskCanceledException or InvalidOperationException)
@@ -1774,11 +1777,19 @@ public class HealthCheckService : BackgroundService
 
             // if the unhealthy item is linked within the organized media-library
             // then we must find the corresponding arr instance and trigger a new search.
+            // The per-path rate limit above misses alternate releases (each import gets a
+            // new filename), so replacement searches are additionally budgeted by the Arr
+            // media identity, which stays stable across re-grabs of the same movie/episode.
+            var arrConfig = _configManager.GetArrConfig();
             var arrDecision = await DecideArrLinkedRepairAsync(
-                _configManager.GetArrConfig().GetArrClients(),
+                arrConfig.GetArrClients(),
                 linkedPath,
                 davItem.HistoryItemId ?? davItem.NzbBlobId,
-                ct).ConfigureAwait(false);
+                ct,
+                (arrClient, mediaIdentity) => _replacementSearchBudget.TryReserve(
+                    $"{arrClient.Host.TrimEnd('/').ToLowerInvariant()}|{mediaIdentity}",
+                    arrConfig.EffectiveQueueReplacementSearchLimit(),
+                    arrConfig.EffectiveQueueReplacementSearchWindow())).ConfigureAwait(false);
 
             if (arrDecision != ArrLinkedRepairDecision.DeferNoMatchingMediaItem)
                 _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);

--- a/docs/configuration/arrs.md
+++ b/docs/configuration/arrs.md
@@ -29,13 +29,15 @@ rules. Typical mappings:
 
 Any action other than **Do Nothing** tells the Arr to delete the queue record with `removeFromClient=true`. The Arr then removes the download from InfiniDysk History even when its own **Remove Completed** checkbox is off. That is independent of mounted files, which stay.
 
-### Replacement-search safety limit
+## Replacement-search safety limit [since 1.2.4](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.4){ .nzbdav-since }
 
 **Remove, Blocklist, and Search** is bounded to **3 automatic replacement searches in
 30 minutes per Radarr movie or Sonarr episode** by default. Once a media item reaches
 that limit, InfiniDysk still removes and blocklists its rejected release but does not
 start another automatic search. Adjust both values in **Automatic queue management**
-when a library needs a stricter or more permissive policy.
+when a library needs a stricter or more permissive policy. The same per-media cap also
+bounds replacement searches triggered by health-check repairs, which additionally keep
+their own per-library-file rate limit.
 
 The queue-monitor warning includes the matching Arr import message, so support packs
 show the actual rejection (for example, an archive, an ineligible file, or an import

--- a/docs/configuration/arrs.md
+++ b/docs/configuration/arrs.md
@@ -18,7 +18,9 @@ additional Arr apps such as Lidarr in the future. Config key: `arr.instances`
 (`GET /api`). It works with already-saved (masked) API keys — you do not need to re-enter
 the key after reload. Failures show a reason (authentication, HTTP status, or network error).
 
-Only **Usenet** queue items are acted upon. Typical mappings:
+Only **Usenet** queue items that Radarr or Sonarr reports as completed or awaiting import
+are acted upon. Downloads that are still queued or downloading are never removed by these
+rules. Typical mappings:
 
 - **Remove, Blocklist, and Search** — no eligible files, samples, no audio tracks
 - **Remove and Blocklist** — not an upgrade / custom format
@@ -26,6 +28,18 @@ Only **Usenet** queue items are acted upon. Typical mappings:
 - **Do Nothing** — ID mismatches and similar manual-import cases
 
 Any action other than **Do Nothing** tells the Arr to delete the queue record with `removeFromClient=true`. The Arr then removes the download from InfiniDysk History even when its own **Remove Completed** checkbox is off. That is independent of mounted files, which stay.
+
+### Replacement-search safety limit
+
+**Remove, Blocklist, and Search** is bounded to **3 automatic replacement searches in
+30 minutes per Radarr movie or Sonarr episode** by default. Once a media item reaches
+that limit, InfiniDysk still removes and blocklists its rejected release but does not
+start another automatic search. Adjust both values in **Automatic queue management**
+when a library needs a stricter or more permissive policy.
+
+The queue-monitor warning includes the matching Arr import message, so support packs
+show the actual rejection (for example, an archive, an ineligible file, or an import
+path problem) that led to the action.
 
 Disabling an instance opts it out of stuck-queue actions, Arr-linked repairs, and health polling. Use **Arr Health** off when you still want queue rules without Overview polling.
 

--- a/frontend/app/routes/settings/arrs/arrs.tsx
+++ b/frontend/app/routes/settings/arrs/arrs.tsx
@@ -221,12 +221,16 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
   );
 
   const updateReplacementSearchBudget = useCallback(
-    (field: "QueueReplacementSearchLimit" | "QueueReplacementSearchWindowMinutes", value: string) => {
-      const fallback =
+    (
+      field: "QueueReplacementSearchLimit" | "QueueReplacementSearchWindowMinutes",
+      value: string,
+    ) => {
+      const limit = field === "QueueReplacementSearchLimit" ? 10 : 1440;
+      const storedValue =
         field === "QueueReplacementSearchLimit"
           ? (arrConfig.QueueReplacementSearchLimit ?? 3)
           : (arrConfig.QueueReplacementSearchWindowMinutes ?? 30);
-      const limit = field === "QueueReplacementSearchLimit" ? 10 : 1440;
+      const fallback = Math.max(1, Math.min(limit, storedValue));
       const parsed = Number.parseInt(value, 10);
       updateConfig({
         ...arrConfig,
@@ -350,7 +354,9 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
                   max={10}
                   className="w-24"
                   value={arrConfig.QueueReplacementSearchLimit ?? 3}
-                  onChange={(e) => updateReplacementSearchBudget("QueueReplacementSearchLimit", e.target.value)}
+                  onChange={(e) =>
+                    updateReplacementSearchBudget("QueueReplacementSearchLimit", e.target.value)
+                  }
                 />
               </label>
               <label className="flex flex-col gap-1 text-sm text-base-content/80">
@@ -362,7 +368,10 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
                   className="w-28"
                   value={arrConfig.QueueReplacementSearchWindowMinutes ?? 30}
                   onChange={(e) =>
-                    updateReplacementSearchBudget("QueueReplacementSearchWindowMinutes", e.target.value)
+                    updateReplacementSearchBudget(
+                      "QueueReplacementSearchWindowMinutes",
+                      e.target.value,
+                    )
                   }
                 />
               </label>

--- a/frontend/app/routes/settings/arrs/arrs.tsx
+++ b/frontend/app/routes/settings/arrs/arrs.tsx
@@ -34,6 +34,8 @@ interface ArrConfig {
   RadarrInstances: ConnectionDetails[];
   SonarrInstances: ConnectionDetails[];
   QueueRules: QueueRule[];
+  QueueReplacementSearchLimit?: number;
+  QueueReplacementSearchWindowMinutes?: number;
 }
 
 function parseArrConfig(value: string): ArrConfig {
@@ -218,6 +220,22 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
     [arrConfig, updateConfig],
   );
 
+  const updateReplacementSearchBudget = useCallback(
+    (field: "QueueReplacementSearchLimit" | "QueueReplacementSearchWindowMinutes", value: string) => {
+      const fallback =
+        field === "QueueReplacementSearchLimit"
+          ? (arrConfig.QueueReplacementSearchLimit ?? 3)
+          : (arrConfig.QueueReplacementSearchWindowMinutes ?? 30);
+      const limit = field === "QueueReplacementSearchLimit" ? 10 : 1440;
+      const parsed = Number.parseInt(value, 10);
+      updateConfig({
+        ...arrConfig,
+        [field]: Number.isFinite(parsed) ? Math.max(1, Math.min(limit, parsed)) : fallback,
+      });
+    },
+    [arrConfig, updateConfig],
+  );
+
   return (
     <SettingsPage>
       <SettingsIntro>
@@ -322,6 +340,37 @@ export function ArrsSettings({ config, setNewConfig }: ArrsSettingsProps) {
               Configure what to do for items stuck in Radarr / Sonarr queues. Different actions can
               be configured for different status messages. Only usenet queue items will be acted
               upon.
+            </div>
+            <div className="flex flex-wrap items-end gap-4 rounded-box border border-base-content/10 bg-base-200 p-3">
+              <label className="flex flex-col gap-1 text-sm text-base-content/80">
+                Automatic replacement searches
+                <Input
+                  type="number"
+                  min={1}
+                  max={10}
+                  className="w-24"
+                  value={arrConfig.QueueReplacementSearchLimit ?? 3}
+                  onChange={(e) => updateReplacementSearchBudget("QueueReplacementSearchLimit", e.target.value)}
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm text-base-content/80">
+                Per window (minutes)
+                <Input
+                  type="number"
+                  min={1}
+                  max={1440}
+                  className="w-28"
+                  value={arrConfig.QueueReplacementSearchWindowMinutes ?? 30}
+                  onChange={(e) =>
+                    updateReplacementSearchBudget("QueueReplacementSearchWindowMinutes", e.target.value)
+                  }
+                />
+              </label>
+              <p className="max-w-xl text-[11px] leading-relaxed text-base-content/55">
+                “Remove, Blocklist, and Search” is limited per movie or episode. When the limit is
+                reached, InfiniDysk still removes and blocklists the rejected release but does not
+                trigger another automatic search.
+              </p>
             </div>
             <ul className="divide-y divide-base-content/10 rounded-box border border-base-content/10 bg-base-200">
               {queueStatusMessages.map((queueStatusMessage, index) => {

--- a/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
@@ -330,6 +330,66 @@ public class RadarrSonarrClientTests
     }
 
     [Fact]
+    public async Task RadarrRepair_WithholdsSearchWhenBudgetDenied()
+    {
+        const string filePath = "/library/movies/Budget Movie/Budget Movie.mkv";
+        var downloadId = Guid.Parse("12121212-1212-1212-1212-121212121212");
+        // No POST /api/v3/command response is queued: an attempted search would throw.
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/movie", JsonResponse($"[{{\"id\":101,\"movieFile\":{{\"id\":201,\"path\":\"{filePath}\"}}}}]")),
+            ($"GET /api/v3/history?downloadId={downloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[{"id":401}]}""")),
+            ("DELETE /api/v3/moviefile/201", Status(HttpStatusCode.OK)),
+            ("POST /api/v3/history/failed/401", JsonResponse("{}"))));
+        var client = new TestRadarrClient("http://radarr-budget.test", httpClient);
+
+        string? mediaIdentity = null;
+        var outcome = await client.RemoveAndBlocklist(
+            filePath,
+            downloadId,
+            identity =>
+            {
+                mediaIdentity = identity;
+                return false;
+            });
+
+        Assert.Equal(ArrRepairOutcome.RemoveAndBlocklistSucceeded, outcome);
+        Assert.Equal("movie:101", mediaIdentity);
+    }
+
+    [Fact]
+    public async Task SonarrRepair_WithholdsSearchWhenBudgetDenied()
+    {
+        const string seriesPath = "/library/tv/Budget Show";
+        const string filePath = seriesPath + "/Budget Show S01E01.mkv";
+        var downloadId = Guid.Parse("34343434-3434-3434-3434-343434343434");
+        // No POST /api/v3/command response is queued: an attempted search would throw.
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/series", JsonResponse($"[{{\"id\":101,\"path\":\"{seriesPath}\"}}]")),
+            ("GET /api/v3/episodefile?seriesId=101",
+                JsonResponse($"[{{\"id\":201,\"seriesId\":101,\"path\":\"{filePath}\"}}]")),
+            ($"GET /api/v3/history?downloadId={downloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[{"id":401}]}""")),
+            ("GET /api/v3/episode?episodeFileId=201", JsonResponse("""[{"id":301,"seriesId":101}]""")),
+            ("DELETE /api/v3/episodefile/201", Status(HttpStatusCode.OK)),
+            ("POST /api/v3/history/failed/401", JsonResponse("{}"))));
+        var client = new TestSonarrClient("http://sonarr-budget.test", httpClient);
+
+        string? mediaIdentity = null;
+        var outcome = await client.RemoveAndBlocklist(
+            filePath,
+            downloadId,
+            identity =>
+            {
+                mediaIdentity = identity;
+                return false;
+            });
+
+        Assert.Equal(ArrRepairOutcome.RemoveAndBlocklistSucceeded, outcome);
+        Assert.Equal("episode:301", mediaIdentity);
+    }
+
+    [Fact]
     public async Task RadarrQueue_PreservesMovieIdForReplacementSearchBudget()
     {
         using var httpClient = new HttpClient(CreateHandler(

--- a/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
@@ -330,6 +330,32 @@ public class RadarrSonarrClientTests
     }
 
     [Fact]
+    public async Task RadarrQueue_PreservesMovieIdForReplacementSearchBudget()
+    {
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/queue?protocol=usenet&pageSize=5000",
+                JsonResponse("""{"records":[{"id":1,"movieId":42}]}"""))));
+        var client = new TestRadarrClient(httpClient);
+
+        var record = Assert.Single((await client.GetQueueAsync()).Records);
+
+        Assert.Equal("movie:42", record.GetMediaIdentity());
+    }
+
+    [Fact]
+    public async Task SonarrQueue_PreservesEpisodeIdForReplacementSearchBudget()
+    {
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/queue?protocol=usenet&pageSize=5000",
+                JsonResponse("""{"records":[{"id":1,"seriesId":42,"episodeId":99}]}"""))));
+        var client = new TestSonarrClient(httpClient);
+
+        var record = Assert.Single((await client.GetQueueAsync()).Records);
+
+        Assert.Equal("episode:99", record.GetMediaIdentity());
+    }
+
+    [Fact]
     public void SharedHttpClient_HasExplicitTimeout()
     {
         Assert.Equal(TimeSpan.FromSeconds(30), ArrClient.RequestTimeout);

--- a/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using NzbWebDAV.Clients.RadarrSonarr;
 using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
+using NzbWebDAV.Services;
 
 namespace NzbWebDAV.Tests.Clients;
 
@@ -334,27 +335,28 @@ public class RadarrSonarrClientTests
     {
         const string filePath = "/library/movies/Budget Movie/Budget Movie.mkv";
         var downloadId = Guid.Parse("12121212-1212-1212-1212-121212121212");
-        // No POST /api/v3/command response is queued: an attempted search would throw.
-        using var httpClient = new HttpClient(CreateHandler(
+        var handler = CreateHandler(
             ("GET /api/v3/movie", JsonResponse($"[{{\"id\":101,\"movieFile\":{{\"id\":201,\"path\":\"{filePath}\"}}}}]")),
             ($"GET /api/v3/history?downloadId={downloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
                 JsonResponse("""{"records":[{"id":401}]}""")),
             ("DELETE /api/v3/moviefile/201", Status(HttpStatusCode.OK)),
-            ("POST /api/v3/history/failed/401", JsonResponse("{}"))));
+            ("POST /api/v3/history/failed/401", JsonResponse("{}")));
+        using var httpClient = new HttpClient(handler);
         var client = new TestRadarrClient("http://radarr-budget.test", httpClient);
 
-        string? mediaIdentity = null;
+        IReadOnlyList<string>? mediaIdentities = null;
         var outcome = await client.RemoveAndBlocklist(
             filePath,
             downloadId,
-            identity =>
+            identities =>
             {
-                mediaIdentity = identity;
+                mediaIdentities = identities;
                 return false;
             });
 
-        Assert.Equal(ArrRepairOutcome.RemoveAndBlocklistSucceeded, outcome);
-        Assert.Equal("movie:101", mediaIdentity);
+        Assert.Equal(ArrRepairOutcome.RemoveAndBlocklistSucceededSearchWithheld, outcome);
+        Assert.Equal(["movie:101"], mediaIdentities);
+        AssertRemoveAndBlocklistWithoutSearch(handler);
     }
 
     [Fact]
@@ -363,8 +365,7 @@ public class RadarrSonarrClientTests
         const string seriesPath = "/library/tv/Budget Show";
         const string filePath = seriesPath + "/Budget Show S01E01.mkv";
         var downloadId = Guid.Parse("34343434-3434-3434-3434-343434343434");
-        // No POST /api/v3/command response is queued: an attempted search would throw.
-        using var httpClient = new HttpClient(CreateHandler(
+        var handler = CreateHandler(
             ("GET /api/v3/series", JsonResponse($"[{{\"id\":101,\"path\":\"{seriesPath}\"}}]")),
             ("GET /api/v3/episodefile?seriesId=101",
                 JsonResponse($"[{{\"id\":201,\"seriesId\":101,\"path\":\"{filePath}\"}}]")),
@@ -372,21 +373,60 @@ public class RadarrSonarrClientTests
                 JsonResponse("""{"records":[{"id":401}]}""")),
             ("GET /api/v3/episode?episodeFileId=201", JsonResponse("""[{"id":301,"seriesId":101}]""")),
             ("DELETE /api/v3/episodefile/201", Status(HttpStatusCode.OK)),
-            ("POST /api/v3/history/failed/401", JsonResponse("{}"))));
+            ("POST /api/v3/history/failed/401", JsonResponse("{}")));
+        using var httpClient = new HttpClient(handler);
         var client = new TestSonarrClient("http://sonarr-budget.test", httpClient);
 
-        string? mediaIdentity = null;
+        IReadOnlyList<string>? mediaIdentities = null;
         var outcome = await client.RemoveAndBlocklist(
             filePath,
             downloadId,
-            identity =>
+            identities =>
             {
-                mediaIdentity = identity;
+                mediaIdentities = identities;
                 return false;
             });
 
-        Assert.Equal(ArrRepairOutcome.RemoveAndBlocklistSucceeded, outcome);
-        Assert.Equal("episode:301", mediaIdentity);
+        Assert.Equal(ArrRepairOutcome.RemoveAndBlocklistSucceededSearchWithheld, outcome);
+        Assert.Equal(["episode:301"], mediaIdentities);
+        AssertRemoveAndBlocklistWithoutSearch(handler);
+    }
+
+    [Fact]
+    public async Task SonarrRepair_WithholdsSearchWhenAnySeasonPackEpisodeIsExhausted()
+    {
+        const string seriesPath = "/library/tv/Season Pack Show";
+        const string filePath = seriesPath + "/Season Pack Show S01E01-E02.mkv";
+        var downloadId = Guid.Parse("56565656-5656-5656-5656-565656565656");
+        var handler = CreateHandler(
+            ("GET /api/v3/series", JsonResponse($"[{{\"id\":101,\"path\":\"{seriesPath}\"}}]")),
+            ("GET /api/v3/episodefile?seriesId=101",
+                JsonResponse($"[{{\"id\":201,\"seriesId\":101,\"path\":\"{filePath}\"}}]")),
+            ($"GET /api/v3/history?downloadId={downloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[{"id":401}]}""")),
+            ("GET /api/v3/episode?episodeFileId=201",
+                JsonResponse("""[{"id":301,"seriesId":101},{"id":302,"seriesId":101}]""")),
+            ("DELETE /api/v3/episodefile/201", Status(HttpStatusCode.OK)),
+            ("POST /api/v3/history/failed/401", JsonResponse("{}")));
+        using var httpClient = new HttpClient(handler);
+        var client = new TestSonarrClient("http://sonarr-pack.test", httpClient);
+        var budget = new ArrReplacementSearchBudget();
+        Assert.True(budget.TryReserve("episode:302", limit: 1, TimeSpan.FromMinutes(30)));
+
+        IReadOnlyList<string>? mediaIdentities = null;
+        var outcome = await client.RemoveAndBlocklist(
+            filePath,
+            downloadId,
+            identities =>
+            {
+                mediaIdentities = identities;
+                return budget.TryReserveAll(identities, limit: 1, TimeSpan.FromMinutes(30));
+            });
+
+        Assert.Equal(ArrRepairOutcome.RemoveAndBlocklistSucceededSearchWithheld, outcome);
+        Assert.Equal(["episode:301", "episode:302"], mediaIdentities);
+        AssertRemoveAndBlocklistWithoutSearch(handler);
+        Assert.True(budget.TryReserve("episode:301", limit: 1, TimeSpan.FromMinutes(30)));
     }
 
     [Fact]
@@ -428,6 +468,16 @@ public class RadarrSonarrClientTests
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json"),
         };
+
+    private static void AssertRemoveAndBlocklistWithoutSearch(ResponseQueueHandler handler)
+    {
+        Assert.Equal(1, handler.Requests.Count(request =>
+            request.StartsWith("DELETE ", StringComparison.Ordinal)));
+        Assert.Equal(1, handler.Requests.Count(request =>
+            request.StartsWith("POST /api/v3/history/failed/", StringComparison.Ordinal)));
+        Assert.DoesNotContain(handler.Requests, request =>
+            request.StartsWith("POST /api/v3/command", StringComparison.Ordinal));
+    }
 
     private static ResponseQueueHandler CreateHandler(
         params (string request, HttpResponseMessage response)[] responses) =>
@@ -489,11 +539,14 @@ public class RadarrSonarrClientTests
     private sealed class ResponseQueueHandler(
         Dictionary<string, Queue<HttpResponseMessage>> responses) : HttpMessageHandler
     {
+        public List<string> Requests { get; } = [];
+
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
             var key = $"{request.Method} {request.RequestUri!.PathAndQuery}";
+            Requests.Add(key);
             if (!responses.TryGetValue(key, out var queuedResponses) || !queuedResponses.TryDequeue(out var response))
                 throw new InvalidOperationException($"Unexpected request: {key}");
 

--- a/tests/NzbWebDAV.Tests/Config/ArrConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/ArrConfigTests.cs
@@ -18,6 +18,21 @@ public class ArrConfigTests
         Assert.Null(instance.Name);
         Assert.True(instance.Enabled);
         Assert.Equal("http://Radarr:7878/", instance.Host);
+        Assert.Equal(3, parsed.EffectiveQueueReplacementSearchLimit());
+        Assert.Equal(TimeSpan.FromMinutes(30), parsed.EffectiveQueueReplacementSearchWindow());
+    }
+
+    [Fact]
+    public void ReplacementSearchBudget_ClampsInvalidConfiguration()
+    {
+        var config = new ArrConfig
+        {
+            QueueReplacementSearchLimit = 99,
+            QueueReplacementSearchWindowMinutes = 0,
+        };
+
+        Assert.Equal(10, config.EffectiveQueueReplacementSearchLimit());
+        Assert.Equal(TimeSpan.FromMinutes(1), config.EffectiveQueueReplacementSearchWindow());
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
@@ -112,6 +112,29 @@ public class ArrLinkedRepairDecisionTests
     }
 
     [Fact]
+    public async Task RemoveAndBlocklistSucceededSearchWithheld_PreservesWithheldOutcome()
+    {
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, _) =>
+                    Task.FromResult(ArrRepairOutcome.RemoveAndBlocklistSucceededSearchWithheld)),
+        };
+
+        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, DownloadId, CancellationToken.None);
+
+        Assert.Equal(
+            HealthCheckService.ArrLinkedRepairDecision.RemoveAndBlocklistSucceededSearchWithheld,
+            decision);
+    }
+
+    [Fact]
     public async Task MissingDownloadIdentity_DefersWithoutCallingArrRepair()
     {
         var clients = new ArrClient[]
@@ -239,7 +262,7 @@ public class ArrLinkedRepairDecisionTests
         public override Task<ArrRepairOutcome> RemoveAndBlocklist(
             string symlinkOrStrmPath,
             Guid downloadId,
-            Func<string, bool>? shouldRequestSearch = null,
+            Func<IReadOnlyList<string>, bool>? shouldRequestSearch = null,
             CancellationToken ct = default) =>
             removeAndBlocklist(symlinkOrStrmPath, downloadId);
     }

--- a/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
@@ -239,6 +239,7 @@ public class ArrLinkedRepairDecisionTests
         public override Task<ArrRepairOutcome> RemoveAndBlocklist(
             string symlinkOrStrmPath,
             Guid downloadId,
+            Func<string, bool>? shouldRequestSearch = null,
             CancellationToken ct = default) =>
             removeAndBlocklist(symlinkOrStrmPath, downloadId);
     }

--- a/tests/NzbWebDAV.Tests/Services/ArrMonitoringAggregationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrMonitoringAggregationTests.cs
@@ -1,4 +1,5 @@
 using NzbWebDAV.Config;
+using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
 using NzbWebDAV.Services;
 using NzbWebDAV.Tests.TestUtils;
 using Serilog;
@@ -105,6 +106,119 @@ public sealed class ArrMonitoringAggregationTests
             Assert.DoesNotContain(
                 sink.Events,
                 e => e.Level == LogEventLevel.Debug && e.Properties.ContainsKey("QueueItemTitle"));
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+    }
+
+    [Fact]
+    public void MatchingStatusMessages_ReturnOriginalArrReason()
+    {
+        var record = new ArrQueueRecord
+        {
+            StatusMessages =
+            [
+                new ArrQueueStatusMessage
+                {
+                    Messages = ["Found archive file, might need to be extracted: release.part01.rar"],
+                },
+            ],
+        };
+
+        var reasons = record.GetMatchingStatusMessages(["Found archive file, might need to be extracted"]);
+
+        Assert.Equal(
+            ["Found archive file, might need to be extracted: release.part01.rar"],
+            reasons);
+    }
+
+    [Fact]
+    public void GetActionableStuckRecords_LeavesDownloadingRecordsAlone()
+    {
+        var queue = new ArrQueue<ArrQueueRecord>
+        {
+            Records =
+            [
+                new ArrQueueRecord
+                {
+                    Id = 1,
+                    Status = "downloading",
+                    StatusMessages =
+                    [
+                        new ArrQueueStatusMessage { Messages = ["Found archive file, might need to be extracted"] },
+                    ],
+                },
+                new ArrQueueRecord
+                {
+                    Id = 2,
+                    Status = "completed",
+                    StatusMessages =
+                    [
+                        new ArrQueueStatusMessage { Messages = ["Found archive file, might need to be extracted"] },
+                    ],
+                },
+            ],
+        };
+
+        var records = ArrMonitoringService.GetActionableStuckRecords(
+            queue,
+            [new ArrConfig.QueueRule
+            {
+                Message = "Found archive file, might need to be extracted",
+                Action = ArrConfig.QueueAction.RemoveAndBlocklistAndSearch,
+            }]);
+
+        Assert.Equal([2], records.Select(x => x.Id));
+    }
+
+    [Fact]
+    public void SummarizeReason_FlattensDeduplicatesAndTruncates()
+    {
+        var reason = ArrMonitoringService.SummarizeReason(
+            [
+                "No files found\nare eligible for import",
+                "No files found\nare eligible for import",
+                new string('x', 600),
+            ],
+            []);
+
+        Assert.StartsWith("No files found are eligible for import; ", reason);
+        Assert.EndsWith("…", reason);
+        Assert.True(reason.Length <= 512);
+    }
+
+    [Fact]
+    public void LogResolutionSummary_EmitsExactArrReason()
+    {
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        try
+        {
+            ArrMonitoringService.LogResolutionSummary(
+                [
+                    (
+                        "Release-A",
+                        ArrConfig.QueueAction.RemoveAndBlocklistAndSearch,
+                        "Found archive file, might need to be extracted: release.part01.rar",
+                        "Arr media ID"
+                    ),
+                ],
+                "http://radarr:7878");
+
+            var warning = Assert.Single(
+                sink.Events,
+                e => e.Level == LogEventLevel.Warning && e.Properties.ContainsKey("Reason"));
+            Assert.Equal(
+                "Found archive file, might need to be extracted: release.part01.rar",
+                warning.Properties["Reason"].LiteralValue());
+            Assert.Equal("Arr media ID", warning.Properties["IdentitySource"].LiteralValue());
         }
         finally
         {

--- a/tests/NzbWebDAV.Tests/Services/ArrReplacementSearchBudgetTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrReplacementSearchBudgetTests.cs
@@ -1,0 +1,75 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public class ArrReplacementSearchBudgetTests
+{
+    [Fact]
+    public void TryReserve_BoundsOneMediaItemWithinWindow()
+    {
+        var time = new TestTimeProvider();
+        var budget = new ArrReplacementSearchBudget(time);
+
+        Assert.True(budget.TryReserve("http://radarr|movie:42", limit: 3, TimeSpan.FromMinutes(30)));
+        Assert.True(budget.TryReserve("http://radarr|movie:42", limit: 3, TimeSpan.FromMinutes(30)));
+        Assert.True(budget.TryReserve("http://radarr|movie:42", limit: 3, TimeSpan.FromMinutes(30)));
+        Assert.False(budget.TryReserve("http://radarr|movie:42", limit: 3, TimeSpan.FromMinutes(30)));
+    }
+
+    [Fact]
+    public void TryReserve_KeepsHostsAndMediaItemsIndependent()
+    {
+        var budget = new ArrReplacementSearchBudget(new TestTimeProvider());
+
+        Assert.True(budget.TryReserve("http://radarr-one|movie:42", limit: 1, TimeSpan.FromMinutes(30)));
+        Assert.True(budget.TryReserve("http://radarr-two|movie:42", limit: 1, TimeSpan.FromMinutes(30)));
+        Assert.True(budget.TryReserve("http://radarr-one|movie:43", limit: 1, TimeSpan.FromMinutes(30)));
+    }
+
+    [Fact]
+    public void TryReserve_ExpiresOldReservations()
+    {
+        var time = new TestTimeProvider();
+        var budget = new ArrReplacementSearchBudget(time);
+
+        Assert.True(budget.TryReserve("http://radarr|movie:42", limit: 1, TimeSpan.FromMinutes(30)));
+        time.Advance(TimeSpan.FromMinutes(30).Add(TimeSpan.FromTicks(1)));
+
+        Assert.True(budget.TryReserve("http://radarr|movie:42", limit: 1, TimeSpan.FromMinutes(30)));
+    }
+
+    [Fact]
+    public void ApplyReplacementSearchBudget_DowngradesAlternateReleasesForOneMovie()
+    {
+        var budget = new ArrReplacementSearchBudget(new TestTimeProvider());
+        var config = new ArrConfig
+        {
+            QueueReplacementSearchLimit = 1,
+            QueueReplacementSearchWindowMinutes = 30,
+        };
+
+        var firstReleaseAction = ArrMonitoringService.ApplyReplacementSearchBudget(
+            ArrConfig.QueueAction.RemoveAndBlocklistAndSearch,
+            "http://radarr|movie:42",
+            config,
+            budget);
+        var alternateReleaseAction = ArrMonitoringService.ApplyReplacementSearchBudget(
+            ArrConfig.QueueAction.RemoveAndBlocklistAndSearch,
+            "http://radarr|movie:42",
+            config,
+            budget);
+
+        Assert.Equal(ArrConfig.QueueAction.RemoveAndBlocklistAndSearch, firstReleaseAction);
+        Assert.Equal(ArrConfig.QueueAction.RemoveAndBlocklist, alternateReleaseAction);
+    }
+
+    private sealed class TestTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _utcNow = new(2026, 8, 23, 0, 0, 0, TimeSpan.Zero);
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan elapsed) => _utcNow += elapsed;
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/ArrReplacementSearchBudgetTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrReplacementSearchBudgetTests.cs
@@ -89,6 +89,41 @@ public class ArrReplacementSearchBudgetTests
         Assert.Equal(ArrConfig.QueueAction.RemoveAndBlocklist, alternateReleaseAction);
     }
 
+    [Fact]
+    public void TryReserveAll_IsAtomicWhenOneKeyIsExhausted()
+    {
+        var budget = new ArrReplacementSearchBudget(new TestTimeProvider());
+        Assert.True(budget.TryReserve("episode:302", limit: 1, TimeSpan.FromMinutes(30)));
+
+        Assert.False(budget.TryReserveAll(["episode:301", "episode:302"], limit: 1, TimeSpan.FromMinutes(30)));
+
+        // The rejected batch must not consume budget for the episode that still had room.
+        Assert.True(budget.TryReserve("episode:301", limit: 1, TimeSpan.FromMinutes(30)));
+    }
+
+    [Fact]
+    public void SharedBudgetInstance_QueueActionAndHealthRepairShareTheCap()
+    {
+        var budget = new ArrReplacementSearchBudget(new TestTimeProvider());
+        var config = new ArrConfig
+        {
+            QueueReplacementSearchLimit = 1,
+            QueueReplacementSearchWindowMinutes = 30,
+        };
+
+        var queueAction = ArrMonitoringService.ApplyReplacementSearchBudget(
+            ArrConfig.QueueAction.RemoveAndBlocklistAndSearch,
+            "http://radarr|movie:42",
+            config,
+            budget);
+
+        Assert.Equal(ArrConfig.QueueAction.RemoveAndBlocklistAndSearch, queueAction);
+        Assert.False(budget.TryReserveAll(
+            ["http://radarr|movie:42"],
+            config.EffectiveQueueReplacementSearchLimit(),
+            config.EffectiveQueueReplacementSearchWindow()));
+    }
+
     private sealed class TestTimeProvider : TimeProvider
     {
         private DateTimeOffset _utcNow = new(2026, 8, 23, 0, 0, 0, TimeSpan.Zero);

--- a/tests/NzbWebDAV.Tests/Services/ArrReplacementSearchBudgetTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrReplacementSearchBudgetTests.cs
@@ -28,6 +28,31 @@ public class ArrReplacementSearchBudgetTests
     }
 
     [Fact]
+    public void TryReserve_FailsClosedForNewKeysAtCapacity()
+    {
+        var budget = new ArrReplacementSearchBudget(new TestTimeProvider());
+        for (var i = 0; i < 4096; i++)
+            Assert.True(budget.TryReserve($"http://radarr|movie:{i}", limit: 2, TimeSpan.FromMinutes(30)));
+
+        // A brand-new key must not evict an active reservation; it is denied instead.
+        Assert.False(budget.TryReserve("http://radarr|movie:99999", limit: 2, TimeSpan.FromMinutes(30)));
+
+        // Already-tracked keys keep working at capacity.
+        Assert.True(budget.TryReserve("http://radarr|movie:0", limit: 2, TimeSpan.FromMinutes(30)));
+    }
+
+    [Fact]
+    public void ReleaseLastReservation_RefundsBudget()
+    {
+        var budget = new ArrReplacementSearchBudget(new TestTimeProvider());
+
+        Assert.True(budget.TryReserve("http://radarr|movie:42", limit: 1, TimeSpan.FromMinutes(30)));
+        budget.ReleaseLastReservation("http://radarr|movie:42");
+
+        Assert.True(budget.TryReserve("http://radarr|movie:42", limit: 1, TimeSpan.FromMinutes(30)));
+    }
+
+    [Fact]
     public void TryReserve_ExpiresOldReservations()
     {
         var time = new TestTimeProvider();

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
@@ -742,7 +742,8 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
             _failureTracker,
             _queueManager,
             par2,
-            _patchStore);
+            _patchStore,
+            new ArrReplacementSearchBudget());
         return (service, par2);
     }
 


### PR DESCRIPTION
## Summary
- only resolve Arr queue warnings after the item is completed or awaiting import, and include the exact upstream warning in support-pack-visible logs
- cap automatic replacement searches per Radarr movie or Sonarr episode while continuing to remove and blocklist rejected releases; the same budget also bounds health-repair-triggered searches, whose per-path rate limit misses alternate releases
- only count confirmed Arr removals against the budget (refund on definitive rejection, fail closed at tracked-media capacity)
- expose the cap in Arr settings and document its behavior

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (3604 passed)
- [x] `cd frontend && npm run format && npm run typecheck && npm test`
- [x] `cd frontend && npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic replacement-search safeguards with configurable limits and time windows.
  - Improved Radarr and Sonarr queue handling, including media-specific identification and cancellation support.
  - Removal and blocklisting can proceed without triggering replacement searches when safeguards deny them.
- **Bug Fixes**
  - Excluded queued or downloading items from automatic queue actions.
  - Queue warnings now include matching import status messages.
- **Documentation**
  - Documented queue-action eligibility and replacement-search safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->