### PR TITLE
fix(webdav): resume lazy RAR playback from tail seeks

### DIFF
--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -169,21 +169,25 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
 
             var filePath = GetRequestFilePath(context);
             var seekPosition = context.Request.GetRange()?.Start?.ToString() ?? "unknown";
-            var dedupeKey = $"{filePath}|{seekPosition}";
+            var reason = e.InnerException?.Message ?? e.Message;
+            var dedupeKey = $"{filePath}|{seekPosition}|{reason}";
             LogWithDedup(RecentSeekErrors, dedupeKey, suppressed =>
             {
                 if (suppressed > 0)
-                    Log.Error(
-                        "File {FilePath} could not seek to byte position {SeekPosition} (suppressed {SuppressedCount} duplicates in last 60s)",
+                    Log.Warning(
+                        "File {FilePath} could not seek to byte position {SeekPosition}. Reason: {Reason} (suppressed {SuppressedCount} duplicates in last 60s)",
                         filePath,
                         seekPosition,
+                        reason,
                         suppressed);
                 else
-                    Log.Error(
-                        "File {FilePath} could not seek to byte position {SeekPosition}",
+                    Log.Warning(
+                        "File {FilePath} could not seek to byte position {SeekPosition}. Reason: {Reason}",
                         filePath,
-                        seekPosition);
+                        seekPosition,
+                        reason);
             });
+            Log.Debug(e, "File {FilePath} seek failure stack", filePath);
 
             // Only a short segment proves the release cannot serve this range. Other seek
             // failures can be transient header-probe errors or corrupt local metadata and

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -229,12 +229,12 @@ public class NzbFileStream(
                         // A lazy RAR part's logical length ends with its packed file
                         // data, while its final yEnc segment can also contain trailing
                         // archive structure. Keep the generic interpolation search
-                        // strict, but trim this known end-only probe overflow so valid
-                        // tail seeks can still locate the final segment.
-                        if (range.StartInclusive >= 0 &&
+                        // strict, but trim this known final-probe overflow so valid
+                        // tail seeks can still converge through the preceding segment.
+                        if (guess == fileSegmentIds.Length - 1 &&
+                            range.StartInclusive >= 0 &&
                             range.StartInclusive < fileSize &&
-                            range.EndExclusive > fileSize &&
-                            range.Contains(byteOffset))
+                            range.EndExclusive > fileSize)
                         {
                             range = new LongRange(range.StartInclusive, fileSize);
                         }

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -178,6 +178,34 @@ public class ExceptionMiddlewareTests
     }
 
     [Fact]
+    public async Task SeekFailure_LogsDeduplicatedWarningWithUnderlyingReason()
+    {
+        var reason = $"final segment range exceeded logical file size ({Guid.NewGuid()})";
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var middleware = CreateMiddleware(
+            _ => throw new SeekPositionNotFoundException(
+                "Corrupt file. Cannot find byte position 50.",
+                new InvalidDataException(reason)));
+
+        var events = await CaptureLogsAsync(async () =>
+        {
+            await middleware.InvokeAsync(context);
+            await middleware.InvokeAsync(context);
+        });
+
+        var logged = Assert.Single(events, e =>
+            e.Level == LogEventLevel.Warning &&
+            e.RenderMessage().Contains("could not seek", StringComparison.Ordinal));
+        Assert.Contains(reason, logged.RenderMessage(), StringComparison.Ordinal);
+        Assert.Null(logged.Exception);
+        Assert.Contains(events, e =>
+            e.Level == LogEventLevel.Debug &&
+            e.Exception is SeekPositionNotFoundException);
+        Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+    }
+
+    [Fact]
     public async Task CorruptRarAfterResponseStarted_AbortsConnection()
     {
         var lifetimeFeature = new TestHttpRequestLifetimeFeature();

--- a/tests/NzbWebDAV.Tests/Streams/DavMultipartFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/DavMultipartFileStreamTests.cs
@@ -87,6 +87,62 @@ public class DavMultipartFileStreamTests
     }
 
     [Fact]
+    public async Task ReadAsync_PersistedLazyPartFindsPenultimateSegmentBeforeTrailingArchiveBytes()
+    {
+        var segmentIds = new[] { "one", "two", "three" };
+        var segments = segmentIds.ToDictionary(
+            id => id,
+            _ => Enumerable.Range(0, 10).Select(value => (byte)value).ToArray());
+        var ranges = new[]
+        {
+            new LongRange(0, 10),
+            new LongRange(10, 20),
+            new LongRange(20, 30),
+        };
+        using var client = new FakeNntpClient(
+            segments,
+            useCachedYencStreams: true,
+            segmentRanges: segmentIds.Zip(ranges).ToDictionary(pair => pair.First, pair => pair.Second));
+        var multipart = new DavMultipartFile
+        {
+            Id = Guid.NewGuid(),
+            Metadata = new DavMultipartFile.Meta
+            {
+                FileParts =
+                [
+                    new DavMultipartFile.FilePart
+                    {
+                        SegmentIds = segmentIds,
+                        SegmentIdByteRange = new LongRange(0, 24),
+                        FilePartByteRange = new LongRange(0, 24),
+                    }
+                ],
+            },
+        };
+        var previousBudget = NzbWebDAV.WebDav.Requests.RangeContext.GetReadBudget();
+        NzbWebDAV.WebDav.Requests.RangeContext.SetReadBudget(1024 * 1024 - 1);
+        try
+        {
+            await using var stream = new DavMultipartFileStream(
+                multipart,
+                client,
+                articleBufferSize: 0,
+                resolver: null,
+                usePipelinedBodyRequests: false,
+                fileName: "movie.mkv");
+            stream.Seek(18, SeekOrigin.Begin);
+
+            var buffer = new byte[1];
+            Assert.Equal(1, await stream.ReadAsync(buffer));
+            Assert.Equal(8, buffer[0]);
+        }
+        finally
+        {
+            NzbWebDAV.WebDav.Requests.RangeContext.SetReadBudget(previousBudget);
+        }
+    }
+
+    [Fact]
     public void Read_PreservesSynchronousArchiveParserCompatibility()
     {
         var volumeBytes = Enumerable.Range(0, 16).Select(x => (byte)x).ToArray();

--- a/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/NzbFileStreamTests.cs
@@ -138,6 +138,46 @@ public class NzbFileStreamTests
     }
 
     [Fact]
+    public async Task Seek_WhenFinalHeaderRangeExtendsPastLogicalFileSize_FindsPenultimateSegment()
+    {
+        var segmentIds = new[] { "one", "two", "three" };
+        var segments = segmentIds.ToDictionary(
+            id => id,
+            _ => Enumerable.Range(0, 10).Select(value => (byte)value).ToArray());
+        var ranges = new[]
+        {
+            new LongRange(0, 10),
+            new LongRange(10, 20),
+            new LongRange(20, 30),
+        };
+        var client = new FakeNntpClient(
+            segments,
+            useCachedYencStreams: true,
+            segmentRanges: segmentIds.Zip(ranges).ToDictionary(pair => pair.First, pair => pair.Second));
+        var previousBudget = NzbWebDAV.WebDav.Requests.RangeContext.GetReadBudget();
+        NzbWebDAV.WebDav.Requests.RangeContext.SetReadBudget(1);
+        try
+        {
+            await using var stream = new NzbFileStream(
+                segmentIds,
+                fileSize: 24,
+                client,
+                articleBufferSize: 0,
+                segmentByteRanges: null,
+                usePipelinedBodyRequests: false);
+            stream.Seek(18, SeekOrigin.Begin);
+
+            var buffer = new byte[1];
+            Assert.Equal(1, await stream.ReadAsync(buffer));
+            Assert.Equal(8, buffer[0]);
+        }
+        finally
+        {
+            NzbWebDAV.WebDav.Requests.RangeContext.SetReadBudget(previousBudget);
+        }
+    }
+
+    [Fact]
     public async Task Seek_WhenHeaderRangeDoesNotCoverLogicalFile_StillThrows()
     {
         var client = new FakeNntpClient(


### PR DESCRIPTION
## Summary
- normalize overflowing final yEnc probes so tail seeks can step back into the preceding segment
- cover direct and multipart lazy-RAR tail seeks, plus the warning-level seek diagnostic
- log handled seek failures with their underlying reason without scheduling repairs unless a segment is genuinely short

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter 'FullyQualifiedName~NzbFileStreamTests|FullyQualifiedName~DavMultipartFileStreamTests|FullyQualifiedName~ExceptionMiddlewareTests'`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved seeking near the end of files, including files with trailing archive data or segments extending beyond the logical file size.
  * Corrected cases where valid data in the preceding segment could not be located.
  * Seek failures now provide clearer diagnostic information while avoiding repetitive warning messages.
  * Detailed failure information is available for troubleshooting without cluttering standard logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->