### PR TITLE
fix(arr): prevent completed downloads waiting indefinitely for import

### DIFF
--- a/backend/Api/Controllers/GetArrHealth/GetArrHealthController.cs
+++ b/backend/Api/Controllers/GetArrHealth/GetArrHealthController.cs
@@ -94,6 +94,8 @@ public class GetArrHealthController(ConfigManager configManager, ArrHealthServic
                 P95HandoffMs = ArrHealthMath.Percentile(handoffs, 0.95),
                 QueueCount = snapshot?.QueueCount ?? 0,
                 AwaitingCount = snapshot?.AwaitingCount ?? 0,
+                HasWarnings = snapshot?.HasWarnings ?? false,
+                HasErrors = snapshot?.HasErrors ?? false,
                 LastImportAtMs = snapshot?.LastImportAtMs,
                 LastError = snapshot?.LastError,
             });
@@ -105,6 +107,7 @@ public class GetArrHealthController(ConfigManager configManager, ArrHealthServic
                 awaiting.Add(new GetArrHealthResponse.ArrAwaitingItem
                 {
                     Title = item.Title,
+                    DownloadId = item.DownloadId,
                     InstanceKey = key,
                     InstanceName = name,
                     WaitingMs = waitingMs,
@@ -112,6 +115,8 @@ public class GetArrHealthController(ConfigManager configManager, ArrHealthServic
                         waitingMs,
                         snapshot.MedianHandoffMs30d,
                         snapshot.MedianSampleCount30d),
+                    TrackedDownloadState = item.TrackedDownloadState,
+                    StatusReason = item.StatusReason,
                 });
             }
         }
@@ -119,6 +124,11 @@ public class GetArrHealthController(ConfigManager configManager, ArrHealthServic
         var enabledKeys = rows.Select(r => r.Key).ToHashSet(StringComparer.Ordinal);
         var includedEvents = events.Where(e => enabledKeys.Contains(e.InstanceKey)).ToList();
         var includedHandoffs = includedEvents.Where(e => e.HandoffMs != null).Select(e => e.HandoffMs!.Value);
+
+        var displayedAwaiting = awaiting
+            .OrderByDescending(a => a.WaitingMs ?? long.MinValue)
+            .Take(AwaitingLimit)
+            .ToList();
 
         return new GetArrHealthResponse
         {
@@ -131,13 +141,11 @@ public class GetArrHealthController(ConfigManager configManager, ArrHealthServic
                 MedianHandoffMs = ArrHealthMath.Percentile(includedHandoffs, 0.50),
                 P95HandoffMs = ArrHealthMath.Percentile(includedHandoffs, 0.95),
                 AwaitingImport = rows.Sum(r => r.AwaitingCount),
+                AwaitingShown = displayedAwaiting.Count,
                 Degraded = rows.Count(r => r.Status == "degraded"),
             },
             Instances = rows,
-            Awaiting = awaiting
-                .OrderByDescending(a => a.WaitingMs ?? long.MinValue)
-                .Take(AwaitingLimit)
-                .ToList(),
+            Awaiting = displayedAwaiting,
         };
     }
 

--- a/backend/Api/Controllers/GetArrHealth/GetArrHealthResponse.cs
+++ b/backend/Api/Controllers/GetArrHealth/GetArrHealthResponse.cs
@@ -15,6 +15,7 @@ public class GetArrHealthResponse : BaseApiResponse
         public long? MedianHandoffMs { get; init; }
         public long? P95HandoffMs { get; init; }
         public int AwaitingImport { get; init; }
+        public int AwaitingShown { get; init; }
         public int Degraded { get; init; }
     }
 
@@ -30,6 +31,8 @@ public class GetArrHealthResponse : BaseApiResponse
         public long? P95HandoffMs { get; init; }
         public int QueueCount { get; init; }
         public int AwaitingCount { get; init; }
+        public bool HasWarnings { get; init; }
+        public bool HasErrors { get; init; }
         public long? LastImportAtMs { get; init; }
         public string? LastError { get; init; }
     }
@@ -37,9 +40,12 @@ public class GetArrHealthResponse : BaseApiResponse
     public class ArrAwaitingItem
     {
         public string? Title { get; init; }
+        public Guid? DownloadId { get; init; }
         public string InstanceKey { get; init; } = "";
         public string InstanceName { get; init; } = "";
         public long? WaitingMs { get; init; }
         public bool IsUnusual { get; init; }
+        public string? TrackedDownloadState { get; init; }
+        public string? StatusReason { get; init; }
     }
 }

--- a/backend/Api/SabControllers/SabApiController.cs
+++ b/backend/Api/SabControllers/SabApiController.cs
@@ -47,6 +47,12 @@ public class SabApiController(
 {
     private static readonly LogThrottle AuthenticationFailureThrottle = new();
     private static readonly TimeSpan AuthenticationFailureLogInterval = TimeSpan.FromMinutes(5);
+    private static readonly HashSet<string> KnownModes =
+    [
+        "version", "status", "get_cats", "get_config", "fullstatus", "server_stats", "warnings",
+        "addfile", "addurl", "pause", "resume", "speedlimit", "queue", "switch", "history",
+        "change_cat", "retry",
+    ];
 
     [HttpGet]
     [HttpPost]
@@ -96,8 +102,15 @@ public class SabApiController(
 
     private void LogAuthenticationFailure()
     {
-        var mode = HttpContext.GetRequestParam("mode") ?? "unknown";
-        var category = HttpContext.GetRequestParam("cat") ?? "none";
+        var requestedMode = HttpContext.GetRequestParam("mode");
+        var mode = requestedMode is not null && KnownModes.Contains(requestedMode)
+            ? requestedMode
+            : "unknown";
+        var requestedCategory = HttpContext.GetRequestParam("cat");
+        var category = configManager.GetApiCategories()
+            .FirstOrDefault(configured =>
+                string.Equals(configured, requestedCategory, StringComparison.OrdinalIgnoreCase))
+            ?? "unknown";
         var source = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
         var key = $"{mode}|{category}|{source}";
         if (!AuthenticationFailureThrottle.ShouldLog(key, AuthenticationFailureLogInterval, out var suppressed))

--- a/backend/Api/SabControllers/SabApiController.cs
+++ b/backend/Api/SabControllers/SabApiController.cs
@@ -29,6 +29,7 @@ using NzbWebDAV.Extensions;
 using NzbWebDAV.Logging;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Websocket;
+using Serilog;
 
 namespace NzbWebDAV.Api.SabControllers;
 
@@ -44,6 +45,9 @@ public class SabApiController(
     WarningLogBuffer warningLogBuffer
 ) : ControllerBase
 {
+    private static readonly LogThrottle AuthenticationFailureThrottle = new();
+    private static readonly TimeSpan AuthenticationFailureLogInterval = TimeSpan.FromMinutes(5);
+
     [HttpGet]
     [HttpPost]
     public async Task<IActionResult> HandleApiRequests()
@@ -72,6 +76,7 @@ public class SabApiController(
         }
         catch (UnauthorizedAccessException e)
         {
+            LogAuthenticationFailure();
             return Unauthorized(new SabBaseResponse()
             {
                 Status = false,
@@ -87,6 +92,24 @@ public class SabApiController(
                 Error = "An internal server error occurred."
             });
         }
+    }
+
+    private void LogAuthenticationFailure()
+    {
+        var mode = HttpContext.GetRequestParam("mode") ?? "unknown";
+        var category = HttpContext.GetRequestParam("cat") ?? "none";
+        var source = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        var key = $"{mode}|{category}|{source}";
+        if (!AuthenticationFailureThrottle.ShouldLog(key, AuthenticationFailureLogInterval, out var suppressed))
+            return;
+
+        Log.Warning(
+            "SAB API authentication rejected for mode {Mode}, category {Category}, source {Source}. " +
+            "Update the configured API key; {SuppressedCount} matching failures were suppressed.",
+            mode,
+            category,
+            source,
+            suppressed);
     }
 
     public BaseController GetController()

--- a/backend/Api/SabControllers/SabApiController.cs
+++ b/backend/Api/SabControllers/SabApiController.cs
@@ -112,7 +112,10 @@ public class SabApiController(
                 string.Equals(configured, requestedCategory, StringComparison.OrdinalIgnoreCase))
             ?? "unknown";
         var source = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
-        var key = $"{mode}|{category}|{source}";
+        // Source remains useful event context, but it must not be part of the
+        // process-lifetime throttle key: unauthenticated clients can generate
+        // an unbounded number of distinct remote addresses.
+        var key = $"{mode}|{category}";
         if (!AuthenticationFailureThrottle.ShouldLog(key, AuthenticationFailureLogInterval, out var suppressed))
             return;
 

--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -225,6 +225,7 @@ public class DavDatabaseContext : DbContext
     public IReadOnlyList<DavNzbFile> BlobNzbFiles => _blobNzbFiles;
     public IReadOnlyList<DavRarFile> BlobRarFiles => _blobRarFiles;
     public IReadOnlyList<DavMultipartFile> BlobMultipartFiles => _blobMultipartFiles;
+    internal bool SuppressAutomaticRcloneVfsForget { get; set; }
 
     public void AddBlob(DavNzbFile file) => _blobNzbFiles.Add(file);
     public void AddBlob(DavRarFile file) => _blobRarFiles.Add(file);
@@ -1010,7 +1011,8 @@ public class DavDatabaseContext : DbContext
             // save db changes
             var addedOrRemovedDavItems = GetAddedOrRemovedDavItems();
             var result = await base.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-            _ = RcloneVfsForget(addedOrRemovedDavItems, cancellationToken);
+            if (!SuppressAutomaticRcloneVfsForget)
+                _ = RcloneVfsForget(addedOrRemovedDavItems, cancellationToken);
 
             // clear pending blob writes
             ClearBlobs();
@@ -1041,7 +1043,7 @@ public class DavDatabaseContext : DbContext
             .ToList();
     }
 
-    private static List<string> GetRcloneVfsForgetDirectories(List<DavItem> addedOrRemoved)
+    internal static List<string> GetRcloneVfsForgetDirectories(List<DavItem> addedOrRemoved)
     {
         var contentDirs = addedOrRemoved
             .Select(x => x.Path)

--- a/backend/Queue/PostProcessors/FinalMediaReadinessValidator.cs
+++ b/backend/Queue/PostProcessors/FinalMediaReadinessValidator.cs
@@ -1,0 +1,112 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Queue.PostProcessors;
+
+/// <summary>
+/// Reads the opening and closing bytes of direct media outputs before SAB reports
+/// completion. This intentionally runs only for categories that already opted into
+/// article-health checks: it is an additional BODY-level signal, not a global delay.
+/// </summary>
+internal sealed class FinalMediaReadinessValidator(
+    DavDatabaseClient dbClient,
+    INntpClient usenetClient,
+    ConfigManager configManager)
+{
+    private const int ProbeBytes = VideoSignatureUtil.First16KBLength;
+
+    public async Task ValidateAsync(CancellationToken ct)
+    {
+        var items = dbClient.Ctx.ChangeTracker.Entries<DavItem>()
+            .Where(entry => entry.State == EntityState.Added)
+            .Select(entry => entry.Entity)
+            .Where(item => item.SubType == DavItem.ItemSubType.NzbFile && FilenameUtil.IsMediaFile(item.Name))
+            .ToList();
+
+        foreach (var item in items)
+        {
+            var payload = dbClient.Ctx.NzbFiles.Local.FirstOrDefault(file => file.Id == item.Id);
+            if (payload is null)
+                throw new NonRetryableDownloadException(
+                    $"Import readiness check could not load media payload for {item.Name}.");
+
+            try
+            {
+                await using var stream = usenetClient.GetFileStream(
+                    payload.SegmentIds,
+                    item.FileSize ?? 0,
+                    configManager.GetArticleBufferSize(),
+                    payload.SegmentByteRanges,
+                    configManager.IsPipelinedBodyRequestsEnabled(),
+                    item.Path,
+                    payload.SegmentFallbackIds,
+                    useContainerAwareFill: configManager.IsContainerAwareFillEnabled(),
+                    streamingBodyBatchWidth: configManager.GetStreamingBodyBatchWidth());
+
+                var head = await ReadExactlyAtAsync(stream, 0, Math.Min(ProbeBytes, item.FileSize ?? 0), ct)
+                    .ConfigureAwait(false);
+                ValidateContainerSignature(item, head);
+
+                var tailStart = Math.Max(0, (item.FileSize ?? 0) - ProbeBytes);
+                _ = await ReadExactlyAtAsync(stream, tailStart, (item.FileSize ?? 0) - tailStart, ct)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception e) when (e.IsNonRetryableDownloadException())
+            {
+                throw new NonRetryableDownloadException(
+                    $"Import readiness check found unreadable media bytes for {item.Name}.", e);
+            }
+            catch (Exception e) when (e is not OutOfMemoryException && !e.IsCancellationException(ct))
+            {
+                throw new RetryableDownloadException(
+                    $"Import readiness check could not read media bytes for {item.Name}.", e);
+            }
+        }
+    }
+
+    private static async Task<byte[]> ReadExactlyAtAsync(Stream stream, long position, long length, CancellationToken ct)
+    {
+        if (length <= 0)
+            throw new NonRetryableDownloadException("Import readiness check found an empty media file.");
+
+        stream.Position = position;
+        var buffer = new byte[length];
+        var read = 0;
+        while (read < buffer.Length)
+        {
+            var count = await stream.ReadAsync(buffer.AsMemory(read), ct).ConfigureAwait(false);
+            if (count == 0)
+                throw new NonRetryableDownloadException(
+                    $"Import readiness check received {read} of {buffer.Length} expected bytes.");
+            read += count;
+        }
+
+        return buffer;
+    }
+
+    private static void ValidateContainerSignature(DavItem item, byte[] head)
+    {
+        var extension = Path.GetExtension(item.Name);
+        var expected = extension.Equals(".mkv", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".webm", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".mp4", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".m4v", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".avi", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".wmv", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".flv", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".mpg", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".mpeg", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".ts", StringComparison.OrdinalIgnoreCase);
+        if (expected && VideoSignatureUtil.GuessVideoExtension(head) is null)
+        {
+            throw new NonRetryableDownloadException(
+                $"Import readiness check found an invalid media container header for {item.Name}.");
+        }
+    }
+}

--- a/backend/Queue/PostProcessors/FinalMediaReadinessValidator.cs
+++ b/backend/Queue/PostProcessors/FinalMediaReadinessValidator.cs
@@ -31,7 +31,9 @@ internal sealed class FinalMediaReadinessValidator(
 
         foreach (var item in items)
         {
-            var payload = dbClient.Ctx.NzbFiles.Local.FirstOrDefault(file => file.Id == item.Id);
+            var payload = item.FileBlobId is { } blobId
+                ? dbClient.Ctx.BlobNzbFiles.FirstOrDefault(file => file.Id == blobId)
+                : null;
             if (payload is null)
                 throw new NonRetryableDownloadException(
                     $"Import readiness check could not load media payload for {item.Name}.");

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -513,6 +513,14 @@ public class QueueItemProcessor(
             if (configManager.IsEnsureImportableMediaEnabled())
                 new EnsureImportableMediaValidator(dbClient).ThrowIfValidationFails();
 
+            if (healthCheckCategories.Contains(queueItem.Category.ToLowerInvariant()))
+            {
+                await RunStageAsync(
+                    "import-readiness",
+                    () => new FinalMediaReadinessValidator(dbClient, usenetClient, configManager)
+                        .ValidateAsync(ct)).ConfigureAwait(false);
+            }
+
             // create strm files, if necessary
             if (configManager.GetImportStrategy() == "strm")
                 await new CreateStrmFilesPostProcessor(configManager, dbClient, queueItem.Id)
@@ -804,6 +812,7 @@ public class QueueItemProcessor(
         HistoryItem? historyItem = null;
         string? historyJson = null;
         IReadOnlyDictionary<string, long>? providerUsage = null;
+        List<string>? vfsForgetPaths = null;
 
         await WithFinalizeLockAsync(async () =>
         {
@@ -819,7 +828,20 @@ public class QueueItemProcessor(
                 historyItem, mountFolder, configManager, providerUsage, displayByMetricsKey).ToJson();
             dbClient.Ctx.QueueItems.Remove(queueItem);
             dbClient.Ctx.HistoryItems.Add(historyItem);
-            await dbClient.Ctx.SaveChangesAsync(finalizeCt).ConfigureAwait(false);
+            vfsForgetPaths = DavDatabaseContext.GetRcloneVfsForgetDirectories(
+                dbClient.Ctx.ChangeTracker.Entries<DavItem>()
+                    .Where(entry => entry.State is EntityState.Added or EntityState.Deleted)
+                    .Select(entry => entry.Entity)
+                    .ToList());
+            dbClient.Ctx.SuppressAutomaticRcloneVfsForget = true;
+            try
+            {
+                await dbClient.Ctx.SaveChangesAsync(finalizeCt).ConfigureAwait(false);
+            }
+            finally
+            {
+                dbClient.Ctx.SuppressAutomaticRcloneVfsForget = false;
+            }
         }, finalizeCt).ConfigureAwait(false);
 
         try
@@ -827,7 +849,8 @@ public class QueueItemProcessor(
             _ = websocketManager.SendMessage(WebsocketTopic.QueueItemRemoved, queueItem.Id.ToString());
             _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemAdded, historyJson!);
             _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"], ct);
-            _ = RefreshMonitoredDownloads();
+            await ForgetVfsBeforeArrRefreshAsync(vfsForgetPaths).ConfigureAwait(false);
+            await RefreshMonitoredDownloads().ConfigureAwait(false);
             if (error is null)
             {
                 Log.Information(
@@ -940,6 +963,22 @@ public class QueueItemProcessor(
             .GetArrClients()
             .Select(RefreshMonitoredDownloads);
         await Task.WhenAll(tasks).ConfigureAwait(false);
+    }
+
+    private async Task ForgetVfsBeforeArrRefreshAsync(List<string>? paths)
+    {
+        if (paths is not { Count: > 0 }) return;
+
+        using var forgetCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        forgetCts.CancelAfter(TimeSpan.FromSeconds(10));
+        try
+        {
+            await DavDatabaseContext.RcloneVfsForget(paths, forgetCts.Token).ConfigureAwait(false);
+        }
+        catch (Exception e) when (e is HttpRequestException or TaskCanceledException or InvalidOperationException)
+        {
+            Log.Debug(e, "Could not invalidate rclone VFS before refreshing monitored downloads");
+        }
     }
 
     private async Task RefreshMonitoredDownloads(ArrClient arrClient)

--- a/backend/Services/ArrHealthService.cs
+++ b/backend/Services/ArrHealthService.cs
@@ -216,7 +216,7 @@ public sealed class ArrHealthService : BackgroundService
                 .MaxAsync(ct).ConfigureAwait(false);
 
             var now = DateTimeOffset.UtcNow;
-            var unusual = awaiting.Any(item =>
+            var unusual = awaiting.Items.Any(item =>
                 ArrHealthMath.IsUnusual(
                     ArrHealthMath.ComputeWaitingMs(item.CreatedAt, now),
                     median,
@@ -236,7 +236,7 @@ public sealed class ArrHealthService : BackgroundService
                 Host = details.Host,
                 Status = status,
                 QueueCount = queueStatus.TotalCount,
-                AwaitingCount = awaiting.Count,
+                AwaitingCount = awaiting.TotalCount,
                 HasWarnings = hasWarnings,
                 HasErrors = hasErrors,
                 LastImportAtMs = lastImport,
@@ -244,7 +244,7 @@ public sealed class ArrHealthService : BackgroundService
                 LastError = null,
                 MedianHandoffMs30d = median,
                 MedianSampleCount30d = handoffs.Count,
-                Awaiting = awaiting,
+                Awaiting = awaiting.Items,
             });
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -361,13 +361,18 @@ public sealed class ArrHealthService : BackgroundService
         }
     }
 
-    private static async Task<List<ArrAwaitingSnapshot>> BuildAwaitingAsync(
+    private static async Task<AwaitingBuildResult> BuildAwaitingAsync(
         IReadOnlyList<ArrQueueRecord> records,
         DavDatabaseContext dav,
         CancellationToken ct)
     {
-        var awaitingRecords = records.Where(r => r.IsAwaitingImport).Take(MaxAwaitingPerInstance).ToList();
-        if (awaitingRecords.Count == 0) return [];
+        var allAwaitingRecords = records.Where(r => r.IsAwaitingImport).ToList();
+        if (allAwaitingRecords.Count == 0) return new AwaitingBuildResult(0, []);
+
+        // Correlate the full import-pending population first: Arr does not
+        // guarantee queue ordering, so truncating before we know CreatedAt can
+        // hide the oldest stuck imports.
+        var awaitingRecords = allAwaitingRecords;
 
         var downloadIds = awaitingRecords
             .Select(record => Guid.TryParse(record.DownloadId, out var id) ? id : (Guid?)null)
@@ -385,7 +390,7 @@ public sealed class ArrHealthService : BackgroundService
                 .ToDictionaryAsync(h => h.Id, h => h.CreatedAt, ct).ConfigureAwait(false);
         }
 
-        return awaitingRecords.Select(record =>
+        var items = awaitingRecords.Select(record =>
         {
             Guid? downloadId = Guid.TryParse(record.DownloadId, out var parsed) ? parsed : null;
             DateTime? createdAt = downloadId is { } id && createdAtById.TryGetValue(id, out var at) ? at : null;
@@ -394,9 +399,20 @@ public sealed class ArrHealthService : BackgroundService
                 Title = record.Title,
                 DownloadId = downloadId,
                 CreatedAt = createdAt,
+                TrackedDownloadState = record.TrackedDownloadState,
+                StatusReason = record.StatusMessages
+                    .SelectMany(message => message.Messages)
+                    .FirstOrDefault(message => !string.IsNullOrWhiteSpace(message)),
             };
-        }).ToList();
+        })
+        .OrderBy(item => item.CreatedAt ?? DateTime.MaxValue)
+        .Take(MaxAwaitingPerInstance)
+        .ToList();
+
+        return new AwaitingBuildResult(allAwaitingRecords.Count, items);
     }
+
+    private sealed record AwaitingBuildResult(int TotalCount, List<ArrAwaitingSnapshot> Items);
 
     private void RecordSuccess(ArrHealthSnapshot snapshot)
     {

--- a/backend/Services/ArrHealthSnapshot.cs
+++ b/backend/Services/ArrHealthSnapshot.cs
@@ -32,4 +32,6 @@ public sealed record ArrAwaitingSnapshot
     public string? Title { get; init; }
     public Guid? DownloadId { get; init; }
     public DateTime? CreatedAt { get; init; }
+    public string? TrackedDownloadState { get; init; }
+    public string? StatusReason { get; init; }
 }

--- a/docs/configuration/arrs.md
+++ b/docs/configuration/arrs.md
@@ -49,6 +49,12 @@ Disabling an instance opts it out of stuck-queue actions, Arr-linked repairs, an
 
 When at least one Radarr or Sonarr instance is configured **and enabled**, Overview shows a compact **Arr Health** section: instance reachability, imports in the selected dashboard window, median/P95 handoff latency (InfiniDysk download completed → Arr `DownloadFolderImported`), queue depth, and items waiting unusually long for import.
 
+**Queue** is every item Arr currently tracks. **Awaiting** is the completed or
+`importPending`/`importing` subset, so the two counts intentionally differ.
+The widget reports the true Awaiting total while showing only its longest waits;
+each displayed row includes the Arr status reason when one is available. Related
+season-pack rows with the same download are grouped in the detail list.
+
 The feature is **completely dormant** otherwise:
 
 - No Overview widget

--- a/docs/configuration/arrs.md
+++ b/docs/configuration/arrs.md
@@ -49,6 +49,8 @@ Disabling an instance opts it out of stuck-queue actions, Arr-linked repairs, an
 
 When at least one Radarr or Sonarr instance is configured **and enabled**, Overview shows a compact **Arr Health** section: instance reachability, imports in the selected dashboard window, median/P95 handoff latency (InfiniDysk download completed → Arr `DownloadFolderImported`), queue depth, and items waiting unusually long for import.
 
+## Awaiting detail [since 1.2.5](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.5){ .nzbdav-since }
+
 **Queue** is every item Arr currently tracks. **Awaiting** is the completed or
 `importPending`/`importing` subset, so the two counts intentionally differ.
 The widget reports the true Awaiting total while showing only its longest waits;

--- a/docs/configuration/sabnzbd.md
+++ b/docs/configuration/sabnzbd.md
@@ -58,7 +58,7 @@ the middle of a release can only be detected when that part is read.
 
 After rotating `api.key`, update the API key in every configured Sonarr/Radarr
 download-client entry and use its test action before resuming a bulk search.
-Rejected SAB API requests are logged without exposing the key, with repeated
-identical failures throttled.
+Rejected SAB API requests are logged without exposing the key, with failures
+for the same mode and category throttled.
 
 [Import strategies](../guides/import-strategies.md) · [Queue settings](queue.md)

--- a/docs/configuration/sabnzbd.md
+++ b/docs/configuration/sabnzbd.md
@@ -23,7 +23,7 @@ SABnzbd-compatible download client API used by Radarr/Sonarr. See also [API comp
 | Trusted local hosts [since 0.8.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.8.0){ .nzbdav-since } | `api.addurl-trusted-hosts` | env `TRUSTED_INTERNAL_HOSTS` | SSRF allowlist for private addurl |
 | Fail downloads without video or audio | `api.ensure-importable-video` | on | Reject NZBs with no media files |
 | Fail when non-media missing articles | inverse of `api.skip-non-video-on-missing-articles` | skip non-media by default | Media files (video/audio) always fail on missing articles; companion files are skipped unless this is enabled |
-| Article health check categories | `api.ensure-article-existence-categories` | empty (off) | Per-category STAT checks plus a final direct-media BODY readiness read; may be slow |
+| Article health check categories [since 1.2.5](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.5){ .nzbdav-since } | `api.ensure-article-existence-categories` | empty (off) | Per-category STAT checks plus a final direct-media BODY readiness read; may be slow |
 | Article health check mode | `api.article-existence-check-mode` | `full` | Full or per-file sampled verification |
 | Always send full History | `api.ignore-history-limit` | on | Ignore client history limit |
 | Save backup copies of incoming NZBs | `api.nzb-backup-enabled` | off | On-disk `*.nzb` copies |
@@ -49,7 +49,7 @@ checks. It is a screen rather than a guarantee: urgent repair remains the
 backstop if an article disappears later or STAT succeeds while BODY fails.
 
 For selected categories, InfiniDysk also reads the head and tail of direct media
-outputs before reporting a successful SAB completion. This rejects unreadable
+outputs before reporting a successful SAB completion [since 1.2.5](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.5){ .nzbdav-since }. This rejects unreadable
 container headers and short reads before Sonarr or Radarr begin import. It does
 not replace streaming corruption detection or PAR2 repair: damage limited to
 the middle of a release can only be detected when that part is read.

--- a/docs/configuration/sabnzbd.md
+++ b/docs/configuration/sabnzbd.md
@@ -54,7 +54,7 @@ container headers and short reads before Sonarr or Radarr begin import. It does
 not replace streaming corruption detection or PAR2 repair: damage limited to
 the middle of a release can only be detected when that part is read.
 
-## API-key rotation
+## API-key rotation [since 1.2.5](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.5){ .nzbdav-since }
 
 After rotating `api.key`, update the API key in every configured Sonarr/Radarr
 download-client entry and use its test action before resuming a bulk search.

--- a/docs/configuration/sabnzbd.md
+++ b/docs/configuration/sabnzbd.md
@@ -23,7 +23,7 @@ SABnzbd-compatible download client API used by Radarr/Sonarr. See also [API comp
 | Trusted local hosts [since 0.8.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.8.0){ .nzbdav-since } | `api.addurl-trusted-hosts` | env `TRUSTED_INTERNAL_HOSTS` | SSRF allowlist for private addurl |
 | Fail downloads without video or audio | `api.ensure-importable-video` | on | Reject NZBs with no media files |
 | Fail when non-media missing articles | inverse of `api.skip-non-video-on-missing-articles` | skip non-media by default | Media files (video/audio) always fail on missing articles; companion files are skipped unless this is enabled |
-| Article health check categories | `api.ensure-article-existence-categories` | empty (off) | Per-category; may be slow |
+| Article health check categories | `api.ensure-article-existence-categories` | empty (off) | Per-category STAT checks plus a final direct-media BODY readiness read; may be slow |
 | Article health check mode | `api.article-existence-check-mode` | `full` | Full or per-file sampled verification |
 | Always send full History | `api.ignore-history-limit` | on | Ignore client history limit |
 | Save backup copies of incoming NZBs | `api.nzb-backup-enabled` | off | On-disk `*.nzb` copies |
@@ -47,5 +47,18 @@ Small files (currently up to roughly 8,000 segments) are still checked in full.
 The sampled mode uses the same standard-depth selection as background health
 checks. It is a screen rather than a guarantee: urgent repair remains the
 backstop if an article disappears later or STAT succeeds while BODY fails.
+
+For selected categories, InfiniDysk also reads the head and tail of direct media
+outputs before reporting a successful SAB completion. This rejects unreadable
+container headers and short reads before Sonarr or Radarr begin import. It does
+not replace streaming corruption detection or PAR2 repair: damage limited to
+the middle of a release can only be detected when that part is read.
+
+## API-key rotation
+
+After rotating `api.key`, update the API key in every configured Sonarr/Radarr
+download-client entry and use its test action before resuming a bulk search.
+Rejected SAB API requests are logged without exposing the key, with repeated
+identical failures throttled.
 
 [Import strategies](../guides/import-strategies.md) · [Queue settings](queue.md)

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -1006,6 +1006,7 @@ export type ArrHealthSummary = {
   medianHandoffMs: number | null;
   p95HandoffMs: number | null;
   awaitingImport: number;
+  awaitingShown: number;
   degraded: number;
 };
 
@@ -1020,16 +1021,21 @@ export type ArrHealthInstanceRow = {
   p95HandoffMs: number | null;
   queueCount: number;
   awaitingCount: number;
+  hasWarnings: boolean;
+  hasErrors: boolean;
   lastImportAtMs: number | null;
   lastError: string | null;
 };
 
 export type ArrAwaitingItem = {
   title: string | null;
+  downloadId: string | null;
   instanceKey: string;
   instanceName: string;
   waitingMs: number | null;
   isUnusual: boolean;
+  trackedDownloadState: string | null;
+  statusReason: string | null;
 };
 
 export type ArrHealthResponse = {

--- a/frontend/app/routes/overview/components/arr-health/arr-health.test.tsx
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.test.tsx
@@ -11,6 +11,7 @@ const emptySummary = {
   medianHandoffMs: null,
   p95HandoffMs: null,
   awaitingImport: 0,
+  awaitingShown: 0,
   degraded: 0,
 };
 
@@ -33,6 +34,7 @@ describe("ArrHealth", () => {
         medianHandoffMs: 7800,
         p95HandoffMs: 21000,
         awaitingImport: 3,
+        awaitingShown: 0,
         degraded: 1,
       },
       instances: [
@@ -47,6 +49,8 @@ describe("ArrHealth", () => {
           p95HandoffMs: 21000,
           queueCount: 0,
           awaitingCount: 0,
+          hasWarnings: false,
+          hasErrors: false,
           lastImportAtMs: Date.now() - 180_000,
           lastError: null,
         },
@@ -61,6 +65,8 @@ describe("ArrHealth", () => {
           p95HandoffMs: 138000,
           queueCount: 3,
           awaitingCount: 3,
+          hasWarnings: false,
+          hasErrors: false,
           lastImportAtMs: Date.now() - 19 * 60_000,
           lastError: null,
         },
@@ -75,6 +81,8 @@ describe("ArrHealth", () => {
           p95HandoffMs: null,
           queueCount: 0,
           awaitingCount: 0,
+          hasWarnings: false,
+          hasErrors: false,
           lastImportAtMs: null,
           lastError: "Unreachable",
         },
@@ -89,6 +97,8 @@ describe("ArrHealth", () => {
           p95HandoffMs: null,
           queueCount: 0,
           awaitingCount: 0,
+          hasWarnings: false,
+          hasErrors: false,
           lastImportAtMs: null,
           lastError: null,
         },
@@ -129,6 +139,7 @@ describe("ArrHealth", () => {
         instancesOnline: 1,
         instancesTotal: 1,
         awaitingImport: 2,
+        awaitingShown: 2,
       },
       instances: [
         {
@@ -142,6 +153,8 @@ describe("ArrHealth", () => {
           p95HandoffMs: 20000,
           queueCount: 2,
           awaitingCount: 2,
+          hasWarnings: false,
+          hasErrors: false,
           lastImportAtMs: null,
           lastError: null,
         },
@@ -149,17 +162,23 @@ describe("ArrHealth", () => {
       awaiting: [
         {
           title: "Example Show S04E06",
+          downloadId: null,
           instanceKey: "sonarr|http://sonarr:8989",
           instanceName: "Sonarr Main",
           waitingMs: 47 * 60_000,
           isUnusual: true,
+          trackedDownloadState: "importPending",
+          statusReason: "Invalid data found when processing input",
         },
         {
           title: "Unknown release",
+          downloadId: null,
           instanceKey: "sonarr|http://sonarr:8989",
           instanceName: "Sonarr Main",
           waitingMs: null,
           isUnusual: false,
+          trackedDownloadState: null,
+          statusReason: null,
         },
       ],
     });
@@ -168,6 +187,8 @@ describe("ArrHealth", () => {
     expect(markup).toContain("unusually long");
     expect(markup).toContain("text-warning");
     expect(markup).toContain("waiting —");
+    expect(markup).toContain("2 of 2 longest waits");
+    expect(markup).toContain("Invalid data found when processing input");
   });
 
   it("notes the 90-day retention on the All window", () => {

--- a/frontend/app/routes/overview/components/arr-health/arr-health.test.tsx
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.test.tsx
@@ -189,6 +189,7 @@ describe("ArrHealth", () => {
     expect(markup).toContain("waiting —");
     expect(markup).toContain("2 of 2 longest waits");
     expect(markup).toContain("Invalid data found when processing input");
+    expect(markup).not.toContain("2 affected items");
   });
 
   it("notes the 90-day retention on the All window", () => {

--- a/frontend/app/routes/overview/components/arr-health/arr-health.test.tsx
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.test.tsx
@@ -171,7 +171,7 @@ describe("ArrHealth", () => {
           statusReason: "Invalid data found when processing input",
         },
         {
-          title: "Unknown release",
+          title: "Example Show S04E06",
           downloadId: null,
           instanceKey: "sonarr|http://sonarr:8989",
           instanceName: "Sonarr Main",

--- a/frontend/app/routes/overview/components/arr-health/arr-health.tsx
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.tsx
@@ -23,6 +23,18 @@ const STATUS_BADGE: Record<ArrInstanceStatus, string> = {
 export function ArrHealth({ data, window }: ArrHealthProps) {
   const { summary, instances, awaiting } = data;
   const sinceLabel = window === "all" ? "all time (~90 days of stored events)" : `last ${window}`;
+  const groupedAwaiting = Array.from(
+    awaiting.reduce((groups, item) => {
+      const key = `${item.instanceKey}:${item.downloadId ?? item.title ?? "item"}`;
+      const group = groups.get(key);
+      if (group) {
+        group.items.push(item);
+      } else {
+        groups.set(key, { ...item, items: [item] });
+      }
+      return groups;
+    }, new Map<string, (typeof awaiting)[number] & { items: (typeof awaiting)[number][] }>()),
+  ).map(([, group]) => group);
 
   return (
     <section className="card w-full min-w-0 border border-base-content/10 bg-base-100 shadow-sm">
@@ -63,8 +75,16 @@ export function ArrHealth({ data, window }: ArrHealthProps) {
                   <th>Imports</th>
                   <th>Median</th>
                   <th>P95</th>
-                  <th>Queue</th>
-                  <th>Awaiting</th>
+                  <th>
+                    <Tooltip content="All items currently in this Arr instance's queue.">
+                      <span className="cursor-help">Queue</span>
+                    </Tooltip>
+                  </th>
+                  <th>
+                    <Tooltip content="Completed downloads that Arr is still importing or has marked import pending.">
+                      <span className="cursor-help">Awaiting</span>
+                    </Tooltip>
+                  </th>
                   <th>Last import</th>
                 </tr>
               </thead>
@@ -113,16 +133,16 @@ export function ArrHealth({ data, window }: ArrHealthProps) {
           <p className="text-xs text-base-content/50">No imports recorded yet.</p>
         )}
 
-        {awaiting.length > 0 && (
+        {groupedAwaiting.length > 0 && (
           <div>
             <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
               <h4 className="text-xs uppercase tracking-wide text-base-content/50">
-                Awaiting import
+                Awaiting import — {summary.awaitingShown} of {summary.awaitingImport} longest waits
               </h4>
               <WidgetLink to="/queue">Open queue</WidgetLink>
             </div>
             <ul className="list bg-base-100 p-0">
-              {awaiting.map((item, index) => (
+              {groupedAwaiting.map((item, index) => (
                 <li
                   key={`${item.instanceKey}-${item.title ?? "item"}-${index}`}
                   className={`list-row py-2 text-xs ${item.isUnusual ? "text-warning" : "text-base-content/80"}`}
@@ -131,6 +151,11 @@ export function ArrHealth({ data, window }: ArrHealthProps) {
                     {item.title ?? "(untitled)"} — {item.instanceName} — waiting{" "}
                     {formatDurationMs(item.waitingMs)}
                     {item.isUnusual ? " — unusually long" : ""}
+                    {item.statusReason ? ` — ${item.statusReason}` : ""}
+                    {!item.statusReason && item.trackedDownloadState
+                      ? ` — ${item.trackedDownloadState}`
+                      : ""}
+                    {item.items.length > 1 ? ` — ${item.items.length} affected items` : ""}
                   </div>
                 </li>
               ))}

--- a/frontend/app/routes/overview/components/arr-health/arr-health.tsx
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.tsx
@@ -3,7 +3,6 @@ import type {
   ArrInstanceStatus,
   OverviewWindow,
 } from "~/clients/backend-client.server";
-import { Tooltip } from "~/components/ui";
 import { formatDurationMs, formatNumber, formatTimeAgo } from "../../utils/format";
 import { settingsPath } from "~/navigation/settings-tabs";
 import { Tooltip } from "~/components/ui";

--- a/frontend/app/routes/overview/components/arr-health/arr-health.tsx
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.tsx
@@ -3,6 +3,7 @@ import type {
   ArrInstanceStatus,
   OverviewWindow,
 } from "~/clients/backend-client.server";
+import { Tooltip } from "~/components/ui";
 import { formatDurationMs, formatNumber, formatTimeAgo } from "../../utils/format";
 import { settingsPath } from "~/navigation/settings-tabs";
 import { Tooltip } from "~/components/ui";
@@ -24,8 +25,10 @@ export function ArrHealth({ data, window }: ArrHealthProps) {
   const { summary, instances, awaiting } = data;
   const sinceLabel = window === "all" ? "all time (~90 days of stored events)" : `last ${window}`;
   const groupedAwaiting = Array.from(
-    awaiting.reduce((groups, item) => {
-      const key = `${item.instanceKey}:${item.downloadId ?? item.title ?? "item"}`;
+    awaiting.reduce((groups, item, index) => {
+      const key = item.downloadId
+        ? `${item.instanceKey}:${item.downloadId}`
+        : `${item.instanceKey}:unidentified:${index}`;
       const group = groups.get(key);
       if (group) {
         group.items.push(item);


### PR DESCRIPTION
## Summary
- validate direct-media headers and tail reads before selected Arr categories report SAB completion
- invalidate rclone VFS before nudging Arr and log throttled, secret-free SAB authentication failures
- make Arr Health show true awaiting totals, longest waits, and Arr-provided reasons

## Test plan
- [x] `dotnet build backend/NzbWebDAV.csproj -c Release --no-restore`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore --filter \"FullyQualifiedName~ArrHealth\"`
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm test -- --run app/routes/overview/components/arr-health/arr-health.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Arr Health displays warning and error indicators for each instance.
  - Awaiting items show download states, status reasons, affected-item counts, and displayed versus total counts.
  - Related awaiting items are grouped by instance and download.
  - Queue and Awaiting sections include explanatory tooltips.
  - Completed downloads receive additional media-readiness validation before finalization.

- **Bug Fixes**
  - Improved handling of incomplete, empty, truncated, or invalid media downloads.
  - Awaiting totals and longest-wait information now reflect the full queue accurately.
  - Repeated authentication failures are logged with throttling.

- **Documentation**
  - Updated Arr Health and article health-check guidance, including API-key rotation recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->