### PR TITLE
perf(queue): fail dead NZBs after one probe instead of scanning every article

### DIFF
--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -148,14 +148,9 @@ public class QueueItemProcessor(
     internal static string? SelectMidpointPreflightSegment(
         IReadOnlyList<IReadOnlyList<string>> segmentsByFile)
     {
-        IReadOnlyList<string>? candidate = null;
-        foreach (var file in segmentsByFile)
-        {
-            if (file.Count < 2) continue;
-            if (candidate is null || file.Count > candidate.Count)
-                candidate = file;
-        }
-
+        var candidate = segmentsByFile
+            .Where(file => file.Count >= 2)
+            .MaxBy(file => file.Count);
         return candidate?[candidate.Count / 2];
     }
 

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -140,6 +140,66 @@ public class QueueItemProcessor(
             : files.SelectMany(segments => segments).ToList();
     }
 
+    /// <summary>
+    /// Picks one strategically distant segment to probe before a full existence sweep:
+    /// the midpoint of the largest eligible file. Returns null when no file has at
+    /// least two segments (step 1 already verified every first segment).
+    /// </summary>
+    internal static string? SelectMidpointPreflightSegment(
+        IReadOnlyList<IReadOnlyList<string>> segmentsByFile)
+    {
+        IReadOnlyList<string>? candidate = null;
+        foreach (var file in segmentsByFile)
+        {
+            if (file.Count < 2) continue;
+            if (candidate is null || file.Count > candidate.Count)
+                candidate = file;
+        }
+
+        return candidate?[candidate.Count / 2];
+    }
+
+    /// <summary>
+    /// Full-mode dead-NZB preflight (#897): one serial STAT on the midpoint of the
+    /// largest file, then the remaining sweep. A definitive miss throws
+    /// <see cref="UsenetArticleNotFoundException"/>, which the outer failure handler
+    /// already caches and fails non-retryably. Sampled mode skips the extra probe.
+    /// </summary>
+    internal static async Task CheckExistenceWithOptionalMidpointPreflightAsync(
+        INntpClient usenetClient,
+        IReadOnlyList<IReadOnlyList<string>> segmentsByFile,
+        IReadOnlyList<string> articlesToCheck,
+        string checkMode,
+        int healthCheckConcurrency,
+        IProgress<int>? part3Progress,
+        CancellationToken ct)
+    {
+        var remaining = articlesToCheck;
+        var completedBeforeSweep = 0;
+
+        if (checkMode == "full" &&
+            SelectMidpointPreflightSegment(segmentsByFile) is { } probeId &&
+            articlesToCheck.Contains(probeId))
+        {
+            await ArticleExistenceChecker.CheckAsync(
+                    usenetClient, [probeId], concurrency: 1, progress: null, ct)
+                .ConfigureAwait(false);
+            completedBeforeSweep = 1;
+            part3Progress?.Report(completedBeforeSweep);
+            remaining = articlesToCheck.Where(id => id != probeId).ToList();
+        }
+
+        var sweepProgress = new OffsetProgress(part3Progress, completedBeforeSweep);
+        await ArticleExistenceChecker.CheckAsync(
+                usenetClient, remaining, healthCheckConcurrency, sweepProgress, ct)
+            .ConfigureAwait(false);
+    }
+
+    private sealed class OffsetProgress(IProgress<int>? inner, int offset) : IProgress<int>
+    {
+        public void Report(int value) => inner?.Report(offset + value);
+    }
+
     private static TimeSpan GetProviderRetryBackoff(int attempt)
     {
         var seconds = Math.Min(60d, 10d * Math.Pow(2, attempt - 1));
@@ -578,8 +638,14 @@ public class QueueItemProcessor(
                 QueueFanOut.GetConcurrency(configManager, ct));
             await RunStageAsync(
                     "health",
-                    () => ArticleExistenceChecker
-                        .CheckAsync(usenetClient, articlesToCheck, healthCheckConcurrency, part3Progress, ct))
+                    () => CheckExistenceWithOptionalMidpointPreflightAsync(
+                        usenetClient,
+                        segmentsByFile,
+                        articlesToCheck,
+                        checkMode,
+                        healthCheckConcurrency,
+                        part3Progress,
+                        ct))
                 .ConfigureAwait(false);
             checkedFullHealth = true;
         }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
@@ -57,9 +57,10 @@ public class NntpClientCheckAllSegmentsTests
         var extraIds = new[] { "extra-0", "extra-1", "extra-2" };
         var client = new CoordinatedStatClient(failId, expectedSlowStarts: slowIds.Length);
         var ids = slowIds.Concat([failId]).Concat(extraIds).ToArray();
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
         var exception = await Assert.ThrowsAsync<UsenetArticleNotFoundException>(() =>
-            client.CheckAllSegmentsAsync(ids, concurrency: 4, progress: null, CancellationToken.None));
+            client.CheckAllSegmentsAsync(ids, concurrency: 4, progress: null, timeoutCts.Token));
 
         Assert.Equal(failId, exception.SegmentId);
         Assert.Equal(0, client.StatStartsAfterFailure);

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Exceptions;
@@ -46,6 +47,27 @@ public class NntpClientCheckAllSegmentsTests
         var client = new StatCodeClient(223);
 
         await client.CheckAllSegmentsAsync(["seg@example"], 1, null, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task CheckAllSegmentsAsync_MidpointMissCancelsInFlightAndStartsNoFurtherStats()
+    {
+        var slowIds = new[] { "slow-0", "slow-1", "slow-2" };
+        const string failId = "fail-mid";
+        var extraIds = new[] { "extra-0", "extra-1", "extra-2" };
+        var client = new CoordinatedStatClient(failId, expectedSlowStarts: slowIds.Length);
+        var ids = slowIds.Concat([failId]).Concat(extraIds).ToArray();
+
+        var exception = await Assert.ThrowsAsync<UsenetArticleNotFoundException>(() =>
+            client.CheckAllSegmentsAsync(ids, concurrency: 4, progress: null, CancellationToken.None));
+
+        Assert.Equal(failId, exception.SegmentId);
+        Assert.Equal(0, client.StatStartsAfterFailure);
+        foreach (var extraId in extraIds)
+            Assert.False(client.StatStartCounts.ContainsKey(extraId), extraId);
+        foreach (var slowId in slowIds)
+            Assert.True(client.StatStartCounts.ContainsKey(slowId), slowId);
+        Assert.True(client.AllStartedStatsCompleted);
     }
 
     [Fact]
@@ -421,6 +443,123 @@ public class NntpClientCheckAllSegmentsTests
                 ResponseMessage = $"{responseCode} <{segmentId}>",
                 ArticleExists = responseCode == (int)UsenetResponseType.ArticleExists,
             });
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+
+    private sealed class CoordinatedStatClient(string failingId, int expectedSlowStarts) : NntpClient
+    {
+        private readonly TaskCompletionSource _slowReady = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _slowStarted;
+        private int _failureObserved;
+        private int _statStartsAfterFailure;
+        private int _started;
+        private int _completed;
+
+        public ConcurrentDictionary<string, int> StatStartCounts { get; } = new(StringComparer.Ordinal);
+        public int StatStartsAfterFailure => Volatile.Read(ref _statStartsAfterFailure);
+        public bool AllStartedStatsCompleted => Volatile.Read(ref _started) == Volatile.Read(ref _completed);
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override async Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken)
+        {
+            var id = segmentId.ToString();
+            Interlocked.Increment(ref _started);
+            try
+            {
+                if (Volatile.Read(ref _failureObserved) == 1)
+                    Interlocked.Increment(ref _statStartsAfterFailure);
+
+                StatStartCounts.AddOrUpdate(id, 1, (_, n) => n + 1);
+
+                if (id == failingId)
+                {
+                    await _slowReady.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    Interlocked.Exchange(ref _failureObserved, 1);
+                    return new UsenetStatResponse
+                    {
+                        ResponseCode = 430,
+                        ResponseMessage = $"430 <{id}>",
+                        ArticleExists = false,
+                    };
+                }
+
+                if (id.StartsWith("slow-", StringComparison.Ordinal))
+                {
+                    if (Interlocked.Increment(ref _slowStarted) >= expectedSlowStarts)
+                        _slowReady.TrySetResult();
+                    try
+                    {
+                        await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // cancelled after the miss; still complete so WithConcurrencyAsync can drain
+                    }
+
+                    return new UsenetStatResponse
+                    {
+                        ResponseCode = 223,
+                        ResponseMessage = $"223 <{id}>",
+                        ArticleExists = true,
+                    };
+                }
+
+                return new UsenetStatResponse
+                {
+                    ResponseCode = 223,
+                    ResponseMessage = $"223 <{id}>",
+                    ArticleExists = true,
+                };
+            }
+            finally
+            {
+                Interlocked.Increment(ref _completed);
+            }
+        }
 
         public override Task<UsenetHeadResponse> HeadAsync(
             SegmentId segmentId, CancellationToken cancellationToken) =>

--- a/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
+++ b/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
@@ -28,6 +28,7 @@ internal sealed class FakeNntpClient(
     public Dictionary<string, int> BodyRequestCounts { get; } = new(StringComparer.Ordinal);
     public Dictionary<string, int> CompletionCallbackCounts { get; } = new(StringComparer.Ordinal);
     public Dictionary<string, int> StatRequestCounts { get; } = new(StringComparer.Ordinal);
+    public List<string> StatRequestOrder { get; } = [];
     public HashSet<string> RequestedSegmentIds { get; } = new(StringComparer.Ordinal);
 
     /// <summary>Adds or restores an article (e.g. provider-side recovery between checks).</summary>
@@ -53,6 +54,7 @@ internal sealed class FakeNntpClient(
         cancellationToken.ThrowIfCancellationRequested();
         var key = segmentId.ToString();
         StatRequestCounts[key] = StatRequestCounts.GetValueOrDefault(key) + 1;
+        StatRequestOrder.Add(key);
         var exists = _segments.ContainsKey(key);
         return Task.FromResult(new UsenetStatResponse
         {

--- a/tests/NzbWebDAV.Tests/Queue/FailFastDeadNzbTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/FailFastDeadNzbTests.cs
@@ -113,4 +113,16 @@ public class FailFastDeadNzbTests
         Assert.Throws<UsenetArticleNotFoundException>(() =>
             HealthCheckService.CheckCachedMissingSegmentIds([segmentId]));
     }
+
+    [Fact]
+    public void MidpointMiss_UsesSameNonRetryableCachePath()
+    {
+        var segmentId = $"midpoint-{Guid.NewGuid():N}@example.com";
+        var exception = new UsenetArticleNotFoundException(segmentId);
+        Assert.IsAssignableFrom<NonRetryableDownloadException>(exception);
+
+        HealthCheckService.AddMissingSegmentIds([exception.SegmentId]);
+        Assert.Throws<UsenetArticleNotFoundException>(() =>
+            HealthCheckService.CheckCachedMissingSegmentIds([segmentId]));
+    }
 }

--- a/tests/NzbWebDAV.Tests/Queue/FailFastDeadNzbTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/FailFastDeadNzbTests.cs
@@ -4,6 +4,7 @@ using NzbWebDAV.Queue;
 using NzbWebDAV.Queue.DeobfuscationSteps._1.FetchFirstSegment;
 using NzbWebDAV.Queue.DeobfuscationSteps._3.GetFileInfos;
 using NzbWebDAV.Services;
+using NzbWebDAV.Tests.Fakes;
 
 namespace NzbWebDAV.Tests.Queue;
 
@@ -99,7 +100,7 @@ public class FailFastDeadNzbTests
     [Fact]
     public void FailMissingImportantFile_CachesSegmentAndThrowsNonRetryable()
     {
-        var segmentId = $"cache-me-{Guid.NewGuid():N}@example.com";
+        const string segmentId = "cache-me-dead-nzb-fail-fast@example.com";
         var nzbFile = new NzbFile
         {
             Subject = "\"dead.rar\" yEnc (1/1)",
@@ -115,14 +116,29 @@ public class FailFastDeadNzbTests
     }
 
     [Fact]
-    public void MidpointMiss_UsesSameNonRetryableCachePath()
+    public async Task MidpointMiss_CachesProbedIdThroughProductionPreflightAndHandler()
     {
-        var segmentId = $"midpoint-{Guid.NewGuid():N}@example.com";
-        var exception = new UsenetArticleNotFoundException(segmentId);
+        IReadOnlyList<IReadOnlyList<string>> files = [["video-0", "video-1", "video-2", "video-3"]];
+        var articles = QueueItemProcessor.SelectArticlesForExistenceCheck(files, "full");
+        var probeId = QueueItemProcessor.SelectMidpointPreflightSegment(files);
+        Assert.Equal("video-2", probeId);
+        Assert.NotNull(probeId);
+
+        var available = articles
+            .Where(id => id != probeId)
+            .ToDictionary(id => id, _ => Array.Empty<byte>());
+        var client = new FakeNntpClient(available);
+
+        var exception = await Assert.ThrowsAsync<UsenetArticleNotFoundException>(() =>
+            QueueItemProcessor.CheckExistenceWithOptionalMidpointPreflightAsync(
+                client, files, articles, "full", healthCheckConcurrency: 4,
+                part3Progress: null, CancellationToken.None));
+
+        Assert.Equal(probeId, exception.SegmentId);
         Assert.IsAssignableFrom<NonRetryableDownloadException>(exception);
 
         HealthCheckService.AddMissingSegmentIds([exception.SegmentId]);
         Assert.Throws<UsenetArticleNotFoundException>(() =>
-            HealthCheckService.CheckCachedMissingSegmentIds([segmentId]));
+            HealthCheckService.CheckCachedMissingSegmentIds([probeId]));
     }
 }

--- a/tests/NzbWebDAV.Tests/Queue/FailFastDeadNzbTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/FailFastDeadNzbTests.cs
@@ -118,10 +118,18 @@ public class FailFastDeadNzbTests
     [Fact]
     public async Task MidpointMiss_CachesProbedIdThroughProductionPreflightAndHandler()
     {
-        IReadOnlyList<IReadOnlyList<string>> files = [["video-0", "video-1", "video-2", "video-3"]];
+        IReadOnlyList<IReadOnlyList<string>> files =
+        [
+            [
+                "midpoint-preflight-video-0@example.com",
+                "midpoint-preflight-video-1@example.com",
+                "midpoint-preflight-video-2@example.com",
+                "midpoint-preflight-video-3@example.com",
+            ],
+        ];
         var articles = QueueItemProcessor.SelectArticlesForExistenceCheck(files, "full");
         var probeId = QueueItemProcessor.SelectMidpointPreflightSegment(files);
-        Assert.Equal("video-2", probeId);
+        Assert.Equal("midpoint-preflight-video-2@example.com", probeId);
         Assert.NotNull(probeId);
 
         var available = articles

--- a/tests/NzbWebDAV.Tests/Queue/QueueArticleExistenceSelectionTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueArticleExistenceSelectionTests.cs
@@ -56,6 +56,113 @@ public sealed class QueueArticleExistenceSelectionTests
         Assert.Equal(file[^1], exception.SegmentId);
     }
 
+    [Fact]
+    public void MidpointPreflight_SelectsMidpointOfLargestFile()
+    {
+        IReadOnlyList<IReadOnlyList<string>> files =
+        [
+            Segments("small", 5),
+            Segments("large", 9),
+            Segments("medium", 7),
+        ];
+        Assert.Equal("large-4", QueueItemProcessor.SelectMidpointPreflightSegment(files));
+    }
+
+    [Fact]
+    public void MidpointPreflight_TieKeepsFirstFile()
+    {
+        IReadOnlyList<IReadOnlyList<string>> files = [Segments("a", 6), Segments("b", 6)];
+        Assert.Equal("a-3", QueueItemProcessor.SelectMidpointPreflightSegment(files));
+    }
+
+    [Fact]
+    public void MidpointPreflight_SkipsSingleSegmentFilesAndEmptyInput()
+    {
+        Assert.Null(QueueItemProcessor.SelectMidpointPreflightSegment([Segments("one", 1)]));
+        Assert.Null(QueueItemProcessor.SelectMidpointPreflightSegment([]));
+    }
+
+    [Theory]
+    [InlineData(8, "even-4")]
+    [InlineData(9, "odd-4")]
+    public void MidpointPreflight_EvenAndOddCountsUseIntegerDivision(int count, string expected)
+    {
+        var prefix = expected.Split('-')[0];
+        Assert.Equal(
+            expected,
+            QueueItemProcessor.SelectMidpointPreflightSegment([Segments(prefix, count)]));
+    }
+
+    [Fact]
+    public async Task MidpointPreflight_MissThrowsWithProbedIdBeforeSweep()
+    {
+        var files = new IReadOnlyList<string>[] { Segments("video", 8), Segments("extra", 4) };
+        var articles = QueueItemProcessor.SelectArticlesForExistenceCheck(files, "full");
+        var probeId = QueueItemProcessor.SelectMidpointPreflightSegment(files);
+        Assert.Equal("video-4", probeId);
+        Assert.NotNull(probeId);
+
+        var available = articles
+            .Where(id => id != probeId)
+            .ToDictionary(id => id, _ => Array.Empty<byte>());
+        var client = new FakeNntpClient(available);
+        var progress = new List<int>();
+
+        var exception = await Assert.ThrowsAsync<UsenetArticleNotFoundException>(() =>
+            QueueItemProcessor.CheckExistenceWithOptionalMidpointPreflightAsync(
+                client, files, articles, "full", healthCheckConcurrency: 4,
+                new CollectingProgress(progress), CancellationToken.None));
+
+        Assert.Equal(probeId, exception.SegmentId);
+        Assert.Equal(new[] { probeId }, client.StatRequestOrder);
+        Assert.Equal(1, client.StatRequestCounts[probeId]);
+    }
+
+    [Fact]
+    public async Task MidpointPreflight_HitChecksEveryRemainingIdExactlyOnce()
+    {
+        var files = new IReadOnlyList<string>[] { Segments("video", 8), Segments("extra", 4) };
+        var articles = QueueItemProcessor.SelectArticlesForExistenceCheck(files, "full");
+        var probeId = QueueItemProcessor.SelectMidpointPreflightSegment(files)!;
+        var available = articles.ToDictionary(id => id, _ => Array.Empty<byte>());
+        var client = new FakeNntpClient(available);
+        var progress = new List<int>();
+
+        await QueueItemProcessor.CheckExistenceWithOptionalMidpointPreflightAsync(
+            client, files, articles, "full", healthCheckConcurrency: 4,
+            new CollectingProgress(progress), CancellationToken.None);
+
+        Assert.Equal(probeId, client.StatRequestOrder[0]);
+        Assert.Equal(articles.Count, client.StatRequestOrder.Count);
+        Assert.Equal(articles.ToHashSet(), client.StatRequestOrder.ToHashSet());
+        Assert.All(client.StatRequestCounts.Values, count => Assert.Equal(1, count));
+        Assert.Equal(articles.Count, progress[^1]);
+    }
+
+    [Fact]
+    public async Task MidpointPreflight_SampledModeIssuesNoExtraRequest()
+    {
+        var files = new IReadOnlyList<string>[] { Segments("video", 20_000) };
+        var articles = QueueItemProcessor.SelectArticlesForExistenceCheck(files, "sampled");
+        var probeId = QueueItemProcessor.SelectMidpointPreflightSegment(files)!;
+        var available = articles.ToDictionary(id => id, _ => Array.Empty<byte>());
+        var client = new FakeNntpClient(available);
+
+        await QueueItemProcessor.CheckExistenceWithOptionalMidpointPreflightAsync(
+            client, files, articles, "sampled", healthCheckConcurrency: 4,
+            part3Progress: null, CancellationToken.None);
+
+        Assert.Equal(articles.Count, client.StatRequestOrder.Count);
+        Assert.Equal(articles.ToHashSet(), client.StatRequestOrder.ToHashSet());
+        if (probeId != articles[0])
+            Assert.NotEqual(probeId, client.StatRequestOrder[0]);
+    }
+
+    private sealed class CollectingProgress(List<int> values) : IProgress<int>
+    {
+        public void Report(int value) => values.Add(value);
+    }
+
     private static List<string> Segments(string prefix, int count) =>
         Enumerable.Range(0, count).Select(i => $"{prefix}-{i}").ToList();
 }


### PR DESCRIPTION
## Summary
- When a category runs a full article-existence check, STAT the midpoint of the largest eligible file first (serial, concurrency 1).
- A definitive miss fails the NZB immediately and reuses the existing missing-segment cache / non-retryable path, so a dead release with surviving first segments no longer fans out STATs across every remaining article.
- A healthy midpoint is excluded from the subsequent sweep so it is not checked twice. Sampled mode and background health checks are unchanged.

Closes #897

## Test plan
- [x] `QueueArticleExistenceSelectionTests` — midpoint selection (largest file, ties, empty/single-segment, even/odd)
- [x] Midpoint miss throws with the probed id and issues no sweep STATs
- [x] Midpoint hit checks every remaining id exactly once; progress ends at the original count
- [x] Sampled mode issues no extra STAT
- [x] `FailFastDeadNzbTests` — midpoint miss uses the same non-retryable cache path
- [x] `NntpClientCheckAllSegmentsTests` — in-flight STATs drain on a midpoint 430; no further STATs start
- [x] Full backend suite: 3669 passed, 14 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved full-mode article availability checks with a midpoint preflight before the complete scan.
  * Missing midpoint articles now stop unnecessary requests promptly.
  * Progress reporting remains accurate throughout the checks.
  * Sampled-mode checks continue without the additional midpoint probe.

* **Tests**
  * Added coverage for midpoint selection, failure handling, cancellation, progress reporting, and request ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->