### PR TITLE
fix(db): allow orphan cleanup with PostgreSQL

### DIFF
--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -29,20 +29,21 @@ public class DavDatabaseContext : DbContext
         value => CloneRarParts(value));
 
     private static readonly ValueConverter<DateTime, DateTime> PostgresWallClockDateTimeConverter = new(
-        value => value.Kind == DateTimeKind.Utc
-            ? DateTime.SpecifyKind(value.ToLocalTime(), DateTimeKind.Unspecified)
-            : DateTime.SpecifyKind(value, DateTimeKind.Unspecified),
+        value => ToPostgresWallClock(value),
         value => DateTime.SpecifyKind(value, DateTimeKind.Unspecified));
 
     private static readonly ValueConverter<DateTime?, DateTime?> PostgresNullableWallClockDateTimeConverter = new(
         value => value.HasValue
-            ? value.Value.Kind == DateTimeKind.Utc
-                ? DateTime.SpecifyKind(value.Value.ToLocalTime(), DateTimeKind.Unspecified)
-                : DateTime.SpecifyKind(value.Value, DateTimeKind.Unspecified)
+            ? ToPostgresWallClock(value.Value)
             : null,
         value => value.HasValue
             ? DateTime.SpecifyKind(value.Value, DateTimeKind.Unspecified)
             : null);
+
+    internal static DateTime ToPostgresWallClock(DateTime value) =>
+        value.Kind == DateTimeKind.Utc
+            ? DateTime.SpecifyKind(value.ToLocalTime(), DateTimeKind.Unspecified)
+            : DateTime.SpecifyKind(value, DateTimeKind.Unspecified);
 
     private static bool StringArraysEqual(string[]? left, string[]? right) =>
         ReferenceEquals(left, right) ||

--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -10,6 +10,7 @@ using NzbWebDAV.Services;
 using NzbWebDAV.Utils;
 using NzbWebDAV.Websocket;
 using Npgsql;
+using NpgsqlTypes;
 using Serilog;
 
 namespace NzbWebDAV.Tasks;
@@ -27,6 +28,17 @@ public class RemoveUnlinkedFilesTask : BaseTask
     private ProgressHeartbeat? _progressHeartbeat;
 
     internal record UnlinkedItemInfo(string Id, int Type, string Path);
+
+    internal static DbParameter CreateWallClockParameter(
+        DavDatabaseContext dbContext,
+        DateTime value) =>
+        dbContext.Database.IsNpgsql()
+            ? new NpgsqlParameter
+            {
+                NpgsqlDbType = NpgsqlDbType.Timestamp,
+                Value = DavDatabaseContext.ToPostgresWallClock(value),
+            }
+            : new SqliteParameter { Value = value };
 
     public RemoveUnlinkedFilesTask(
         ConfigManager configManager,
@@ -387,7 +399,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
                  SELECT CAST(COUNT(i."Id") AS INT) AS "Value" FROM "DavItems" i
                  WHERE i."Type" = {usenetFileType}
                    AND i."HistoryItemId" IS NULL
-                   AND i."CreatedAt" < {createdBefore}
+                   AND i."CreatedAt" < {CreateWallClockParameter(dbContext, createdBefore)}
                  """)
             .SingleAsync()
             .ConfigureAwait(false);
@@ -412,7 +424,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
                  LEFT JOIN TMP_LINKED_FILES t ON t.Id = i."Id"
                  WHERE i."Type" = {usenetFileType}
                    AND i."HistoryItemId" IS NULL
-                   AND i."CreatedAt" < {createdBefore}
+                   AND i."CreatedAt" < {CreateWallClockParameter(dbContext, createdBefore)}
                    AND t.Id IS NULL
                  """)
             .SingleAsync()
@@ -439,7 +451,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
                      SELECT CAST("Id" AS TEXT) AS "Id", "Type", "Path" FROM "DavItems"
                      WHERE "Type" = {usenetFileType}
                        AND "HistoryItemId" IS NULL
-                       AND "CreatedAt" < {createdBefore}
+                       AND "CreatedAt" < {CreateWallClockParameter(dbContext, createdBefore)}
                        AND NOT EXISTS (
                            SELECT 1 FROM TMP_LINKED_FILES t
                            WHERE t.Id = "DavItems"."Id"
@@ -537,7 +549,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
                      SELECT CAST(d."Id" AS TEXT) AS "Id", d."Type" AS "Type", d."Path" AS "Path" FROM "DavItems" d
                      WHERE d."SubType" = {directorySubType}
                        AND d."HistoryItemId" IS NULL
-                       AND d."CreatedAt" < {createdBefore}
+                       AND d."CreatedAt" < {CreateWallClockParameter(dbContext, createdBefore)}
                        AND d."ParentId" NOT IN ({contentFolderId}, {nzbFolderId})
                        AND NOT EXISTS (
                            SELECT 1 FROM "DavItems" c WHERE c."ParentId" = d."Id"
@@ -619,7 +631,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
                      SELECT CAST("Id" AS TEXT) AS "Id", "Type", "Path" FROM "DavItems"
                      WHERE "Type" = {usenetFileType}
                        AND "HistoryItemId" IS NULL
-                       AND "CreatedAt" < {createdBefore}
+                       AND "CreatedAt" < {CreateWallClockParameter(dbContext, createdBefore)}
                        AND CAST("Id" AS TEXT) > {lastId}
                        AND NOT EXISTS (
                            SELECT 1 FROM TMP_LINKED_FILES t

--- a/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
@@ -59,6 +59,57 @@ public sealed class PostgresMigrationTests
     }
 
     [SkippableFact]
+    public async Task RemoveEmptyDirectoriesAsync_AcceptsLocalTimestampCutoff()
+    {
+        Skip.IfNot(
+            DatabaseProviderConfig.IsPostgres,
+            "PostgreSQL migration tests require DATABASE_PROVIDER=postgres.");
+
+        var schema = $"nzbdav_orphan_cleanup_{Guid.NewGuid():N}";
+        var connectionString = DatabaseProviderConfig.PostgresConnectionString;
+        await using var adminConnection = new NpgsqlConnection(connectionString);
+        await adminConnection.OpenAsync();
+        await ExecuteAsync(adminConnection, $"CREATE SCHEMA \"{schema}\"");
+
+        try
+        {
+            var scopedConnectionString = new NpgsqlConnectionStringBuilder(connectionString)
+            {
+                SearchPath = schema
+            }.ConnectionString;
+            var options = new DbContextOptionsBuilder<PostgresDavDatabaseContext>()
+                .UseNpgsql(scopedConnectionString)
+                .Options;
+            await using var context = new PostgresDavDatabaseContext(options);
+            await context.Database.MigrateAsync();
+
+            var id = Guid.NewGuid();
+            context.Items.Add(new DavItem
+            {
+                Id = id,
+                IdPrefix = id.ToString("N")[..DavItem.IdPrefixLength],
+                CreatedAt = DateTime.Now.AddMinutes(-1),
+                ParentId = DavItem.Root.Id,
+                Name = "orphaned-directory",
+                Type = DavItem.ItemType.Directory,
+                SubType = DavItem.ItemSubType.Directory,
+                Path = "/orphaned-directory",
+            });
+            await context.SaveChangesAsync();
+
+            var removed = await RemoveUnlinkedFilesTask.RemoveEmptyDirectoriesAsync(
+                context, DateTime.Now);
+
+            Assert.Equal(1, removed);
+            Assert.Null(await context.Items.FindAsync(id));
+        }
+        finally
+        {
+            await ExecuteAsync(adminConnection, $"DROP SCHEMA IF EXISTS \"{schema}\" CASCADE");
+        }
+    }
+
+    [SkippableFact]
     public async Task SabQueue_CountAndPageQueriesAreSequenced()
     {
         Skip.IfNot(DatabaseProviderConfig.IsPostgres,

--- a/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
@@ -84,11 +84,12 @@ public sealed class PostgresMigrationTests
             await context.Database.MigrateAsync();
 
             var id = Guid.NewGuid();
+            var cutoff = new DateTime(2026, 8, 23, 12, 34, 56, DateTimeKind.Local);
             context.Items.Add(new DavItem
             {
                 Id = id,
                 IdPrefix = id.ToString("N")[..DavItem.IdPrefixLength],
-                CreatedAt = DateTime.Now.AddMinutes(-1),
+                CreatedAt = cutoff.AddMinutes(-1),
                 ParentId = DavItem.Root.Id,
                 Name = "orphaned-directory",
                 Type = DavItem.ItemType.Directory,
@@ -98,7 +99,7 @@ public sealed class PostgresMigrationTests
             await context.SaveChangesAsync();
 
             var removed = await RemoveUnlinkedFilesTask.RemoveEmptyDirectoriesAsync(
-                context, DateTime.Now);
+                context, cutoff);
 
             Assert.Equal(1, removed);
             Assert.Null(await context.Items.FindAsync(id));

--- a/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
@@ -97,12 +97,13 @@ public sealed class PostgresMigrationTests
                 Path = "/orphaned-directory",
             });
             await context.SaveChangesAsync();
+            context.ChangeTracker.Clear();
 
             var removed = await RemoveUnlinkedFilesTask.RemoveEmptyDirectoriesAsync(
                 context, cutoff);
 
             Assert.Equal(1, removed);
-            Assert.Null(await context.Items.FindAsync(id));
+            Assert.False(await context.Items.AsNoTracking().AnyAsync(x => x.Id == id));
         }
         finally
         {

--- a/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
@@ -39,7 +39,7 @@ public class RemoveUnlinkedFilesTaskTests
             .UseNpgsql("Host=localhost;Database=nzbdav")
             .Options;
         using var context = new DavDatabaseContext(options);
-        var value = DateTime.UtcNow;
+        var value = new DateTime(2026, 8, 23, 12, 34, 56, DateTimeKind.Utc);
 
         var parameter = Assert.IsType<NpgsqlParameter>(
             RemoveUnlinkedFilesTask.CreateWallClockParameter(context, value));

--- a/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql;
+using NpgsqlTypes;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Interceptors;
@@ -14,6 +16,40 @@ namespace NzbWebDAV.Tests.Tasks;
 [Collection(nameof(BaseTaskCollection))]
 public class RemoveUnlinkedFilesTaskTests
 {
+    [Theory]
+    [InlineData(DateTimeKind.Local)]
+    [InlineData(DateTimeKind.Unspecified)]
+    [InlineData(DateTimeKind.Utc)]
+    public void ToPostgresWallClock_NormalizesDateTimeKind(DateTimeKind kind)
+    {
+        var value = new DateTime(2026, 8, 23, 12, 34, 56, kind);
+
+        var result = DavDatabaseContext.ToPostgresWallClock(value);
+
+        Assert.Equal(DateTimeKind.Unspecified, result.Kind);
+        Assert.Equal(
+            kind == DateTimeKind.Utc ? value.ToLocalTime().Ticks : value.Ticks,
+            result.Ticks);
+    }
+
+    [Fact]
+    public void CreateWallClockParameter_UsesPostgresTimestamp()
+    {
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseNpgsql("Host=localhost;Database=nzbdav")
+            .Options;
+        using var context = new DavDatabaseContext(options);
+        var value = DateTime.UtcNow;
+
+        var parameter = Assert.IsType<NpgsqlParameter>(
+            RemoveUnlinkedFilesTask.CreateWallClockParameter(context, value));
+
+        Assert.Equal(NpgsqlDbType.Timestamp, parameter.NpgsqlDbType);
+        var boundValue = Assert.IsType<DateTime>(parameter.Value);
+        Assert.Equal(DateTimeKind.Unspecified, boundValue.Kind);
+        Assert.Equal(value.ToLocalTime().Ticks, boundValue.Ticks);
+    }
+
     [Fact]
     public async Task ProgressHeartbeat_ReportsElapsedUntilCompleted()
     {


### PR DESCRIPTION
## Summary
- bind raw orphan-cleanup timestamp cutoffs as PostgreSQL wall-clock timestamps
- retain the existing DateTime conversion semantics and cover local cutoffs in PostgreSQL tests

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [ ] Run PostgreSQL-specific tests with `DATABASE_PROVIDER=postgres`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of local timestamps during PostgreSQL database cleanup.
  * Prevented timestamp conversion issues when removing unlinked files and empty directories.
  * Ensured cleanup operations use consistent wall-clock time values across supported databases.

* **Tests**
  * Added coverage for PostgreSQL timestamp handling and cleanup with local time cutoffs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->