### PR TITLE
feat(ui): make Overview easier to scan and recover when stats fail to load

### DIFF
--- a/frontend/app/routes/overview/components/activity-heatmap/activity-heatmap.module.css
+++ b/frontend/app/routes/overview/components/activity-heatmap/activity-heatmap.module.css
@@ -30,6 +30,8 @@
 }
 
 .cell {
+  border: 0;
+  padding: 0;
   transition:
     filter 80ms ease,
     box-shadow 80ms ease;
@@ -41,11 +43,13 @@
   pointer-events: none;
 }
 
-.cell:hover {
+.cell:hover,
+.cell:focus-visible {
   filter: brightness(1.4);
   box-shadow: 0 0 0 1px var(--color-base-content);
   z-index: 1;
   position: relative;
+  outline: none;
 }
 
 .grid[data-mode="day"] .cell,

--- a/frontend/app/routes/overview/components/activity-heatmap/activity-heatmap.tsx
+++ b/frontend/app/routes/overview/components/activity-heatmap/activity-heatmap.tsx
@@ -58,14 +58,25 @@ export function ActivityHeatmap({
   bucketSizeMs,
   cells,
 }: ActivityHeatmapProps) {
-  const [hover, setHover] = useState<GridCell | null>(null);
-  const [selected, setSelected] = useState<GridCell | null>(null);
-  const shown = hover ?? selected;
+  const [hoverBucket, setHoverBucket] = useState<number | null>(null);
+  const [selectedBucket, setSelectedBucket] = useState<number | null>(null);
 
   const grid = useMemo(
     () => buildGrid(mode, windowStartMs, windowEndMs, cells),
     [mode, windowStartMs, windowEndMs, cells],
   );
+  const cellByBucket = useMemo(() => {
+    const map = new Map<number, GridCell>();
+    for (const row of grid.rows) {
+      for (const cell of row.cells) {
+        if (cell.inRange) map.set(cell.bucket, cell);
+      }
+    }
+    return map;
+  }, [grid]);
+  const hover = hoverBucket === null ? null : (cellByBucket.get(hoverBucket) ?? null);
+  const selected = selectedBucket === null ? null : (cellByBucket.get(selectedBucket) ?? null);
+  const shown = hover ?? selected;
 
   const total = useMemo(() => cells.reduce((s, c) => s + c.count, 0), [cells]);
   const empty = total === 0;
@@ -132,13 +143,11 @@ export function ActivityHeatmap({
                           data-tip={`${formatBucket(cell.bucket, bucketSizeMs)}: ${formatNumber(cell.count)} ${cell.count === 1 ? "article" : "articles"}`}
                           className={`tooltip ${styles.cell}`}
                           style={{ backgroundColor: cellColor(intensity) }}
-                          onMouseEnter={() => setHover(cell)}
-                          onMouseLeave={() =>
-                            setHover((h) => (h && h.bucket === cell.bucket ? null : h))
-                          }
-                          onFocus={() => setHover(cell)}
-                          onBlur={() => setHover((h) => (h && h.bucket === cell.bucket ? null : h))}
-                          onClick={() => setSelected(cell)}
+                          onMouseEnter={() => setHoverBucket(cell.bucket)}
+                          onMouseLeave={() => setHoverBucket((h) => (h === cell.bucket ? null : h))}
+                          onFocus={() => setHoverBucket(cell.bucket)}
+                          onBlur={() => setHoverBucket((h) => (h === cell.bucket ? null : h))}
+                          onClick={() => setSelectedBucket(cell.bucket)}
                         />
                       );
                     })}

--- a/frontend/app/routes/overview/components/activity-heatmap/activity-heatmap.tsx
+++ b/frontend/app/routes/overview/components/activity-heatmap/activity-heatmap.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import styles from "./activity-heatmap.module.css";
 import type { HeatmapCell, HeatmapMode } from "~/clients/backend-client.server";
 import { formatNumber } from "../../utils/format";
+import { Tooltip } from "~/components/ui";
 
 export type ActivityHeatmapProps = {
   maxCell: number;
@@ -107,12 +108,11 @@ export function ActivityHeatmap({
             <div className={styles.grid} data-mode={mode}>
               {grid.rows.map((row, r) => (
                 <div key={r} className={styles.row}>
-                  <div
-                    className="w-[30px] shrink-0 text-right text-[11px] font-medium text-base-content/50 select-none"
-                    title={row.title}
-                  >
-                    {row.label}
-                  </div>
+                  <Tooltip content={row.title ?? row.label}>
+                    <div className="w-[30px] shrink-0 text-right text-[11px] font-medium text-base-content/50 select-none">
+                      {row.label}
+                    </div>
+                  </Tooltip>
                   <div
                     className={styles.cellRow}
                     style={{ gridTemplateColumns: `repeat(${grid.cols}, minmax(0, 1fr))` }}
@@ -126,9 +126,10 @@ export function ActivityHeatmap({
                         <button
                           type="button"
                           key={c}
-                          className={styles.cell}
-                          style={{ backgroundColor: cellColor(intensity) }}
                           aria-label={`${formatBucket(cell.bucket, bucketSizeMs)}: ${formatNumber(cell.count)} ${cell.count === 1 ? "article" : "articles"}`}
+                          data-tip={`${formatBucket(cell.bucket, bucketSizeMs)}: ${formatNumber(cell.count)} ${cell.count === 1 ? "article" : "articles"}`}
+                          className={`tooltip ${styles.cell}`}
+                          style={{ backgroundColor: cellColor(intensity) }}
                           onMouseEnter={() => setHover(cell)}
                           onMouseLeave={() =>
                             setHover((h) => (h && h.bucket === cell.bucket ? null : h))

--- a/frontend/app/routes/overview/components/activity-heatmap/activity-heatmap.tsx
+++ b/frontend/app/routes/overview/components/activity-heatmap/activity-heatmap.tsx
@@ -59,6 +59,8 @@ export function ActivityHeatmap({
   cells,
 }: ActivityHeatmapProps) {
   const [hover, setHover] = useState<GridCell | null>(null);
+  const [selected, setSelected] = useState<GridCell | null>(null);
+  const shown = hover ?? selected;
 
   const grid = useMemo(
     () => buildGrid(mode, windowStartMs, windowEndMs, cells),
@@ -136,6 +138,7 @@ export function ActivityHeatmap({
                           }
                           onFocus={() => setHover(cell)}
                           onBlur={() => setHover((h) => (h && h.bucket === cell.bucket ? null : h))}
+                          onClick={() => setSelected(cell)}
                         />
                       );
                     })}
@@ -165,10 +168,10 @@ export function ActivityHeatmap({
 
             <div className="mt-3 flex flex-wrap items-center justify-between gap-4">
               <div className="text-[11px] text-base-content/50 tabular-nums">
-                {hover ? (
+                {shown ? (
                   <>
-                    {formatBucket(hover.bucket, bucketSizeMs)} &mdash; {formatNumber(hover.count)}{" "}
-                    {hover.count === 1 ? "article" : "articles"}
+                    {formatBucket(shown.bucket, bucketSizeMs)} &mdash; {formatNumber(shown.count)}{" "}
+                    {shown.count === 1 ? "article" : "articles"}
                   </>
                 ) : (
                   <>Select a cell for details</>

--- a/frontend/app/routes/overview/components/activity-heatmap/activity-heatmap.tsx
+++ b/frontend/app/routes/overview/components/activity-heatmap/activity-heatmap.tsx
@@ -123,14 +123,18 @@ export function ActivityHeatmap({
                       }
                       const intensity = maxCell > 0 ? cell.count / maxCell : 0;
                       return (
-                        <div
+                        <button
+                          type="button"
                           key={c}
                           className={styles.cell}
                           style={{ backgroundColor: cellColor(intensity) }}
+                          aria-label={`${formatBucket(cell.bucket, bucketSizeMs)}: ${formatNumber(cell.count)} ${cell.count === 1 ? "article" : "articles"}`}
                           onMouseEnter={() => setHover(cell)}
                           onMouseLeave={() =>
                             setHover((h) => (h && h.bucket === cell.bucket ? null : h))
                           }
+                          onFocus={() => setHover(cell)}
+                          onBlur={() => setHover((h) => (h && h.bucket === cell.bucket ? null : h))}
                         />
                       );
                     })}
@@ -166,7 +170,7 @@ export function ActivityHeatmap({
                     {hover.count === 1 ? "article" : "articles"}
                   </>
                 ) : (
-                  <>Hover a cell for details</>
+                  <>Select a cell for details</>
                 )}
               </div>
               <div className="flex items-center gap-1 text-[10px] text-base-content/50">

--- a/frontend/app/routes/overview/components/arr-health/arr-health.test.tsx
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.test.tsx
@@ -1,4 +1,5 @@
 import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
 import { describe, expect, it } from "vitest";
 import type { ArrHealthResponse } from "~/clients/backend-client.server";
 import { ArrHealth } from "./arr-health";
@@ -14,7 +15,11 @@ const emptySummary = {
 };
 
 function render(data: ArrHealthResponse, window: "24h" | "all" = "24h") {
-  return renderToStaticMarkup(<ArrHealth data={data} window={window} />);
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <ArrHealth data={data} window={window} />
+    </MemoryRouter>,
+  );
 }
 
 describe("ArrHealth", () => {

--- a/frontend/app/routes/overview/components/arr-health/arr-health.tsx
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.tsx
@@ -4,6 +4,8 @@ import type {
   OverviewWindow,
 } from "~/clients/backend-client.server";
 import { formatDurationMs, formatNumber, formatTimeAgo } from "../../utils/format";
+import { settingsPath } from "~/navigation/settings-tabs";
+import { WidgetLink } from "../widget-link/widget-link";
 
 export type ArrHealthProps = {
   data: ArrHealthResponse;
@@ -24,11 +26,17 @@ export function ArrHealth({ data, window }: ArrHealthProps) {
   return (
     <section className="card w-full min-w-0 border border-base-content/10 bg-base-100 shadow-sm">
       <div className="card-body gap-3 p-4">
-        <div>
-          <h3 className="card-title text-base">Arr Health</h3>
-          <p className="text-xs text-base-content/50">
-            InfiniDysk completion → Sonarr/Radarr import, {sinceLabel}
-          </p>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h3 className="card-title text-base">Arr Health</h3>
+            <p className="text-xs text-base-content/50">
+              InfiniDysk completion → Sonarr/Radarr import, {sinceLabel}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <WidgetLink to="/queue">Queue</WidgetLink>
+            <WidgetLink to={settingsPath("arrs")}>Arr settings</WidgetLink>
+          </div>
         </div>
 
         <div className="flex flex-wrap gap-2">
@@ -110,9 +118,12 @@ export function ArrHealth({ data, window }: ArrHealthProps) {
 
         {awaiting.length > 0 && (
           <div>
-            <h4 className="mb-2 text-xs uppercase tracking-wide text-base-content/50">
-              Awaiting import
-            </h4>
+            <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+              <h4 className="text-xs uppercase tracking-wide text-base-content/50">
+                Awaiting import
+              </h4>
+              <WidgetLink to="/queue">Open queue</WidgetLink>
+            </div>
             <ul className="space-y-1">
               {awaiting.map((item, index) => (
                 <li

--- a/frontend/app/routes/overview/components/arr-health/arr-health.tsx
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.tsx
@@ -5,6 +5,7 @@ import type {
 } from "~/clients/backend-client.server";
 import { formatDurationMs, formatNumber, formatTimeAgo } from "../../utils/format";
 import { settingsPath } from "~/navigation/settings-tabs";
+import { Tooltip } from "~/components/ui";
 import { WidgetLink } from "../widget-link/widget-link";
 
 export type ArrHealthProps = {
@@ -33,23 +34,20 @@ export function ArrHealth({ data, window }: ArrHealthProps) {
               InfiniDysk completion → Sonarr/Radarr import, {sinceLabel}
             </p>
           </div>
-          <div className="flex flex-wrap items-center gap-3">
+          <div className="card-actions m-0">
             <WidgetLink to="/queue">Queue</WidgetLink>
             <WidgetLink to={settingsPath("arrs")}>Arr settings</WidgetLink>
           </div>
         </div>
 
-        <div className="flex flex-wrap gap-2">
-          <Chip
-            label="Instances online"
-            value={`${summary.instancesOnline}/${summary.instancesTotal}`}
-          />
-          <Chip label="Imports" value={formatNumber(summary.importsCompleted)} />
-          <Chip label="Median handoff" value={formatDurationMs(summary.medianHandoffMs)} />
-          <Chip label="P95" value={formatDurationMs(summary.p95HandoffMs)} />
-          <Chip label="Awaiting" value={formatNumber(summary.awaitingImport)} />
+        <div className="stats stats-vertical w-full border border-base-content/10 sm:stats-horizontal">
+          <MiniStat label="Online" value={`${summary.instancesOnline}/${summary.instancesTotal}`} />
+          <MiniStat label="Imports" value={formatNumber(summary.importsCompleted)} />
+          <MiniStat label="Median handoff" value={formatDurationMs(summary.medianHandoffMs)} />
+          <MiniStat label="P95" value={formatDurationMs(summary.p95HandoffMs)} />
+          <MiniStat label="Awaiting" value={formatNumber(summary.awaitingImport)} />
           {summary.degraded > 0 && (
-            <Chip label="Degraded" value={formatNumber(summary.degraded)} warning />
+            <MiniStat label="Degraded" value={formatNumber(summary.degraded)} warning />
           )}
         </div>
 
@@ -74,12 +72,11 @@ export function ArrHealth({ data, window }: ArrHealthProps) {
                 {instances.map((instance) => (
                   <tr key={instance.key}>
                     <td className="max-w-[220px] font-medium">
-                      <span
-                        className="inline-block max-w-full truncate align-middle"
-                        title={instance.host}
-                      >
-                        {instance.name}
-                      </span>
+                      <Tooltip content={instance.host}>
+                        <span className="inline-block max-w-full truncate align-middle">
+                          {instance.name}
+                        </span>
+                      </Tooltip>
                       <span className="mt-0.5 block text-[11px] font-normal capitalize text-base-content/45">
                         {instance.appType}
                       </span>
@@ -124,15 +121,17 @@ export function ArrHealth({ data, window }: ArrHealthProps) {
               </h4>
               <WidgetLink to="/queue">Open queue</WidgetLink>
             </div>
-            <ul className="space-y-1">
+            <ul className="list bg-base-100 p-0">
               {awaiting.map((item, index) => (
                 <li
                   key={`${item.instanceKey}-${item.title ?? "item"}-${index}`}
-                  className={`text-xs ${item.isUnusual ? "text-warning" : "text-base-content/80"}`}
+                  className={`list-row py-2 text-xs ${item.isUnusual ? "text-warning" : "text-base-content/80"}`}
                 >
-                  {item.title ?? "(untitled)"} — {item.instanceName} — waiting{" "}
-                  {formatDurationMs(item.waitingMs)}
-                  {item.isUnusual ? " — unusually long" : ""}
+                  <div className="list-col-grow">
+                    {item.title ?? "(untitled)"} — {item.instanceName} — waiting{" "}
+                    {formatDurationMs(item.waitingMs)}
+                    {item.isUnusual ? " — unusually long" : ""}
+                  </div>
                 </li>
               ))}
             </ul>
@@ -143,7 +142,7 @@ export function ArrHealth({ data, window }: ArrHealthProps) {
   );
 }
 
-function Chip({
+function MiniStat({
   label,
   value,
   warning = false,
@@ -153,9 +152,9 @@ function Chip({
   warning?: boolean;
 }) {
   return (
-    <span className={`badge badge-sm gap-1 ${warning ? "badge-warning" : "badge-ghost"}`}>
-      <span className="text-base-content/60">{label}</span>
-      <span className="font-mono tabular-nums">{value}</span>
-    </span>
+    <div className="stat py-2">
+      <div className="stat-title text-xs">{label}</div>
+      <div className={`stat-value font-mono text-lg ${warning ? "text-warning" : ""}`}>{value}</div>
+    </div>
   );
 }

--- a/frontend/app/routes/overview/components/catalogue-block/catalogue-block.tsx
+++ b/frontend/app/routes/overview/components/catalogue-block/catalogue-block.tsx
@@ -11,14 +11,14 @@ export type CatalogueBlockProps = {
 
 export function CatalogueBlock({ catalogue }: CatalogueBlockProps) {
   return (
-    <section className="card w-full border border-base-content/10 bg-base-100 shadow-sm">
+    <section className="card w-full border border-base-content/10 bg-base-100">
       <div className="card-body gap-3 p-4">
         <div>
           <h3 className="card-title text-base">Catalogue</h3>
           <p className="text-xs text-base-content/50">Your mounted library</p>
         </div>
 
-        <div className="stats stats-vertical w-full border border-base-content/10 bg-base-200 shadow sm:stats-horizontal">
+        <div className="stats stats-vertical w-full bg-base-200/40 sm:stats-horizontal">
           <Stat label="Files" value={formatNumber(catalogue.fileCount)} />
           <Stat label="Total size" value={formatBytes(catalogue.totalBytes)} />
           <Stat label="Largest file" value={formatBytes(catalogue.largestFileBytes)} />

--- a/frontend/app/routes/overview/components/catalogue-block/catalogue-block.tsx
+++ b/frontend/app/routes/overview/components/catalogue-block/catalogue-block.tsx
@@ -11,23 +11,21 @@ export type CatalogueBlockProps = {
 
 export function CatalogueBlock({ catalogue }: CatalogueBlockProps) {
   return (
-    <section className="card w-full border border-base-content/10 bg-base-100">
-      <div className="card-body gap-3 p-4">
-        <div>
-          <h3 className="card-title text-base">Catalogue</h3>
-          <p className="text-xs text-base-content/50">Your mounted library</p>
-        </div>
+    <section className="w-full min-w-0">
+      <header className="mb-2">
+        <h3 className="text-sm font-semibold text-base-content">Catalogue</h3>
+        <p className="text-xs text-base-content/50">Your mounted library</p>
+      </header>
 
-        <div className="stats stats-vertical w-full bg-base-200/40 sm:stats-horizontal">
-          <Stat label="Files" value={formatNumber(catalogue.fileCount)} />
-          <Stat label="Total size" value={formatBytes(catalogue.totalBytes)} />
-          <Stat label="Largest file" value={formatBytes(catalogue.largestFileBytes)} />
-          <Stat
-            label="Added 7d"
-            value={formatNumber(catalogue.addedLast7Days)}
-            accent={catalogue.addedLast7Days > 0 ? "good" : undefined}
-          />
-        </div>
+      <div className="stats stats-vertical w-full border border-base-content/10 bg-base-100 sm:stats-horizontal">
+        <Stat label="Files" value={formatNumber(catalogue.fileCount)} />
+        <Stat label="Total size" value={formatBytes(catalogue.totalBytes)} />
+        <Stat label="Largest file" value={formatBytes(catalogue.largestFileBytes)} />
+        <Stat
+          label="Added 7d"
+          value={formatNumber(catalogue.addedLast7Days)}
+          accent={catalogue.addedLast7Days > 0 ? "good" : undefined}
+        />
       </div>
     </section>
   );

--- a/frontend/app/routes/overview/components/error-donut/error-donut.tsx
+++ b/frontend/app/routes/overview/components/error-donut/error-donut.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import styles from "./error-donut.module.css";
 import type { ErrorSlice } from "~/clients/backend-client.server";
 import { formatNumber, formatPercent } from "../../utils/format";
+import { Tooltip } from "~/components/ui";
 import { WidgetLink } from "../widget-link/widget-link";
 
 export type ErrorDonutProps = {
@@ -73,12 +74,16 @@ export function ErrorBreakdown({ errors }: ErrorDonutProps) {
               Hard failures vs expected provider misses
             </p>
           </div>
-          {hardTotal > 0 && <WidgetLink to="/logs">View logs</WidgetLink>}
+          {hardTotal > 0 && (
+            <div className="card-actions m-0">
+              <WidgetLink to="/logs">View logs</WidgetLink>
+            </div>
+          )}
         </div>
 
         {allClear ? (
           <div className="flex items-center gap-3 px-3 pt-4 pb-2">
-            <div className="h-3 w-3 shrink-0 rounded-full bg-success" />
+            <span className="status status-success" />
             <div>
               <div className="text-sm font-semibold text-base-content">All clear</div>
               <div className="mt-0.5 text-xs text-base-content/50">
@@ -118,16 +123,19 @@ export function ErrorBreakdown({ errors }: ErrorDonutProps) {
                   aria-label={`${hardTotal} hard fetch errors broken down by type`}
                 >
                   {hardSegments.map((s) => (
-                    <div
+                    <Tooltip
                       key={s.status}
-                      className={`${styles.stackSeg} ${hover && hover !== s.status ? styles.stackSegDim : ""}`}
-                      style={{
-                        flex: s.count,
-                        background: s.color,
-                      }}
-                      onMouseEnter={() => setHover(s.status)}
-                      title={`${statusLabel(s.status)}: ${formatNumber(s.count)} (${formatPercent(s.fraction * 100, 1)})`}
-                    />
+                      content={`${statusLabel(s.status)}: ${formatNumber(s.count)} (${formatPercent(s.fraction * 100, 1)})`}
+                    >
+                      <div
+                        className={`${styles.stackSeg} ${hover && hover !== s.status ? styles.stackSegDim : ""}`}
+                        style={{
+                          flex: s.count,
+                          background: s.color,
+                        }}
+                        onMouseEnter={() => setHover(s.status)}
+                      />
+                    </Tooltip>
                   ))}
                 </div>
 

--- a/frontend/app/routes/overview/components/error-donut/error-donut.tsx
+++ b/frontend/app/routes/overview/components/error-donut/error-donut.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import styles from "./error-donut.module.css";
 import type { ErrorSlice } from "~/clients/backend-client.server";
 import { formatNumber, formatPercent } from "../../utils/format";
+import { WidgetLink } from "../widget-link/widget-link";
 
 export type ErrorDonutProps = {
   errors: ErrorSlice[];
@@ -65,9 +66,14 @@ export function ErrorBreakdown({ errors }: ErrorDonutProps) {
   return (
     <section className="card w-full min-w-0 overflow-hidden border border-base-content/10 bg-base-100 shadow-sm">
       <div className="card-body gap-3 p-4">
-        <div>
-          <h3 className="card-title text-base">Error breakdown</h3>
-          <p className="text-xs text-base-content/50">Hard failures vs expected provider misses</p>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h3 className="card-title text-base">Error breakdown</h3>
+            <p className="text-xs text-base-content/50">
+              Hard failures vs expected provider misses
+            </p>
+          </div>
+          {hardTotal > 0 && <WidgetLink to="/logs">View logs</WidgetLink>}
         </div>
 
         {allClear ? (

--- a/frontend/app/routes/overview/components/failover-saves/failover-saves.tsx
+++ b/frontend/app/routes/overview/components/failover-saves/failover-saves.tsx
@@ -88,10 +88,10 @@ export function FailoverSaves({ failover, window }: FailoverSavesProps) {
               </div>
               {momentum && (
                 <div
-                  className={`badge badge-lg h-auto flex-col gap-0.5 border border-base-content/10 bg-base-200 px-3 py-2 ${
+                  className={`tooltip badge badge-lg h-auto flex-col gap-0.5 border border-base-content/10 bg-base-200 px-3 py-2 ${
                     momentum.neutral ? "" : momentum.good ? "text-success" : "text-error"
                   }`}
-                  title={`Failover load ${momentum.label} vs the previous ${window}`}
+                  data-tip={`Failover load ${momentum.label} vs the previous ${window}`}
                 >
                   <span className="text-sm font-bold leading-none">{momentum.arrow}</span>
                   <span className="font-mono text-sm font-bold tabular-nums leading-none">
@@ -123,8 +123,8 @@ export function FailoverSaves({ failover, window }: FailoverSavesProps) {
                       Most saves
                     </div>
                     <div
-                      className="truncate text-sm font-semibold text-base-content"
-                      title={topHero.provider}
+                      className="tooltip truncate text-sm font-semibold text-base-content"
+                      data-tip={topHero.provider}
                     >
                       {topHero.nickname?.trim() || topHero.provider}
                     </div>
@@ -140,8 +140,8 @@ export function FailoverSaves({ failover, window }: FailoverSavesProps) {
                       Most misses
                     </div>
                     <div
-                      className="truncate text-sm font-semibold text-base-content"
-                      title={topVillain.provider}
+                      className="tooltip truncate text-sm font-semibold text-base-content"
+                      data-tip={topVillain.provider}
                     >
                       {topVillain.nickname?.trim() || topVillain.provider}
                     </div>
@@ -166,9 +166,9 @@ export function FailoverSaves({ failover, window }: FailoverSavesProps) {
                     return (
                       <span
                         key={r.status}
-                        className={`${styles.reasonSeg} ${meta.cls}`}
+                        className={`tooltip ${styles.reasonSeg} ${meta.cls}`}
                         style={{ width: `${width.toFixed(1)}%` }}
-                        title={`${meta.label}: ${formatNumber(r.count)} (${width.toFixed(0)}%)`}
+                        data-tip={`${meta.label}: ${formatNumber(r.count)} (${width.toFixed(0)}%)`}
                       />
                     );
                   })}
@@ -178,7 +178,7 @@ export function FailoverSaves({ failover, window }: FailoverSavesProps) {
                     const meta = reasonMeta(r.status);
                     return (
                       <span key={r.status} className="badge badge-ghost badge-sm gap-1.5">
-                        <span className={`h-1.5 w-1.5 rounded-full ${meta.cls}`} />
+                        <span className={`status status-xs ${reasonStatus(r.status)}`} />
                         {meta.label} <strong className="font-mono">{formatNumber(r.count)}</strong>
                       </span>
                     );
@@ -200,8 +200,8 @@ export function FailoverSaves({ failover, window }: FailoverSavesProps) {
                     return (
                       <div
                         key={p.provider}
-                        className="flex items-center gap-3 border-b border-base-content/10 py-2 last:border-b-0"
-                        title={p.nickname?.trim() || p.provider}
+                        className="tooltip flex items-center gap-3 border-b border-base-content/10 py-2 last:border-b-0"
+                        data-tip={p.nickname?.trim() || p.provider}
                       >
                         <span className="w-[130px] shrink-0 truncate text-[13px] font-medium text-base-content">
                           {p.nickname?.trim() || p.provider}
@@ -238,8 +238,8 @@ export function FailoverSaves({ failover, window }: FailoverSavesProps) {
                     return (
                       <div
                         key={p.provider}
-                        className="flex items-center gap-3 border-b border-base-content/10 py-2 last:border-b-0"
-                        title={p.nickname?.trim() || p.provider}
+                        className="tooltip flex items-center gap-3 border-b border-base-content/10 py-2 last:border-b-0"
+                        data-tip={p.nickname?.trim() || p.provider}
                       >
                         <span className="w-[130px] shrink-0 truncate text-[13px] font-medium text-base-content">
                           {p.nickname?.trim() || p.provider}
@@ -481,6 +481,20 @@ function computeMomentum(current: number, previous: number | null): Momentum | n
   const up = delta > 0;
   const pct = `${Math.abs(delta).toFixed(0)}%`;
   return { arrow: up ? "↑" : "↓", text: pct, label: `${up ? "up" : "down"} ${pct}`, good: !up };
+}
+
+function reasonStatus(status: string): string {
+  switch (status) {
+    case "Timeout":
+      return "status-warning";
+    case "Auth":
+      return "status-info";
+    case "Network":
+    case "Corrupt":
+      return "status-error";
+    default:
+      return "status-neutral";
+  }
 }
 
 function reasonMeta(status: string): { label: string; cls: string } {

--- a/frontend/app/routes/overview/components/indexer-api-usage/indexer-api-usage.tsx
+++ b/frontend/app/routes/overview/components/indexer-api-usage/indexer-api-usage.tsx
@@ -53,10 +53,18 @@ export function IndexerApiUsage({ rows }: IndexerApiUsageProps) {
                       </Tooltip>
                     </td>
                     <td>
-                      <UsageBar used={r.apiHits} limit={r.apiHitLimit} />
+                      <UsageBar
+                        used={r.apiHits}
+                        limit={r.apiHitLimit}
+                        label={`${r.name} API hits`}
+                      />
                     </td>
                     <td>
-                      <UsageBar used={r.downloadHits} limit={r.downloadHitLimit} />
+                      <UsageBar
+                        used={r.downloadHits}
+                        limit={r.downloadHitLimit}
+                        label={`${r.name} downloads`}
+                      />
                     </td>
                     <td className="whitespace-nowrap font-mono text-xs tabular-nums text-base-content/50">
                       {formatReset(r.resetAtMs, r.resetHourUtc, now)}
@@ -72,12 +80,25 @@ export function IndexerApiUsage({ rows }: IndexerApiUsageProps) {
   );
 }
 
-function UsageBar({ used, limit }: { used: number; limit: number | null | undefined }) {
+function UsageBar({
+  used,
+  limit,
+  label,
+}: {
+  used: number;
+  limit: number | null | undefined;
+  label: string;
+}) {
   if (!limit || limit <= 0) {
     return (
       <div className="flex items-center gap-2.5">
         <Tooltip content="No limit configured">
-          <progress className="progress progress-success h-2 min-w-20 flex-1" value={0} max={100} />
+          <progress
+            aria-label={`${label}: ${formatNumber(used)}, unlimited`}
+            className="progress progress-success h-2 min-w-20 flex-1"
+            value={0}
+            max={100}
+          />
         </Tooltip>
         <span className="text-xs text-base-content tabular-nums whitespace-nowrap">
           {formatNumber(used)}
@@ -92,7 +113,12 @@ function UsageBar({ used, limit }: { used: number; limit: number | null | undefi
   const tone = over ? "progress-error" : near ? "progress-warning" : "progress-success";
   return (
     <div className="flex items-center gap-2.5">
-      <progress className={`progress h-2 min-w-20 flex-1 ${tone}`} value={pct} max={100} />
+      <progress
+        aria-label={`${label}: ${formatNumber(used)} of ${formatNumber(limit)}`}
+        className={`progress h-2 min-w-20 flex-1 ${tone}`}
+        value={pct}
+        max={100}
+      />
       <span className="text-xs text-base-content tabular-nums whitespace-nowrap">
         {formatNumber(used)}
         <span className="text-base-content/50"> / {formatNumber(limit)}</span>

--- a/frontend/app/routes/overview/components/indexer-api-usage/indexer-api-usage.tsx
+++ b/frontend/app/routes/overview/components/indexer-api-usage/indexer-api-usage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
-import styles from "./indexer-api-usage.module.css";
 import type { IndexerApiUsageRow } from "~/clients/backend-client.server";
 import { formatNumber } from "../../utils/format";
+import { Tooltip } from "~/components/ui";
 
 export type IndexerApiUsageProps = {
   rows: IndexerApiUsageRow[];
@@ -46,12 +46,11 @@ export function IndexerApiUsage({ rows }: IndexerApiUsageProps) {
                 {rows.map((r) => (
                   <tr key={r.name}>
                     <td className="max-w-[220px] font-medium">
-                      <span
-                        className="inline-block max-w-full truncate align-middle"
-                        title={r.name}
-                      >
-                        {r.name}
-                      </span>
+                      <Tooltip content={r.name}>
+                        <span className="inline-block max-w-full truncate align-middle">
+                          {r.name}
+                        </span>
+                      </Tooltip>
                     </td>
                     <td>
                       <UsageBar used={r.apiHits} limit={r.apiHitLimit} />
@@ -77,12 +76,9 @@ function UsageBar({ used, limit }: { used: number; limit: number | null | undefi
   if (!limit || limit <= 0) {
     return (
       <div className="flex items-center gap-2.5">
-        <div
-          className="relative h-2 min-w-20 flex-1 overflow-hidden rounded bg-base-200"
-          title="No limit configured"
-        >
-          <div className={styles.usageFillInfinite} />
-        </div>
+        <Tooltip content="No limit configured">
+          <progress className="progress progress-success h-2 min-w-20 flex-1" value={0} max={100} />
+        </Tooltip>
         <span className="text-xs text-base-content tabular-nums whitespace-nowrap">
           {formatNumber(used)}
           <span className="text-base-content/50"> · unlimited</span>
@@ -93,15 +89,10 @@ function UsageBar({ used, limit }: { used: number; limit: number | null | undefi
   const pct = Math.min(100, (used / limit) * 100);
   const near = pct >= 80 && pct < 100;
   const over = pct >= 100;
-  const fillClass = over ? "bg-error/80" : near ? "bg-warning/70" : "bg-success/55";
+  const tone = over ? "progress-error" : near ? "progress-warning" : "progress-success";
   return (
     <div className="flex items-center gap-2.5">
-      <div className="relative h-2 min-w-20 flex-1 overflow-hidden rounded bg-base-200">
-        <div
-          className={`absolute inset-y-0 left-0 rounded transition-[width] duration-200 ${fillClass}`}
-          style={{ width: `${pct}%` }}
-        />
-      </div>
+      <progress className={`progress h-2 min-w-20 flex-1 ${tone}`} value={pct} max={100} />
       <span className="text-xs text-base-content tabular-nums whitespace-nowrap">
         {formatNumber(used)}
         <span className="text-base-content/50"> / {formatNumber(limit)}</span>

--- a/frontend/app/routes/overview/components/indexer-scoreboard/indexer-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/indexer-scoreboard/indexer-scoreboard.tsx
@@ -81,7 +81,12 @@ export function IndexerScoreboard({ indexers }: IndexerScoreboardProps) {
 function SuccessBar({ rate }: { rate: number }) {
   return (
     <div className="flex items-center gap-2">
-      <progress className="progress progress-success w-20" value={rate * 100} max={100} />
+      <progress
+        className="progress progress-success w-20"
+        value={rate * 100}
+        max={100}
+        aria-label={`Success rate: ${formatPercent(rate * 100, 0)}`}
+      />
       <span className="font-mono text-[11px] tabular-nums">{formatPercent(rate * 100, 0)}</span>
     </div>
   );

--- a/frontend/app/routes/overview/components/indexer-scoreboard/indexer-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/indexer-scoreboard/indexer-scoreboard.tsx
@@ -1,6 +1,7 @@
 import type { IndexerRow } from "~/clients/backend-client.server";
 import { formatBytes, formatNumber, formatPercent } from "../../utils/format";
 import { settingsPath } from "~/navigation/settings-tabs";
+import { Tooltip } from "~/components/ui";
 import { WidgetLink } from "../widget-link/widget-link";
 
 export type IndexerScoreboardProps = {
@@ -19,7 +20,9 @@ export function IndexerScoreboard({ indexers }: IndexerScoreboardProps) {
               Completed vs failed downloads, last 30 days
             </p>
           </div>
-          <WidgetLink to={settingsPath("indexers")}>Indexer settings</WidgetLink>
+          <div className="card-actions m-0">
+            <WidgetLink to={settingsPath("indexers")}>Indexer settings</WidgetLink>
+          </div>
         </div>
         {failedTotal > 0 && (
           <p className="text-xs text-error">
@@ -47,12 +50,11 @@ export function IndexerScoreboard({ indexers }: IndexerScoreboardProps) {
                 {indexers.map((i) => (
                   <tr key={i.name}>
                     <th scope="row" className="bg-base-100 max-w-[220px] font-medium">
-                      <span
-                        className="inline-block max-w-full truncate align-middle"
-                        title={i.name}
-                      >
-                        {i.name}
-                      </span>
+                      <Tooltip content={i.name}>
+                        <span className="inline-block max-w-full truncate align-middle">
+                          {i.name}
+                        </span>
+                      </Tooltip>
                     </th>
                     <td className="font-mono tabular-nums">{formatNumber(i.completed)}</td>
                     <td className={`font-mono tabular-nums ${i.failed > 0 ? "text-error" : ""}`}>
@@ -76,14 +78,9 @@ export function IndexerScoreboard({ indexers }: IndexerScoreboardProps) {
 
 function SuccessBar({ rate }: { rate: number }) {
   return (
-    <div className="relative h-4 w-20 overflow-hidden rounded bg-base-200">
-      <div
-        className="absolute inset-0 bg-success opacity-[0.28]"
-        style={{ width: `${(rate * 100).toFixed(1)}%` }}
-      />
-      <span className="relative block px-1.5 text-center text-[11px] leading-4 text-base-content tabular-nums">
-        {formatPercent(rate * 100, 0)}
-      </span>
+    <div className="flex items-center gap-2">
+      <progress className="progress progress-success w-20" value={rate * 100} max={100} />
+      <span className="font-mono text-[11px] tabular-nums">{formatPercent(rate * 100, 0)}</span>
     </div>
   );
 }

--- a/frontend/app/routes/overview/components/indexer-scoreboard/indexer-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/indexer-scoreboard/indexer-scoreboard.tsx
@@ -1,26 +1,38 @@
 import type { IndexerRow } from "~/clients/backend-client.server";
 import { formatBytes, formatNumber, formatPercent } from "../../utils/format";
+import { settingsPath } from "~/navigation/settings-tabs";
+import { WidgetLink } from "../widget-link/widget-link";
 
 export type IndexerScoreboardProps = {
   indexers: IndexerRow[];
 };
 
 export function IndexerScoreboard({ indexers }: IndexerScoreboardProps) {
+  const failedTotal = indexers.reduce((s, i) => s + i.failed, 0);
   return (
     <section className="card w-full min-w-0 border border-base-content/10 bg-base-100 shadow-sm">
       <div className="card-body gap-3 p-4">
-        <div>
-          <h3 className="card-title text-base">Indexers</h3>
-          <p className="text-xs text-base-content/50">
-            Completed vs failed downloads, last 30 days
-          </p>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h3 className="card-title text-base">Indexers</h3>
+            <p className="text-xs text-base-content/50">
+              Completed vs failed downloads, last 30 days
+            </p>
+          </div>
+          <WidgetLink to={settingsPath("indexers")}>Indexer settings</WidgetLink>
         </div>
+        {failedTotal > 0 && (
+          <p className="text-xs text-error">
+            {failedTotal} failed import{failedTotal === 1 ? "" : "s"}.{" "}
+            <WidgetLink to={settingsPath("indexers")}>Review indexer settings</WidgetLink>
+          </p>
+        )}
 
         {indexers.length === 0 ? (
           <p className="py-6 text-center text-xs text-base-content/50">No imports recorded yet.</p>
         ) : (
           <div className="overflow-x-auto">
-            <table className="table table-sm min-w-[560px]">
+            <table className="table table-pin-cols table-sm min-w-[560px]">
               <thead>
                 <tr>
                   <th>Indexer</th>
@@ -34,14 +46,14 @@ export function IndexerScoreboard({ indexers }: IndexerScoreboardProps) {
               <tbody>
                 {indexers.map((i) => (
                   <tr key={i.name}>
-                    <td className="max-w-[220px] font-medium">
+                    <th scope="row" className="bg-base-100 max-w-[220px] font-medium">
                       <span
                         className="inline-block max-w-full truncate align-middle"
                         title={i.name}
                       >
                         {i.name}
                       </span>
-                    </td>
+                    </th>
                     <td className="font-mono tabular-nums">{formatNumber(i.completed)}</td>
                     <td className={`font-mono tabular-nums ${i.failed > 0 ? "text-error" : ""}`}>
                       {formatNumber(i.failed)}

--- a/frontend/app/routes/overview/components/indexer-scoreboard/indexer-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/indexer-scoreboard/indexer-scoreboard.tsx
@@ -26,13 +26,15 @@ export function IndexerScoreboard({ indexers }: IndexerScoreboardProps) {
         </div>
         {failedTotal > 0 && (
           <p className="text-xs text-error">
-            {failedTotal} failed import{failedTotal === 1 ? "" : "s"}.{" "}
+            {failedTotal} failed download{failedTotal === 1 ? "" : "s"}.{" "}
             <WidgetLink to={settingsPath("indexers")}>Review indexer settings</WidgetLink>
           </p>
         )}
 
         {indexers.length === 0 ? (
-          <p className="py-6 text-center text-xs text-base-content/50">No imports recorded yet.</p>
+          <p className="py-6 text-center text-xs text-base-content/50">
+            No downloads recorded yet.
+          </p>
         ) : (
           <div className="overflow-x-auto">
             <table className="table table-pin-cols table-sm min-w-[560px]">

--- a/frontend/app/routes/overview/components/latency-histogram/latency-histogram.module.css
+++ b/frontend/app/routes/overview/components/latency-histogram/latency-histogram.module.css
@@ -15,6 +15,10 @@
   gap: 6px;
   height: 100%;
   min-width: 0;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
 }
 
 .barWrap {
@@ -37,6 +41,10 @@
 }
 
 .barCol:hover .bar,
+.barCol:focus-visible .bar,
 .barHover .bar {
   filter: brightness(1.3);
+}
+.barCol:focus-visible {
+  outline: none;
 }

--- a/frontend/app/routes/overview/components/latency-histogram/latency-histogram.module.css
+++ b/frontend/app/routes/overview/components/latency-histogram/latency-histogram.module.css
@@ -46,5 +46,7 @@
   filter: brightness(1.3);
 }
 .barCol:focus-visible {
-  outline: none;
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: 0.25rem;
 }

--- a/frontend/app/routes/overview/components/latency-histogram/latency-histogram.tsx
+++ b/frontend/app/routes/overview/components/latency-histogram/latency-histogram.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import styles from "./latency-histogram.module.css";
 import type { LatencyBucket } from "~/clients/backend-client.server";
 import { formatNumber, formatPercent } from "../../utils/format";
+import { Tooltip } from "~/components/ui";
 
 export type LatencyHistogramProps = {
   p50Ms: number;
@@ -55,7 +56,8 @@ export function LatencyHistogram({ p50Ms, p95Ms, p99Ms, samples, buckets }: Late
                   <button
                     type="button"
                     key={i}
-                    className={`${styles.barCol} ${isHover ? styles.barHover : ""}`}
+                    className={`tooltip ${styles.barCol} ${isHover ? styles.barHover : ""}`}
+                    data-tip={`${fullBucketLabel(b)}: ${formatNumber(b.count)} ${b.count === 1 ? "fetch" : "fetches"}`}
                     aria-label={`${fullBucketLabel(b)}: ${formatNumber(b.count)} ${b.count === 1 ? "fetch" : "fetches"}`}
                     onMouseEnter={() => setHover(b)}
                     onMouseLeave={() => setHover((h) => (h === b ? null : h))}
@@ -108,22 +110,21 @@ function Pctile({
 }) {
   const valueClass = kind === "danger" ? "text-error" : kind === "warn" ? "text-warning" : "";
   return (
-    <div
-      className="min-w-[78px] rounded-box border border-base-content/10 bg-base-200 px-3 py-1.5 text-right"
-      title={`${caption} — ${ms} ms`}
-    >
-      <div className="flex items-baseline justify-end gap-1.5">
-        <span className="text-[10px] font-medium tracking-wide text-base-content/50 uppercase">
-          {label}
-        </span>
-        <span className="text-[9px] tracking-wide text-base-content/50 lowercase">{caption}</span>
+    <Tooltip content={`${caption} — ${ms} ms`}>
+      <div className="min-w-[78px] rounded-box border border-base-content/10 bg-base-200 px-3 py-1.5 text-right">
+        <div className="flex items-baseline justify-end gap-1.5">
+          <span className="text-[10px] font-medium tracking-wide text-base-content/50 uppercase">
+            {label}
+          </span>
+          <span className="text-[9px] tracking-wide text-base-content/50 lowercase">{caption}</span>
+        </div>
+        <div
+          className={`mt-px text-[17px] leading-tight font-semibold tracking-tight tabular-nums ${valueClass}`}
+        >
+          {formatMs(ms)}
+        </div>
       </div>
-      <div
-        className={`mt-px text-[17px] leading-tight font-semibold tracking-tight tabular-nums ${valueClass}`}
-      >
-        {formatMs(ms)}
-      </div>
-    </div>
+    </Tooltip>
   );
 }
 

--- a/frontend/app/routes/overview/components/latency-histogram/latency-histogram.tsx
+++ b/frontend/app/routes/overview/components/latency-histogram/latency-histogram.tsx
@@ -52,11 +52,15 @@ export function LatencyHistogram({ p50Ms, p95Ms, p99Ms, samples, buckets }: Late
                 const h = maxCount > 0 ? (b.count / maxCount) * 100 : 0;
                 const isHover = hover === b;
                 return (
-                  <div
+                  <button
+                    type="button"
                     key={i}
                     className={`${styles.barCol} ${isHover ? styles.barHover : ""}`}
+                    aria-label={`${fullBucketLabel(b)}: ${formatNumber(b.count)} ${b.count === 1 ? "fetch" : "fetches"}`}
                     onMouseEnter={() => setHover(b)}
                     onMouseLeave={() => setHover((h) => (h === b ? null : h))}
+                    onFocus={() => setHover(b)}
+                    onBlur={() => setHover((h) => (h === b ? null : h))}
                   >
                     <div className={styles.barWrap}>
                       <div className={styles.bar} style={{ height: `${h.toFixed(1)}%` }} />
@@ -64,7 +68,7 @@ export function LatencyHistogram({ p50Ms, p95Ms, p99Ms, samples, buckets }: Late
                     <div className="max-w-full overflow-hidden text-center text-[10px] leading-none text-base-content/50 tabular-nums">
                       {bucketLabel(b)}
                     </div>
-                  </div>
+                  </button>
                 );
               })}
             </div>
@@ -80,7 +84,7 @@ export function LatencyHistogram({ p50Ms, p95Ms, p99Ms, samples, buckets }: Late
                     {samples > 0 && <> · {formatPercent((hover.count / samples) * 100, 1)}</>}
                   </>
                 ) : (
-                  <>Hover a bar for the exact count</>
+                  <>Select a bar for the exact count</>
                 )}
               </div>
             </div>

--- a/frontend/app/routes/overview/components/lifetime-block/lifetime-block.tsx
+++ b/frontend/app/routes/overview/components/lifetime-block/lifetime-block.tsx
@@ -15,26 +15,24 @@ export function LifetimeBlock({ lifetime }: LifetimeBlockProps) {
   const isEmpty = lifetime.bytesRead === 0 && lifetime.articles === 0;
 
   return (
-    <section className="card w-full border border-base-content/10 bg-base-100">
-      <div className="card-body gap-3 p-4">
-        <div>
-          <h3 className="card-title text-base">All time</h3>
-          <p className="text-xs text-base-content/50">{since(lifetime.firstSeenAt)}</p>
-        </div>
+    <section className="w-full min-w-0">
+      <header className="mb-2">
+        <h3 className="text-sm font-semibold text-base-content">All time</h3>
+        <p className="text-xs text-base-content/50">{since(lifetime.firstSeenAt)}</p>
+      </header>
 
-        {isEmpty ? (
-          <p className="text-sm text-base-content/50">
-            Lifetime totals appear after your first reads.
-          </p>
-        ) : (
-          <div className="stats stats-vertical w-full bg-base-200/40 sm:stats-horizontal">
-            <Stat label="Read" value={formatBytes(lifetime.bytesRead)} />
-            <Stat label="Articles" value={formatNumber(lifetime.articles)} />
-            <Stat label="Read sessions" value={formatNumber(lifetime.readSessions)} />
-            <Stat label="Active-reads time" value={formatHours(lifetime.readSeconds)} />
-          </div>
-        )}
-      </div>
+      {isEmpty ? (
+        <p className="text-sm text-base-content/50">
+          Lifetime totals appear after your first reads.
+        </p>
+      ) : (
+        <div className="stats stats-vertical w-full border border-base-content/10 bg-base-100 sm:stats-horizontal">
+          <Stat label="Read" value={formatBytes(lifetime.bytesRead)} />
+          <Stat label="Articles" value={formatNumber(lifetime.articles)} />
+          <Stat label="Read sessions" value={formatNumber(lifetime.readSessions)} />
+          <Stat label="Active-reads time" value={formatHours(lifetime.readSeconds)} />
+        </div>
+      )}
     </section>
   );
 }

--- a/frontend/app/routes/overview/components/lifetime-block/lifetime-block.tsx
+++ b/frontend/app/routes/overview/components/lifetime-block/lifetime-block.tsx
@@ -15,7 +15,7 @@ export function LifetimeBlock({ lifetime }: LifetimeBlockProps) {
   const isEmpty = lifetime.bytesRead === 0 && lifetime.articles === 0;
 
   return (
-    <section className="card w-full border border-base-content/10 bg-base-100 shadow-sm">
+    <section className="card w-full border border-base-content/10 bg-base-100">
       <div className="card-body gap-3 p-4">
         <div>
           <h3 className="card-title text-base">All time</h3>
@@ -27,7 +27,7 @@ export function LifetimeBlock({ lifetime }: LifetimeBlockProps) {
             Lifetime totals appear after your first reads.
           </p>
         ) : (
-          <div className="stats stats-vertical w-full border border-base-content/10 bg-base-200 shadow sm:stats-horizontal">
+          <div className="stats stats-vertical w-full bg-base-200/40 sm:stats-horizontal">
             <Stat label="Read" value={formatBytes(lifetime.bytesRead)} />
             <Stat label="Articles" value={formatNumber(lifetime.articles)} />
             <Stat label="Read sessions" value={formatNumber(lifetime.readSessions)} />

--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.test.tsx
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.test.tsx
@@ -7,6 +7,6 @@ describe("LiveReadsPanel", () => {
     const markup = renderToStaticMarkup(<LiveReadsPanel />);
 
     expect(markup).toContain("Right now");
-    expect(markup).toContain("No active reads.");
+    expect(markup).toContain("No files are being read right now.");
   });
 });

--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
@@ -112,22 +112,25 @@ export function LiveReadsPanel({ paused = false }: { paused?: boolean }) {
                 <li key={r.id} className="list-row px-0">
                   <div className="list-col-grow min-w-0 gap-2">
                     <Tooltip content={r.path}>
-                      <div className="truncate text-sm font-medium text-base-content">
+                      <span className="block truncate text-sm font-medium text-base-content">
                         {r.fileName || lastSegment(r.path)}
-                      </div>
+                      </span>
                     </Tooltip>
                     <Tooltip content={clientIdentityTooltip(r.clientUserAgent, r.clientIp) ?? ""}>
-                      <div className="truncate text-xs text-base-content/50">
+                      <span className="block truncate text-xs text-base-content/50">
                         {clientLabelFromUserAgent(r.clientUserAgent)}
                         {r.clientIp ? (
                           <span className="font-mono text-base-content/40"> · {r.clientIp}</span>
                         ) : null}
-                      </div>
+                      </span>
                     </Tooltip>
                     <Tooltip content={`Copy session id: ${r.id}`}>
                       <button
                         type="button"
                         className="btn btn-link btn-xs h-auto min-h-0 px-0 font-mono"
+                        aria-label={`Copy session id: ${r.id}${
+                          copiedId === r.id ? " (copied)" : ""
+                        }`}
                         onClick={() => {
                           void copySessionId(r.id);
                         }}
@@ -142,7 +145,11 @@ export function LiveReadsPanel({ paused = false }: { paused?: boolean }) {
                         max={100}
                       />
                     ) : (
-                      <span className="loading loading-bars loading-sm text-success" />
+                      <span
+                        className="loading loading-bars loading-sm text-success"
+                        role="status"
+                        aria-label="Loading progress"
+                      />
                     )}
                     <div className="flex items-baseline justify-between font-mono text-xs tabular-nums">
                       <span className="font-medium text-base-content">

--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
@@ -1,9 +1,9 @@
 import { useRef, useState } from "react";
-import styles from "./live-reads-panel.module.css";
 import type { ActiveRead, ActiveReadsMessage } from "~/clients/backend-client.server";
 import { formatBytes } from "../../utils/format";
 import { clientIdentityTooltip, clientLabelFromUserAgent } from "~/utils/client-label";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
+import { Tooltip } from "~/components/ui";
 
 const TOPIC_ACTIVE_READS = "ar";
 
@@ -54,7 +54,7 @@ export function LiveReadsPanel({ paused = false }: { paused?: boolean }) {
     <section className="card w-full min-w-0 border border-base-content/10 bg-base-100 shadow-sm xl:h-full">
       <div className="card-body gap-3 p-4">
         <div className="flex items-center gap-2.5">
-          <span className={styles.livePulse} aria-hidden="true" />
+          <span className="status status-success animate-pulse" aria-hidden="true" />
           <h3 className="card-title m-0 text-base">Right now</h3>
           {reads.length > 0 && (
             <span className="badge badge-ghost badge-sm ml-auto font-mono tabular-nums">
@@ -72,7 +72,7 @@ export function LiveReadsPanel({ paused = false }: { paused?: boolean }) {
             No files are being read right now. Open a mounted file to see live progress here.
           </p>
         ) : (
-          <div className="flex flex-col gap-2.5">
+          <ul className="list w-full p-0">
             {reads.map((r) => {
               const meta = prevRef.current.get(r.id);
               const rate = meta?.rate ?? 0;
@@ -84,81 +84,84 @@ export function LiveReadsPanel({ paused = false }: { paused?: boolean }) {
                   ? Math.min(100, (r.currentOffset / r.fileSize) * 100)
                   : null;
               return (
-                <div
-                  key={r.id}
-                  className="flex min-w-0 w-full flex-col gap-2 rounded-box border border-base-content/10 bg-base-200 p-3"
-                >
-                  <div className="truncate text-sm font-medium text-base-content" title={r.path}>
-                    {r.fileName || lastSegment(r.path)}
-                  </div>
-                  <div
-                    className="truncate text-xs text-base-content/50"
-                    title={clientIdentityTooltip(r.clientUserAgent, r.clientIp)}
-                  >
-                    {clientLabelFromUserAgent(r.clientUserAgent)}
-                    {r.clientIp ? (
-                      <span className="font-mono text-base-content/40"> · {r.clientIp}</span>
-                    ) : null}
-                  </div>
-                  <button
-                    type="button"
-                    className="btn btn-ghost btn-xs self-start px-0 font-mono text-base-content/50 hover:underline"
-                    title={`Copy session id: ${r.id}`}
-                    onClick={() => {
-                      void navigator.clipboard.writeText(r.id);
-                      setCopiedId(r.id);
-                      window.setTimeout(() => setCopiedId((id) => (id === r.id ? null : id)), 1500);
-                    }}
-                  >
-                    {copiedId === r.id ? "Copied" : shortSessionId(r.id)}
-                  </button>
-                  {pct !== null ? (
-                    <progress
-                      className="progress progress-success h-1 w-full"
-                      value={pct}
-                      max={100}
-                    />
-                  ) : (
-                    <div className={styles.progressIndeterminateWrap}>
-                      <div className={styles.progressIndeterminate} />
+                <li key={r.id} className="list-row px-0">
+                  <div className="list-col-grow min-w-0 gap-2">
+                    <Tooltip content={r.path}>
+                      <div className="truncate text-sm font-medium text-base-content">
+                        {r.fileName || lastSegment(r.path)}
+                      </div>
+                    </Tooltip>
+                    <Tooltip content={clientIdentityTooltip(r.clientUserAgent, r.clientIp) ?? ""}>
+                      <div className="truncate text-xs text-base-content/50">
+                        {clientLabelFromUserAgent(r.clientUserAgent)}
+                        {r.clientIp ? (
+                          <span className="font-mono text-base-content/40"> · {r.clientIp}</span>
+                        ) : null}
+                      </div>
+                    </Tooltip>
+                    <Tooltip content={`Copy session id: ${r.id}`}>
+                      <button
+                        type="button"
+                        className="btn btn-link btn-xs h-auto min-h-0 px-0 font-mono"
+                        onClick={() => {
+                          void navigator.clipboard.writeText(r.id);
+                          setCopiedId(r.id);
+                          window.setTimeout(
+                            () => setCopiedId((id) => (id === r.id ? null : id)),
+                            1500,
+                          );
+                        }}
+                      >
+                        {copiedId === r.id ? "Copied" : shortSessionId(r.id)}
+                      </button>
+                    </Tooltip>
+                    {pct !== null ? (
+                      <progress
+                        className="progress progress-success h-1 w-full"
+                        value={pct}
+                        max={100}
+                      />
+                    ) : (
+                      <span className="loading loading-bars loading-sm text-success" />
+                    )}
+                    <div className="flex items-baseline justify-between font-mono text-xs tabular-nums">
+                      <span className="font-medium text-base-content">
+                        {r.fileSize ? (
+                          <>
+                            at {formatBytes(r.currentOffset)}{" "}
+                            <span className="font-normal text-base-content/50">
+                              / {formatBytes(r.fileSize)}
+                            </span>
+                          </>
+                        ) : (
+                          <>at {formatBytes(r.currentOffset)}</>
+                        )}
+                      </span>
+                      <span className="font-medium text-base-content">{formatBytes(rate)}/s</span>
                     </div>
-                  )}
-                  <div className="flex items-baseline justify-between font-mono text-xs tabular-nums">
-                    <span className="font-medium text-base-content">
-                      {r.fileSize ? (
-                        <>
-                          at {formatBytes(r.currentOffset)}{" "}
-                          <span className="font-normal text-base-content/50">
-                            / {formatBytes(r.fileSize)}
-                          </span>
-                        </>
-                      ) : (
-                        <>at {formatBytes(r.currentOffset)}</>
-                      )}
-                    </span>
-                    <span className="font-medium text-base-content">{formatBytes(rate)}/s</span>
+                    {r.providers.length > 0 && (
+                      <div className="flex min-w-0 flex-wrap gap-1">
+                        {r.providers.slice(0, 6).map((p, i) => {
+                          const label = p.nickname?.trim() || p.host;
+                          return (
+                            <Tooltip
+                              key={`${p.host}-${i}`}
+                              content={`${label} (${p.host}): ${p.segments} segments`}
+                            >
+                              <span className="badge badge-ghost badge-sm gap-1.5 font-mono tabular-nums">
+                                <span className="max-w-[8rem] truncate">{label}</span>
+                                <span className="font-medium">{p.segments}</span>
+                              </span>
+                            </Tooltip>
+                          );
+                        })}
+                      </div>
+                    )}
                   </div>
-                  {r.providers.length > 0 && (
-                    <div className="flex min-w-0 flex-wrap gap-1">
-                      {r.providers.slice(0, 6).map((p, i) => {
-                        const label = p.nickname?.trim() || p.host;
-                        return (
-                          <span
-                            key={`${p.host}-${i}`}
-                            className={`badge badge-sm gap-1.5 font-mono tabular-nums ${i === 0 ? "badge-primary" : "badge-ghost"}`}
-                            title={`${label} (${p.host}): ${p.segments} segments`}
-                          >
-                            <span className="max-w-[8rem] truncate">{label}</span>
-                            <span className="font-medium">{p.segments}</span>
-                          </span>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
+                </li>
               );
             })}
-          </div>
+          </ul>
         )}
       </div>
     </section>

--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ActiveRead, ActiveReadsMessage } from "~/clients/backend-client.server";
 import { formatBytes } from "../../utils/format";
 import { clientIdentityTooltip, clientLabelFromUserAgent } from "~/utils/client-label";
@@ -15,8 +15,33 @@ const TOPIC_ACTIVE_READS = "ar";
 export function LiveReadsPanel({ paused = false }: { paused?: boolean }) {
   const [reads, setReads] = useState<ActiveRead[]>([]);
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [copyNotice, setCopyNotice] = useState<{ seq: number; text: string } | null>(null);
+  const copySeqRef = useRef(0);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Track previous bytesRead per session for live MiB/s computation.
   const prevRef = useRef<Map<string, { bytes: number; at: number; rate: number }>>(new Map());
+
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+    };
+  }, []);
+
+  const copySessionId = async (id: string) => {
+    try {
+      await navigator.clipboard.writeText(id);
+    } catch {
+      return;
+    }
+    copySeqRef.current += 1;
+    setCopiedId(id);
+    setCopyNotice({ seq: copySeqRef.current, text: "Session id copied" });
+    if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+    copyTimerRef.current = setTimeout(() => {
+      setCopiedId((current) => (current === id ? null : current));
+      copyTimerRef.current = null;
+    }, 1500);
+  };
 
   useWebsocketTopic(
     TOPIC_ACTIVE_READS,
@@ -63,8 +88,8 @@ export function LiveReadsPanel({ paused = false }: { paused?: boolean }) {
           )}
         </div>
 
-        <div className="sr-only" aria-live="polite">
-          {copiedId ? "Session id copied" : ""}
+        <div key={copyNotice?.seq ?? 0} className="sr-only" aria-live="polite">
+          {copyNotice?.text ?? ""}
         </div>
 
         {reads.length === 0 ? (
@@ -104,12 +129,7 @@ export function LiveReadsPanel({ paused = false }: { paused?: boolean }) {
                         type="button"
                         className="btn btn-link btn-xs h-auto min-h-0 px-0 font-mono"
                         onClick={() => {
-                          void navigator.clipboard.writeText(r.id);
-                          setCopiedId(r.id);
-                          window.setTimeout(
-                            () => setCopiedId((id) => (id === r.id ? null : id)),
-                            1500,
-                          );
+                          void copySessionId(r.id);
                         }}
                       >
                         {copiedId === r.id ? "Copied" : shortSessionId(r.id)}

--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
@@ -14,6 +14,7 @@ const TOPIC_ACTIVE_READS = "ar";
  */
 export function LiveReadsPanel({ paused = false }: { paused?: boolean }) {
   const [reads, setReads] = useState<ActiveRead[]>([]);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
   // Track previous bytesRead per session for live MiB/s computation.
   const prevRef = useRef<Map<string, { bytes: number; at: number; rate: number }>>(new Map());
 
@@ -62,8 +63,14 @@ export function LiveReadsPanel({ paused = false }: { paused?: boolean }) {
           )}
         </div>
 
+        <div className="sr-only" aria-live="polite">
+          {copiedId ? "Session id copied" : ""}
+        </div>
+
         {reads.length === 0 ? (
-          <p className="m-0 text-sm text-base-content/50">No active reads.</p>
+          <p className="m-0 text-sm text-base-content/50">
+            No files are being read right now. Open a mounted file to see live progress here.
+          </p>
         ) : (
           <div className="flex flex-col gap-2.5">
             {reads.map((r) => {
@@ -97,9 +104,13 @@ export function LiveReadsPanel({ paused = false }: { paused?: boolean }) {
                     type="button"
                     className="btn btn-ghost btn-xs self-start px-0 font-mono text-base-content/50 hover:underline"
                     title={`Copy session id: ${r.id}`}
-                    onClick={() => void navigator.clipboard.writeText(r.id)}
+                    onClick={() => {
+                      void navigator.clipboard.writeText(r.id);
+                      setCopiedId(r.id);
+                      window.setTimeout(() => setCopiedId((id) => (id === r.id ? null : id)), 1500);
+                    }}
                   >
-                    {shortSessionId(r.id)}
+                    {copiedId === r.id ? "Copied" : shortSessionId(r.id)}
                   </button>
                   {pct !== null ? (
                     <progress

--- a/frontend/app/routes/overview/components/live-tiles/live-tiles.tsx
+++ b/frontend/app/routes/overview/components/live-tiles/live-tiles.tsx
@@ -74,6 +74,11 @@ function Tile({
   const valueClass = accent === "live" ? "text-success" : accent === "danger" ? "text-error" : "";
   return (
     <div className="stat">
+      {accent && (
+        <div className="stat-figure">
+          <span className={`status ${accent === "live" ? "status-success" : "status-error"}`} />
+        </div>
+      )}
       <div className="stat-title">{label}</div>
       <div className={`stat-value font-mono text-2xl md:text-3xl ${valueClass}`}>{value}</div>
       {sub && <div className="stat-desc">{sub}</div>}

--- a/frontend/app/routes/overview/components/live-tiles/live-tiles.tsx
+++ b/frontend/app/routes/overview/components/live-tiles/live-tiles.tsx
@@ -20,7 +20,11 @@ export function LiveTiles({ tiles }: LiveTilesProps) {
   const throttles = tiles.inFlightArticleThrottleEvents ?? 0;
   const budgetPressure = cap > 0 && leased >= cap * 0.9;
   return (
-    <div className="stats stats-vertical w-full border border-base-content/10 bg-base-200 shadow lg:stats-horizontal">
+    <div
+      role="region"
+      aria-label="Live status"
+      className="stats stats-vertical w-full border border-base-content/10 bg-base-200 shadow lg:stats-horizontal"
+    >
       <Tile
         label="Active reads"
         value={tiles.activeReads.toString()}

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.test.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.test.tsx
@@ -33,6 +33,7 @@ describe("ProviderScoreboard", () => {
     expect(active).toContain(">MB/s<");
     expect(active).toContain(">12.3<");
     expect(active).toContain("not wall-clock aggregate bandwidth");
+    expect(active).toContain('aria-label="Article share: 100%"');
     expect(idle).toContain(">—<");
   });
 });

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.test.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.test.tsx
@@ -1,4 +1,5 @@
 import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
 import { describe, expect, it } from "vitest";
 import type { ProviderRow } from "~/clients/backend-client.server";
 import { OutageBuckets, ProviderScoreboard, Sparkline } from "./provider-scoreboard";
@@ -19,10 +20,14 @@ const provider = (speedMbPerSec: number | null): ProviderRow => ({
 describe("ProviderScoreboard", () => {
   it("shows sustained speed and an em dash when speed is unavailable", () => {
     const active = renderToStaticMarkup(
-      <ProviderScoreboard providers={[provider(12.34)]} window="1h" />,
+      <MemoryRouter>
+        <ProviderScoreboard providers={[provider(12.34)]} window="1h" />
+      </MemoryRouter>,
     );
     const idle = renderToStaticMarkup(
-      <ProviderScoreboard providers={[provider(null)]} window="1h" />,
+      <MemoryRouter>
+        <ProviderScoreboard providers={[provider(null)]} window="1h" />
+      </MemoryRouter>,
     );
 
     expect(active).toContain(">MB/s<");

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
@@ -220,7 +220,12 @@ function buildProviderTooltip(p: ProviderRow, state: ProviderCircuitState) {
 function ShareBar({ share }: { share: number }) {
   return (
     <div className="flex items-center gap-2">
-      <progress className="progress progress-success w-20" value={share} max={100} />
+      <progress
+        className="progress progress-success w-20"
+        value={share}
+        max={100}
+        aria-label={`Article share: ${formatPercent(share, 0)}`}
+      />
       <span className="font-mono text-[11px] tabular-nums">{formatPercent(share, 0)}</span>
     </div>
   );

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
@@ -5,6 +5,7 @@ import type {
 } from "~/clients/backend-client.server";
 import { formatBytes, formatNumber, formatPercent, formatSpeed } from "../../utils/format";
 import { settingsPath } from "~/navigation/settings-tabs";
+import { Tooltip } from "~/components/ui";
 import { WidgetLink } from "../widget-link/widget-link";
 
 export type ProviderScoreboardProps = {
@@ -31,7 +32,9 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
               Per-provider fetches, {window === "all" ? "all time" : `last ${window}`}
             </p>
           </div>
-          <WidgetLink to={settingsPath("usenet")}>Usenet settings</WidgetLink>
+          <div className="card-actions m-0">
+            <WidgetLink to={settingsPath("usenet")}>Usenet settings</WidgetLink>
+          </div>
         </div>
         {hasOpenCircuit && (
           <p className="text-xs text-warning">
@@ -49,19 +52,25 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                 <tr>
                   <th>Provider</th>
                   <th className="w-[120px]">Activity</th>
-                  <th className="w-[120px]" title={outageHelp}>
-                    Outages
+                  <th className="w-[120px]">
+                    <Tooltip content={outageHelp}>
+                      <span>Outages</span>
+                    </Tooltip>
                   </th>
                   <th>Articles</th>
                   <th>Read</th>
                   <th>Share</th>
-                  <th className="w-[120px]" title={speedHelp}>
-                    MB/s
+                  <th className="w-[120px]">
+                    <Tooltip content={speedHelp}>
+                      <span>MB/s</span>
+                    </Tooltip>
                   </th>
                   <th className="w-[120px]">Errors</th>
                   <th className="w-[120px]">Retries</th>
-                  <th title="Mean duration of successful fetches only. Includes connection-pool wait inside the provider call — not pure wire RTT. Misses and errors are excluded.">
-                    Avg ok ms
+                  <th>
+                    <Tooltip content="Mean duration of successful fetches only. Includes connection-pool wait inside the provider call — not pure wire RTT. Misses and errors are excluded.">
+                      <span>Avg ok ms</span>
+                    </Tooltip>
                   </th>
                 </tr>
               </thead>
@@ -72,41 +81,46 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                   return (
                     <tr key={p.provider}>
                       <th scope="row" className="bg-base-100 font-medium">
-                        <div
-                          className="flex max-w-[240px] min-w-0 items-center gap-2 font-medium"
-                          title={buildProviderTooltip(p, circuitState)}
-                        >
-                          <span
-                            className={`h-1.5 w-1.5 shrink-0 rounded-full ${dotClass(circuitState)}`}
-                          />
-                          <span className="min-w-0 truncate">
-                            {p.nickname?.trim() || p.provider}
-                          </span>
-                          {circuitState !== "closed" && (
-                            <span className={`badge badge-sm shrink-0 ${badgeClass(circuitState)}`}>
-                              {circuitLabel(circuitState, p.cooldownRemainingSeconds)}
+                        <Tooltip content={buildProviderTooltip(p, circuitState)}>
+                          <div className="flex max-w-[240px] min-w-0 items-center gap-2 font-medium">
+                            <span
+                              className={`status status-xs shrink-0 ${statusClass(circuitState)}`}
+                            />
+                            <span className="min-w-0 truncate">
+                              {p.nickname?.trim() || p.provider}
                             </span>
-                          )}
-                        </div>
+                            {circuitState !== "closed" && (
+                              <span
+                                className={`badge badge-sm shrink-0 ${badgeClass(circuitState)}`}
+                              >
+                                {circuitLabel(circuitState, p.cooldownRemainingSeconds)}
+                              </span>
+                            )}
+                          </div>
+                        </Tooltip>
                       </th>
                       <td>
                         <Sparkline values={p.spark} tone="success" />
                       </td>
-                      <td title={outageHelp}>
-                        <OutageBuckets values={p.outageSpark ?? []} />
+                      <td>
+                        <Tooltip content={outageHelp}>
+                          <OutageBuckets values={p.outageSpark ?? []} />
+                        </Tooltip>
                       </td>
                       <td className="font-mono tabular-nums">{formatNumber(p.articles)}</td>
                       <td className="font-mono tabular-nums">{formatBytes(p.bytesFetched)}</td>
                       <td>
                         <ShareBar share={share} />
                       </td>
-                      <td title={speedHelp}>
-                        <div className="flex flex-col gap-0.5">
-                          <Sparkline values={p.speedSpark ?? []} tone="success" />
-                          <div className="font-mono text-[11px] tabular-nums text-base-content/60">
-                            {formatSpeed(p.speedMbPerSec)}
+                      <td>
+                        <Tooltip content={speedHelp}>
+                          <div className="flex flex-col gap-0.5">
+                            <Sparkline values={p.speedSpark ?? []} tone="success" />
+                            <div className="font-mono text-[11px] tabular-nums text-base-content/60">
+                              {formatSpeed(p.speedMbPerSec)}
+                            </div>
                           </div>
-                        </div>
+                        </Tooltip>
                       </td>
                       <td>
                         <div className="flex flex-col gap-0.5">
@@ -134,11 +148,10 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                           </div>
                         </div>
                       </td>
-                      <td
-                        className="font-mono tabular-nums"
-                        title="Successful fetches only (includes pool wait)"
-                      >
-                        {p.avgDurationMs.toFixed(0)}
+                      <td className="font-mono tabular-nums">
+                        <Tooltip content="Successful fetches only (includes pool wait)">
+                          <span>{p.avgDurationMs.toFixed(0)}</span>
+                        </Tooltip>
                       </td>
                     </tr>
                   );
@@ -152,14 +165,14 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
   );
 }
 
-function dotClass(state: ProviderCircuitState) {
+function statusClass(state: ProviderCircuitState) {
   switch (state) {
     case "open":
-      return "bg-error";
+      return "status-error";
     case "halfOpen":
-      return "bg-warning";
+      return "status-warning";
     default:
-      return "bg-success";
+      return "status-success";
   }
 }
 
@@ -206,14 +219,9 @@ function buildProviderTooltip(p: ProviderRow, state: ProviderCircuitState) {
 
 function ShareBar({ share }: { share: number }) {
   return (
-    <div className="relative h-4 w-20 overflow-hidden rounded bg-base-200">
-      <div
-        className="absolute inset-0 bg-success opacity-25"
-        style={{ width: `${share.toFixed(1)}%` }}
-      />
-      <span className="relative block px-1.5 text-center text-[11px] leading-4 text-base-content tabular-nums">
-        {formatPercent(share, 0)}
-      </span>
+    <div className="flex items-center gap-2">
+      <progress className="progress progress-success w-20" value={share} max={100} />
+      <span className="font-mono text-[11px] tabular-nums">{formatPercent(share, 0)}</span>
     </div>
   );
 }

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
@@ -4,6 +4,8 @@ import type {
   ProviderRow,
 } from "~/clients/backend-client.server";
 import { formatBytes, formatNumber, formatPercent, formatSpeed } from "../../utils/format";
+import { settingsPath } from "~/navigation/settings-tabs";
+import { WidgetLink } from "../widget-link/widget-link";
 
 export type ProviderScoreboardProps = {
   providers: ProviderRow[];
@@ -12,6 +14,9 @@ export type ProviderScoreboardProps = {
 
 export function ProviderScoreboard({ providers, window }: ProviderScoreboardProps) {
   const total = providers.reduce((s, p) => s + p.articles, 0);
+  const hasOpenCircuit = providers.some(
+    (p) => p.circuitState === "open" || p.circuitState === "halfOpen",
+  );
   const outageHelp = `Circuit-open time per ${outageIntervalLabel(window)} interval on a fixed 0–100% scale. Brief trips use a minimum-height tick.`;
   const speedHelp =
     "Historical average: bytes fetched divided by summed successful fetch durations over the selected window. Durations include connection-pool wait and overlap across concurrent fetches, so this is not wall-clock aggregate bandwidth. Use the provider benchmark for line-rate calibration.";
@@ -19,18 +24,27 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
   return (
     <section className="card w-full min-w-0 border border-base-content/10 bg-base-100 shadow-sm">
       <div className="card-body gap-3 p-4">
-        <div>
-          <h3 className="card-title text-base">Providers</h3>
-          <p className="text-xs text-base-content/50">
-            Per-provider fetches, {window === "all" ? "all time" : `last ${window}`}
-          </p>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h3 className="card-title text-base">Providers</h3>
+            <p className="text-xs text-base-content/50">
+              Per-provider fetches, {window === "all" ? "all time" : `last ${window}`}
+            </p>
+          </div>
+          <WidgetLink to={settingsPath("usenet")}>Usenet settings</WidgetLink>
         </div>
+        {hasOpenCircuit && (
+          <p className="text-xs text-warning">
+            A provider circuit is open.{" "}
+            <WidgetLink to={settingsPath("usenet")}>Review Usenet settings</WidgetLink>
+          </p>
+        )}
 
         {providers.length === 0 ? (
           <p className="py-6 text-center text-xs text-base-content/50">No providers configured.</p>
         ) : (
           <div className="overflow-x-auto">
-            <table className="table table-sm min-w-[800px]">
+            <table className="table table-pin-cols table-sm min-w-[800px]">
               <thead>
                 <tr>
                   <th>Provider</th>
@@ -57,7 +71,7 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                   const circuitState = p.circuitState ?? "closed";
                   return (
                     <tr key={p.provider}>
-                      <td>
+                      <th scope="row" className="bg-base-100 font-medium">
                         <div
                           className="flex max-w-[240px] min-w-0 items-center gap-2 font-medium"
                           title={buildProviderTooltip(p, circuitState)}
@@ -74,7 +88,7 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                             </span>
                           )}
                         </div>
-                      </td>
+                      </th>
                       <td>
                         <Sparkline values={p.spark} tone="success" />
                       </td>

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
@@ -38,7 +38,7 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
         </div>
         {hasOpenCircuit && (
           <p className="text-xs text-warning">
-            A provider circuit is open.{" "}
+            A provider circuit is open or recovering.{" "}
             <WidgetLink to={settingsPath("usenet")}>Review Usenet settings</WidgetLink>
           </p>
         )}

--- a/frontend/app/routes/overview/components/records-block/records-block.tsx
+++ b/frontend/app/routes/overview/components/records-block/records-block.tsx
@@ -13,7 +13,7 @@ export function RecordsBlock({ records }: RecordsBlockProps) {
   const isEmpty = records.bestDayBytes === 0 && records.bestHourBytes === 0;
 
   return (
-    <section className="card w-full border border-base-content/10 bg-base-100 shadow-sm">
+    <section className="card w-full border border-base-content/10 bg-base-100">
       <div className="card-body gap-3 p-4">
         <div>
           <h3 className="card-title text-base">Records</h3>
@@ -23,7 +23,7 @@ export function RecordsBlock({ records }: RecordsBlockProps) {
         {isEmpty ? (
           <p className="text-sm text-base-content/50">Records appear after some activity.</p>
         ) : (
-          <div className="stats stats-vertical w-full border border-base-content/10 bg-base-200 shadow sm:stats-horizontal">
+          <div className="stats stats-vertical w-full bg-base-200/40 sm:stats-horizontal">
             <Stat
               label="Busiest day"
               value={formatBytes(records.bestDayBytes)}

--- a/frontend/app/routes/overview/components/records-block/records-block.tsx
+++ b/frontend/app/routes/overview/components/records-block/records-block.tsx
@@ -13,30 +13,28 @@ export function RecordsBlock({ records }: RecordsBlockProps) {
   const isEmpty = records.bestDayBytes === 0 && records.bestHourBytes === 0;
 
   return (
-    <section className="card w-full border border-base-content/10 bg-base-100">
-      <div className="card-body gap-3 p-4">
-        <div>
-          <h3 className="card-title text-base">Records</h3>
-          <p className="text-xs text-base-content/50">Personal bests since you started</p>
-        </div>
+    <section className="w-full min-w-0">
+      <header className="mb-2">
+        <h3 className="text-sm font-semibold text-base-content">Records</h3>
+        <p className="text-xs text-base-content/50">Personal bests since you started</p>
+      </header>
 
-        {isEmpty ? (
-          <p className="text-sm text-base-content/50">Records appear after some activity.</p>
-        ) : (
-          <div className="stats stats-vertical w-full bg-base-200/40 sm:stats-horizontal">
-            <Stat
-              label="Busiest day"
-              value={formatBytes(records.bestDayBytes)}
-              desc={records.bestDayAt ? formatDay(records.bestDayAt) : undefined}
-            />
-            <Stat
-              label="Busiest hour"
-              value={formatBytes(records.bestHourBytes)}
-              desc={records.bestHourAt ? formatHour(records.bestHourAt) : undefined}
-            />
-          </div>
-        )}
-      </div>
+      {isEmpty ? (
+        <p className="text-sm text-base-content/50">Records appear after some activity.</p>
+      ) : (
+        <div className="stats stats-vertical w-full border border-base-content/10 bg-base-100 sm:stats-horizontal">
+          <Stat
+            label="Busiest day"
+            value={formatBytes(records.bestDayBytes)}
+            desc={records.bestDayAt ? formatDay(records.bestDayAt) : undefined}
+          />
+          <Stat
+            label="Busiest hour"
+            value={formatBytes(records.bestHourBytes)}
+            desc={records.bestHourAt ? formatHour(records.bestHourAt) : undefined}
+          />
+        </div>
+      )}
     </section>
   );
 }

--- a/frontend/app/routes/overview/components/section-load-error/section-load-error.test.tsx
+++ b/frontend/app/routes/overview/components/section-load-error/section-load-error.test.tsx
@@ -1,0 +1,15 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { SectionLoadError } from "./section-load-error";
+
+describe("SectionLoadError", () => {
+  it("names the failed section and offers a retry action", () => {
+    const markup = renderToStaticMarkup(
+      <SectionLoadError label="provider stats" onRetry={vi.fn()} />,
+    );
+
+    expect(markup).toContain("Could not load provider stats");
+    expect(markup).toContain("Retry");
+    expect(markup).toContain('role="alert"');
+  });
+});

--- a/frontend/app/routes/overview/components/section-load-error/section-load-error.tsx
+++ b/frontend/app/routes/overview/components/section-load-error/section-load-error.tsx
@@ -1,0 +1,15 @@
+import { Alert, Button, Icon } from "~/components/ui";
+
+export function SectionLoadError({ label, onRetry }: { label: string; onRetry: () => void }) {
+  return (
+    <Alert variant="warning" className="alert-soft items-center">
+      <Icon name="error" className="shrink-0 !text-[20px]" />
+      <span className="min-w-0 flex-1 text-sm">
+        Could not load {label}. Check the connection and try again.
+      </span>
+      <Button variant="ghost" size="xsmall" onClick={onRetry}>
+        Retry
+      </Button>
+    </Alert>
+  );
+}

--- a/frontend/app/routes/overview/components/sessions-block/sessions-block.tsx
+++ b/frontend/app/routes/overview/components/sessions-block/sessions-block.tsx
@@ -26,7 +26,7 @@ export function SessionsBlock({ sessions, window }: SessionsBlockProps) {
         {sessions.count === 0 ? (
           <p className="text-sm text-base-content/50">No completed read sessions yet.</p>
         ) : (
-          <div className="stats stats-vertical w-full border border-base-content/10 bg-base-200 shadow sm:stats-horizontal">
+          <div className="stats stats-vertical w-full bg-base-200/40 sm:stats-horizontal">
             <Stat label="Sessions" value={formatNumber(sessions.count)} />
             <Stat label="Bytes served" value={formatBytes(sessions.totalBytesServed)} />
             <Stat label="Avg duration" value={formatDuration(sessions.avgDurationMs)} />

--- a/frontend/app/routes/overview/components/sessions-block/sessions-block.tsx
+++ b/frontend/app/routes/overview/components/sessions-block/sessions-block.tsx
@@ -14,27 +14,25 @@ export type SessionsBlockProps = {
 
 export function SessionsBlock({ sessions, window }: SessionsBlockProps) {
   return (
-    <section className="card w-full border border-base-content/10 bg-base-100 shadow-sm">
-      <div className="card-body gap-3 p-4">
-        <div>
-          <h3 className="card-title text-base">Read sessions</h3>
-          <p className="text-xs text-base-content/50">
-            {window === "all" ? "All time" : `Last ${window}`}
-          </p>
-        </div>
+    <section className="w-full min-w-0">
+      <header className="mb-2">
+        <h3 className="text-sm font-semibold text-base-content">Read sessions</h3>
+        <p className="text-xs text-base-content/50">
+          {window === "all" ? "All time" : `Last ${window}`}
+        </p>
+      </header>
 
-        {sessions.count === 0 ? (
-          <p className="text-sm text-base-content/50">No completed read sessions yet.</p>
-        ) : (
-          <div className="stats stats-vertical w-full bg-base-200/40 sm:stats-horizontal">
-            <Stat label="Sessions" value={formatNumber(sessions.count)} />
-            <Stat label="Bytes served" value={formatBytes(sessions.totalBytesServed)} />
-            <Stat label="Avg duration" value={formatDuration(sessions.avgDurationMs)} />
-            <Stat label="Longest read" value={formatDuration(sessions.longestDurationMs)} />
-            <Stat label="Biggest single read" value={formatBytes(sessions.biggestReadBytes)} />
-          </div>
-        )}
-      </div>
+      {sessions.count === 0 ? (
+        <p className="text-sm text-base-content/50">No completed read sessions yet.</p>
+      ) : (
+        <div className="stats stats-vertical w-full border border-base-content/10 bg-base-100 sm:stats-horizontal">
+          <Stat label="Sessions" value={formatNumber(sessions.count)} />
+          <Stat label="Bytes served" value={formatBytes(sessions.totalBytesServed)} />
+          <Stat label="Avg duration" value={formatDuration(sessions.avgDurationMs)} />
+          <Stat label="Longest read" value={formatDuration(sessions.longestDurationMs)} />
+          <Stat label="Biggest single read" value={formatBytes(sessions.biggestReadBytes)} />
+        </div>
+      )}
     </section>
   );
 }

--- a/frontend/app/routes/overview/components/sortable-row/sortable-row.tsx
+++ b/frontend/app/routes/overview/components/sortable-row/sortable-row.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { Icon } from "~/components/ui";
 
 type Props = {
   id: string;
@@ -39,14 +40,7 @@ export function SortableRow({ id, editMode, children }: Props) {
           {...attributes}
           {...listeners}
         >
-          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-            <circle cx="5" cy="3" r="1.4" />
-            <circle cx="11" cy="3" r="1.4" />
-            <circle cx="5" cy="8" r="1.4" />
-            <circle cx="11" cy="8" r="1.4" />
-            <circle cx="5" cy="13" r="1.4" />
-            <circle cx="11" cy="13" r="1.4" />
-          </svg>
+          <Icon name="drag_indicator" className="!text-[18px]" />
         </button>
       )}
       <div className="min-w-0">{children}</div>

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.module.css
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.module.css
@@ -12,6 +12,11 @@
   cursor: crosshair;
   touch-action: pan-y;
 }
+.chartArea:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
 
 .svg {
   width: 100%;

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.test.tsx
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.test.tsx
@@ -1,5 +1,7 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import type { ThroughputPoint } from "~/clients/backend-client.server";
 import { ThroughputChart } from "./throughput-chart";
 
@@ -12,7 +14,7 @@ const point = (articles: number, errors = 0): ThroughputPoint => ({
   bytesFetched: 0,
 });
 
-function render(points: ThroughputPoint[], totalErrors = 0) {
+function renderMarkup(points: ThroughputPoint[], totalErrors = 0) {
   return renderToStaticMarkup(
     <ThroughputChart
       points={points}
@@ -34,21 +36,24 @@ function articlesPathD(markup: string): string {
 }
 
 describe("ThroughputChart", () => {
+  afterEach(() => {
+    cleanup();
+  });
   it("does not draw the green series when every article bucket is zero", () => {
-    const markup = render([point(0, 1), point(0)], 1);
+    const markup = renderMarkup([point(0, 1), point(0)], 1);
 
     expect(markup).not.toContain('data-series="articles"');
     expect(markup).toContain('data-series="errors"');
   });
 
   it("draws the green series when an article bucket has activity", () => {
-    const markup = render([point(0), point(2)]);
+    const markup = renderMarkup([point(0), point(2)]);
 
     expect(markup).toContain('data-series="articles"');
   });
 
   it("skips idle stretches but anchors each run to leading and trailing zeros", () => {
-    const markup = render([point(0), point(5), point(0), point(0), point(3), point(0)]);
+    const markup = renderMarkup([point(0), point(5), point(0), point(0), point(3), point(0)]);
     const d = articlesPathD(markup);
 
     expect(d).not.toBe("");
@@ -60,5 +65,32 @@ describe("ThroughputChart", () => {
     expect(d.startsWith("M0.0,156.0")).toBe(true);
     expect(d).toContain("L160.0,6.0");
     expect(d).toContain("L320.0,156.0");
+  });
+
+  it("announces keyboard-selected bucket details to assistive tech", () => {
+    const points = [
+      point(3),
+      { ...point(8), misses: 1, errors: 2, bytesServed: 100, bytesFetched: 50 },
+    ];
+    const { container } = render(
+      <ThroughputChart
+        points={points}
+        totalArticles={11}
+        totalMisses={1}
+        totalErrors={2}
+        totalBytesServed={100}
+        bucketSizeMs={60_000}
+        window="24h"
+      />,
+    );
+
+    const chart = container.querySelector('[role="img"]');
+    expect(chart).not.toBeNull();
+    fireEvent.keyDown(chart!, { key: "ArrowRight" });
+    fireEvent.keyDown(chart!, { key: "ArrowRight" });
+
+    const status = container.querySelector("#overview-throughput-keyboard-status");
+    expect(status?.textContent).toMatch(/8 articles/);
+    expect(status?.textContent).toMatch(/2 errors/);
   });
 });

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.test.tsx
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.test.tsx
@@ -69,10 +69,17 @@ describe("ThroughputChart", () => {
 
   it("announces keyboard-selected bucket details to assistive tech", () => {
     const points = [
-      point(3),
-      { ...point(8), misses: 1, errors: 2, bytesServed: 100, bytesFetched: 50 },
+      { ...point(3), bucket: 1 },
+      {
+        ...point(8),
+        bucket: 2,
+        misses: 1,
+        errors: 2,
+        bytesServed: 100,
+        bytesFetched: 50,
+      },
     ];
-    const { container } = render(
+    const { container, rerender } = render(
       <ThroughputChart
         points={points}
         totalArticles={11}
@@ -85,12 +92,30 @@ describe("ThroughputChart", () => {
     );
 
     const chart = container.querySelector('[role="img"]');
-    expect(chart).not.toBeNull();
+    expect(chart).toBeInstanceOf(HTMLElement);
+    (chart as HTMLElement).focus();
+    expect(document.activeElement).toBe(chart);
+
     fireEvent.keyDown(chart!, { key: "ArrowRight" });
     fireEvent.keyDown(chart!, { key: "ArrowRight" });
 
     const status = container.querySelector("#overview-throughput-keyboard-status");
     expect(status?.textContent).toMatch(/8 articles/);
     expect(status?.textContent).toMatch(/2 errors/);
+
+    const updated = [points[0]!, { ...points[1]!, articles: 12, errors: 4 }];
+    rerender(
+      <ThroughputChart
+        points={updated}
+        totalArticles={15}
+        totalMisses={1}
+        totalErrors={4}
+        totalBytesServed={100}
+        bucketSizeMs={60_000}
+        window="24h"
+      />,
+    );
+    expect(status?.textContent).toMatch(/12 articles/);
+    expect(status?.textContent).toMatch(/4 errors/);
   });
 });

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.test.tsx
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.test.tsx
@@ -118,4 +118,51 @@ describe("ThroughputChart", () => {
     expect(status?.textContent).toMatch(/12 articles/);
     expect(status?.textContent).toMatch(/4 errors/);
   });
+
+  it("keeps hover and keyboard cursors on the same bucket after polling prepends a point", () => {
+    const points = [
+      { ...point(3), bucket: 1 },
+      { ...point(8), bucket: 2, errors: 2 },
+    ];
+    const { container, rerender } = render(
+      <ThroughputChart
+        points={points}
+        totalArticles={11}
+        totalMisses={0}
+        totalErrors={2}
+        totalBytesServed={0}
+        bucketSizeMs={60_000}
+        window="24h"
+      />,
+    );
+
+    const chart = container.querySelector('[role="img"]');
+    expect(chart).toBeInstanceOf(HTMLElement);
+    (chart as HTMLElement).focus();
+    fireEvent.keyDown(chart!, { key: "ArrowRight" });
+    fireEvent.keyDown(chart!, { key: "ArrowRight" });
+
+    const status = container.querySelector("#overview-throughput-keyboard-status");
+    expect(status?.textContent).toMatch(/8 articles/);
+
+    const shifted = [{ ...point(1), bucket: 0 }, points[0]!, points[1]!];
+    rerender(
+      <ThroughputChart
+        points={shifted}
+        totalArticles={12}
+        totalMisses={0}
+        totalErrors={2}
+        totalBytesServed={0}
+        bucketSizeMs={60_000}
+        window="24h"
+      />,
+    );
+
+    expect(status?.textContent).toMatch(/8 articles/);
+    expect(status?.textContent).toMatch(/2 errors/);
+
+    fireEvent.keyDown(chart!, { key: "ArrowLeft" });
+    expect(status?.textContent).toMatch(/3 articles/);
+    expect(status?.textContent).not.toMatch(/8 articles/);
+  });
 });

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
@@ -28,6 +28,7 @@ export function ThroughputChart({
   window,
 }: ThroughputChartProps) {
   const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+  const [keyboardStatus, setKeyboardStatus] = useState("");
 
   const bucketSeconds = Math.max(1, (bucketSizeMs || 60_000) / 1000);
 
@@ -94,21 +95,29 @@ export function ThroughputChart({
   const handleMouseLeave = () => setHoverIdx(null);
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (points.length === 0) return;
+    let next: number | null;
     if (e.key === "ArrowRight") {
       e.preventDefault();
-      setHoverIdx((i) => Math.min(points.length - 1, (i ?? -1) + 1));
+      next = Math.min(points.length - 1, (hoverIdx ?? -1) + 1);
     } else if (e.key === "ArrowLeft") {
       e.preventDefault();
-      setHoverIdx((i) => Math.max(0, (i ?? points.length) - 1));
+      next = Math.max(0, (hoverIdx ?? points.length) - 1);
     } else if (e.key === "Home") {
       e.preventDefault();
-      setHoverIdx(0);
+      next = 0;
     } else if (e.key === "End") {
       e.preventDefault();
-      setHoverIdx(points.length - 1);
+      next = points.length - 1;
     } else if (e.key === "Escape") {
       setHoverIdx(null);
+      setKeyboardStatus("");
+      return;
+    } else {
+      return;
     }
+    setHoverIdx(next);
+    const point = points[next];
+    setKeyboardStatus(point ? describeThroughputBucket(point, window, bucketSeconds) : "");
   };
   const handleTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
     const t = e.touches[0];
@@ -170,6 +179,7 @@ export function ThroughputChart({
                 tabIndex={0}
                 role="img"
                 aria-label={`${formatNumber(totalArticles)} articles, ${formatNumber(totalErrors)} errors, ${formatBytes(totalBytesServed)} served. Use arrow keys for bucket details.`}
+                aria-describedby="overview-throughput-keyboard-status"
                 onMouseMove={handleMouseMove}
                 onMouseLeave={handleMouseLeave}
                 onTouchStart={handleTouchStart}
@@ -255,6 +265,15 @@ export function ThroughputChart({
                   </>
                 )}
               </div>
+            </div>
+            <div
+              id="overview-throughput-keyboard-status"
+              className="sr-only"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+            >
+              {keyboardStatus}
             </div>
 
             <div className="relative mt-1.5 ml-[46px] h-4 text-[10px] text-base-content/50 tabular-nums select-none">
@@ -404,6 +423,23 @@ function Total({
       </div>
     </div>
   );
+}
+
+function describeThroughputBucket(
+  point: ThroughputPoint,
+  window: OverviewWindow,
+  bucketSeconds: number,
+): string {
+  const parts = [
+    formatBucketTime(point.bucket, window),
+    `${formatNumber(point.articles)} articles`,
+  ];
+  const rate = (point.bytesFetched ?? 0) / bucketSeconds;
+  if (rate > 0) parts.push(`${formatBytes(rate)}/s downloaded`);
+  if ((point.misses ?? 0) > 0) parts.push(`${formatNumber(point.misses)} misses`);
+  if (point.errors > 0) parts.push(`${formatNumber(point.errors)} errors`);
+  if (point.bytesServed > 0) parts.push(`${formatBytes(point.bytesServed)} served`);
+  return parts.join(", ");
 }
 
 function formatBucketTime(ms: number, window: OverviewWindow): string {

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
@@ -92,6 +92,24 @@ export function ThroughputChart({
   const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) =>
     onMove(e.clientX, e.currentTarget);
   const handleMouseLeave = () => setHoverIdx(null);
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (points.length === 0) return;
+    if (e.key === "ArrowRight") {
+      e.preventDefault();
+      setHoverIdx((i) => Math.min(points.length - 1, (i ?? -1) + 1));
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      setHoverIdx((i) => Math.max(0, (i ?? points.length) - 1));
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      setHoverIdx(0);
+    } else if (e.key === "End") {
+      e.preventDefault();
+      setHoverIdx(points.length - 1);
+    } else if (e.key === "Escape") {
+      setHoverIdx(null);
+    }
+  };
   const handleTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
     const t = e.touches[0];
     if (t) onMove(t.clientX, e.currentTarget);
@@ -149,10 +167,14 @@ export function ThroughputChart({
               </div>
               <div
                 className={styles.chartArea}
+                tabIndex={0}
+                role="img"
+                aria-label={`${formatNumber(totalArticles)} articles, ${formatNumber(totalErrors)} errors, ${formatBytes(totalBytesServed)} served. Use arrow keys for bucket details.`}
                 onMouseMove={handleMouseMove}
                 onMouseLeave={handleMouseLeave}
                 onTouchStart={handleTouchStart}
                 onTouchMove={handleTouchMove}
+                onKeyDown={handleKeyDown}
               >
                 <svg
                   viewBox={`0 0 ${VB_W} ${VB_H}`}
@@ -260,7 +282,7 @@ export function ThroughputChart({
                 </span>
               )}
               <span className="ml-auto tabular-nums">
-                Peak {formatNumber(maxArticles)} / {bucketLabel} · hover for details
+                Peak {formatNumber(maxArticles)} / {bucketLabel} · hover or use arrow keys
               </span>
             </div>
           </>

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
@@ -27,13 +27,16 @@ export function ThroughputChart({
   bucketSizeMs,
   window,
 }: ThroughputChartProps) {
-  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+  const [hoverBucket, setHoverBucket] = useState<number | null>(null);
   const [keyboardBucket, setKeyboardBucket] = useState<number | null>(null);
 
   const bucketSeconds = Math.max(1, (bucketSizeMs || 60_000) / 1000);
+  const hoverIdx = indexOfBucket(points, hoverBucket);
+  const keyboardIdx = indexOfBucket(points, keyboardBucket);
+  const cursorIdx = hoverIdx ?? keyboardIdx;
 
   useEffect(() => {
-    setHoverIdx(null);
+    setHoverBucket(null);
     setKeyboardBucket(null);
   }, [window]);
 
@@ -90,23 +93,25 @@ export function ThroughputChart({
       const rect = target.getBoundingClientRect();
       const rel = (clientX - rect.left) / rect.width;
       const idx = Math.round(rel * (points.length - 1));
-      setHoverIdx(Math.max(0, Math.min(points.length - 1, idx)));
+      const clamped = Math.max(0, Math.min(points.length - 1, idx));
+      setHoverBucket(points[clamped]?.bucket ?? null);
     },
-    [points.length],
+    [points],
   );
 
   const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) =>
     onMove(e.clientX, e.currentTarget);
-  const handleMouseLeave = () => setHoverIdx(null);
+  const handleMouseLeave = () => setHoverBucket(null);
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (points.length === 0) return;
+    const from = keyboardIdx ?? hoverIdx;
     let next: number | null;
     if (e.key === "ArrowRight") {
       e.preventDefault();
-      next = Math.min(points.length - 1, (hoverIdx ?? -1) + 1);
+      next = Math.min(points.length - 1, (from ?? -1) + 1);
     } else if (e.key === "ArrowLeft") {
       e.preventDefault();
-      next = Math.max(0, (hoverIdx ?? points.length) - 1);
+      next = Math.max(0, (from ?? points.length) - 1);
     } else if (e.key === "Home") {
       e.preventDefault();
       next = 0;
@@ -114,13 +119,13 @@ export function ThroughputChart({
       e.preventDefault();
       next = points.length - 1;
     } else if (e.key === "Escape") {
-      setHoverIdx(null);
+      setHoverBucket(null);
       setKeyboardBucket(null);
       return;
     } else {
       return;
     }
-    setHoverIdx(next);
+    setHoverBucket(null);
     setKeyboardBucket(points[next]?.bucket ?? null);
   };
   const handleTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
@@ -136,18 +141,17 @@ export function ThroughputChart({
   const hasArticleActivity = maxArticles > 0;
   const bucketLabel =
     window === "1h" || window === "24h" ? "min" : window === "all" ? "day" : "hour";
-  const hover = hoverIdx !== null ? points[hoverIdx] : null;
-  const keyboardPoint =
-    keyboardBucket === null ? undefined : points.find((p) => p.bucket === keyboardBucket);
+  const hover = cursorIdx !== null ? (points[cursorIdx] ?? null) : null;
+  const keyboardPoint = keyboardIdx !== null ? points[keyboardIdx] : undefined;
   const keyboardStatus = keyboardPoint
     ? describeThroughputBucket(keyboardPoint, window, bucketSeconds)
     : "";
   const hoverNetworkRate = hover ? (hover.bytesFetched ?? 0) / bucketSeconds : 0;
   const tooltipPlacement =
-    hoverIdx === null || points.length < 2
+    cursorIdx === null || points.length < 2
       ? "tooltip-top"
       : (() => {
-          const rel = hoverIdx / (points.length - 1);
+          const rel = cursorIdx / (points.length - 1);
           if (rel < 0.2) return "tooltip-right";
           if (rel > 0.8) return "tooltip-left";
           return "tooltip-top";
@@ -230,13 +234,13 @@ export function ThroughputChart({
                   )}
                 </svg>
 
-                {hover && hoverIdx !== null && (
+                {hover && cursorIdx !== null && (
                   <>
-                    <div className={styles.crosshair} style={{ left: `${xPercent(hoverIdx)}%` }} />
+                    <div className={styles.crosshair} style={{ left: `${xPercent(cursorIdx)}%` }} />
                     <div
                       className={`tooltip tooltip-open ${tooltipPlacement} ${styles.hoverTooltip}`}
                       style={{
-                        left: `${xPercent(hoverIdx)}%`,
+                        left: `${xPercent(cursorIdx)}%`,
                         top: `${yPercent(hover.articles)}%`,
                       }}
                     >
@@ -266,7 +270,7 @@ export function ThroughputChart({
                       <div
                         className={`${styles.hoverDot} ${styles.hoverDotErr}`}
                         style={{
-                          left: `${xPercent(hoverIdx)}%`,
+                          left: `${xPercent(cursorIdx)}%`,
                           top: `${yPercent(hover.errors)}%`,
                         }}
                       />
@@ -432,6 +436,12 @@ function Total({
       </div>
     </div>
   );
+}
+
+function indexOfBucket(points: ThroughputPoint[], bucket: number | null): number | null {
+  if (bucket === null) return null;
+  const idx = points.findIndex((p) => p.bucket === bucket);
+  return idx >= 0 ? idx : null;
 }
 
 function describeThroughputBucket(

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useCallback } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import styles from "./throughput-chart.module.css";
 import type { OverviewWindow, ThroughputPoint } from "~/clients/backend-client.server";
 import { formatBytes, formatNumber } from "../../utils/format";
@@ -28,9 +28,14 @@ export function ThroughputChart({
   window,
 }: ThroughputChartProps) {
   const [hoverIdx, setHoverIdx] = useState<number | null>(null);
-  const [keyboardStatus, setKeyboardStatus] = useState("");
+  const [keyboardBucket, setKeyboardBucket] = useState<number | null>(null);
 
   const bucketSeconds = Math.max(1, (bucketSizeMs || 60_000) / 1000);
+
+  useEffect(() => {
+    setHoverIdx(null);
+    setKeyboardBucket(null);
+  }, [window]);
 
   const { articlesPath, errorsPath, maxArticles, maxNetworkRate, xPercent, yPercent } =
     useMemo(() => {
@@ -110,14 +115,13 @@ export function ThroughputChart({
       next = points.length - 1;
     } else if (e.key === "Escape") {
       setHoverIdx(null);
-      setKeyboardStatus("");
+      setKeyboardBucket(null);
       return;
     } else {
       return;
     }
     setHoverIdx(next);
-    const point = points[next];
-    setKeyboardStatus(point ? describeThroughputBucket(point, window, bucketSeconds) : "");
+    setKeyboardBucket(points[next]?.bucket ?? null);
   };
   const handleTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
     const t = e.touches[0];
@@ -133,6 +137,11 @@ export function ThroughputChart({
   const bucketLabel =
     window === "1h" || window === "24h" ? "min" : window === "all" ? "day" : "hour";
   const hover = hoverIdx !== null ? points[hoverIdx] : null;
+  const keyboardPoint =
+    keyboardBucket === null ? undefined : points.find((p) => p.bucket === keyboardBucket);
+  const keyboardStatus = keyboardPoint
+    ? describeThroughputBucket(keyboardPoint, window, bucketSeconds)
+    : "";
   const hoverNetworkRate = hover ? (hover.bytesFetched ?? 0) / bucketSeconds : 0;
   const tooltipPlacement =
     hoverIdx === null || points.length < 2

--- a/frontend/app/routes/overview/components/widget-link/widget-link.tsx
+++ b/frontend/app/routes/overview/components/widget-link/widget-link.tsx
@@ -1,0 +1,9 @@
+import { Link } from "react-router";
+
+export function WidgetLink({ to, children }: { to: string; children: string }) {
+  return (
+    <Link to={to} className="link link-hover shrink-0 text-xs font-normal text-base-content/60">
+      {children}
+    </Link>
+  );
+}

--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -1,6 +1,14 @@
 import { withUrlBase } from "~/utils/url-base";
 import type { Route } from "./+types/route";
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
 import { useWebsocketTopics } from "~/utils/shared-websocket";
 import {
   DndContext,
@@ -33,6 +41,8 @@ import { RecordsBlock } from "./components/records-block/records-block";
 import { FailoverSaves } from "./components/failover-saves/failover-saves";
 import { ArrHealth } from "./components/arr-health/arr-health";
 import { SortableRow } from "./components/sortable-row/sortable-row";
+import { SectionLoadError } from "./components/section-load-error/section-load-error";
+import { Icon } from "~/components/ui";
 import { backendClient, type ArrHealthResponse } from "~/clients/backend-client.server";
 import { useRowOrder } from "./utils/use-row-order";
 import { hasConfiguredIndexers } from "./utils/has-configured-indexers";
@@ -119,9 +129,25 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
   const [staticLoaded, setStaticLoaded] = useState(false);
   const [arrHealth, setArrHealth] = useState<ArrHealthResponse | null>(null);
   const [arrHealthLoaded, setArrHealthLoaded] = useState(false);
+  const [windowError, setWindowError] = useState(false);
+  const [detailError, setDetailError] = useState(false);
+  const [staticError, setStaticError] = useState(false);
+  const [arrHealthError, setArrHealthError] = useState(false);
+  const [windowRetry, setWindowRetry] = useState(0);
+  const [detailRetry, setDetailRetry] = useState(0);
+  const [staticRetry, setStaticRetry] = useState(0);
+  const [arrHealthRetry, setArrHealthRetry] = useState(0);
   const { order, save, reset } = useRowOrder(DEFAULT_ROW_ORDER);
   const editModeRef = useRef(editMode);
   editModeRef.current = editMode;
+  const windowLoadedRef = useRef(false);
+  const detailLoadedRef = useRef(false);
+  const staticLoadedRef = useRef(false);
+  const arrHealthLoadedRef = useRef(false);
+  windowLoadedRef.current = windowLoaded;
+  detailLoadedRef.current = detailLoaded;
+  staticLoadedRef.current = staticLoaded;
+  arrHealthLoadedRef.current = arrHealthLoaded;
 
   const liveTiles = stats.tiles;
   const isLongWindow = window === "7d" || window === "30d" || window === "all";
@@ -130,8 +156,11 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
   useEffect(() => {
     let cancelled = false;
     setWindowLoaded(false);
-    if (isLongWindow) setDetailLoaded(true);
-    else setDetailLoaded(false);
+    setWindowError(false);
+    if (isLongWindow) {
+      setDetailLoaded(true);
+      setDetailError(false);
+    } else setDetailLoaded(false);
 
     const fetchWindow = async () => {
       if (typeof document !== "undefined" && document.hidden) return;
@@ -139,14 +168,19 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
         const res = await fetch(
           withUrlBase(`/api/get-overview-stats?window=${window}&sections=window`),
         );
-        if (!res.ok || cancelled) return;
+        if (cancelled) return;
+        if (!res.ok) {
+          if (!windowLoadedRef.current) setWindowError(true);
+          return;
+        }
         // /api/get-overview-stats returns OverviewStatsResponse
         const data = (await res.json()) as OverviewStatsResponse;
         if (cancelled) return;
         setStats((s) => mergeOverviewStats(s, data));
         setWindowLoaded(true);
+        setWindowError(false);
       } catch {
-        /* network blip, retry next tick */
+        if (!cancelled && !windowLoadedRef.current) setWindowError(true);
       }
     };
 
@@ -165,25 +199,31 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
       clearInterval(interval);
       document.removeEventListener("visibilitychange", onVisible);
     };
-  }, [window, isLongWindow]);
+  }, [window, isLongWindow, windowRetry]);
 
   // Arr Health: poll on the same 30s cadence, only when Arr instances are configured.
   useEffect(() => {
     if (!loaderData.hasConfiguredArrs) return;
     let cancelled = false;
     setArrHealthLoaded(false);
+    setArrHealthError(false);
 
     const fetchArrHealth = async () => {
       if (typeof document !== "undefined" && document.hidden) return;
       try {
         const res = await fetch(withUrlBase(`/api/get-arr-health?window=${window}`));
-        if (!res.ok || cancelled) return;
+        if (cancelled) return;
+        if (!res.ok) {
+          if (!arrHealthLoadedRef.current) setArrHealthError(true);
+          return;
+        }
         const data = (await res.json()) as ArrHealthResponse;
         if (cancelled) return;
         setArrHealth(data);
         setArrHealthLoaded(true);
+        setArrHealthError(false);
       } catch {
-        /* network blip, retry next tick */
+        if (!cancelled && !arrHealthLoadedRef.current) setArrHealthError(true);
       }
     };
 
@@ -202,7 +242,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
       clearInterval(interval);
       document.removeEventListener("visibilitychange", onVisible);
     };
-  }, [window, loaderData.hasConfiguredArrs]);
+  }, [window, loaderData.hasConfiguredArrs, arrHealthRetry]);
 
   // Detail (latency + errors): once per 24h window selection — not on the 30s poll.
   useEffect(() => {
@@ -213,20 +253,25 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
         const res = await fetch(
           withUrlBase(`/api/get-overview-stats?window=${window}&sections=detail`),
         );
-        if (!res.ok || cancelled) return;
+        if (cancelled) return;
+        if (!res.ok) {
+          if (!detailLoadedRef.current) setDetailError(true);
+          return;
+        }
         // /api/get-overview-stats returns OverviewStatsResponse
         const data = (await res.json()) as OverviewStatsResponse;
         if (cancelled) return;
         setStats((s) => mergeOverviewStats(s, data));
         setDetailLoaded(true);
+        setDetailError(false);
       } catch {
-        /* ignore */
+        if (!cancelled && !detailLoadedRef.current) setDetailError(true);
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [window, isLongWindow]);
+  }, [window, isLongWindow, detailRetry]);
 
   // Static blocks: once per page visit.
   useEffect(() => {
@@ -236,20 +281,25 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
         const res = await fetch(
           withUrlBase(`/api/get-overview-stats?window=${window}&sections=static`),
         );
-        if (!res.ok || cancelled) return;
+        if (cancelled) return;
+        if (!res.ok) {
+          if (!staticLoadedRef.current) setStaticError(true);
+          return;
+        }
         // /api/get-overview-stats returns OverviewStatsResponse
         const data = (await res.json()) as OverviewStatsResponse;
         if (cancelled) return;
         setStats((s) => mergeOverviewStats(s, data));
         setStaticLoaded(true);
+        setStaticError(false);
       } catch {
-        /* ignore */
+        if (!cancelled && !staticLoadedRef.current) setStaticError(true);
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps -- once per visit
+  }, [staticRetry]); // eslint-disable-line react-hooks/exhaustive-deps -- once per visit unless retried
 
   const onWsMessage = useCallback((topic: string, message: string) => {
     if (topic !== topicNames.liveStats) return;
@@ -300,33 +350,41 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
   const rowContent = useMemo<Record<string, ReactNode>>(
     () => ({
       liveTiles: <LiveTiles tiles={liveTiles} />,
-      throughput: windowLoaded ? (
-        <ThroughputChart
-          points={stats.throughput}
-          totalArticles={stats.totalArticles}
-          totalMisses={stats.totalMisses}
-          totalErrors={stats.totalErrors}
-          totalBytesServed={stats.sessions.totalBytesServed}
-          bucketSizeMs={stats.throughputBucketSizeMs}
-          window={window}
-        />
-      ) : (
-        <Skeleton height={180} />
-      ),
-      activity: windowLoaded ? (
-        <ActivityHeatmap
-          maxCell={stats.heatmap.maxCell}
-          mode={stats.heatmap.mode}
-          windowStartMs={stats.heatmap.windowStartMs}
-          windowEndMs={stats.heatmap.windowEndMs}
-          bucketSizeMs={stats.heatmap.bucketSizeMs}
-          cells={stats.heatmap.cells}
-        />
-      ) : (
-        <Skeleton height={140} />
-      ),
+      throughput:
+        windowError && !windowLoaded ? (
+          <SectionLoadError label="activity" onRetry={() => setWindowRetry((n) => n + 1)} />
+        ) : windowLoaded ? (
+          <ThroughputChart
+            points={stats.throughput}
+            totalArticles={stats.totalArticles}
+            totalMisses={stats.totalMisses}
+            totalErrors={stats.totalErrors}
+            totalBytesServed={stats.sessions.totalBytesServed}
+            bucketSizeMs={stats.throughputBucketSizeMs}
+            window={window}
+          />
+        ) : (
+          <Skeleton height={180} />
+        ),
+      activity:
+        windowError && !windowLoaded ? (
+          <SectionLoadError label="activity heatmap" onRetry={() => setWindowRetry((n) => n + 1)} />
+        ) : windowLoaded ? (
+          <ActivityHeatmap
+            maxCell={stats.heatmap.maxCell}
+            mode={stats.heatmap.mode}
+            windowStartMs={stats.heatmap.windowStartMs}
+            windowEndMs={stats.heatmap.windowEndMs}
+            bucketSizeMs={stats.heatmap.bucketSizeMs}
+            cells={stats.heatmap.cells}
+          />
+        ) : (
+          <Skeleton height={140} />
+        ),
       latency: !isLongWindow ? (
-        detailLoaded ? (
+        detailError && !detailLoaded ? (
+          <SectionLoadError label="fetch latency" onRetry={() => setDetailRetry((n) => n + 1)} />
+        ) : detailLoaded ? (
           <LatencyHistogram
             p50Ms={stats.latency.p50Ms}
             p95Ms={stats.latency.p95Ms}
@@ -338,61 +396,99 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
           <Skeleton height={160} />
         )
       ) : null,
-      errorsSessions: (
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-          {!isLongWindow &&
-            (detailLoaded ? <ErrorDonut errors={stats.errors} /> : <Skeleton height={160} />)}
-          {windowLoaded ? (
+      errorsSessions: (() => {
+        const sessions =
+          windowError && !windowLoaded ? (
+            <SectionLoadError label="read sessions" onRetry={() => setWindowRetry((n) => n + 1)} />
+          ) : windowLoaded ? (
             <SessionsBlock sessions={stats.sessions} window={window} />
           ) : (
             <Skeleton height={160} />
-          )}
-        </div>
-      ),
-      providers: windowLoaded ? (
-        <ProviderScoreboard providers={stats.providers} window={window} />
-      ) : (
-        <Skeleton height={160} />
-      ),
-      failover: windowLoaded ? (
-        <FailoverSaves failover={stats.failover} window={window} />
-      ) : (
-        <Skeleton height={180} />
-      ),
+          );
+        if (isLongWindow) return sessions;
+        const errors =
+          detailError && !detailLoaded ? (
+            <SectionLoadError
+              label="error breakdown"
+              onRetry={() => setDetailRetry((n) => n + 1)}
+            />
+          ) : detailLoaded ? (
+            <ErrorDonut errors={stats.errors} />
+          ) : (
+            <Skeleton height={160} />
+          );
+        return (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            {errors}
+            {sessions}
+          </div>
+        );
+      })(),
+      providers:
+        windowError && !windowLoaded ? (
+          <SectionLoadError label="providers" onRetry={() => setWindowRetry((n) => n + 1)} />
+        ) : windowLoaded ? (
+          <ProviderScoreboard providers={stats.providers} window={window} />
+        ) : (
+          <Skeleton height={160} />
+        ),
+      failover:
+        windowError && !windowLoaded ? (
+          <SectionLoadError label="backup rescues" onRetry={() => setWindowRetry((n) => n + 1)} />
+        ) : windowLoaded ? (
+          <FailoverSaves failover={stats.failover} window={window} />
+        ) : (
+          <Skeleton height={180} />
+        ),
       arrHealth: loaderData.hasConfiguredArrs ? (
-        arrHealthLoaded && arrHealth ? (
+        arrHealthError && !arrHealthLoaded ? (
+          <SectionLoadError label="Arr health" onRetry={() => setArrHealthRetry((n) => n + 1)} />
+        ) : arrHealthLoaded && arrHealth ? (
           <ArrHealth data={arrHealth} window={window} />
         ) : (
           <Skeleton height={140} />
         )
       ) : null,
       indexers:
-        loaderData.hasConfiguredIndexers && staticLoaded ? (
+        loaderData.hasConfiguredIndexers && staticError && !staticLoaded ? (
+          <SectionLoadError label="indexers" onRetry={() => setStaticRetry((n) => n + 1)} />
+        ) : loaderData.hasConfiguredIndexers && staticLoaded ? (
           <IndexerScoreboard indexers={stats.indexers} />
         ) : loaderData.hasConfiguredIndexers ? (
           <Skeleton height={140} />
         ) : null,
       indexerApiUsage:
-        loaderData.hasConfiguredIndexers && staticLoaded ? (
+        loaderData.hasConfiguredIndexers && staticError && !staticLoaded ? (
+          <SectionLoadError
+            label="indexer API usage"
+            onRetry={() => setStaticRetry((n) => n + 1)}
+          />
+        ) : loaderData.hasConfiguredIndexers && staticLoaded ? (
           <IndexerApiUsage rows={stats.indexerApiUsage} />
         ) : loaderData.hasConfiguredIndexers ? (
           <Skeleton height={120} />
         ) : null,
-      recordsCatalogue: (
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-          {staticLoaded ? <RecordsBlock records={stats.records} /> : <Skeleton height={120} />}
-          {staticLoaded ? (
-            <CatalogueBlock catalogue={stats.catalogue} />
-          ) : (
-            <Skeleton height={120} />
-          )}
-        </div>
-      ),
-      lifetime: staticLoaded ? (
-        <LifetimeBlock lifetime={stats.lifetime} />
-      ) : (
-        <Skeleton height={120} />
-      ),
+      recordsCatalogue:
+        staticError && !staticLoaded ? (
+          <SectionLoadError label="library stats" onRetry={() => setStaticRetry((n) => n + 1)} />
+        ) : (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            {staticLoaded ? <RecordsBlock records={stats.records} /> : <Skeleton height={120} />}
+            {staticLoaded ? (
+              <CatalogueBlock catalogue={stats.catalogue} />
+            ) : (
+              <Skeleton height={120} />
+            )}
+          </div>
+        ),
+      lifetime:
+        staticError && !staticLoaded ? (
+          <SectionLoadError label="lifetime totals" onRetry={() => setStaticRetry((n) => n + 1)} />
+        ) : staticLoaded ? (
+          <LifetimeBlock lifetime={stats.lifetime} />
+        ) : (
+          <Skeleton height={120} />
+        ),
     }),
     [
       liveTiles,
@@ -400,12 +496,16 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
       window,
       isLongWindow,
       windowLoaded,
+      windowError,
       detailLoaded,
+      detailError,
       staticLoaded,
+      staticError,
       loaderData.hasConfiguredIndexers,
       loaderData.hasConfiguredArrs,
       arrHealth,
       arrHealthLoaded,
+      arrHealthError,
     ],
   );
 
@@ -434,10 +534,36 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
     save(arrayMove(order, oldIndex, newIndex));
   };
 
+  const onWindowKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const keys = ["ArrowRight", "ArrowLeft", "Home", "End", "ArrowDown", "ArrowUp"];
+    if (!keys.includes(event.key)) return;
+    event.preventDefault();
+    const idx = WINDOWS.findIndex((w) => w.value === window);
+    const last = WINDOWS.length - 1;
+    let next = idx < 0 ? 0 : idx;
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") next = idx === last ? 0 : idx + 1;
+    else if (event.key === "ArrowLeft" || event.key === "ArrowUp") next = idx <= 0 ? last : idx - 1;
+    else if (event.key === "Home") next = 0;
+    else if (event.key === "End") next = last;
+    const selected = WINDOWS[next];
+    if (!selected) return;
+    setWindow(selected.value);
+    document.getElementById(`overview-window-${selected.value}`)?.focus();
+  };
+
   return (
-    <div className="mx-auto flex w-full max-w-[1680px] flex-col gap-4 p-4">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <h2 className="m-0 text-xl font-semibold tracking-tight text-base-content">Overview</h2>
+    <div className="mx-auto flex w-full max-w-[1680px] flex-col gap-6 px-4 py-4 md:gap-8 md:px-8">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h1 className="m-0 text-2xl font-bold tracking-tight text-base-content md:text-3xl">
+            Overview
+          </h1>
+          {(window === "7d" || window === "30d" || window === "all") && (
+            <p className="mt-1 text-xs text-base-content/50">
+              Latency and error breakdown are available for the 1h and 24h windows.
+            </p>
+          )}
+        </div>
         <div className="inline-flex flex-wrap items-center gap-2">
           {editMode && (
             <button
@@ -456,15 +582,19 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
             aria-pressed={editMode}
             title={editMode ? "Done editing layout" : "Reorder widgets"}
           >
+            <Icon name={editMode ? "check" : "tune"} className="!text-[18px]" />
             {editMode ? "Done" : "Edit layout"}
           </button>
-          <div className="join">
+          <div className="join" role="tablist" aria-label="Time window" onKeyDown={onWindowKeyDown}>
             {WINDOWS.map((w) => (
               <button
                 key={w.value}
+                id={`overview-window-${w.value}`}
                 type="button"
                 role="tab"
                 aria-selected={window === w.value}
+                aria-controls="overview-dashboard"
+                tabIndex={window === w.value ? 0 : -1}
                 className={`btn btn-sm join-item ${window === w.value ? "btn-primary" : "btn-ghost"}`}
                 onClick={() => setWindow(w.value)}
               >
@@ -488,7 +618,10 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
         </div>
       )}
 
-      <div className="flex min-w-0 flex-col items-stretch gap-4 xl:flex-row">
+      <div
+        id="overview-dashboard"
+        className="flex min-w-0 flex-col items-stretch gap-4 xl:flex-row"
+      >
         <div className="flex min-w-0 flex-1 flex-col gap-4">
           <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
             <SortableContext items={visibleOrder} strategy={verticalListSortingStrategy}>
@@ -505,7 +638,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
           </DndContext>
         </div>
         {/* Pin above widgets when stacked; restore document order for the xl right rail. */}
-        <aside className="order-first flex w-full shrink-0 xl:order-none xl:w-80 xl:self-stretch">
+        <aside className="order-first flex w-full shrink-0 xl:sticky xl:top-4 xl:order-none xl:max-h-[calc(100vh-2rem)] xl:w-80 xl:self-start">
           <LiveReadsPanel paused={editMode} />
         </aside>
       </div>

--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -152,6 +152,21 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
   const liveTiles = stats.tiles;
   const isLongWindow = window === "7d" || window === "30d" || window === "all";
 
+  const applyWindow = (next: OverviewWindow) => {
+    if (next === window) return;
+    const nextLong = next === "7d" || next === "30d" || next === "all";
+    setWindow(next);
+    if (nextLong) {
+      setDetailLoaded(true);
+      setDetailError(false);
+      detailLoadedRef.current = true;
+    } else {
+      setDetailLoaded(false);
+      setDetailError(false);
+      detailLoadedRef.current = false;
+    }
+  };
+
   // Window section: load on mount / window change, poll every 30s while visible.
   useEffect(() => {
     let cancelled = false;
@@ -248,6 +263,9 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
   useEffect(() => {
     if (isLongWindow) return;
     let cancelled = false;
+    detailLoadedRef.current = false;
+    setDetailLoaded(false);
+    setDetailError(false);
     void (async () => {
       try {
         const res = await fetch(
@@ -547,7 +565,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
     else if (event.key === "End") next = last;
     const selected = WINDOWS[next];
     if (!selected) return;
-    setWindow(selected.value);
+    applyWindow(selected.value);
     document.getElementById(`overview-window-${selected.value}`)?.focus();
   };
 
@@ -597,7 +615,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
                 aria-controls="overview-dashboard"
                 tabIndex={window === w.value ? 0 : -1}
                 className={`tab ${window === w.value ? "tab-active" : ""}`}
-                onClick={() => setWindow(w.value)}
+                onClick={() => applyWindow(w.value)}
               >
                 {w.label}
               </button>
@@ -621,9 +639,12 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
 
       <div
         id="overview-dashboard"
-        className="flex min-w-0 flex-col items-stretch gap-4 xl:flex-row"
+        className="grid min-w-0 grid-cols-1 items-start gap-4 xl:grid-cols-[minmax(0,1fr)_20rem]"
       >
-        <div className="flex min-w-0 flex-1 flex-col gap-4">
+        <aside className="flex w-full min-w-0 xl:col-start-2 xl:row-start-1 xl:sticky xl:top-4 xl:max-h-[calc(100vh-2rem)]">
+          <LiveReadsPanel paused={editMode} />
+        </aside>
+        <div className="flex min-w-0 flex-col gap-4 xl:col-start-1 xl:row-start-1">
           <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
             <SortableContext items={visibleOrder} strategy={verticalListSortingStrategy}>
               {visibleOrder.map((id) => {
@@ -638,10 +659,6 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
             </SortableContext>
           </DndContext>
         </div>
-        {/* Pin above widgets when stacked; restore document order for the xl right rail. */}
-        <aside className="order-first flex w-full shrink-0 xl:sticky xl:top-4 xl:order-none xl:max-h-[calc(100vh-2rem)] xl:w-80 xl:self-start">
-          <LiveReadsPanel paused={editMode} />
-        </aside>
       </div>
     </div>
   );

--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -42,7 +42,7 @@ import { FailoverSaves } from "./components/failover-saves/failover-saves";
 import { ArrHealth } from "./components/arr-health/arr-health";
 import { SortableRow } from "./components/sortable-row/sortable-row";
 import { SectionLoadError } from "./components/section-load-error/section-load-error";
-import { Icon } from "~/components/ui";
+import { Icon, Tooltip } from "~/components/ui";
 import { backendClient, type ArrHealthResponse } from "~/clients/backend-client.server";
 import { useRowOrder } from "./utils/use-row-order";
 import { hasConfiguredIndexers } from "./utils/has-configured-indexers";
@@ -555,9 +555,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
     <div className="mx-auto flex w-full max-w-[1680px] flex-col gap-6 px-4 py-4 md:gap-8 md:px-8">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0">
-          <h1 className="m-0 text-2xl font-bold tracking-tight text-base-content md:text-3xl">
-            Overview
-          </h1>
+          <h1 className="m-0 text-4xl font-bold tracking-tight text-base-content">Overview</h1>
           {(window === "7d" || window === "30d" || window === "all") && (
             <p className="mt-1 text-xs text-base-content/50">
               Latency and error breakdown are available for the 1h and 24h windows.
@@ -566,26 +564,29 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
         </div>
         <div className="inline-flex flex-wrap items-center gap-2">
           {editMode && (
+            <Tooltip content="Restore default order">
+              <button type="button" className="btn btn-ghost btn-sm" onClick={reset}>
+                Reset
+              </button>
+            </Tooltip>
+          )}
+          <Tooltip content={editMode ? "Done editing layout" : "Reorder widgets"}>
             <button
               type="button"
-              className="btn btn-ghost btn-sm"
-              onClick={reset}
-              title="Restore default order"
+              className={`btn btn-sm ${editMode ? "btn-primary" : "btn-ghost"}`}
+              onClick={() => setEditMode((v) => !v)}
+              aria-pressed={editMode}
             >
-              Reset
+              <Icon name={editMode ? "check" : "tune"} className="!text-[18px]" />
+              {editMode ? "Done" : "Edit layout"}
             </button>
-          )}
-          <button
-            type="button"
-            className={`btn btn-sm ${editMode ? "btn-primary" : "btn-ghost"}`}
-            onClick={() => setEditMode((v) => !v)}
-            aria-pressed={editMode}
-            title={editMode ? "Done editing layout" : "Reorder widgets"}
+          </Tooltip>
+          <div
+            role="tablist"
+            className="tabs tabs-border tabs-sm"
+            aria-label="Time window"
+            onKeyDown={onWindowKeyDown}
           >
-            <Icon name={editMode ? "check" : "tune"} className="!text-[18px]" />
-            {editMode ? "Done" : "Edit layout"}
-          </button>
-          <div className="join" role="tablist" aria-label="Time window" onKeyDown={onWindowKeyDown}>
             {WINDOWS.map((w) => (
               <button
                 key={w.value}
@@ -595,7 +596,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
                 aria-selected={window === w.value}
                 aria-controls="overview-dashboard"
                 tabIndex={window === w.value ? 0 : -1}
-                className={`btn btn-sm join-item ${window === w.value ? "btn-primary" : "btn-ghost"}`}
+                className={`tab ${window === w.value ? "tab-active" : ""}`}
                 onClick={() => setWindow(w.value)}
               >
                 {w.label}

--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -170,6 +170,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
   // Window section: load on mount / window change, poll every 30s while visible.
   useEffect(() => {
     let cancelled = false;
+    windowLoadedRef.current = false;
     setWindowLoaded(false);
     setWindowError(false);
     if (isLongWindow) {
@@ -220,6 +221,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
   useEffect(() => {
     if (!loaderData.hasConfiguredArrs) return;
     let cancelled = false;
+    arrHealthLoadedRef.current = false;
     setArrHealthLoaded(false);
     setArrHealthError(false);
 


### PR DESCRIPTION
## Summary
Overview is now easier to scan and recover from: a real page heading, time-window tabs with keyboard support, retryable section errors instead of infinite skeletons, live-rail empty/copy feedback, and drill-down links into existing Usenet, indexer, Arr, queue, and logs pages.

## Test plan
- [ ] Open `/overview` at desktop width: heading is `Overview`, 24h tab selected, live tiles labeled as live status
- [ ] Switch to 7d/30d/All: latency and error widgets hide; hint explains they exist on 1h/24h; sessions use the full row
- [ ] Arrow keys move between time-window tabs; heatmap cells and latency bars are focusable
- [ ] Edit layout shows drag handles using the Material drag-indicator icon; Done/Reset work
- [ ] Stop the backend after first paint and confirm failed sections show a warning with Retry (polling stays silent once data exists)
- [ ] Narrow viewport: Right now sits above widgets, tables scroll, night-theme contrast holds
- [ ] With configured providers/indexers/Arrs, open-circuit and failed-import rows link to the matching settings/queue/logs pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added keyboard navigation and accessible labels for dashboard charts and heatmaps.
  - Added links to settings, queues, and logs.
  - Added retryable error states for dashboard sections.
  - Added session ID copy confirmation and clearer live-read status messages.
  - Added warnings for failed imports and provider issues.
  - Added contextual tooltips and semantic progress indicators.
- **Bug Fixes**
  - Improved focus behavior and screen-reader support across dashboard widgets.
- **Style**
  - Refined backgrounds, spacing, pinned columns, and responsive layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->