### PR TITLE
chore(test): accept cancelled stream exception subtypes

### DIFF
--- a/tests/UsenetSharp.Tests/Clients/UsenetClientDeterministicTests.cs
+++ b/tests/UsenetSharp.Tests/Clients/UsenetClientDeterministicTests.cs
@@ -1425,7 +1425,7 @@ public class UsenetClientDeterministicTests
         cts.Cancel();
         continueBody.SetResult();
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () => await copyTask);
+        Assert.That(async () => await copyTask, Throws.InstanceOf<OperationCanceledException>());
         Assert.ThrowsAsync<OperationCanceledException>(async () =>
             await batch.Responses[1]);
         Assert.That(await completion.Task.WaitAsync(TimeSpan.FromSeconds(2)),


### PR DESCRIPTION
## Summary
- accept `TaskCanceledException` when validating cancellation from streamed `CopyToAsync`
- preserve coverage of the cancellation and connection-reuse path

## Test plan
- [x] `RAPIDYENC_LIBRARY_PATH=... dotnet test tests/UsenetSharp.Tests/UsenetSharp.Tests.csproj -c Release --no-restore --filter \"FullyQualifiedName~DecodedBodiesAsync_CancellationDrainsBatchAndReusesConnection\"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated cancellation test coverage to verify that canceled batch body-copy operations raise the expected cancellation exception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->