### PR TITLE
fix(health): enable health checks and PAR2 repair without Radarr or Sonarr

### DIFF
--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1830,30 +1830,19 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
     }
 
     /// <summary>
-    /// When repairs are not fully enabled, returns a human-readable reason naming the missing prerequisite.
+    /// When repairs are disabled, returns a human-readable reason.
     /// </summary>
     public string? GetRepairDisabledReason()
     {
         var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairEnable));
         var isRepairJobEnabled = configValue != null && bool.Parse(configValue);
-        var hasLibraryDir = GetLibraryDir() != null;
-        var arrInstanceCount = GetArrConfig().GetInstanceCount();
-        return GetRepairDisabledReason(isRepairJobEnabled, hasLibraryDir, arrInstanceCount);
+        return GetRepairDisabledReason(isRepairJobEnabled);
     }
 
-    internal static string? GetRepairDisabledReason(
-        bool isRepairEnabled,
-        bool hasLibraryDir,
-        int arrInstanceCount)
+    internal static string? GetRepairDisabledReason(bool isRepairEnabled)
     {
         if (!isRepairEnabled)
             return "Enable Background Repairs is off";
-
-        if (!hasLibraryDir)
-            return "Library Directory is not set";
-
-        if (arrInstanceCount <= 0)
-            return "no Radarr/Sonarr instances are configured";
 
         return null;
     }

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -549,8 +549,8 @@ public class HealthCheckService : BackgroundService
                 }
             }
 
-            // when usenet article is missing, try PAR2 repair before Arr remove/re-grab
-            if (_configManager.IsPar2RepairEnabled() && _configManager.IsPar2PreferredOverArr()
+            // When no Arr replacement is available, PAR2 remains the only automatic recovery path.
+            if (ShouldAttemptPar2Repair()
                 && await _par2RepairService.TryPar2RepairAsync(davItem, [e.SegmentId], ct).ConfigureAwait(false))
             {
                 var utcNow = DateTimeOffset.UtcNow;
@@ -632,7 +632,8 @@ public class HealthCheckService : BackgroundService
         var holeSegmentIds = holeIndices.Select(index => segments[index]).ToArray();
 
         // PAR2 first, with the full hole list: reconstruct from parity before any verdict.
-        if (_configManager.IsPar2RepairEnabled() && _configManager.IsPar2PreferredOverArr()
+        // It is also the only automatic recovery path when no Arr replacement is available.
+        if (ShouldAttemptPar2Repair()
             && await _par2RepairService.TryPar2RepairAsync(davItem, holeSegmentIds, ct).ConfigureAwait(false))
         {
             var utcNow = DateTimeOffset.UtcNow;
@@ -1629,7 +1630,7 @@ public class HealthCheckService : BackgroundService
             return;
         }
 
-        if (_configManager.IsPar2RepairEnabled() && _configManager.IsPar2PreferredOverArr()
+        if (ShouldAttemptPar2Repair()
             && await _par2RepairService.TryPar2RepairAsync(davItem, null, ct).ConfigureAwait(false))
         {
             var utcNow = DateTimeOffset.UtcNow;
@@ -1652,6 +1653,15 @@ public class HealthCheckService : BackgroundService
             ct,
             forceDelete: disposition == UrgentRepairDisposition.ForceDelete,
             streamingFailureCount: failureCount).ConfigureAwait(false);
+    }
+
+    private bool ShouldAttemptPar2Repair()
+    {
+        if (!_configManager.IsPar2RepairEnabled())
+            return false;
+
+        return _configManager.IsPar2PreferredOverArr()
+               || !_configManager.GetArrConfig().GetArrClients().Any();
     }
 
     private async Task Repair(
@@ -1689,6 +1699,7 @@ public class HealthCheckService : BackgroundService
             // A missing library link is not proof that the item is orphaned: a FUSE mount can
             // temporarily present a successfully empty or partial view. Only an explicit
             // force-delete policy may remove the item from this branch.
+            var libraryDir = _configManager.GetLibraryDir();
             var symlinkOrStrmPath = OrganizedLinksUtil.GetLink(davItem, _configManager);
             var linkDisposition = GetLibraryLinkRepairDisposition(symlinkOrStrmPath, forceDelete);
             if (linkDisposition != LibraryLinkRepairDisposition.RepairLinked)
@@ -1741,16 +1752,23 @@ public class HealthCheckService : BackgroundService
                 var utcNow = DateTimeOffset.UtcNow;
                 davItem.LastHealthCheck = utcNow;
                 davItem.NextHealthCheck = utcNow + TimeSpan.FromDays(1);
-                await RecordHealthResult(
-                    dbClient, davItem,
-                    HealthCheckResult.HealthResult.Unhealthy,
-                    HealthCheckResult.RepairAction.ActionNeeded,
-                    string.Join(" ", [
+                var missingLinkMessage = libraryDir == null
+                    ? string.Join(" ", [
+                        "File failed health validation.",
+                        "No Library Directory is configured, so an Arr replacement cannot be determined.",
+                        "The webdav-file was left in place."
+                    ])
+                    : string.Join(" ", [
                         "File failed health validation.",
                         "Could not find a corresponding symlink or strm-file within Library Dir.",
                         "The library scan may be incomplete, so the webdav-file was left in place.",
                         "Use Remove Orphaned Files for deliberate unlinked-item cleanup."
-                    ]), ct).ConfigureAwait(false);
+                    ]);
+                await RecordHealthResult(
+                    dbClient, davItem,
+                    HealthCheckResult.HealthResult.Unhealthy,
+                    HealthCheckResult.RepairAction.ActionNeeded,
+                    missingLinkMessage, ct).ConfigureAwait(false);
                 return;
             }
 
@@ -1791,8 +1809,26 @@ public class HealthCheckService : BackgroundService
             // new filename), so replacement searches are additionally budgeted by the Arr
             // media identity, which stays stable across re-grabs of the same movie/episode.
             var arrConfig = _configManager.GetArrConfig();
+            var arrClients = arrConfig.GetArrClients().ToArray();
+            if (arrClients.Length == 0)
+            {
+                var utcNow = DateTimeOffset.UtcNow;
+                davItem.LastHealthCheck = utcNow;
+                davItem.NextHealthCheck = utcNow + TimeSpan.FromDays(1);
+                await RecordHealthResult(
+                    dbClient, davItem,
+                    HealthCheckResult.HealthResult.Unhealthy,
+                    HealthCheckResult.RepairAction.ActionNeeded,
+                    string.Join(" ", [
+                        "File failed health validation.",
+                        $"Corresponding {linkType} found within Library Dir.",
+                        "No enabled Radarr/Sonarr instances are configured, so replacement was skipped.",
+                        $"The webdav-file and {linkType} were left in place."
+                    ]), ct).ConfigureAwait(false);
+                return;
+            }
             var arrDecision = await DecideArrLinkedRepairAsync(
-                arrConfig.GetArrClients(),
+                arrClients,
                 linkedPath,
                 davItem.HistoryItemId ?? davItem.NzbBlobId,
                 ct,

--- a/backend/Utils/OrganizedLinksUtil.cs
+++ b/backend/Utils/OrganizedLinksUtil.cs
@@ -21,6 +21,9 @@ public static class OrganizedLinksUtil
     /// <returns>The path to a symlink or strm in the organized media library that points to the given target.</returns>
     public static string? GetLink(DavItem targetDavItem, ConfigManager configManager)
     {
+        if (configManager.GetLibraryDir() == null)
+            return null;
+
         return !TryGetLinkFromCache(targetDavItem, configManager, out var linkFromCache)
             ? SearchForLink(targetDavItem, configManager)
             : linkFromCache;
@@ -33,7 +36,10 @@ public static class OrganizedLinksUtil
     /// <returns>All DavItemLinks within the organized media library that point to nzbdav dav-items.</returns>
     public static IEnumerable<DavItemLink> GetLibraryDavItemLinks(ConfigManager configManager)
     {
-        var libraryRoot = configManager.GetLibraryDir()!;
+        var libraryRoot = configManager.GetLibraryDir();
+        if (libraryRoot == null)
+            return [];
+
         var allSymlinksAndStrms = SymlinkAndStrmUtil.GetAllSymlinksAndStrms(libraryRoot);
         return GetDavItemLinks(allSymlinksAndStrms, configManager);
     }

--- a/docs/configuration/repairs.md
+++ b/docs/configuration/repairs.md
@@ -33,7 +33,7 @@ enabled; urgent repairs already queued from streaming failures keep their priori
 !!! note "Streaming failure repair requires Background Repairs"
 
     **Repair After Streaming Failures** (`repair.auto-remove-after-failures`) only takes effect when
-    **Enable Background Repairs** (`repair.enable`) is on. A Library Directory and *Arr are only
+    **Enable Background Repairs** (`repair.enable`) is on. A Library Directory and \*Arr are only
     needed to replace linked library items. Without them, PAR2 can still reconstruct the file and
     threshold-based removal can delete unlinked items.
 
@@ -41,7 +41,7 @@ enabled; urgent repairs already queued from streaming failures keep their priori
 articles, corrupt archives, and seeks that find missing or truncated article data. With a value
 greater than `0`, InfiniDysk waits for that many consecutive failures before it starts an urgent
 repair. At the threshold, linked library items are removed and their original downloads are marked
-failed in *Arr when **Auto-remove unlinked files only** is enabled. *Arr blocklists those releases
+failed in \*Arr when **Auto-remove unlinked files only** is enabled. \*Arr blocklists those releases
 and applies its configured failed-download redownload policy. Unlinked files are removed. Disable
 that option to force-delete linked items at the threshold. With the default value `0`, failed
 unlinked files are kept and surfaced as **Action needed**; set a value greater than `0` to

--- a/docs/configuration/repairs.md
+++ b/docs/configuration/repairs.md
@@ -1,17 +1,17 @@
 # Repairs
 
-Background health monitoring and replacement of unhealthy library items.
+Background health monitoring, PAR2 reconstruction, and replacement of unhealthy library items.
 
 !!! tip "Headless ENV"
 
     Map config keys below to `NZBDAV_CONFIG__...` with the
     [naming algorithm](headless.md#naming-algorithm)
-    (`repair.enable` → `NZBDAV_CONFIG__REPAIR__ENABLE`). Enabling repairs via ENV
-    also needs `media.library-dir` and configured [*Arr instances](arrs.md).
+    (`repair.enable` → `NZBDAV_CONFIG__REPAIR__ENABLE`). A Library Directory and configured
+    [*Arr instances](arrs.md) are optional; they are only needed to replace linked library items.
 
 | Control | Config key | Default | Effect |
 |---------|------------|---------|--------|
-| Enable Background Repairs | `repair.enable` | off | Needs library dir + *Arr |
+| Enable Background Repairs [since 1.2.5](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.5){ .nzbdav-since } | `repair.enable` | off | Enables health checks, PAR2, and damage tolerance; Library Directory + *Arr are only needed for linked-item replacement |
 | Health Check Concurrency [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since } | `repair.healthcheck-concurrency` | `50` | Worker ceiling for concurrent STAT checks; capped by the provider pool. Actual contention with playback is governed by provider-pool admission and **Streaming Priority** |
 | Health Check Depth | `repair.healthcheck-depth` | `standard` | standard / enhanced / deep / complete |
 | Check older releases less thoroughly [since 0.8.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.8.0){ .nzbdav-since } | `repair.healthcheck-aging` | off | Aging taper |
@@ -33,10 +33,9 @@ enabled; urgent repairs already queued from streaming failures keep their priori
 !!! note "Streaming failure repair requires Background Repairs"
 
     **Repair After Streaming Failures** (`repair.auto-remove-after-failures`) only takes effect when
-    **Enable Background Repairs** (`repair.enable`) is on, which itself requires **Library Directory**
-    and at least one configured *Arr instance. If a streaming failure is detected but repairs are not
-    fully enabled, InfiniDysk logs a warning naming the missing prerequisite instead of scheduling
-    urgent repair.
+    **Enable Background Repairs** (`repair.enable`) is on. A Library Directory and *Arr are only
+    needed to replace linked library items. Without them, PAR2 can still reconstruct the file and
+    threshold-based removal can delete unlinked items.
 
 `repair.auto-remove-after-failures` applies only to streaming-triggered failures such as missing
 articles, corrupt archives, and seeks that find missing or truncated article data. With a value
@@ -44,7 +43,9 @@ greater than `0`, InfiniDysk waits for that many consecutive failures before it 
 repair. At the threshold, linked library items are removed and their original downloads are marked
 failed in *Arr when **Auto-remove unlinked files only** is enabled. *Arr blocklists those releases
 and applies its configured failed-download redownload policy. Unlinked files are removed. Disable
-that option to force-delete linked items at the threshold.
+that option to force-delete linked items at the threshold. With the default value `0`, failed
+unlinked files are kept and surfaced as **Action needed**; set a value greater than `0` to
+auto-remove them after repeated failures.
 
 Successful full-file playback and a successful background health check reset the in-memory failure
 count. The count resets when InfiniDysk restarts, so it is intentionally not a durable replacement for
@@ -68,7 +69,8 @@ enabled, releases old enough to be sampled are not classified.
   over a gap fill, and the next full health sweep detects a provider-side recovery.
 - **Failed** — over any cap, any hole in an unsafe layout, or an unrecognized container.
   These take the normal repair path (PAR2 reconstruction first when enabled, then Arr
-  remove-and-replace), exactly as before.
+  remove-and-replace when a linked library item has an enabled Arr instance). Without an Arr
+  replacement path, the file remains mounted as **Action needed**.
 
 Eligible containers: `.mkv`, `.mk3d`, `.webm`, `.ts`, `.m2ts` (resync at cluster/packet
 boundaries) and `.mp4`/`.m4v`/`.mov`, whose layout is probed once from a bounded read of the
@@ -110,8 +112,8 @@ silent garbage. InfiniDysk now detects that on the playback path:
 4. **Classify** — full-coverage health sweeps union remaining recorded corruption with
    STAT holes, so a present-but-corrupt file is no longer reported Healthy.
 5. **Escalate** — when playback actually breaks, the same streaming-failure path used for
-   missing articles runs: PAR2-first when enabled, then *Arr remove-and-blocklist, with
-   re-grab protection.
+   missing articles runs: PAR2-first when enabled, then *Arr remove-and-blocklist for linked
+   library items with an enabled Arr instance.
 
 Disable **Track corrupt articles during playback** if you need the previous retry-only
 behavior. Playback-breaking corruption still schedules repair whenever Background Repairs

--- a/docs/guides/stremio.md
+++ b/docs/guides/stremio.md
@@ -44,6 +44,14 @@ Then in **Addons → Marketplace → Usenet → Newznab**, add each indexer (URL
 
 **Save & Install** in AIOStreams, then install the addon in Stremio.
 
+## Repairs without *Arr [since 1.2.5](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.5){ .nzbdav-since }
+
+Enable **Background Repairs** to run health checks, reconstruct recoverable gaps from PAR2 parity,
+and retain playable files with limited damage. A Library Directory and *Arr are only necessary to
+replace linked library items. To auto-remove a broken unlinked item after repeated playback failures,
+set **Repair After Streaming Failures** above `0`; the default (`0`) keeps the item and marks it
+**Action needed**.
+
 ## Security and reachability
 
 - The profile token in the Path A manifest URL is a capability credential. Do not paste it into public chats or commit it.

--- a/docs/operations/health-repairs.md
+++ b/docs/operations/health-repairs.md
@@ -2,13 +2,13 @@
 
 ## Background repairs
 
-**Settings → Repairs** monitors library items and can trigger *Arr replacements when content is unhealthy.
+**Settings → Repairs** monitors mounted media, reconstructs missing segments from PAR2 parity, and
+can trigger *Arr replacements for unhealthy linked library items.
 
-Requires:
+Requires **Enable Background Repairs**. To automatically replace linked library items, also configure:
 
 - **Library Directory** visible inside the container — the organized library root (parent of Arr root folders), never the rclone mount or `/completed-symlinks`
 - At least one configured [Radarr/Sonarr instance](../configuration/arrs.md)
-- **Enable Background Repairs**
 
 Tune concurrency, health-check depth, aging [since 0.8.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.8.0){ .nzbdav-since }, and streaming-failure thresholds — [Repairs settings](../configuration/repairs.md).
 

--- a/docs/use-cases/streaming-only.md
+++ b/docs/use-cases/streaming-only.md
@@ -16,4 +16,12 @@ Use InfiniDysk without building a traditional *Arr library.
 3. Watchdog on for playback failover.
 4. Skip rclone unless you want a local FUSE mount for VLC/etc.
 
+## Repairs without *Arr [since 1.2.5](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.5){ .nzbdav-since }
+
+Enable **Background Repairs** to run health checks, reconstruct recoverable gaps from PAR2 parity,
+and keep slightly damaged video files playable. A Library Directory and *Arr are only needed to
+replace linked library items. To automatically remove broken unlinked items after playback failures,
+set **Repair After Streaming Failures** above `0`; its default (`0`) keeps the item and marks it
+**Action needed**.
+
 Secure the UI and WebDAV the same way as any other deploy — TLS, strong passwords, no open port `3000` on the internet.

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -22,7 +22,7 @@ function isNonNegativeInteger(value: string) {
 export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) {
   const libraryDirConfig = config["media.library-dir"];
   // `arr.instances` config value shape (backend contract)
-  const arrConfig = JSON.parse(config["arr.instances"] ?? "{}") as {
+  const arrConfig = (JSON.parse(config["arr.instances"] ?? "{}") ?? {}) as {
     RadarrInstances?: { Enabled?: boolean }[];
     SonarrInstances?: { Enabled?: boolean }[];
   };

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -22,17 +22,17 @@ function isNonNegativeInteger(value: string) {
 export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) {
   const libraryDirConfig = config["media.library-dir"];
   // `arr.instances` config value shape (backend contract)
-  const arrConfig = JSON.parse(config["arr.instances"]!) as {
-    RadarrInstances: unknown[];
-    SonarrInstances: unknown[];
+  const arrConfig = JSON.parse(config["arr.instances"] ?? "{}") as {
+    RadarrInstances?: { Enabled?: boolean }[];
+    SonarrInstances?: { Enabled?: boolean }[];
   };
-  const areArrInstancesConfigured =
-    arrConfig.RadarrInstances.length > 0 || arrConfig.SonarrInstances.length > 0;
-  const canEnableRepairs = !!libraryDirConfig && areArrInstancesConfigured;
-  const helpText = canEnableRepairs
-    ? "When enabled, usenet items will be continuously monitored for health. Unhealthy items will be removed. If an unhealthy item is part of your Radarr/Sonarr library, a new search will be triggered to find a replacement."
-    : "When enabled, usenet items will be continuously monitored for health. Unhealthy items will be removed and replaced. This setting can only be enabled once your Library-Directory and Radarr/Sonarr instances are configured.";
-  const isRepairEnabled = canEnableRepairs && config["repair.enable"] === "true";
+  const hasEnabledArrInstance = [
+    ...(arrConfig.RadarrInstances ?? []),
+    ...(arrConfig.SonarrInstances ?? []),
+  ].some((instance) => instance.Enabled !== false);
+  const helpText =
+    "Continuously monitor mounted media for health, reconstruct missing segments from PAR2 parity, and retain playable files with limited damage. Library Directory and enabled Radarr/Sonarr instances are only needed to replace linked library items.";
+  const isRepairEnabled = config["repair.enable"] === "true";
   const autoRemoveAfter = config["repair.auto-remove-after-failures"] ?? "0";
   const autoRemoveEnabled = isNonNegativeInteger(autoRemoveAfter) && Number(autoRemoveAfter) > 0;
 
@@ -47,7 +47,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
         <SettingsCard
           icon="build"
           title="Background repairs"
-          description="Connect repair monitoring to the organized media library."
+          description="Monitor mounted media and recover or classify missing segments."
           contentClassName="grid grid-cols-1 gap-4 lg:grid-cols-2"
         >
           <ManagedSetting configKey="repair.enable">
@@ -55,8 +55,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
               <Toggle
                 id="enable-repairs-checkbox"
                 className="cursor-pointer gap-2 p-0"
-                checked={canEnableRepairs && config["repair.enable"] === "true"}
-                disabled={!canEnableRepairs}
+                checked={isRepairEnabled}
                 onChange={(e) =>
                   setNewConfig({ ...config, "repair.enable": "" + e.target.checked })
                 }
@@ -64,6 +63,14 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
               />
             </Tooltip>
           </ManagedSetting>
+
+          {(!libraryDirConfig || !hasEnabledArrInstance) && (
+            <p className="text-[11px] leading-relaxed text-base-content/45 lg:col-span-2">
+              Health checks, PAR2 repair, degraded damage tolerance, and unlinked-file handling work
+              without a library. Configure a Library Directory and an enabled Radarr or Sonarr
+              instance to replace linked library items automatically.
+            </p>
+          )}
 
           <ManagedSetting configKey="media.library-dir">
             <div className="space-y-2">

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -22,7 +22,8 @@ function isNonNegativeInteger(value: string) {
 export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) {
   const libraryDirConfig = config["media.library-dir"];
   // `arr.instances` config value shape (backend contract)
-  const arrConfig = (JSON.parse(config["arr.instances"] ?? "{}") ?? {}) as {
+  const rawArrConfig = config["arr.instances"]?.trim();
+  const arrConfig = (JSON.parse(rawArrConfig || "{}") ?? {}) as {
     RadarrInstances?: { Enabled?: boolean }[];
     SonarrInstances?: { Enabled?: boolean }[];
   };

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -838,29 +838,27 @@ public class ExceptionMiddlewareTests
         Assert.Equal(expected, ExceptionMiddleware.ShouldScheduleUrgentRepair(threshold, failureCount));
     }
 
-    [Theory]
-    [InlineData(false, true, 1, "Enable Background Repairs is off")]
-    [InlineData(true, false, 1, "Library Directory is not set")]
-    [InlineData(true, true, 0, "no Radarr/Sonarr instances are configured")]
-    public void GetRepairDisabledReason_NamesMissingPrerequisite(
-        bool isRepairEnabled,
-        bool hasLibraryDir,
-        int arrInstanceCount,
-        string expected)
+    [Fact]
+    public void GetRepairDisabledReason_NamesDisabledToggle()
     {
-        Assert.Equal(expected, ConfigManager.GetRepairDisabledReason(isRepairEnabled, hasLibraryDir, arrInstanceCount));
+        Assert.Equal("Enable Background Repairs is off", ConfigManager.GetRepairDisabledReason(false));
     }
 
     [Fact]
-    public void GetRepairDisabledReason_ReturnsNullWhenFullyEnabled()
+    public void GetRepairDisabledReason_ReturnsNullWhenEnabled()
     {
-        Assert.Null(ConfigManager.GetRepairDisabledReason(true, true, 1));
+        Assert.Null(ConfigManager.GetRepairDisabledReason(true));
     }
 
     [Fact]
-    public void GetRepairDisabledReason_InstanceReflectsConfiguredPrerequisites()
+    public void GetRepairDisabledReason_InstanceAllowsNoLibraryOrArr()
     {
-        var configManager = CreateRepairEnabledConfig();
+        var configManager = new ConfigManager();
+        configManager.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "true" },
+        ]);
+
         Assert.Null(configManager.GetRepairDisabledReason());
         Assert.True(configManager.IsRepairJobEnabled());
     }

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
@@ -261,6 +261,53 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Par2Success_RunsWithoutEnabledArrWhenArrPreferenceIsOff()
+    {
+        _configManager.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.RepairPar2PreferredOverArr, ConfigValue = "false" },
+        ]);
+        var segments = NewSegmentIds(6);
+        var sizes = new long[] { 10_000, 10_000, 50, 10_000, 10_000, 10_000 };
+        var (item, _) = await AddVideoFileAsync(
+            "movie.mkv", segments, sizes, preExistingHoles: [2]);
+        var fake = NewFakeClient(segments, missing: [2]);
+        var (service, par2) = await NewServiceAsync(fake, par2Outcome: true);
+
+        await service.PerformHealthCheck(item, _dbClient, concurrency: 4, CancellationToken.None);
+
+        var row = Assert.Single(GetHealthRows(item.Id));
+        Assert.Equal(HealthCheckResult.RepairAction.RepairedViaPar2, row.RepairStatus);
+        Assert.Equal([segments[2]], Assert.Single(par2.Requests));
+    }
+
+    [Fact]
+    public async Task LinkedFile_WithoutEnabledArr_IsLeftInPlace()
+    {
+        _configManager.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.RepairPar2Enabled, ConfigValue = "false" },
+        ]);
+        var segments = NewSegmentIds(6);
+        var sizes = Enumerable.Repeat(10_000L, segments.Length).ToArray();
+        var (item, _) = await AddVideoFileAsync("movie.mkv", segments, sizes);
+        var libraryPath = Path.Join(_configRoot, "library", "movie.strm");
+        await File.WriteAllTextAsync(
+            libraryPath,
+            $"http://localhost:3000/view/.ids/{item.Id}.mkv");
+        var fake = NewFakeClient(segments, missing: [0]);
+        var (service, _) = await NewServiceAsync(fake, par2Outcome: false);
+
+        await service.PerformHealthCheck(item, _dbClient, concurrency: 4, CancellationToken.None);
+
+        var row = Assert.Single(GetHealthRows(item.Id));
+        Assert.Equal(HealthCheckResult.RepairAction.ActionNeeded, row.RepairStatus);
+        Assert.Contains("No enabled Radarr/Sonarr instances are configured", row.Message);
+        Assert.Equal(1, _context.Items.AsNoTracking().Count(x => x.Id == item.Id));
+        Assert.True(File.Exists(libraryPath));
+    }
+
+    [Fact]
     public async Task PartialSample_UsesLegacyAbortOnFirstMissPath()
     {
         var segments = NewSegmentIds(HealthCheckService.SampleFloor + 1000);

--- a/tests/NzbWebDAV.Tests/Utils/OrganizedLinksUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/OrganizedLinksUtilTests.cs
@@ -1,9 +1,29 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
 using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Tests.Utils;
 
 public class OrganizedLinksUtilTests
 {
+    [Fact]
+    public void GetLink_WithoutLibraryDirectory_ReturnsNullWithoutScanning()
+    {
+        var configManager = new ConfigManager();
+        var id = Guid.NewGuid();
+        var item = new DavItem
+        {
+            Id = id,
+            IdPrefix = id.ToString("N")[..DavItem.IdPrefixLength],
+            CreatedAt = DateTime.UtcNow,
+            Name = "movie.mkv",
+            Path = "/content/movie.mkv",
+        };
+
+        Assert.Null(OrganizedLinksUtil.GetLink(item, configManager));
+        Assert.Empty(OrganizedLinksUtil.GetLibraryDavItemLinks(configManager));
+    }
+
     [Fact]
     public void GetDavItemLink_Symlink_SkipsNonGuidTarget()
     {


### PR DESCRIPTION
## Summary
- allow Background Repairs to run without a Library Directory or enabled Radarr/Sonarr instance
- keep linked-item replacement guarded by an enabled Arr client while enabling PAR2, health checks, and damage tolerance for streaming-only installs
- clarify the Arr-less repair behavior in settings and documentation

## Upgrade note
Headless installs with `repair.enable=true` but no library or Arr configuration will begin running background health checks after upgrading. The default streaming-failure threshold keeps unlinked failed items as Action needed; set it above zero to auto-remove them after repeated failures.

## Test plan
- [x] Focused .NET repair, middleware, and link tests
- [x] Frontend repairs settings tests
- [x] Frontend typecheck
- [x] Strict docs build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background repairs can run without a configured library directory or Radarr/Sonarr.
  * PAR2 can reconstruct missing content, including streamed media.
  * Damaged and unlinked files can be retained or automatically removed after repeated failures.
  * Linked-item replacement remains available with library and Arr integration configured.

* **Bug Fixes**
  * Improved repair handling when Arr services are unavailable.
  * Prevented errors when no library directory is configured.

* **Documentation**
  * Expanded repair guidance across configuration, operations, streaming, and Stremio.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->