### PR TITLE
fix(repair): wait for PAR2 recovery before removing failed playback

### DIFF
--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -577,7 +577,7 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
         // Count every distinct streaming failure before applying either threshold or deduplication.
         // Repeated failures must still advance the repair threshold while duplicate DB scheduling
         // writes remain suppressed below.
-        var failureCount = segmentId == null
+        var failureCount = string.IsNullOrEmpty(segmentId)
             ? failureTracker.RecordUnattributedFailure(davItemId).Count
             : failureTracker.RecordAttributedFailure(davItemId, segmentId).Count;
         var threshold = configManager.GetAutoRemoveAfterFailures();

--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -115,7 +115,7 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
             if (context.Items["DavItem"] is DavItem davItem)
             {
                 RecordMissingArticleForFailFast(davItem, notFound.SegmentId);
-                ScheduleRepair(davItem);
+                ScheduleRepair(davItem, notFound.SegmentId);
             }
 
             AbortStartedResponse(context);
@@ -154,7 +154,7 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
             if (context.Items["DavItem"] is DavItem davItem)
             {
                 RecordMissingArticleForFailFast(davItem, corrupt.SegmentId);
-                ScheduleRepair(davItem);
+                ScheduleRepair(davItem, corrupt.SegmentId);
             }
 
             AbortStartedResponse(context);
@@ -564,7 +564,7 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
             context.Abort();
     }
 
-    private void ScheduleRepair(DavItem davItem)
+    private void ScheduleRepair(DavItem davItem, string? segmentId = null)
     {
         var davItemId = davItem.Id;
         var repairDisabledReason = configManager.GetRepairDisabledReason();
@@ -577,7 +577,9 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
         // Count every distinct streaming failure before applying either threshold or deduplication.
         // Repeated failures must still advance the repair threshold while duplicate DB scheduling
         // writes remain suppressed below.
-        var failureCount = failureTracker.RecordFailure(davItemId);
+        var failureCount = segmentId == null
+            ? failureTracker.RecordUnattributedFailure(davItemId).Count
+            : failureTracker.RecordAttributedFailure(davItemId, segmentId).Count;
         var threshold = configManager.GetAutoRemoveAfterFailures();
         if (!ShouldScheduleUrgentRepair(threshold, failureCount))
         {

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -69,10 +69,11 @@ public class HealthCheckService : BackgroundService
     private readonly WebsocketManager _websocketManager;
     private readonly BenchmarkGate _benchmarkGate;
     private readonly StreamingFailureTracker _failureTracker;
-    private readonly QueueManager _queueManager;
+    private readonly IQueueCoordinator _queueManager;
     private readonly Par2RepairService _par2RepairService;
     private readonly RepairPatchStore _repairPatchStore;
     private readonly IDbContextFactory<DavDatabaseContext>? _dbContextFactory;
+    private readonly TimeProvider _timeProvider;
 
     private static readonly HashSet<string> _missingSegmentIds = [];
     private static readonly Queue<string> _missingSegmentOrder = [];
@@ -86,11 +87,12 @@ public class HealthCheckService : BackgroundService
         WebsocketManager websocketManager,
         BenchmarkGate benchmarkGate,
         StreamingFailureTracker failureTracker,
-        QueueManager queueManager,
+        IQueueCoordinator queueManager,
         Par2RepairService par2RepairService,
         RepairPatchStore repairPatchStore,
         ArrReplacementSearchBudget replacementSearchBudget,
-        IDbContextFactory<DavDatabaseContext>? dbContextFactory = null
+        IDbContextFactory<DavDatabaseContext>? dbContextFactory = null,
+        TimeProvider? timeProvider = null
     )
     {
         _configManager = configManager;
@@ -103,6 +105,7 @@ public class HealthCheckService : BackgroundService
         _par2RepairService = par2RepairService;
         _repairPatchStore = repairPatchStore;
         _dbContextFactory = dbContextFactory;
+        _timeProvider = timeProvider ?? TimeProvider.System;
 
         _configManager.OnConfigChanged += (_, configEventArgs) =>
         {
@@ -120,7 +123,7 @@ public class HealthCheckService : BackgroundService
     {
         try
         {
-            await Task.Delay(StartupGracePeriod, stoppingToken).ConfigureAwait(false);
+            await Task.Delay(StartupGracePeriod, _timeProvider, stoppingToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
         {
@@ -136,14 +139,14 @@ public class HealthCheckService : BackgroundService
                 // pause verification while a connection speed-test is running
                 if (_benchmarkGate.IsPaused)
                 {
-                    await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken).ConfigureAwait(false);
+                    await Task.Delay(TimeSpan.FromSeconds(5), _timeProvider, stoppingToken).ConfigureAwait(false);
                     continue;
                 }
 
                 // if the repair-job is disabled, then don't do anything
                 if (!_configManager.IsRepairJobEnabled())
                 {
-                    await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken).ConfigureAwait(false);
+                    await Task.Delay(TimeSpan.FromSeconds(5), _timeProvider, stoppingToken).ConfigureAwait(false);
                     continue;
                 }
 
@@ -152,7 +155,7 @@ public class HealthCheckService : BackgroundService
                 // queue-item article validation inside QueueItemProcessor is separate.
                 if (_queueManager.HasActiveQueueItems)
                 {
-                    await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken).ConfigureAwait(false);
+                    await Task.Delay(TimeSpan.FromSeconds(5), _timeProvider, stoppingToken).ConfigureAwait(false);
                     continue;
                 }
 
@@ -185,7 +188,7 @@ public class HealthCheckService : BackgroundService
                 // if there is no item to health-check, don't do anything
                 if (davItem == null)
                 {
-                    await Task.Delay(TimeSpan.FromSeconds(5), cts.Token).ConfigureAwait(false);
+                    await Task.Delay(TimeSpan.FromSeconds(5), _timeProvider, cts.Token).ConfigureAwait(false);
                     continue;
                 }
 
@@ -209,7 +212,7 @@ public class HealthCheckService : BackgroundService
                     Log.Error(e, "Unexpected error performing background health checks: {Message}", e.Message);
                 }
 
-                await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken).ConfigureAwait(false);
+                await Task.Delay(TimeSpan.FromSeconds(5), _timeProvider, stoppingToken).ConfigureAwait(false);
             }
         }
     }
@@ -1373,6 +1376,8 @@ public class HealthCheckService : BackgroundService
         Defer,
         /// <summary>Force the repair-delete path even for library-linked items.</summary>
         ForceDelete,
+        /// <summary>Force deletion only if the fresh repair-boundary lookup finds no library link.</summary>
+        ForceDeleteIfUnlinked,
     }
 
     /// <summary>
@@ -1383,7 +1388,6 @@ public class HealthCheckService : BackgroundService
     public static UrgentRepairDisposition GetUrgentRepairDisposition(
         int threshold,
         int failureCount,
-        bool hasLibraryLink,
         bool autoRemoveUnlinkedOnly)
     {
         if (threshold <= 0)
@@ -1392,10 +1396,9 @@ public class HealthCheckService : BackgroundService
         if (failureCount < threshold)
             return UrgentRepairDisposition.Defer;
 
-        if (hasLibraryLink && autoRemoveUnlinkedOnly)
-            return UrgentRepairDisposition.RepairNormally;
-
-        return UrgentRepairDisposition.ForceDelete;
+        return autoRemoveUnlinkedOnly
+            ? UrgentRepairDisposition.ForceDeleteIfUnlinked
+            : UrgentRepairDisposition.ForceDelete;
     }
 
     /// <summary>
@@ -1608,10 +1611,10 @@ public class HealthCheckService : BackgroundService
     private async Task HandleUrgentRepair(DavItem davItem, DavDatabaseClient dbClient, CancellationToken ct)
     {
         var threshold = _configManager.GetAutoRemoveAfterFailures();
-        var failureCount = _failureTracker.GetFailureCount(davItem.Id);
+        var failureSnapshot = _failureTracker.GetSnapshot(davItem.Id);
+        var failureCount = failureSnapshot.Count;
         var unlinkedOnly = _configManager.IsAutoRemoveUnlinkedOnly();
-        var hasLibraryLink = OrganizedLinksUtil.GetLink(davItem, _configManager) != null;
-        var disposition = GetUrgentRepairDisposition(threshold, failureCount, hasLibraryLink, unlinkedOnly);
+        var disposition = GetUrgentRepairDisposition(threshold, failureCount, unlinkedOnly);
 
         if (disposition == UrgentRepairDisposition.Defer)
         {
@@ -1631,7 +1634,10 @@ public class HealthCheckService : BackgroundService
         }
 
         if (ShouldAttemptPar2Repair()
-            && await _par2RepairService.TryPar2RepairAsync(davItem, null, ct).ConfigureAwait(false))
+            && await _par2RepairService.TryPar2RepairAsync(
+                davItem,
+                failureSnapshot.HasTargetableSegmentIds ? failureSnapshot.SegmentIds : null,
+                ct).ConfigureAwait(false))
         {
             var utcNow = DateTimeOffset.UtcNow;
             davItem.LastHealthCheck = utcNow;
@@ -1652,6 +1658,7 @@ public class HealthCheckService : BackgroundService
             dbClient,
             ct,
             forceDelete: disposition == UrgentRepairDisposition.ForceDelete,
+            forceDeleteIfUnlinked: disposition == UrgentRepairDisposition.ForceDeleteIfUnlinked,
             streamingFailureCount: failureCount).ConfigureAwait(false);
     }
 
@@ -1669,6 +1676,7 @@ public class HealthCheckService : BackgroundService
         DavDatabaseClient dbClient,
         CancellationToken ct,
         bool forceDelete = false,
+        bool forceDeleteIfUnlinked = false,
         int? streamingFailureCount = null)
     {
         try
@@ -1701,7 +1709,9 @@ public class HealthCheckService : BackgroundService
             // force-delete policy may remove the item from this branch.
             var libraryDir = _configManager.GetLibraryDir();
             var symlinkOrStrmPath = OrganizedLinksUtil.GetLink(davItem, _configManager);
-            var linkDisposition = GetLibraryLinkRepairDisposition(symlinkOrStrmPath, forceDelete);
+            var linkDisposition = GetLibraryLinkRepairDisposition(
+                symlinkOrStrmPath,
+                forceDelete || (forceDeleteIfUnlinked && symlinkOrStrmPath == null));
             if (linkDisposition != LibraryLinkRepairDisposition.RepairLinked)
                 _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);
             if (linkDisposition == LibraryLinkRepairDisposition.ForceDelete)

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -36,6 +36,7 @@ public class Par2RepairService : BackgroundService
     private readonly Channel<RepairWorkItem> _queue;
     private readonly Channel<ZeroFillEvent> _zeroFillQueue;
     private readonly ConcurrentDictionary<Guid, byte> _queuedOrRunning = new();
+    private readonly ConcurrentDictionary<Guid, RepairFlight> _repairFlights = new();
     private readonly ConcurrentDictionary<string, byte> _pendingZeroFillPaths = new(StringComparer.Ordinal);
     private long _totalSucceeded;
     private long _totalFailed;
@@ -116,10 +117,22 @@ public class Par2RepairService : BackgroundService
         if (!_queuedOrRunning.TryAdd(davItem.Id, 0))
             return;
 
-        var item = new RepairWorkItem(davItem.Id, davItem.Path, missingSegmentIds.Distinct().ToArray());
+        var flight = new RepairFlight();
+        if (!_repairFlights.TryAdd(davItem.Id, flight))
+        {
+            _queuedOrRunning.TryRemove(davItem.Id, out _);
+            return;
+        }
+
+        var item = new RepairWorkItem(
+            davItem.Id,
+            davItem.Path,
+            missingSegmentIds.Distinct().ToArray(),
+            flight);
         if (!_queue.Writer.TryWrite(item))
         {
             _queuedOrRunning.TryRemove(davItem.Id, out _);
+            _repairFlights.TryRemove(new KeyValuePair<Guid, RepairFlight>(davItem.Id, flight));
             Log.Warning(
                 "PAR2 repair queue full ({Capacity}); dropping repair request for {Path}",
                 MaxQueueLength, davItem.Path);
@@ -135,11 +148,22 @@ public class Par2RepairService : BackgroundService
     /// Returns true when reconstruction succeeded and patches were committed.
     /// Virtual so health-check classification tests can script the outcome.
     /// </summary>
-    public virtual Task<bool> TryPar2RepairAsync(
+    public virtual async Task<bool> TryPar2RepairAsync(
         DavItem davItem,
         IReadOnlyList<string>? missingSegmentIds,
         CancellationToken ct)
-        => RunRepairAsync(davItem, missingSegmentIds, queueGuard: false, ct);
+    {
+        if (!_configManager.IsPar2RepairEnabled())
+            return false;
+
+        var mine = new RepairFlight();
+        var flight = _repairFlights.GetOrAdd(davItem.Id, mine);
+        if (ReferenceEquals(flight, mine))
+            return await RunFlightAsync(flight, davItem, missingSegmentIds, queueGuard: false, ct)
+                .ConfigureAwait(false);
+
+        return await flight.Task.WaitAsync(ct).ConfigureAwait(false);
+    }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -213,16 +237,20 @@ public class Par2RepairService : BackgroundService
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
+                item.Flight.Completion.TrySetCanceled(stoppingToken);
+                _repairFlights.TryRemove(new KeyValuePair<Guid, RepairFlight>(item.DavItemId, item.Flight));
                 throw;
             }
             catch (Exception e) when (e is not OutOfMemoryException)
             {
                 _queuedOrRunning.TryRemove(item.DavItemId, out _);
+                CompleteFlight(item.DavItemId, item.Flight, false);
                 e.LogWarningKnownOrStack("PAR2 background repair worker failed for {Path}", item.Path);
             }
             catch (OutOfMemoryException oom)
             {
                 _queuedOrRunning.TryRemove(item.DavItemId, out _);
+                CompleteFlight(item.DavItemId, item.Flight, false);
                 OomDiagnostics.LogHeapStateOnOom(oom, "PAR2 background repair worker");
                 Log.Warning("PAR2 background repair worker deferred after exhausting managed memory. Path: {Path}", item.Path);
             }
@@ -362,11 +390,47 @@ public class Par2RepairService : BackgroundService
         if (davItem == null)
         {
             _queuedOrRunning.TryRemove(item.DavItemId, out _);
+            CompleteFlight(item.DavItemId, item.Flight, false);
             return;
         }
 
-        await RunRepairAsync(davItem, item.MissingSegmentIds, queueGuard: true, ct)
+        await RunFlightAsync(item.Flight, davItem, item.MissingSegmentIds, queueGuard: true, ct)
             .ConfigureAwait(false);
+    }
+
+    private async Task<bool> RunFlightAsync(
+        RepairFlight flight,
+        DavItem davItem,
+        IReadOnlyList<string>? missingSegmentIds,
+        bool queueGuard,
+        CancellationToken ct)
+    {
+        try
+        {
+            var result = await RunRepairAsync(davItem, missingSegmentIds, queueGuard, ct).ConfigureAwait(false);
+            flight.Completion.TrySetResult(result);
+            return result;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            flight.Completion.TrySetCanceled(ct);
+            throw;
+        }
+        catch (Exception e)
+        {
+            flight.Completion.TrySetException(e);
+            throw;
+        }
+        finally
+        {
+            _repairFlights.TryRemove(new KeyValuePair<Guid, RepairFlight>(davItem.Id, flight));
+        }
+    }
+
+    private void CompleteFlight(Guid davItemId, RepairFlight flight, bool result)
+    {
+        flight.Completion.TrySetResult(result);
+        _repairFlights.TryRemove(new KeyValuePair<Guid, RepairFlight>(davItemId, flight));
     }
 
     private async Task<bool> RunRepairAsync(
@@ -1590,7 +1654,19 @@ public class Par2RepairService : BackgroundService
         long PeakRetainedSourceBytes,
         long RetainedSourceLimitBytes);
 
-    private sealed record RepairWorkItem(Guid DavItemId, string Path, string[] MissingSegmentIds);
+    private sealed class RepairFlight
+    {
+        public TaskCompletionSource<bool> Completion { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<bool> Task => Completion.Task;
+    }
+
+    private sealed record RepairWorkItem(
+        Guid DavItemId,
+        string Path,
+        string[] MissingSegmentIds,
+        RepairFlight Flight);
 
     private sealed record ZeroFillEvent(string Path, string SegmentId, bool IsCorruption = false);
 

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -162,7 +162,16 @@ public class Par2RepairService : BackgroundService
             return await RunFlightAsync(flight, davItem, missingSegmentIds, queueGuard: false, ct)
                 .ConfigureAwait(false);
 
-        return await flight.Task.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            return await flight.Task.WaitAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            // The repair owner stopped; callers should follow their normal safe fallback
+            // rather than surfacing a cancellation that they did not request.
+            return false;
+        }
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -229,30 +238,40 @@ public class Par2RepairService : BackgroundService
 
     private async Task ProcessRepairQueueAsync(CancellationToken stoppingToken)
     {
-        await foreach (var item in _queue.Reader.ReadAllAsync(stoppingToken).ConfigureAwait(false))
+        try
         {
-            try
+            await foreach (var item in _queue.Reader.ReadAllAsync(stoppingToken).ConfigureAwait(false))
             {
-                await ProcessQueueItemAsync(item, stoppingToken).ConfigureAwait(false);
+                try
+                {
+                    await ProcessQueueItemAsync(item, stoppingToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    CancelFlight(item.DavItemId, item.Flight, stoppingToken);
+                    throw;
+                }
+                catch (Exception e) when (e is not OutOfMemoryException)
+                {
+                    _queuedOrRunning.TryRemove(item.DavItemId, out _);
+                    CompleteFlight(item.DavItemId, item.Flight, false);
+                    e.LogWarningKnownOrStack("PAR2 background repair worker failed for {Path}", item.Path);
+                }
+                catch (OutOfMemoryException oom)
+                {
+                    _queuedOrRunning.TryRemove(item.DavItemId, out _);
+                    CompleteFlight(item.DavItemId, item.Flight, false);
+                    OomDiagnostics.LogHeapStateOnOom(oom, "PAR2 background repair worker");
+                    Log.Warning("PAR2 background repair worker deferred after exhausting managed memory. Path: {Path}", item.Path);
+                }
             }
-            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        }
+        finally
+        {
+            while (_queue.Reader.TryRead(out var abandoned))
             {
-                item.Flight.Completion.TrySetCanceled(stoppingToken);
-                _repairFlights.TryRemove(new KeyValuePair<Guid, RepairFlight>(item.DavItemId, item.Flight));
-                throw;
-            }
-            catch (Exception e) when (e is not OutOfMemoryException)
-            {
-                _queuedOrRunning.TryRemove(item.DavItemId, out _);
-                CompleteFlight(item.DavItemId, item.Flight, false);
-                e.LogWarningKnownOrStack("PAR2 background repair worker failed for {Path}", item.Path);
-            }
-            catch (OutOfMemoryException oom)
-            {
-                _queuedOrRunning.TryRemove(item.DavItemId, out _);
-                CompleteFlight(item.DavItemId, item.Flight, false);
-                OomDiagnostics.LogHeapStateOnOom(oom, "PAR2 background repair worker");
-                Log.Warning("PAR2 background repair worker deferred after exhausting managed memory. Path: {Path}", item.Path);
+                _queuedOrRunning.TryRemove(abandoned.DavItemId, out _);
+                CancelFlight(abandoned.DavItemId, abandoned.Flight, stoppingToken);
             }
         }
     }
@@ -430,6 +449,12 @@ public class Par2RepairService : BackgroundService
     private void CompleteFlight(Guid davItemId, RepairFlight flight, bool result)
     {
         flight.Completion.TrySetResult(result);
+        _repairFlights.TryRemove(new KeyValuePair<Guid, RepairFlight>(davItemId, flight));
+    }
+
+    private void CancelFlight(Guid davItemId, RepairFlight flight, CancellationToken cancellationToken)
+    {
+        flight.Completion.TrySetCanceled(cancellationToken);
         _repairFlights.TryRemove(new KeyValuePair<Guid, RepairFlight>(davItemId, flight));
     }
 

--- a/backend/Services/StreamingFailureTracker.cs
+++ b/backend/Services/StreamingFailureTracker.cs
@@ -15,23 +15,71 @@ namespace NzbWebDAV.Services;
 /// </summary>
 public class StreamingFailureTracker
 {
-    private readonly ConcurrentDictionary<Guid, int> _failureCounts = new();
+    private const int MaximumAttributedSegmentIds = 64;
+    private readonly ConcurrentDictionary<Guid, StreamingFailureSnapshot> _failures = new();
 
-    /// <summary>Increments and returns the new failure count for the item.</summary>
+    /// <summary>Records a definitive article failure and returns the new immutable snapshot.</summary>
+    public StreamingFailureSnapshot RecordAttributedFailure(Guid davItemId, string segmentId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(segmentId);
+        return _failures.AddOrUpdate(
+            davItemId,
+            _ => new StreamingFailureSnapshot(1, false, [segmentId]),
+            (_, previous) => previous.WithAttributedFailure(segmentId, MaximumAttributedSegmentIds));
+    }
+
+    /// <summary>Records a structural failure whose responsible segment cannot be proven.</summary>
+    public StreamingFailureSnapshot RecordUnattributedFailure(Guid davItemId)
+    {
+        return _failures.AddOrUpdate(
+            davItemId,
+            _ => new StreamingFailureSnapshot(1, true, []),
+            (_, previous) => previous.WithUnattributedFailure());
+    }
+
+    /// <summary>Increments a structural failure for compatibility with existing callers.</summary>
     public int RecordFailure(Guid davItemId)
     {
-        return _failureCounts.AddOrUpdate(davItemId, 1, (_, count) => count + 1);
+        return RecordUnattributedFailure(davItemId).Count;
     }
 
     /// <summary>Returns the current failure count for the item (0 if never recorded).</summary>
     public int GetFailureCount(Guid davItemId)
     {
-        return _failureCounts.GetValueOrDefault(davItemId);
+        return GetSnapshot(davItemId).Count;
+    }
+
+    public StreamingFailureSnapshot GetSnapshot(Guid davItemId)
+    {
+        return _failures.TryGetValue(davItemId, out var snapshot)
+            ? snapshot
+            : StreamingFailureSnapshot.Empty;
     }
 
     /// <summary>Clears the counter after a successful full read, health check, repair, or deletion.</summary>
     public void ClearFailure(Guid davItemId)
     {
-        _failureCounts.TryRemove(davItemId, out _);
+        _failures.TryRemove(davItemId, out _);
     }
+}
+
+public readonly record struct StreamingFailureSnapshot(
+    int Count,
+    bool HasUnattributedFailure,
+    string[] SegmentIds)
+{
+    public static readonly StreamingFailureSnapshot Empty = new(0, false, []);
+
+    public bool HasTargetableSegmentIds => Count > 0 && !HasUnattributedFailure && SegmentIds.Length > 0;
+
+    internal StreamingFailureSnapshot WithAttributedFailure(string segmentId, int maximumSegmentIds)
+    {
+        if (SegmentIds.Contains(segmentId, StringComparer.Ordinal) || SegmentIds.Length >= maximumSegmentIds)
+            return this with { Count = Count + 1 };
+
+        return this with { Count = Count + 1, SegmentIds = [.. SegmentIds, segmentId] };
+    }
+
+    internal StreamingFailureSnapshot WithUnattributedFailure() =>
+        this with { Count = Count + 1, HasUnattributedFailure = true };
 }

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -634,6 +634,26 @@ public class ExceptionMiddlewareTests
     }
 
     [Fact]
+    public async Task MissingArticleWithEmptySegmentId_RecordsUnattributedFailure()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var davItem = Assert.IsType<DavItem>(context.Items["DavItem"]);
+        var failureTracker = new StreamingFailureTracker();
+        var middleware = CreateMiddleware(
+            _ => throw new UsenetArticleNotFoundException(""),
+            CreateRepairEnabledConfig(),
+            failureTracker);
+
+        await middleware.InvokeAsync(context);
+
+        var snapshot = failureTracker.GetSnapshot(davItem.Id);
+        Assert.Equal(1, snapshot.Count);
+        Assert.True(snapshot.HasUnattributedFailure);
+        Assert.False(snapshot.HasTargetableSegmentIds);
+    }
+
+    [Fact]
     public async Task CorruptArticleWithDavItem_RecordsFailureAndSeedsFailFastCache()
     {
         var segmentId = $"<{Guid.NewGuid():N}@test>";

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -118,6 +118,8 @@ public class ExceptionMiddlewareTests
         await middleware.InvokeAsync(context);
 
         Assert.Equal(1, failureTracker.GetFailureCount(davItem.Id));
+        Assert.Equal([segmentId], failureTracker.GetSnapshot(davItem.Id).SegmentIds);
+        Assert.True(failureTracker.GetSnapshot(davItem.Id).HasTargetableSegmentIds);
         Assert.Throws<UsenetArticleNotFoundException>(
             () => HealthCheckService.CheckCachedMissingSegmentIds([segmentId]));
     }
@@ -141,6 +143,7 @@ public class ExceptionMiddlewareTests
         Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
         Assert.False(lifetimeFeature.Aborted);
         Assert.Equal(1, failureTracker.GetFailureCount(davItem.Id));
+        Assert.True(failureTracker.GetSnapshot(davItem.Id).HasUnattributedFailure);
     }
 
     [Fact]
@@ -649,6 +652,8 @@ public class ExceptionMiddlewareTests
         Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
         Assert.False(lifetimeFeature.Aborted);
         Assert.Equal(1, failureTracker.GetFailureCount(davItem.Id));
+        Assert.Equal([segmentId], failureTracker.GetSnapshot(davItem.Id).SegmentIds);
+        Assert.True(failureTracker.GetSnapshot(davItem.Id).HasTargetableSegmentIds);
         Assert.Throws<UsenetArticleNotFoundException>(
             () => HealthCheckService.CheckCachedMissingSegmentIds([segmentId]));
     }
@@ -861,6 +866,71 @@ public class ExceptionMiddlewareTests
 
         Assert.Null(configManager.GetRepairDisabledReason());
         Assert.True(configManager.IsRepairJobEnabled());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ProviderAvailabilityFailures_DoNotRecordStreamingFailure(bool loginFailure)
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var davItem = Assert.IsType<DavItem>(context.Items["DavItem"]);
+        var failureTracker = new StreamingFailureTracker();
+        var middleware = CreateMiddleware(
+            _ => throw (loginFailure
+                ? new CouldNotLoginToUsenetException("Authentication rejected.")
+                : new CouldNotConnectToUsenetException("Provider unavailable.")),
+            CreateRepairEnabledConfig(),
+            failureTracker);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, context.Response.StatusCode);
+        Assert.Equal(0, failureTracker.GetFailureCount(davItem.Id));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ClientOrBackendStalls_DoNotRecordStreamingFailure(bool backendReadTimeout)
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var davItem = Assert.IsType<DavItem>(context.Items["DavItem"]);
+        var failureTracker = new StreamingFailureTracker();
+        var middleware = CreateMiddleware(
+            _ => throw (backendReadTimeout
+                ? new StreamingReadTimeoutException("Backend read timed out.")
+                : new StreamingWriteTimeoutException("Client stopped reading.")),
+            CreateRepairEnabledConfig(),
+            failureTracker);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(backendReadTimeout ? StatusCodes.Status503ServiceUnavailable : 499, context.Response.StatusCode);
+        Assert.Equal(0, failureTracker.GetFailureCount(davItem.Id));
+    }
+
+    [Fact]
+    public async Task TruncatedCiphertext_RecordsStreamingFailure()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var davItem = Assert.IsType<DavItem>(context.Items["DavItem"]);
+        var failureTracker = new StreamingFailureTracker();
+        var middleware = CreateMiddleware(
+            _ => throw new RetryableDownloadException(
+                "Encrypted stream ended early.",
+                new EndOfStreamException(
+                    NzbWebDAV.Streams.AesDecoderStream.TruncatedCiphertextMessagePrefix + " while reading payload.")),
+            CreateRepairEnabledConfig(),
+            failureTracker);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(StatusCodes.Status500InternalServerError, context.Response.StatusCode);
+        Assert.Equal(1, failureTracker.GetFailureCount(davItem.Id));
     }
 
     private static ExceptionMiddleware CreateMiddleware(

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
@@ -111,6 +111,27 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task UrgentRepair_UsesFullyAttributedStreamingFailureIdsAsPar2Seed()
+    {
+        var segments = NewSegmentIds(3);
+        var sizes = new long[] { 10_000, 10_000, 10_000 };
+        var (item, _) = await AddVideoFileAsync("movie.mkv", segments, sizes);
+        item.NextHealthCheck = DateTimeOffset.UnixEpoch;
+        await _context.SaveChangesAsync();
+        _configManager.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.RepairPar2Enabled, ConfigValue = "true" },
+        ]);
+        _failureTracker.RecordAttributedFailure(item.Id, segments[1]);
+        var (service, par2) = await NewServiceAsync(NewFakeClient(segments, missing: []), par2Outcome: true);
+
+        await service.PerformHealthCheck(item, _dbClient, concurrency: 4, CancellationToken.None);
+
+        Assert.Equal([segments[1]], Assert.Single(par2.Requests));
+        Assert.Equal(StreamingFailureSnapshot.Empty, _failureTracker.GetSnapshot(item.Id));
+    }
+
+    [Fact]
     public async Task BoundedHole_MarksDegraded_PersistsHoles_AndSkipsRepair()
     {
         var segments = NewSegmentIds(6);

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckWorkerAdmissionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckWorkerAdmissionTests.cs
@@ -4,11 +4,13 @@ using NzbWebDAV.Database.Models;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Repair;
+using NzbWebDAV.Tests.Database;
 using NzbWebDAV.Tests.TestUtils;
 using NzbWebDAV.Websocket;
 
 namespace NzbWebDAV.Tests.Services;
 
+[Collection(nameof(ConfigPathCollection))]
 public sealed class HealthCheckWorkerAdmissionTests
 {
     [Fact]

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckWorkerAdmissionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckWorkerAdmissionTests.cs
@@ -1,0 +1,133 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Repair;
+using NzbWebDAV.Tests.TestUtils;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.Services;
+
+public sealed class HealthCheckWorkerAdmissionTests
+{
+    [Fact]
+    public async Task StartupGrace_CancellationStopsBeforeQueueAdmission()
+    {
+        var queue = new RecordingQueueCoordinator(active: false);
+        await using var fixture = await HealthFixture.CreateAsync(queue);
+        var previousGrace = HealthCheckService.StartupGracePeriod;
+        HealthCheckService.StartupGracePeriod = TimeSpan.FromHours(1);
+        try
+        {
+            await fixture.Service.StartAsync(CancellationToken.None);
+            await fixture.Service.StopAsync(CancellationToken.None);
+
+            Assert.Equal(0, queue.ActiveReadCount);
+        }
+        finally
+        {
+            HealthCheckService.StartupGracePeriod = previousGrace;
+        }
+    }
+
+    [Fact]
+    public async Task ActiveQueue_DefersHealthWorkUntilStopped()
+    {
+        var queue = new RecordingQueueCoordinator(active: true);
+        await using var fixture = await HealthFixture.CreateAsync(queue);
+        var previousGrace = HealthCheckService.StartupGracePeriod;
+        HealthCheckService.StartupGracePeriod = TimeSpan.Zero;
+        try
+        {
+            await fixture.Service.StartAsync(CancellationToken.None);
+            await queue.FirstActiveRead.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+            Assert.Equal(1, queue.ActiveReadCount);
+            fixture.Time.Advance(TimeSpan.FromSeconds(30));
+            Assert.Equal(1, queue.ActiveReadCount);
+        }
+        finally
+        {
+            await fixture.Service.StopAsync(CancellationToken.None);
+            HealthCheckService.StartupGracePeriod = previousGrace;
+        }
+    }
+
+    private sealed class HealthFixture : IAsyncDisposable
+    {
+        private readonly string _patchDirectory;
+
+        private HealthFixture(HealthCheckService service, ControllableTimeProvider time, string patchDirectory)
+        {
+            Service = service;
+            Time = time;
+            _patchDirectory = patchDirectory;
+        }
+
+        public HealthCheckService Service { get; }
+        public ControllableTimeProvider Time { get; }
+
+        public static async Task<HealthFixture> CreateAsync(IQueueCoordinator queue)
+        {
+            var patchDirectory = Path.Join(Path.GetTempPath(), $"nzbdav-health-worker-{Guid.NewGuid():N}");
+            var config = new ConfigManager();
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "true" },
+            ]);
+            var patchStore = new RepairPatchStore(patchDirectory, 1024 * 1024);
+            await patchStore.CatalogLoadTask;
+            var time = new ControllableTimeProvider();
+            var service = new HealthCheckService(
+                config,
+                null!,
+                new WebsocketManager(),
+                new BenchmarkGate(),
+                new StreamingFailureTracker(),
+                queue,
+                new Par2RepairService(config, null!, patchStore),
+                patchStore,
+                new ArrReplacementSearchBudget(),
+                timeProvider: time);
+            return new HealthFixture(service, time, patchDirectory);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            if (Directory.Exists(_patchDirectory))
+                Directory.Delete(_patchDirectory, recursive: true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingQueueCoordinator(bool active) : IQueueCoordinator
+    {
+        private readonly bool _active = active;
+        public TaskCompletionSource FirstActiveRead { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int ActiveReadCount { get; private set; }
+
+        public bool HasActiveQueueItems
+        {
+            get
+            {
+                ActiveReadCount++;
+                FirstActiveRead.TrySetResult();
+                return _active;
+            }
+        }
+
+        public IReadOnlyList<QueueManager.InProgressQueueItemSnapshot> GetInProgressQueueItems() => [];
+        public QueueManager.InProgressQueueItemSnapshot? FindInProgressQueueItem(Guid queueItemId) => null;
+        public IDisposable? TryReserveQueueSlot(int persistedCount, int maxItems, int resumeThreshold) => null;
+        public void AwakenQueue(DateTime? dateTime = null) { }
+        public Task RemoveQueueItemsAsync(List<Guid> queueItemIds, DavDatabaseClient dbClient, CancellationToken ct = default) => Task.CompletedTask;
+        public Task PauseQueueItemsAsync(List<Guid> queueItemIds, DavDatabaseClient dbClient, CancellationToken ct = default) => Task.CompletedTask;
+        public Task ResumeQueueItemsAsync(List<Guid> queueItemIds, DavDatabaseClient dbClient, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SetQueueItemsPriorityAsync(List<Guid> queueItemIds, QueueItem.PriorityOption priority, DavDatabaseClient dbClient, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<DavDatabaseClient.QueueSwitchResult> SwitchQueueItemAsync(Guid sourceId, string target, DavDatabaseClient dbClient, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<List<Guid>> MoveQueueItemsToTopAsync(List<Guid> queueItemIds, DavDatabaseClient dbClient, CancellationToken ct = default) => Task.FromResult(queueItemIds);
+        public Task<List<Guid>> SetQueueItemsCategoryAsync(List<Guid> queueItemIds, string category, DavDatabaseClient dbClient, CancellationToken ct = default) => Task.FromResult(queueItemIds);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckWorkerAdmissionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckWorkerAdmissionTests.cs
@@ -44,8 +44,6 @@ public sealed class HealthCheckWorkerAdmissionTests
             await queue.FirstActiveRead.Task.WaitAsync(TimeSpan.FromSeconds(2));
 
             Assert.Equal(1, queue.ActiveReadCount);
-            fixture.Time.Advance(TimeSpan.FromSeconds(30));
-            Assert.Equal(1, queue.ActiveReadCount);
         }
         finally
         {

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceCorruptSourceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceCorruptSourceTests.cs
@@ -277,6 +277,59 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task BackgroundRepair_UrgentCallJoinsFlight_AndCanceledJoinerDoesNotCancelOwner()
+    {
+        var fileData = PatternBytes(SliceSize * 3, 0x78);
+        var sourceReadStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowSourceRead = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var release = await SeedAsync(
+            fileData,
+            EqualSegments(3),
+            recoveryExponents: [0u],
+            corruptOnRead: [0],
+            sourceReadStarted: sourceReadStarted,
+            allowSourceRead: allowSourceRead.Task);
+
+        await release.Service.StartAsync(CancellationToken.None);
+        try
+        {
+            await release.Service.EnqueueAsync(
+                release.Item,
+                [release.ContentSegmentIds[0]],
+                CancellationToken.None);
+            await sourceReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            using var canceledJoinerCts = new CancellationTokenSource();
+            var canceledJoiner = release.Service.TryPar2RepairAsync(
+                release.Item,
+                [release.ContentSegmentIds[0]],
+                canceledJoinerCts.Token);
+            canceledJoinerCts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledJoiner);
+
+            var successfulJoiner = release.Service.TryPar2RepairAsync(
+                release.Item,
+                [release.ContentSegmentIds[0]],
+                CancellationToken.None);
+            Assert.False(successfulJoiner.IsCompleted);
+
+            allowSourceRead.TrySetResult(true);
+            Assert.True(await successfulJoiner.WaitAsync(TimeSpan.FromSeconds(10)));
+            Assert.True(release.Store.Contains(release.ContentSegmentIds[0]));
+            Assert.Equal(1, release.Service.GetDiagnosticSnapshot().TotalSucceeded);
+
+            var job = await ReadJobAsync(release.Item.Id);
+            Assert.Equal(1, job.Attempts);
+            Assert.Equal(Par2RepairJob.RepairJobState.Succeeded, job.State);
+        }
+        finally
+        {
+            using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await release.Service.StopAsync(stopCts.Token);
+        }
+    }
+
+    [Fact]
     public async Task InsufficientRecoverySlices_IsInfeasibleAndCommitsNothing()
     {
         var fileData = PatternBytes(SliceSize * 3, 0x88);
@@ -360,7 +413,9 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
         CancellationTokenSource? cancel = null,
         byte[]? fileHashOverride = null,
         IReadOnlyList<(string FileName, byte[] Data, int[] Sizes)>? extraFiles = null,
-        string? maxMissingSlices = null)
+        string? maxMissingSlices = null,
+        TaskCompletionSource<bool>? sourceReadStarted = null,
+        Task? allowSourceRead = null)
     {
         _config.UpdateValues(
         [
@@ -430,6 +485,10 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
                     return new CancelOnReadStream(cancel ?? throw new InvalidOperationException("cancel CTS required"));
                 if (corruptIds.Contains(id))
                     return new ThrowingReadStream(id);
+                if (sourceReadStarted is not null
+                    && allowSourceRead is not null
+                    && contentIds.Contains(id, StringComparer.Ordinal))
+                    return new GateOnFirstReadStream(bytes, sourceReadStarted, allowSourceRead);
                 return new MemoryStream(bytes, writable: false);
             });
 
@@ -611,6 +670,27 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
         {
             cts.Cancel();
             return ValueTask.FromException<int>(new OperationCanceledException(cts.Token));
+        }
+    }
+
+    private sealed class GateOnFirstReadStream(
+        byte[] buffer,
+        TaskCompletionSource<bool> started,
+        Task release) : MemoryStream(buffer, writable: false)
+    {
+        private int _hasWaited;
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            if (Interlocked.Exchange(ref _hasWaited, 1) == 0)
+            {
+                started.TrySetResult(true);
+                await release.WaitAsync(cancellationToken);
+            }
+
+            return await base.ReadAsync(buffer, cancellationToken);
         }
     }
 }

--- a/tests/NzbWebDAV.Tests/Services/StreamingFailureTrackerTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/StreamingFailureTrackerTests.cs
@@ -50,4 +50,63 @@ public class StreamingFailureTrackerTests
         Assert.Equal(2, tracker.GetFailureCount(a));
         Assert.Equal(1, tracker.GetFailureCount(b));
     }
+
+    [Fact]
+    public void AttributedFailures_DeduplicateOrdinalSegmentIds()
+    {
+        var tracker = new StreamingFailureTracker();
+        var id = Guid.NewGuid();
+
+        tracker.RecordAttributedFailure(id, "<segment@test>");
+        tracker.RecordAttributedFailure(id, "<segment@test>");
+        tracker.RecordAttributedFailure(id, "<SEGMENT@test>");
+
+        var snapshot = tracker.GetSnapshot(id);
+        Assert.Equal(3, snapshot.Count);
+        Assert.True(snapshot.HasTargetableSegmentIds);
+        Assert.Equal(["<segment@test>", "<SEGMENT@test>"], snapshot.SegmentIds);
+    }
+
+    [Fact]
+    public void UnattributedFailure_MakesEntireStreakConservative()
+    {
+        var tracker = new StreamingFailureTracker();
+        var id = Guid.NewGuid();
+
+        tracker.RecordAttributedFailure(id, "<segment@test>");
+        tracker.RecordUnattributedFailure(id);
+
+        var snapshot = tracker.GetSnapshot(id);
+        Assert.Equal(2, snapshot.Count);
+        Assert.True(snapshot.HasUnattributedFailure);
+        Assert.False(snapshot.HasTargetableSegmentIds);
+        Assert.Equal(["<segment@test>"], snapshot.SegmentIds);
+    }
+
+    [Fact]
+    public void ClearFailure_RemovesCountAndContextAtomically()
+    {
+        var tracker = new StreamingFailureTracker();
+        var id = Guid.NewGuid();
+        tracker.RecordAttributedFailure(id, "<segment@test>");
+
+        tracker.ClearFailure(id);
+
+        Assert.Equal(StreamingFailureSnapshot.Empty, tracker.GetSnapshot(id));
+    }
+
+    [Fact]
+    public void AttributedFailureCap_PreservesCountAndTargetability()
+    {
+        var tracker = new StreamingFailureTracker();
+        var id = Guid.NewGuid();
+
+        for (var i = 0; i < 65; i++)
+            tracker.RecordAttributedFailure(id, $"<{i}@test>");
+
+        var snapshot = tracker.GetSnapshot(id);
+        Assert.Equal(65, snapshot.Count);
+        Assert.Equal(64, snapshot.SegmentIds.Length);
+        Assert.True(snapshot.HasTargetableSegmentIds);
+    }
 }

--- a/tests/NzbWebDAV.Tests/Services/UrgentRepairDispositionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/UrgentRepairDispositionTests.cs
@@ -5,19 +5,18 @@ namespace NzbWebDAV.Tests.Services;
 public class UrgentRepairDispositionTests
 {
     [Theory]
-    [InlineData(0, 0, false, true, HealthCheckService.UrgentRepairDisposition.RepairNormally)]
-    [InlineData(0, 5, false, true, HealthCheckService.UrgentRepairDisposition.RepairNormally)]
-    [InlineData(0, 5, true, true, HealthCheckService.UrgentRepairDisposition.RepairNormally)]
+    [InlineData(0, 0, true, HealthCheckService.UrgentRepairDisposition.RepairNormally)]
+    [InlineData(0, 5, true, HealthCheckService.UrgentRepairDisposition.RepairNormally)]
+    [InlineData(0, 5, false, HealthCheckService.UrgentRepairDisposition.RepairNormally)]
     public void ThresholdZero_AlwaysRepairNormally(
         int threshold,
         int failureCount,
-        bool hasLibraryLink,
         bool unlinkedOnly,
         HealthCheckService.UrgentRepairDisposition expected)
     {
         Assert.Equal(
             expected,
-            HealthCheckService.GetUrgentRepairDisposition(threshold, failureCount, hasLibraryLink, unlinkedOnly));
+            HealthCheckService.GetUrgentRepairDisposition(threshold, failureCount, unlinkedOnly));
     }
 
     [Fact]
@@ -25,26 +24,26 @@ public class UrgentRepairDispositionTests
     {
         Assert.Equal(
             HealthCheckService.UrgentRepairDisposition.Defer,
-            HealthCheckService.GetUrgentRepairDisposition(3, 2, hasLibraryLink: false, autoRemoveUnlinkedOnly: true));
+            HealthCheckService.GetUrgentRepairDisposition(3, 2, autoRemoveUnlinkedOnly: true));
     }
 
     [Fact]
-    public void Unlinked_AtThreshold_ForceDeletes()
+    public void UnlinkedOnly_AtThreshold_DefersLinkDecisionUntilRepair()
     {
         Assert.Equal(
-            HealthCheckService.UrgentRepairDisposition.ForceDelete,
-            HealthCheckService.GetUrgentRepairDisposition(3, 3, hasLibraryLink: false, autoRemoveUnlinkedOnly: true));
+            HealthCheckService.UrgentRepairDisposition.ForceDeleteIfUnlinked,
+            HealthCheckService.GetUrgentRepairDisposition(3, 3, autoRemoveUnlinkedOnly: true));
     }
 
     [Fact]
-    public void Linked_UnlinkedOnly_DefersUntilThresholdThenUsesArrPath()
+    public void UnlinkedOnly_DefersUntilThresholdThenDefersLinkDecision()
     {
         Assert.Equal(
             HealthCheckService.UrgentRepairDisposition.Defer,
-            HealthCheckService.GetUrgentRepairDisposition(3, 1, hasLibraryLink: true, autoRemoveUnlinkedOnly: true));
+            HealthCheckService.GetUrgentRepairDisposition(3, 1, autoRemoveUnlinkedOnly: true));
         Assert.Equal(
-            HealthCheckService.UrgentRepairDisposition.RepairNormally,
-            HealthCheckService.GetUrgentRepairDisposition(3, 3, hasLibraryLink: true, autoRemoveUnlinkedOnly: true));
+            HealthCheckService.UrgentRepairDisposition.ForceDeleteIfUnlinked,
+            HealthCheckService.GetUrgentRepairDisposition(3, 3, autoRemoveUnlinkedOnly: true));
     }
 
     [Fact]
@@ -52,10 +51,10 @@ public class UrgentRepairDispositionTests
     {
         Assert.Equal(
             HealthCheckService.UrgentRepairDisposition.Defer,
-            HealthCheckService.GetUrgentRepairDisposition(3, 2, hasLibraryLink: true, autoRemoveUnlinkedOnly: false));
+            HealthCheckService.GetUrgentRepairDisposition(3, 2, autoRemoveUnlinkedOnly: false));
         Assert.Equal(
             HealthCheckService.UrgentRepairDisposition.ForceDelete,
-            HealthCheckService.GetUrgentRepairDisposition(3, 3, hasLibraryLink: true, autoRemoveUnlinkedOnly: false));
+            HealthCheckService.GetUrgentRepairDisposition(3, 3, autoRemoveUnlinkedOnly: false));
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/WebDav/GetAndHeadHandlerRangeTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/GetAndHeadHandlerRangeTests.cs
@@ -108,6 +108,20 @@ public class GetAndHeadHandlerRangeTests
         Assert.Equal(0, tracker.GetFailureCount(item.Id));
     }
 
+    [Fact]
+    public void CompletedSuffixRange_DoesNotClearStreamingFailures()
+    {
+        var tracker = new StreamingFailureTracker();
+        var item = NewDavItem();
+        tracker.RecordFailure(item.Id);
+
+        var cleared = GetAndHeadHandlerPatch.ClearStreamingFailureAfterCompletedRead(
+            tracker, item, isHeadRequest: false, copySucceeded: true, copyStart: 50, copyEnd: 99, streamLength: 100);
+
+        Assert.False(cleared);
+        Assert.Equal(1, tracker.GetFailureCount(item.Id));
+    }
+
     [Theory]
     [InlineData(true, false, 0, 99, 100)]
     [InlineData(false, false, 1, 99, 100)]

--- a/tests/UsenetSharp.Tests/Clients/UsenetClientDeterministicTests.cs
+++ b/tests/UsenetSharp.Tests/Clients/UsenetClientDeterministicTests.cs
@@ -1426,8 +1426,7 @@ public class UsenetClientDeterministicTests
         continueBody.SetResult();
 
         Assert.That(async () => await copyTask, Throws.InstanceOf<OperationCanceledException>());
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
-            await batch.Responses[1]);
+        Assert.That(async () => await batch.Responses[1], Throws.InstanceOf<OperationCanceledException>());
         Assert.That(await completion.Task.WaitAsync(TimeSpan.FromSeconds(2)),
             Is.EqualTo(ArticleBodyResult.Cancelled));
         Assert.That(callbackCount, Is.EqualTo(1));


### PR DESCRIPTION
## Summary
- coalesce same-item PAR2 repair callers so urgent repair waits for an active background repair outcome
- retain bounded, attributed streaming failure context for safe PAR2 seeding and defer library-link policy to the final action boundary
- add regression coverage for repair classification, worker admission, range failure resets, PAR2 joining, and repair policy

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`
- [ ] Manually verify rclone/Plex range playback, repairable and infeasible PAR2, concurrent imports, and Arr remove/blocklist/search behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repair decisions by distinguishing attributed and unattributed streaming failures.
  * PAR2 repairs now reuse in-progress operations, preventing duplicate concurrent repairs.
  * Urgent repairs use recorded segment information and defer deletion decisions until link status is confirmed.
  * Streaming-failure records are preserved after completed range requests.
  * Non-content errors, including provider issues and timeouts, no longer record streaming failures.

* **Tests**
  * Added coverage for repair coordination, failure tracking, queue admission, and urgent repair behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->