### PR TITLE
feat(ui): inspect each provider's speed history from Overview

### DIFF
--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -68,6 +68,10 @@ public class GetOverviewStatsController(
         var throughput = new List<GetOverviewStatsResponse.ThroughputPoint>();
         long throughputBucketSizeMs = 0;
         var providers = new List<GetOverviewStatsResponse.ProviderRow>();
+        long providerSpeedBucketSizeMs = 0;
+        long providerSpeedWindowStartMs = 0;
+        long providerSpeedWindowEndMs = 0;
+        var providerSpeedHistoryTruncated = false;
         var sessionsBlock = new GetOverviewStatsResponse.SessionsBlock();
         var heatmap = new GetOverviewStatsResponse.HeatmapBlock();
         var failover = new GetOverviewStatsResponse.FailoverBlock();
@@ -106,6 +110,10 @@ public class GetOverviewStatsController(
             throughput = w.Throughput;
             throughputBucketSizeMs = w.ThroughputBucketSizeMs;
             providers = w.Providers;
+            providerSpeedBucketSizeMs = w.ProviderSpeedBucketSizeMs;
+            providerSpeedWindowStartMs = w.ProviderSpeedWindowStartMs;
+            providerSpeedWindowEndMs = w.ProviderSpeedWindowEndMs;
+            providerSpeedHistoryTruncated = w.ProviderSpeedHistoryTruncated;
             sessionsBlock = w.Sessions;
             heatmap = w.Heatmap;
             failover = w.Failover;
@@ -151,6 +159,10 @@ public class GetOverviewStatsController(
             TotalErrors = totalErrors,
             TotalBytesFetched = totalBytesFetched,
             Providers = providers,
+            ProviderSpeedBucketSizeMs = providerSpeedBucketSizeMs,
+            ProviderSpeedWindowStartMs = providerSpeedWindowStartMs,
+            ProviderSpeedWindowEndMs = providerSpeedWindowEndMs,
+            ProviderSpeedHistoryTruncated = providerSpeedHistoryTruncated,
             Catalogue = catalogue,
             Sessions = sessionsBlock,
             Heatmap = heatmap,
@@ -176,7 +188,11 @@ public class GetOverviewStatsController(
         long TotalArticles,
         long TotalMisses,
         long TotalErrors,
-        long TotalBytesFetched);
+        long TotalBytesFetched,
+        long ProviderSpeedBucketSizeMs,
+        long ProviderSpeedWindowStartMs,
+        long ProviderSpeedWindowEndMs,
+        bool ProviderSpeedHistoryTruncated);
 
     private sealed record DetailSectionResult(
         GetOverviewStatsResponse.LatencyBlock Latency,
@@ -294,6 +310,7 @@ public class GetOverviewStatsController(
                 bucketSize,
                 nowMs,
                 labelsByMetricsKey,
+                window,
                 window == GetOverviewStatsRequest.OverviewWindow.AllTime ? lifetimeTotals : null);
             totalArticles = hours.Sum(h => h.Articles);
             totalMisses = hours.Sum(h => h.Misses);
@@ -353,7 +370,7 @@ public class GetOverviewStatsController(
                 bucketSize);
             providers = BuildProvidersFromMinutes(
                 minutes.Select(m => (m.Minute, m.Provider, m.Articles, m.BytesFetched, m.Misses, m.Errors, m.Retries, m.SumDurationMs)),
-                windowStart, window, labelsByMetricsKey);
+                windowStart, window, labelsByMetricsKey, nowMs);
             totalArticles = minutes.Sum(m => m.Articles);
             totalMisses = minutes.Sum(m => m.Misses);
             totalErrors = minutes.Sum(m => m.Errors);
@@ -406,9 +423,14 @@ public class GetOverviewStatsController(
             nowMs,
             useRollups);
 
+        var series = ResolveProviderSeriesGeometry(window, windowStart, nowMs);
+        var truncated = series.Truncated
+                        || (window == GetOverviewStatsRequest.OverviewWindow.AllTime
+                            && lifetimeTotals.Count > 0);
         return new WindowSectionResult(
             tiles, throughput, bucketSize, providers, sessionsBlock, heatmap, failover,
-            totalArticles, totalMisses, totalErrors, totalBytesFetched);
+            totalArticles, totalMisses, totalErrors, totalBytesFetched,
+            series.BucketSize, series.Start, series.End, truncated);
     }
 
     private static void ApplyOutageSparks(
@@ -441,6 +463,16 @@ public class GetOverviewStatsController(
         if (useRollups)
         {
             const long sparkSize = OneDay;
+            if (windowStart <= 0)
+            {
+                // All-time sparks are capped at 60 daily buckets. End-align on the
+                // current day so the latest hour is not clipped (windowStart=0 used
+                // to index from the Unix epoch).
+                const int allTimeSparkBuckets = 60;
+                var sparkEnd = nowMs - (nowMs % sparkSize) + sparkSize;
+                return (allTimeSparkBuckets, sparkSize, sparkEnd - allTimeSparkBuckets * sparkSize);
+            }
+
             var totalSpan = nowMs - windowStart;
             var sparkBuckets = Math.Max(1, (int)Math.Min(60, totalSpan / sparkSize + 1));
             return (sparkBuckets, sparkSize, windowStart - windowStart % sparkSize);
@@ -807,12 +839,53 @@ public class GetOverviewStatsController(
             .ToList();
     }
 
+    internal static (long Start, long End, long BucketSize, bool Truncated) ResolveProviderSeriesGeometry(
+        GetOverviewStatsRequest.OverviewWindow window,
+        long windowStart,
+        long nowMs)
+    {
+        const long fifteenMinutes = 15 * OneMinute;
+        const long sixHours = 6 * OneHour;
+        const long oneWeek = 7 * OneDay;
+        var (bucketSize, count, truncated) = window switch
+        {
+            GetOverviewStatsRequest.OverviewWindow.Last1Hour => (OneMinute, 60, false),
+            GetOverviewStatsRequest.OverviewWindow.Last24Hours => (fifteenMinutes, 96, false),
+            GetOverviewStatsRequest.OverviewWindow.Last7Days => (OneHour, 168, false),
+            GetOverviewStatsRequest.OverviewWindow.Last30Days => (sixHours, 120, false),
+            _ => (oneWeek, 0, true),
+        };
+
+        if (window == GetOverviewStatsRequest.OverviewWindow.AllTime)
+        {
+            var start = nowMs - 365 * OneDay;
+            start -= start % bucketSize;
+            var end = nowMs - (nowMs % bucketSize) + bucketSize;
+            if (end <= start) end = start + bucketSize;
+            return (start, end, bucketSize, true);
+        }
+
+        var alignedStart = windowStart - windowStart % bucketSize;
+        return (alignedStart, alignedStart + (long)count * bucketSize, bucketSize, truncated);
+    }
+
     internal static List<GetOverviewStatsResponse.ProviderRow> BuildProvidersFromMinutes(
         IEnumerable<(long Minute, string Provider, long Articles, long BytesFetched, long Misses, long Errors, long Retries, long SumDurationMs)> minutes,
         long windowStart,
         GetOverviewStatsRequest.OverviewWindow window,
-        IReadOnlyDictionary<string, string?> labelsByMetricsKey)
+        IReadOnlyDictionary<string, string?> labelsByMetricsKey,
+        long nowMs = 0)
     {
+        if (nowMs <= 0)
+        {
+            nowMs = windowStart + window switch
+            {
+                GetOverviewStatsRequest.OverviewWindow.Last1Hour => OneHour,
+                GetOverviewStatsRequest.OverviewWindow.Last7Days => 7 * OneDay,
+                _ => OneDay,
+            };
+        }
+
         var (sparkBuckets, sparkSize) = window switch
         {
             GetOverviewStatsRequest.OverviewWindow.Last1Hour => (60, OneMinute),
@@ -820,12 +893,14 @@ public class GetOverviewStatsController(
             _ => (24, OneHour),
         };
         var sparkStart = windowStart - (windowStart % sparkSize);
+        var series = ResolveProviderSeriesGeometry(window, windowStart, nowMs);
+        var seriesBuckets = (int)((series.End - series.Start) / series.BucketSize);
 
         var byProvider = new Dictionary<string, ProviderAccumulator>();
         foreach (var m in minutes)
         {
             if (!byProvider.TryGetValue(m.Provider, out var acc))
-                acc = new ProviderAccumulator(sparkBuckets);
+                acc = new ProviderAccumulator(sparkBuckets, seriesBuckets);
             acc.Articles += m.Articles;
             acc.Misses += m.Misses;
             acc.Errors += m.Errors;
@@ -840,6 +915,12 @@ public class GetOverviewStatsController(
                 acc.RetrySpark[idx] += m.Retries;
                 acc.BytesSpark[idx] += m.BytesFetched;
                 acc.DurationSpark[idx] += m.SumDurationMs;
+            }
+            var seriesIdx = (int)((m.Minute - series.Start) / series.BucketSize);
+            if (seriesIdx >= 0 && seriesIdx < seriesBuckets)
+            {
+                acc.SeriesBytes[seriesIdx] += m.BytesFetched;
+                acc.SeriesDurations[seriesIdx] += m.SumDurationMs;
             }
             byProvider[m.Provider] = acc;
         }
@@ -859,6 +940,7 @@ public class GetOverviewStatsController(
                     Retries = kv.Value.Retries,
                     SpeedMbPerSec = CalculateSpeedMbPerSec(kv.Value.Bytes, kv.Value.SumDurationMs),
                     SpeedSpark = BuildSpeedSpark(kv.Value.BytesSpark, kv.Value.DurationSpark),
+                    SpeedSeries = BuildSpeedSeries(kv.Value.SeriesBytes, kv.Value.SeriesDurations, series.Start, series.BucketSize),
                     // SumDurationMs is Ok-only from rollup; divide by Ok count, not all attempts.
                     AvgDurationMs = okArticles > 0 ? (double)kv.Value.SumDurationMs / okArticles : 0,
                     ErrorRate = kv.Value.Articles > 0 ? (double)kv.Value.Errors / kv.Value.Articles : 0,
@@ -877,19 +959,20 @@ public class GetOverviewStatsController(
         long bucketSize,
         long nowMs,
         IReadOnlyDictionary<string, string?> labelsByMetricsKey,
+        GetOverviewStatsRequest.OverviewWindow window = GetOverviewStatsRequest.OverviewWindow.Last30Days,
         IEnumerable<ProviderLifetimeTotal>? foldedLifetimeTotals = null)
     {
-        var totalSpan = nowMs - windowStart;
-        var sparkSize = OneDay;
-        var sparkBuckets = Math.Max(1, (int)Math.Min(60, totalSpan / sparkSize + 1));
-        var sparkStart = windowStart - (windowStart % sparkSize);
+        var (sparkBuckets, sparkSize, sparkStart) = ResolveProviderSparkGeometry(
+            windowStart, window, nowMs, useRollups: true);
+        var series = ResolveProviderSeriesGeometry(window, windowStart, nowMs);
+        var seriesBuckets = (int)((series.End - series.Start) / series.BucketSize);
 
         var byProvider = new Dictionary<string, ProviderAccumulator>();
         foreach (var h in hours)
         {
             var host = h.Provider;
             if (!byProvider.TryGetValue(host, out var acc))
-                acc = new ProviderAccumulator(sparkBuckets);
+                acc = new ProviderAccumulator(sparkBuckets, seriesBuckets);
             acc.Articles += h.Articles;
             acc.Misses += h.Misses;
             acc.Errors += h.Errors;
@@ -905,6 +988,12 @@ public class GetOverviewStatsController(
                 acc.BytesSpark[idx] += h.BytesFetched;
                 acc.DurationSpark[idx] += h.SumDurationMs;
             }
+            var seriesIdx = (int)((h.Hour - series.Start) / series.BucketSize);
+            if (seriesIdx >= 0 && seriesIdx < seriesBuckets)
+            {
+                acc.SeriesBytes[seriesIdx] += h.BytesFetched;
+                acc.SeriesDurations[seriesIdx] += h.SumDurationMs;
+            }
             byProvider[host] = acc;
         }
 
@@ -914,7 +1003,7 @@ public class GetOverviewStatsController(
                          .Where(lt => IsConfiguredMetricsKey(lt.Provider, labelsByMetricsKey)))
             {
                 if (!byProvider.TryGetValue(lifetime.Provider, out var acc))
-                    acc = new ProviderAccumulator(sparkBuckets);
+                    acc = new ProviderAccumulator(sparkBuckets, seriesBuckets);
                 acc.Articles += lifetime.Articles;
                 acc.Misses += lifetime.Misses;
                 acc.Errors += lifetime.Errors;
@@ -940,6 +1029,7 @@ public class GetOverviewStatsController(
                     Retries = kv.Value.Retries,
                     SpeedMbPerSec = CalculateSpeedMbPerSec(kv.Value.Bytes, kv.Value.SumDurationMs),
                     SpeedSpark = BuildSpeedSpark(kv.Value.BytesSpark, kv.Value.DurationSpark),
+                    SpeedSeries = BuildSpeedSeries(kv.Value.SeriesBytes, kv.Value.SeriesDurations, series.Start, series.BucketSize),
                     AvgDurationMs = okArticles > 0 ? (double)kv.Value.SumDurationMs / okArticles : 0,
                     ErrorRate = kv.Value.Articles > 0 ? (double)kv.Value.Errors / kv.Value.Articles : 0,
                     Spark = kv.Value.Spark.ToList(),
@@ -973,6 +1063,25 @@ public class GetOverviewStatsController(
                 CalculateSpeedMbPerSec(value, durations[index]) ?? 0)
             .ToList();
 
+    private static List<GetOverviewStatsResponse.ProviderSpeedPoint> BuildSpeedSeries(
+        long[] bytes,
+        long[] durations,
+        long start,
+        long bucketSize)
+    {
+        var points = new List<GetOverviewStatsResponse.ProviderSpeedPoint>(bytes.Length);
+        for (var i = 0; i < bytes.Length; i++)
+        {
+            points.Add(new GetOverviewStatsResponse.ProviderSpeedPoint
+            {
+                Bucket = start + i * bucketSize,
+                BytesFetched = bytes[i],
+                SpeedMbPerSec = CalculateSpeedMbPerSec(bytes[i], durations[i]) ?? 0,
+            });
+        }
+        return points;
+    }
+
     private sealed class ProviderAccumulator
     {
         public long Articles, Misses, Errors, Retries, SumDurationMs, Bytes;
@@ -981,13 +1090,17 @@ public class GetOverviewStatsController(
         public readonly long[] RetrySpark;
         public readonly long[] BytesSpark;
         public readonly long[] DurationSpark;
-        public ProviderAccumulator(int n)
+        public readonly long[] SeriesBytes;
+        public readonly long[] SeriesDurations;
+        public ProviderAccumulator(int sparkBuckets, int seriesBuckets)
         {
-            Spark = new long[n];
-            ErrorSpark = new long[n];
-            RetrySpark = new long[n];
-            BytesSpark = new long[n];
-            DurationSpark = new long[n];
+            Spark = new long[sparkBuckets];
+            ErrorSpark = new long[sparkBuckets];
+            RetrySpark = new long[sparkBuckets];
+            BytesSpark = new long[sparkBuckets];
+            DurationSpark = new long[sparkBuckets];
+            SeriesBytes = new long[seriesBuckets];
+            SeriesDurations = new long[seriesBuckets];
         }
     }
 

--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsResponse.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsResponse.cs
@@ -16,6 +16,15 @@ public class GetOverviewStatsResponse
     public long TotalErrors { get; init; }
     public long TotalBytesFetched { get; init; }
     public List<ProviderRow> Providers { get; init; } = new();
+    /// <summary>Detail-chart bucket width in ms for per-provider speed series.</summary>
+    public long ProviderSpeedBucketSizeMs { get; init; }
+    public long ProviderSpeedWindowStartMs { get; init; }
+    public long ProviderSpeedWindowEndMs { get; init; }
+    /// <summary>
+    /// True when the series is clipped to retained hourly history (all-time) or
+    /// when folded lifetime totals exist that cannot be placed on the chart.
+    /// </summary>
+    public bool ProviderSpeedHistoryTruncated { get; init; }
     public CatalogueBlock Catalogue { get; init; } = new();
     public SessionsBlock Sessions { get; init; } = new();
 
@@ -60,6 +69,14 @@ public class GetOverviewStatsResponse
         public long BytesFetched { get; init; }
     }
 
+    public class ProviderSpeedPoint
+    {
+        public long Bucket { get; init; }
+        /// <summary>Effective decimal MB/s: bytes ÷ summed successful-fetch duration in the bucket.</summary>
+        public double SpeedMbPerSec { get; init; }
+        public long BytesFetched { get; init; }
+    }
+
     public class ProviderRow
     {
         public string Provider { get; init; } = "";
@@ -71,6 +88,8 @@ public class GetOverviewStatsResponse
         /// <summary>Decimal megabytes fetched per second over the selected window.</summary>
         public double? SpeedMbPerSec { get; set; }
         public List<double> SpeedSpark { get; init; } = new();
+        /// <summary>Timestamped effective MB/s for the detail chart. Same metric as <see cref="SpeedMbPerSec"/>.</summary>
+        public List<ProviderSpeedPoint> SpeedSeries { get; init; } = new();
         /// <summary>
         /// Mean duration of successful (Ok) fetches only. Includes connection-pool wait
         /// inside the provider call; not pure wire RTT. Misses/errors are excluded.

--- a/backend/Api/Controllers/GetOverviewStats/ProviderOverviewRowMapper.cs
+++ b/backend/Api/Controllers/GetOverviewStats/ProviderOverviewRowMapper.cs
@@ -14,6 +14,14 @@ internal static class ProviderOverviewRowMapper
         Retries = row.Retries,
         SpeedMbPerSec = row.SpeedMbPerSec,
         SpeedSpark = row.SpeedSpark,
+        SpeedSeries = row.SpeedSeries
+            .Select(p => new ProviderSpeedPoint
+            {
+                Bucket = p.Bucket,
+                SpeedMbPerSec = p.SpeedMbPerSec,
+                BytesFetched = p.BytesFetched,
+            })
+            .ToList(),
         AvgDurationMs = row.AvgDurationMs,
         ErrorRate = row.ErrorRate,
         Spark = row.Spark,
@@ -38,6 +46,14 @@ internal static class ProviderOverviewRowMapper
         Retries = row.Retries,
         SpeedMbPerSec = row.SpeedMbPerSec,
         SpeedSpark = row.SpeedSpark,
+        SpeedSeries = row.SpeedSeries
+            .Select(p => new GetOverviewStatsResponse.ProviderSpeedPoint
+            {
+                Bucket = p.Bucket,
+                SpeedMbPerSec = p.SpeedMbPerSec,
+                BytesFetched = p.BytesFetched,
+            })
+            .ToList(),
         AvgDurationMs = row.AvgDurationMs,
         ErrorRate = row.ErrorRate,
         Spark = row.Spark,

--- a/backend/Services/Metrics/ProviderCircuitOverviewEnricher.cs
+++ b/backend/Services/Metrics/ProviderCircuitOverviewEnricher.cs
@@ -27,6 +27,7 @@ internal static class ProviderCircuitOverviewEnricher
                     Retries = existing.Retries,
                     SpeedMbPerSec = existing.SpeedMbPerSec,
                     SpeedSpark = existing.SpeedSpark,
+                    SpeedSeries = existing.SpeedSeries,
                     AvgDurationMs = existing.AvgDurationMs,
                     ErrorRate = existing.ErrorRate,
                     Spark = existing.Spark,

--- a/backend/Services/Metrics/ProviderOverviewRow.cs
+++ b/backend/Services/Metrics/ProviderOverviewRow.cs
@@ -1,6 +1,17 @@
 namespace NzbWebDAV.Services.Metrics;
 
 /// <summary>
+/// Timestamped effective MB/s point owned by Metrics so circuit enrichment
+/// does not depend on admin API response types.
+/// </summary>
+internal sealed class ProviderSpeedPoint
+{
+    public long Bucket { get; init; }
+    public double SpeedMbPerSec { get; init; }
+    public long BytesFetched { get; init; }
+}
+
+/// <summary>
 /// Provider overview row owned by Metrics so circuit enrichment does not depend
 /// on admin API response types.
 /// </summary>
@@ -14,6 +25,7 @@ internal sealed class ProviderOverviewRow
     public long Retries { get; init; }
     public double? SpeedMbPerSec { get; set; }
     public List<double> SpeedSpark { get; init; } = [];
+    public List<ProviderSpeedPoint> SpeedSeries { get; init; } = [];
     public double AvgDurationMs { get; init; }
     public double ErrorRate { get; init; }
     public List<long> Spark { get; init; } = [];

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -943,6 +943,10 @@ export type OverviewStatsResponse = {
   totalErrors: number;
   totalBytesFetched: number;
   providers: ProviderRow[];
+  providerSpeedBucketSizeMs: number;
+  providerSpeedWindowStartMs: number;
+  providerSpeedWindowEndMs: number;
+  providerSpeedHistoryTruncated: boolean;
   catalogue: {
     fileCount: number;
     totalBytes: number;
@@ -1092,6 +1096,12 @@ export type ThroughputPoint = {
 
 export type ProviderCircuitState = "closed" | "open" | "halfOpen";
 
+export type ProviderSpeedPoint = {
+  bucket: number;
+  speedMbPerSec: number;
+  bytesFetched: number;
+};
+
 export type ProviderRow = {
   provider: string;
   nickname?: string | null | undefined;
@@ -1101,6 +1111,7 @@ export type ProviderRow = {
   retries: number;
   speedMbPerSec?: number | null | undefined;
   speedSpark?: number[];
+  speedSeries?: ProviderSpeedPoint[];
   avgDurationMs: number;
   errorRate: number;
   spark: number[];

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.test.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.test.tsx
@@ -36,6 +36,47 @@ describe("ProviderScoreboard", () => {
     expect(active).toContain('aria-label="Article share: 100%"');
     expect(idle).toContain(">—<");
   });
+
+  it("places the speed chart after the horizontal scroll wrapper", () => {
+    const selected = {
+      ...provider(2),
+      speedSeries: [{ bucket: 1_700_000_000_000, speedMbPerSec: 2.25, bytesFetched: 4_000 }],
+    };
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <ProviderScoreboard
+          providers={[selected]}
+          window="1h"
+          selectedProvider="provider-1"
+          onSelectProvider={() => {}}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(markup).toContain('aria-expanded="true"');
+    expect(markup).toContain('id="provider-speed-chart"');
+    expect(markup.indexOf("overflow-x-auto")).toBeGreaterThan(-1);
+    expect(markup.indexOf('id="provider-speed-chart"')).toBeGreaterThan(
+      markup.indexOf("overflow-x-auto"),
+    );
+    expect(markup).toContain("2.25 MB/s");
+  });
+
+  it("captions retained history when the series is truncated", () => {
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <ProviderScoreboard
+          providers={[provider(1)]}
+          window="all"
+          selectedProvider="provider-1"
+          onSelectProvider={() => {}}
+          providerSpeedHistoryTruncated
+        />
+      </MemoryRouter>,
+    );
+
+    expect(markup).toContain("retained provider history (last 365 days)");
+  });
 });
 
 describe("OutageBuckets", () => {

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
@@ -5,15 +5,27 @@ import type {
 } from "~/clients/backend-client.server";
 import { formatBytes, formatNumber, formatPercent, formatSpeed } from "../../utils/format";
 import { settingsPath } from "~/navigation/settings-tabs";
-import { Tooltip } from "~/components/ui";
+import { Icon, Tooltip } from "~/components/ui";
 import { WidgetLink } from "../widget-link/widget-link";
+import { ProviderSpeedChart } from "../provider-speed-chart/provider-speed-chart";
 
 export type ProviderScoreboardProps = {
   providers: ProviderRow[];
   window: OverviewWindow;
+  selectedProvider?: string | null;
+  onSelectProvider?: (provider: string | null) => void;
+  providerSpeedBucketSizeMs?: number;
+  providerSpeedHistoryTruncated?: boolean;
 };
 
-export function ProviderScoreboard({ providers, window }: ProviderScoreboardProps) {
+export function ProviderScoreboard({
+  providers,
+  window,
+  selectedProvider = null,
+  onSelectProvider,
+  providerSpeedBucketSizeMs = 900_000,
+  providerSpeedHistoryTruncated = false,
+}: ProviderScoreboardProps) {
   const total = providers.reduce((s, p) => s + p.articles, 0);
   const hasOpenCircuit = providers.some(
     (p) => p.circuitState === "open" || p.circuitState === "halfOpen",
@@ -21,6 +33,7 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
   const outageHelp = `Circuit-open time per ${outageIntervalLabel(window)} interval on a fixed 0–100% scale. Brief trips use a minimum-height tick.`;
   const speedHelp =
     "Historical average: bytes fetched divided by summed successful fetch durations over the selected window. Durations include connection-pool wait and overlap across concurrent fetches, so this is not wall-clock aggregate bandwidth. Use the provider benchmark for line-rate calibration.";
+  const selected = providers.find((p) => p.provider === selectedProvider);
 
   return (
     <section className="card w-full min-w-0 border border-base-content/10 bg-base-100 shadow-sm">
@@ -46,6 +59,7 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
         {providers.length === 0 ? (
           <p className="py-6 text-center text-xs text-base-content/50">No providers configured.</p>
         ) : (
+          <>
           <div className="overflow-x-auto">
             <table className="table table-pin-cols table-sm min-w-[800px]">
               <thead>
@@ -81,23 +95,41 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
                   return (
                     <tr key={p.provider}>
                       <th scope="row" className="bg-base-100 font-medium">
-                        <Tooltip content={buildProviderTooltip(p, circuitState)}>
-                          <div className="flex max-w-[240px] min-w-0 items-center gap-2 font-medium">
-                            <span
-                              className={`status status-xs shrink-0 ${statusClass(circuitState)}`}
-                            />
-                            <span className="min-w-0 truncate">
-                              {p.nickname?.trim() || p.provider}
-                            </span>
-                            {circuitState !== "closed" && (
+                        <div className="flex max-w-[260px] min-w-0 items-center gap-1">
+                          <Tooltip content={buildProviderTooltip(p, circuitState)}>
+                            <div className="flex min-w-0 items-center gap-2 font-medium">
                               <span
-                                className={`badge badge-sm shrink-0 ${badgeClass(circuitState)}`}
-                              >
-                                {circuitLabel(circuitState, p.cooldownRemainingSeconds)}
+                                className={`status status-xs shrink-0 ${statusClass(circuitState)}`}
+                              />
+                              <span className="min-w-0 truncate">
+                                {p.nickname?.trim() || p.provider}
                               </span>
-                            )}
-                          </div>
-                        </Tooltip>
+                              {circuitState !== "closed" && (
+                                <span
+                                  className={`badge badge-sm shrink-0 ${badgeClass(circuitState)}`}
+                                >
+                                  {circuitLabel(circuitState, p.cooldownRemainingSeconds)}
+                                </span>
+                              )}
+                            </div>
+                          </Tooltip>
+                          {onSelectProvider && (
+                            <button
+                              type="button"
+                              className="btn btn-ghost btn-xs shrink-0"
+                              aria-expanded={selectedProvider === p.provider}
+                              aria-controls="provider-speed-chart"
+                              aria-label={`Show speed history for ${p.nickname?.trim() || p.provider}`}
+                              onClick={() =>
+                                onSelectProvider(
+                                  selectedProvider === p.provider ? null : p.provider,
+                                )
+                              }
+                            >
+                              <Icon name="monitoring" className="!text-[16px]" />
+                            </button>
+                          )}
+                        </div>
                       </th>
                       <td>
                         <Sparkline values={p.spark} tone="success" />
@@ -159,6 +191,18 @@ export function ProviderScoreboard({ providers, window }: ProviderScoreboardProp
               </tbody>
             </table>
           </div>
+          {selected && (
+            <div id="provider-speed-chart">
+              <ProviderSpeedChart
+                providerLabel={selected.nickname?.trim() || selected.provider}
+                points={selected.speedSeries ?? []}
+                bucketSizeMs={providerSpeedBucketSizeMs}
+                historyTruncated={providerSpeedHistoryTruncated}
+                window={window}
+              />
+            </div>
+          )}
+        </>
         )}
       </div>
     </section>

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
@@ -60,149 +60,149 @@ export function ProviderScoreboard({
           <p className="py-6 text-center text-xs text-base-content/50">No providers configured.</p>
         ) : (
           <>
-          <div className="overflow-x-auto">
-            <table className="table table-pin-cols table-sm min-w-[800px]">
-              <thead>
-                <tr>
-                  <th>Provider</th>
-                  <th className="w-[120px]">Activity</th>
-                  <th className="w-[120px]">
-                    <Tooltip content={outageHelp}>
-                      <span>Outages</span>
-                    </Tooltip>
-                  </th>
-                  <th>Articles</th>
-                  <th>Read</th>
-                  <th>Share</th>
-                  <th className="w-[120px]">
-                    <Tooltip content={speedHelp}>
-                      <span>MB/s</span>
-                    </Tooltip>
-                  </th>
-                  <th className="w-[120px]">Errors</th>
-                  <th className="w-[120px]">Retries</th>
-                  <th>
-                    <Tooltip content="Mean duration of successful fetches only. Includes connection-pool wait inside the provider call — not pure wire RTT. Misses and errors are excluded.">
-                      <span>Avg ok ms</span>
-                    </Tooltip>
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {providers.map((p) => {
-                  const share = total > 0 ? (p.articles / total) * 100 : 0;
-                  const circuitState = p.circuitState ?? "closed";
-                  return (
-                    <tr key={p.provider}>
-                      <th scope="row" className="bg-base-100 font-medium">
-                        <div className="flex max-w-[260px] min-w-0 items-center gap-1">
-                          <Tooltip content={buildProviderTooltip(p, circuitState)}>
-                            <div className="flex min-w-0 items-center gap-2 font-medium">
-                              <span
-                                className={`status status-xs shrink-0 ${statusClass(circuitState)}`}
-                              />
-                              <span className="min-w-0 truncate">
-                                {p.nickname?.trim() || p.provider}
-                              </span>
-                              {circuitState !== "closed" && (
+            <div className="overflow-x-auto">
+              <table className="table table-pin-cols table-sm min-w-[800px]">
+                <thead>
+                  <tr>
+                    <th>Provider</th>
+                    <th className="w-[120px]">Activity</th>
+                    <th className="w-[120px]">
+                      <Tooltip content={outageHelp}>
+                        <span>Outages</span>
+                      </Tooltip>
+                    </th>
+                    <th>Articles</th>
+                    <th>Read</th>
+                    <th>Share</th>
+                    <th className="w-[120px]">
+                      <Tooltip content={speedHelp}>
+                        <span>MB/s</span>
+                      </Tooltip>
+                    </th>
+                    <th className="w-[120px]">Errors</th>
+                    <th className="w-[120px]">Retries</th>
+                    <th>
+                      <Tooltip content="Mean duration of successful fetches only. Includes connection-pool wait inside the provider call — not pure wire RTT. Misses and errors are excluded.">
+                        <span>Avg ok ms</span>
+                      </Tooltip>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {providers.map((p) => {
+                    const share = total > 0 ? (p.articles / total) * 100 : 0;
+                    const circuitState = p.circuitState ?? "closed";
+                    return (
+                      <tr key={p.provider}>
+                        <th scope="row" className="bg-base-100 font-medium">
+                          <div className="flex max-w-[260px] min-w-0 items-center gap-1">
+                            <Tooltip content={buildProviderTooltip(p, circuitState)}>
+                              <div className="flex min-w-0 items-center gap-2 font-medium">
                                 <span
-                                  className={`badge badge-sm shrink-0 ${badgeClass(circuitState)}`}
-                                >
-                                  {circuitLabel(circuitState, p.cooldownRemainingSeconds)}
+                                  className={`status status-xs shrink-0 ${statusClass(circuitState)}`}
+                                />
+                                <span className="min-w-0 truncate">
+                                  {p.nickname?.trim() || p.provider}
+                                </span>
+                                {circuitState !== "closed" && (
+                                  <span
+                                    className={`badge badge-sm shrink-0 ${badgeClass(circuitState)}`}
+                                  >
+                                    {circuitLabel(circuitState, p.cooldownRemainingSeconds)}
+                                  </span>
+                                )}
+                              </div>
+                            </Tooltip>
+                            {onSelectProvider && (
+                              <button
+                                type="button"
+                                className="btn btn-ghost btn-xs shrink-0"
+                                aria-expanded={selectedProvider === p.provider}
+                                aria-controls="provider-speed-chart"
+                                aria-label={`Show speed history for ${p.nickname?.trim() || p.provider}`}
+                                onClick={() =>
+                                  onSelectProvider(
+                                    selectedProvider === p.provider ? null : p.provider,
+                                  )
+                                }
+                              >
+                                <Icon name="monitoring" className="!text-[16px]" />
+                              </button>
+                            )}
+                          </div>
+                        </th>
+                        <td>
+                          <Sparkline values={p.spark} tone="success" />
+                        </td>
+                        <td>
+                          <Tooltip content={outageHelp}>
+                            <OutageBuckets values={p.outageSpark ?? []} />
+                          </Tooltip>
+                        </td>
+                        <td className="font-mono tabular-nums">{formatNumber(p.articles)}</td>
+                        <td className="font-mono tabular-nums">{formatBytes(p.bytesFetched)}</td>
+                        <td>
+                          <ShareBar share={share} />
+                        </td>
+                        <td>
+                          <Tooltip content={speedHelp}>
+                            <div className="flex flex-col gap-0.5">
+                              <Sparkline values={p.speedSpark ?? []} tone="success" />
+                              <div className="font-mono text-[11px] tabular-nums text-base-content/60">
+                                {formatSpeed(p.speedMbPerSec)}
+                              </div>
+                            </div>
+                          </Tooltip>
+                        </td>
+                        <td>
+                          <div className="flex flex-col gap-0.5">
+                            <Sparkline values={p.errorSpark ?? []} tone="error" eventsOnly />
+                            <div
+                              className={`font-mono text-[11px] tabular-nums ${p.errorRate > 0.05 ? "text-error" : "text-base-content/60"}`}
+                            >
+                              {formatNumber(p.errors)}
+                              {p.errorRate > 0 && (
+                                <span className="text-base-content/50">
+                                  {" "}
+                                  ({formatPercent(p.errorRate * 100, 1)})
                                 </span>
                               )}
                             </div>
-                          </Tooltip>
-                          {onSelectProvider && (
-                            <button
-                              type="button"
-                              className="btn btn-ghost btn-xs shrink-0"
-                              aria-expanded={selectedProvider === p.provider}
-                              aria-controls="provider-speed-chart"
-                              aria-label={`Show speed history for ${p.nickname?.trim() || p.provider}`}
-                              onClick={() =>
-                                onSelectProvider(
-                                  selectedProvider === p.provider ? null : p.provider,
-                                )
-                              }
-                            >
-                              <Icon name="monitoring" className="!text-[16px]" />
-                            </button>
-                          )}
-                        </div>
-                      </th>
-                      <td>
-                        <Sparkline values={p.spark} tone="success" />
-                      </td>
-                      <td>
-                        <Tooltip content={outageHelp}>
-                          <OutageBuckets values={p.outageSpark ?? []} />
-                        </Tooltip>
-                      </td>
-                      <td className="font-mono tabular-nums">{formatNumber(p.articles)}</td>
-                      <td className="font-mono tabular-nums">{formatBytes(p.bytesFetched)}</td>
-                      <td>
-                        <ShareBar share={share} />
-                      </td>
-                      <td>
-                        <Tooltip content={speedHelp}>
+                          </div>
+                        </td>
+                        <td>
                           <div className="flex flex-col gap-0.5">
-                            <Sparkline values={p.speedSpark ?? []} tone="success" />
-                            <div className="font-mono text-[11px] tabular-nums text-base-content/60">
-                              {formatSpeed(p.speedMbPerSec)}
+                            <Sparkline values={p.retrySpark ?? []} tone="warning" eventsOnly />
+                            <div
+                              className={`font-mono text-[11px] tabular-nums ${p.retries > 0 ? "text-warning" : "text-base-content/60"}`}
+                            >
+                              {formatNumber(p.retries)}
                             </div>
                           </div>
-                        </Tooltip>
-                      </td>
-                      <td>
-                        <div className="flex flex-col gap-0.5">
-                          <Sparkline values={p.errorSpark ?? []} tone="error" eventsOnly />
-                          <div
-                            className={`font-mono text-[11px] tabular-nums ${p.errorRate > 0.05 ? "text-error" : "text-base-content/60"}`}
-                          >
-                            {formatNumber(p.errors)}
-                            {p.errorRate > 0 && (
-                              <span className="text-base-content/50">
-                                {" "}
-                                ({formatPercent(p.errorRate * 100, 1)})
-                              </span>
-                            )}
-                          </div>
-                        </div>
-                      </td>
-                      <td>
-                        <div className="flex flex-col gap-0.5">
-                          <Sparkline values={p.retrySpark ?? []} tone="warning" eventsOnly />
-                          <div
-                            className={`font-mono text-[11px] tabular-nums ${p.retries > 0 ? "text-warning" : "text-base-content/60"}`}
-                          >
-                            {formatNumber(p.retries)}
-                          </div>
-                        </div>
-                      </td>
-                      <td className="font-mono tabular-nums">
-                        <Tooltip content="Successful fetches only (includes pool wait)">
-                          <span>{p.avgDurationMs.toFixed(0)}</span>
-                        </Tooltip>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-          {selected && (
-            <div id="provider-speed-chart">
-              <ProviderSpeedChart
-                providerLabel={selected.nickname?.trim() || selected.provider}
-                points={selected.speedSeries ?? []}
-                bucketSizeMs={providerSpeedBucketSizeMs}
-                historyTruncated={providerSpeedHistoryTruncated}
-                window={window}
-              />
+                        </td>
+                        <td className="font-mono tabular-nums">
+                          <Tooltip content="Successful fetches only (includes pool wait)">
+                            <span>{p.avgDurationMs.toFixed(0)}</span>
+                          </Tooltip>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
             </div>
-          )}
-        </>
+            {selected && (
+              <div id="provider-speed-chart">
+                <ProviderSpeedChart
+                  providerLabel={selected.nickname?.trim() || selected.provider}
+                  points={selected.speedSeries ?? []}
+                  bucketSizeMs={providerSpeedBucketSizeMs}
+                  historyTruncated={providerSpeedHistoryTruncated}
+                  window={window}
+                />
+              </div>
+            )}
+          </>
         )}
       </div>
     </section>

--- a/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.module.css
+++ b/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.module.css
@@ -1,0 +1,75 @@
+.plot {
+  display: flex;
+  gap: 10px;
+  min-width: 0;
+}
+
+.chartArea {
+  flex: 1;
+  position: relative;
+  height: 160px;
+  min-width: 0;
+  cursor: crosshair;
+  touch-action: pan-y;
+}
+.chartArea:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.gridline {
+  stroke: color-mix(in srgb, var(--color-base-content) 5%, transparent);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.lineSpeed {
+  stroke: var(--color-success);
+  stroke-width: 1.5;
+  fill: none;
+  vector-effect: non-scaling-stroke;
+}
+
+.crosshair {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: color-mix(in srgb, var(--color-base-content) 25%, transparent);
+  pointer-events: none;
+  transform: translateX(-0.5px);
+}
+
+.hoverTooltip {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  z-index: 10;
+}
+
+.hoverDotAnchor {
+  display: block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-success);
+  box-shadow: 0 0 0 2px var(--color-base-100);
+}
+
+.hoverDot {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-success);
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  box-shadow: 0 0 0 2px var(--color-base-100);
+}

--- a/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.module.css.d.ts
+++ b/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.module.css.d.ts
@@ -1,0 +1,12 @@
+declare const styles: {
+  readonly plot: string;
+  readonly chartArea: string;
+  readonly svg: string;
+  readonly gridline: string;
+  readonly lineSpeed: string;
+  readonly crosshair: string;
+  readonly hoverTooltip: string;
+  readonly hoverDotAnchor: string;
+  readonly hoverDot: string;
+};
+export = styles;

--- a/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.test.tsx
+++ b/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.test.tsx
@@ -52,5 +52,6 @@ describe("ProviderSpeedChart", () => {
     expect(xs.length).toBeGreaterThan(0);
     expect(Math.min(...xs)).toBeGreaterThanOrEqual(0);
     expect(Math.max(...xs)).toBeLessThanOrEqual(800);
+    expect(Math.min(...xs)).toBeLessThan(800);
   });
 });

--- a/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.test.tsx
+++ b/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.test.tsx
@@ -34,4 +34,23 @@ describe("ProviderSpeedChart", () => {
     // Three buckets span 800 viewBox units, so the idle bucket is at x=400.
     expect(d).not.toContain("400.0,");
   });
+
+  it("keeps a terminal isolated sample inside the viewBox", () => {
+    const markup = renderToStaticMarkup(
+      <ProviderSpeedChart
+        providerLabel="Alpha"
+        points={[point(0), point(0), point(7)]}
+        bucketSizeMs={60_000}
+        historyTruncated={false}
+        window="1h"
+      />,
+    );
+    const d = speedPathD(markup);
+    const xs = [...d.matchAll(/[ML]([\d.]+),/g)].map((match) => Number(match[1]));
+
+    expect(d).not.toBe("");
+    expect(xs.length).toBeGreaterThan(0);
+    expect(Math.min(...xs)).toBeGreaterThanOrEqual(0);
+    expect(Math.max(...xs)).toBeLessThanOrEqual(800);
+  });
 });

--- a/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.test.tsx
+++ b/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.test.tsx
@@ -1,0 +1,37 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { ProviderSpeedPoint } from "~/clients/backend-client.server";
+import { ProviderSpeedChart } from "./provider-speed-chart";
+
+const point = (speedMbPerSec: number): ProviderSpeedPoint => ({
+  bucket: 1_700_000_000_000,
+  speedMbPerSec,
+  bytesFetched: speedMbPerSec > 0 ? 1_000 : 0,
+});
+
+function speedPathD(markup: string): string {
+  const match = markup.match(
+    /d="([^"]*)"[^>]*data-series="speed"|data-series="speed"[^>]*d="([^"]*)"/,
+  );
+  return match?.[1] ?? match?.[2] ?? "";
+}
+
+describe("ProviderSpeedChart", () => {
+  it("does not connect positive runs through a single idle bucket", () => {
+    const markup = renderToStaticMarkup(
+      <ProviderSpeedChart
+        providerLabel="Alpha"
+        points={[point(4), point(0), point(7)]}
+        bucketSizeMs={60_000}
+        historyTruncated={false}
+        window="1h"
+      />,
+    );
+    const d = speedPathD(markup);
+
+    expect(d).not.toBe("");
+    expect((d.match(/M/g) ?? []).length).toBe(2);
+    // Three buckets span 800 viewBox units, so the idle bucket is at x=400.
+    expect(d).not.toContain("400.0,");
+  });
+});

--- a/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.tsx
+++ b/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.tsx
@@ -1,0 +1,349 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import styles from "./provider-speed-chart.module.css";
+import type { OverviewWindow, ProviderSpeedPoint } from "~/clients/backend-client.server";
+import { formatBytes } from "../../utils/format";
+
+export type ProviderSpeedChartProps = {
+  providerLabel: string;
+  points: ProviderSpeedPoint[];
+  bucketSizeMs: number;
+  historyTruncated: boolean;
+  window: OverviewWindow;
+};
+
+const VB_W = 800;
+const VB_H = 160;
+const TOP_PAD = 6;
+const BOT_PAD = 4;
+
+export function ProviderSpeedChart({
+  providerLabel,
+  points,
+  bucketSizeMs: _bucketSizeMs,
+  historyTruncated,
+  window,
+}: ProviderSpeedChartProps) {
+  const [hoverBucket, setHoverBucket] = useState<number | null>(null);
+  const [keyboardBucket, setKeyboardBucket] = useState<number | null>(null);
+
+  const hoverIdx = indexOfBucket(points, hoverBucket);
+  const keyboardIdx = indexOfBucket(points, keyboardBucket);
+  const cursorIdx = hoverIdx ?? keyboardIdx;
+
+  useEffect(() => {
+    setHoverBucket(null);
+    setKeyboardBucket(null);
+  }, [window, providerLabel]);
+
+  const { speedPath, maxSpeed, xPercent, yPercent } = useMemo(() => {
+    if (points.length === 0) {
+      return {
+        speedPath: "",
+        maxSpeed: 0,
+        xPercent: (_: number) => 0,
+        yPercent: (_: number) => 0,
+      };
+    }
+    const peak = Math.max(0, ...points.map((p) => p.speedMbPerSec));
+    const scaleMax = Math.max(0.1, peak);
+    const xStep = points.length > 1 ? VB_W / (points.length - 1) : 0;
+    const innerH = VB_H - TOP_PAD - BOT_PAD;
+    const y = (v: number) => VB_H - BOT_PAD - (v / scaleMax) * innerH;
+    const xPct = (i: number) => (points.length > 1 ? (i / (points.length - 1)) * 100 : 50);
+    const yPct = (v: number) =>
+      100 - ((v / scaleMax) * (1 - (TOP_PAD + BOT_PAD) / VB_H) * 100 + (BOT_PAD / VB_H) * 100);
+
+    return {
+      speedPath: buildSpeedPath(points, xStep, y),
+      maxSpeed: peak,
+      xPercent: xPct,
+      yPercent: yPct,
+    };
+  }, [points]);
+
+  const xTicks = useMemo(() => {
+    if (points.length === 0) return [];
+    const count = Math.min(5, points.length);
+    if (count < 2) {
+      const first = points[0];
+      return first ? [{ idx: 0, label: formatBucketTime(first.bucket, window) }] : [];
+    }
+    return Array.from({ length: count }, (_, i) => {
+      const idx = Math.round((points.length - 1) * (i / (count - 1)));
+      const point = points[idx];
+      return { idx, label: point ? formatBucketTime(point.bucket, window) : "" };
+    });
+  }, [points, window]);
+
+  const onMove = useCallback(
+    (clientX: number, target: HTMLElement) => {
+      if (points.length === 0) return;
+      const rect = target.getBoundingClientRect();
+      const rel = (clientX - rect.left) / rect.width;
+      const idx = Math.round(rel * (points.length - 1));
+      const clamped = Math.max(0, Math.min(points.length - 1, idx));
+      setHoverBucket(points[clamped]?.bucket ?? null);
+    },
+    [points],
+  );
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (points.length === 0) return;
+    const from = keyboardIdx ?? hoverIdx;
+    let next: number | null;
+    if (e.key === "ArrowRight") {
+      e.preventDefault();
+      next = Math.min(points.length - 1, (from ?? -1) + 1);
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      next = Math.max(0, (from ?? points.length) - 1);
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      next = 0;
+    } else if (e.key === "End") {
+      e.preventDefault();
+      next = points.length - 1;
+    } else if (e.key === "Escape") {
+      setHoverBucket(null);
+      setKeyboardBucket(null);
+      return;
+    } else {
+      return;
+    }
+    setHoverBucket(null);
+    setKeyboardBucket(points[next]?.bucket ?? null);
+  };
+
+  const hasData = points.length > 0;
+  const hover = cursorIdx !== null ? (points[cursorIdx] ?? null) : null;
+  const keyboardPoint = keyboardIdx !== null ? points[keyboardIdx] : undefined;
+  const keyboardStatus = keyboardPoint ? describeSpeedBucket(keyboardPoint, window) : "";
+  const tooltipPlacement =
+    cursorIdx === null || points.length < 2
+      ? "tooltip-top"
+      : (() => {
+          const rel = cursorIdx / (points.length - 1);
+          if (rel < 0.2) return "tooltip-right";
+          if (rel > 0.8) return "tooltip-left";
+          return "tooltip-top";
+        })();
+
+  return (
+    <section className="card w-full min-w-0 overflow-visible border border-base-content/10 bg-base-100 shadow-sm">
+      <div className="card-body gap-3 overflow-visible p-4">
+        <div>
+          <h3 className="card-title text-base">{providerLabel}</h3>
+          <p className="text-xs text-base-content/50">
+            Effective MB/s
+            {historyTruncated
+              ? " · retained provider history (last 365 days)"
+              : window === "all"
+                ? " · all time"
+                : ` · last ${window}`}
+            {maxSpeed > 0 ? ` · peak ${maxSpeed.toFixed(2)} MB/s` : ""}
+          </p>
+        </div>
+
+        {hasData ? (
+          <>
+            <div className={styles.plot}>
+              <div className="flex h-40 w-9 shrink-0 flex-col items-end justify-between text-[10px] text-base-content/50 tabular-nums select-none">
+                <span>{maxSpeed.toFixed(2)}</span>
+                <span>{(maxSpeed / 2).toFixed(2)}</span>
+                <span>0</span>
+              </div>
+              <div
+                className={styles.chartArea}
+                tabIndex={0}
+                role="img"
+                aria-label={`Speed history for ${providerLabel}. Use arrow keys for bucket details.`}
+                aria-describedby="provider-speed-keyboard-status"
+                onMouseMove={(e) => onMove(e.clientX, e.currentTarget)}
+                onMouseLeave={() => setHoverBucket(null)}
+                onTouchStart={(e) => {
+                  const t = e.touches[0];
+                  if (t) onMove(t.clientX, e.currentTarget);
+                }}
+                onTouchMove={(e) => {
+                  const t = e.touches[0];
+                  if (t) onMove(t.clientX, e.currentTarget);
+                }}
+                onKeyDown={handleKeyDown}
+              >
+                <svg
+                  viewBox={`0 0 ${VB_W} ${VB_H}`}
+                  preserveAspectRatio="none"
+                  className={styles.svg}
+                >
+                  <line
+                    x1="0"
+                    y1={(VB_H - BOT_PAD).toFixed(1)}
+                    x2={VB_W}
+                    y2={(VB_H - BOT_PAD).toFixed(1)}
+                    className={styles.gridline}
+                  />
+                  <line
+                    x1="0"
+                    y1={(VB_H / 2).toFixed(1)}
+                    x2={VB_W}
+                    y2={(VB_H / 2).toFixed(1)}
+                    className={styles.gridline}
+                  />
+                  <line
+                    x1="0"
+                    y1={TOP_PAD.toFixed(1)}
+                    x2={VB_W}
+                    y2={TOP_PAD.toFixed(1)}
+                    className={styles.gridline}
+                  />
+                  {maxSpeed > 0 && speedPath && (
+                    <path d={speedPath} className={styles.lineSpeed} data-series="speed" />
+                  )}
+                </svg>
+
+                {hover && cursorIdx !== null && (
+                  <>
+                    <div className={styles.crosshair} style={{ left: `${xPercent(cursorIdx)}%` }} />
+                    <div
+                      className={`tooltip tooltip-open ${tooltipPlacement} ${styles.hoverTooltip}`}
+                      style={{
+                        left: `${xPercent(cursorIdx)}%`,
+                        top: `${yPercent(hover.speedMbPerSec)}%`,
+                      }}
+                    >
+                      <div className="tooltip-content">
+                        <div className="space-y-0.5 text-left font-mono text-xs">
+                          <div className="font-semibold">{formatFullBucketTime(hover.bucket)}</div>
+                          <div>{hover.speedMbPerSec.toFixed(2)} MB/s</div>
+                          <div>{formatBytes(hover.bytesFetched)} fetched</div>
+                        </div>
+                      </div>
+                      <span className={styles.hoverDotAnchor} />
+                    </div>
+                    <div
+                      className={styles.hoverDot}
+                      style={{
+                        left: `${xPercent(cursorIdx)}%`,
+                        top: `${yPercent(hover.speedMbPerSec)}%`,
+                      }}
+                    />
+                  </>
+                )}
+              </div>
+            </div>
+            <div
+              id="provider-speed-keyboard-status"
+              className="sr-only"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+            >
+              {keyboardStatus}
+            </div>
+
+            <div className="relative mt-1.5 ml-[46px] h-4 text-[10px] text-base-content/50 tabular-nums select-none">
+              {xTicks.map((t) => (
+                <span
+                  key={t.idx}
+                  className="absolute top-0 -translate-x-1/2 whitespace-nowrap"
+                  style={{ left: `${xPercent(t.idx)}%` }}
+                >
+                  {t.label}
+                </span>
+              ))}
+            </div>
+          </>
+        ) : (
+          <div className="py-12 text-center text-[13px] text-base-content/50">
+            No speed samples in this window yet.
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function buildSpeedPath(
+  points: ProviderSpeedPoint[],
+  xStep: number,
+  y: (v: number) => number,
+): string {
+  const parts: string[] = [];
+  let i = 0;
+  while (i < points.length) {
+    const current = points[i];
+    if (!current || current.speedMbPerSec <= 0) {
+      i++;
+      continue;
+    }
+    const runStart = i;
+    while (i < points.length) {
+      const p = points[i];
+      if (!p || p.speedMbPerSec <= 0) break;
+      i++;
+    }
+    const runEnd = i - 1;
+    const from = runStart > 0 ? runStart - 1 : runStart;
+    const to = runEnd < points.length - 1 ? runEnd + 1 : runEnd;
+
+    for (let j = from; j <= to; j++) {
+      const p = points[j];
+      if (!p) continue;
+      const x = (j * xStep).toFixed(1);
+      const yy = y(p.speedMbPerSec).toFixed(1);
+      parts.push(`${j === from ? "M" : "L"}${x},${yy}`);
+    }
+    if (from === to) {
+      const p = points[from];
+      if (p) {
+        const x2 = (from * xStep + Math.max(xStep * 0.15, 1)).toFixed(1);
+        const yy = y(p.speedMbPerSec).toFixed(1);
+        parts.push(`L${x2},${yy}`);
+      }
+    }
+  }
+  return parts.join(" ");
+}
+
+function indexOfBucket(points: ProviderSpeedPoint[], bucket: number | null): number | null {
+  if (bucket === null) return null;
+  const idx = points.findIndex((p) => p.bucket === bucket);
+  return idx >= 0 ? idx : null;
+}
+
+function describeSpeedBucket(point: ProviderSpeedPoint, window: OverviewWindow): string {
+  return [
+    formatBucketTime(point.bucket, window),
+    `${point.speedMbPerSec.toFixed(2)} MB/s`,
+    `${formatBytes(point.bytesFetched)} fetched`,
+  ].join(", ");
+}
+
+function formatFullBucketTime(ms: number): string {
+  return new Date(ms).toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatBucketTime(ms: number, window: OverviewWindow): string {
+  const d = new Date(ms);
+  if (window === "1h" || window === "24h") {
+    const hh = String(d.getHours()).padStart(2, "0");
+    const mm = String(d.getMinutes()).padStart(2, "0");
+    return `${hh}:${mm}`;
+  }
+  if (window === "7d") {
+    const day = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"][d.getDay()];
+    const hh = String(d.getHours()).padStart(2, "0");
+    return `${day} ${hh}:00`;
+  }
+  const day = String(d.getDate()).padStart(2, "0");
+  const mon = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"][
+    d.getMonth()
+  ];
+  return `${day} ${mon}`;
+}

--- a/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.tsx
+++ b/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.tsx
@@ -283,7 +283,11 @@ function buildSpeedPath(
         const next = points[i + 1];
         const nextZero = i === points.length - 1 || !next || next.speedMbPerSec <= 0;
         if (nextZero) {
-          const x2 = (i * xStep + Math.max(xStep * 0.15, 1)).toFixed(1);
+          const extension = Math.max(xStep * 0.15, 1);
+          const x2 = Math.max(
+            0,
+            Math.min(VB_W, i * xStep + (i === points.length - 1 && i > 0 ? -extension : extension)),
+          ).toFixed(1);
           parts.push(`L${x2},${yy}`);
         }
       } else {

--- a/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.tsx
+++ b/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.tsx
@@ -269,37 +269,28 @@ function buildSpeedPath(
   y: (v: number) => number,
 ): string {
   const parts: string[] = [];
-  let i = 0;
-  while (i < points.length) {
-    const current = points[i];
-    if (!current || current.speedMbPerSec <= 0) {
-      i++;
-      continue;
-    }
-    const runStart = i;
-    while (i < points.length) {
-      const p = points[i];
-      if (!p || p.speedMbPerSec <= 0) break;
-      i++;
-    }
-    const runEnd = i - 1;
-    const from = runStart > 0 ? runStart - 1 : runStart;
-    const to = runEnd < points.length - 1 ? runEnd + 1 : runEnd;
-
-    for (let j = from; j <= to; j++) {
-      const p = points[j];
-      if (!p) continue;
-      const x = (j * xStep).toFixed(1);
-      const yy = y(p.speedMbPerSec).toFixed(1);
-      parts.push(`${j === from ? "M" : "L"}${x},${yy}`);
-    }
-    if (from === to) {
-      const p = points[from];
-      if (p) {
-        const x2 = (from * xStep + Math.max(xStep * 0.15, 1)).toFixed(1);
-        const yy = y(p.speedMbPerSec).toFixed(1);
-        parts.push(`L${x2},${yy}`);
+  let inSegment = false;
+  for (let i = 0; i < points.length; i++) {
+    const p = points[i];
+    if (!p) continue;
+    const value = p.speedMbPerSec;
+    const x = (i * xStep).toFixed(1);
+    const yy = y(value).toFixed(1);
+    if (value > 0) {
+      if (!inSegment) {
+        parts.push(`M${x},${yy}`);
+        inSegment = true;
+        const next = points[i + 1];
+        const nextZero = i === points.length - 1 || !next || next.speedMbPerSec <= 0;
+        if (nextZero) {
+          const x2 = (i * xStep + Math.max(xStep * 0.15, 1)).toFixed(1);
+          parts.push(`L${x2},${yy}`);
+        }
+      } else {
+        parts.push(`L${x},${yy}`);
       }
+    } else {
+      inSegment = false;
     }
   }
   return parts.join(" ");

--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -139,6 +139,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
   const [detailRetry, setDetailRetry] = useState(0);
   const [staticRetry, setStaticRetry] = useState(0);
   const [arrHealthRetry, setArrHealthRetry] = useState(0);
+  const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
   const { order, save, reset } = useRowOrder(DEFAULT_ROW_ORDER);
   const editModeRef = useRef(editMode);
   editModeRef.current = editMode;
@@ -153,6 +154,15 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
 
   const liveTiles = stats.tiles;
   const isLongWindow = window === "7d" || window === "30d" || window === "all";
+
+  useEffect(() => {
+    if (
+      selectedProvider &&
+      !stats.providers.some((provider) => provider.provider === selectedProvider)
+    ) {
+      setSelectedProvider(null);
+    }
+  }, [stats.providers, selectedProvider]);
 
   const applyWindow = (next: OverviewWindow) => {
     if (next === window) return;
@@ -451,7 +461,14 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
         windowError && !windowLoaded ? (
           <SectionLoadError label="providers" onRetry={() => setWindowRetry((n) => n + 1)} />
         ) : windowLoaded ? (
-          <ProviderScoreboard providers={stats.providers} window={window} />
+          <ProviderScoreboard
+            providers={stats.providers}
+            window={window}
+            selectedProvider={selectedProvider}
+            onSelectProvider={setSelectedProvider}
+            providerSpeedBucketSizeMs={stats.providerSpeedBucketSizeMs ?? 900_000}
+            providerSpeedHistoryTruncated={stats.providerSpeedHistoryTruncated ?? false}
+          />
         ) : (
           <Skeleton height={160} />
         ),
@@ -530,6 +547,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
       arrHealth,
       arrHealthLoaded,
       arrHealthError,
+      selectedProvider,
     ],
   );
 

--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -464,7 +464,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
           <ProviderScoreboard
             providers={stats.providers}
             window={window}
-            selectedProvider={selectedProvider}
+            selectedProvider={stats.window === window ? selectedProvider : null}
             onSelectProvider={setSelectedProvider}
             providerSpeedBucketSizeMs={stats.providerSpeedBucketSizeMs ?? 900_000}
             providerSpeedHistoryTruncated={stats.providerSpeedHistoryTruncated ?? false}

--- a/frontend/app/routes/overview/utils/merge-overview-stats.ts
+++ b/frontend/app/routes/overview/utils/merge-overview-stats.ts
@@ -27,6 +27,10 @@ export const EMPTY_OVERVIEW_STATS: OverviewStatsResponse = {
   totalErrors: 0,
   totalBytesFetched: 0,
   providers: [],
+  providerSpeedBucketSizeMs: 900_000,
+  providerSpeedWindowStartMs: 0,
+  providerSpeedWindowEndMs: 0,
+  providerSpeedHistoryTruncated: false,
   catalogue: { fileCount: 0, totalBytes: 0, largestFileBytes: 0, addedLast7Days: 0 },
   sessions: {
     count: 0,
@@ -100,6 +104,14 @@ export function mergeOverviewStats(
     next.totalErrors = partial.totalErrors;
     next.totalBytesFetched = partial.totalBytesFetched;
     next.providers = partial.providers;
+    next.providerSpeedBucketSizeMs =
+      partial.providerSpeedBucketSizeMs ?? prev.providerSpeedBucketSizeMs ?? 900_000;
+    next.providerSpeedWindowStartMs =
+      partial.providerSpeedWindowStartMs ?? prev.providerSpeedWindowStartMs ?? 0;
+    next.providerSpeedWindowEndMs =
+      partial.providerSpeedWindowEndMs ?? prev.providerSpeedWindowEndMs ?? 0;
+    next.providerSpeedHistoryTruncated =
+      partial.providerSpeedHistoryTruncated ?? prev.providerSpeedHistoryTruncated ?? false;
     next.sessions = partial.sessions;
     next.heatmap = partial.heatmap;
     next.failover = partial.failover;
@@ -146,6 +158,7 @@ export function mergeProviderCircuitBreakers(
         errorSpark: [],
         retrySpark: [],
         outageSpark: [],
+        speedSeries: [],
       }),
       circuitState: breaker.circuitState,
       cooldownRemainingSeconds: breaker.cooldownRemainingSeconds,

--- a/tests/NzbWebDAV.Tests/Api/GetOverviewStatsProviderSeriesTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetOverviewStatsProviderSeriesTests.cs
@@ -5,8 +5,8 @@ namespace NzbWebDAV.Tests.Api;
 
 public class GetOverviewStatsProviderSeriesTests
 {
-    private static readonly string ProviderA = Guid.NewGuid().ToString("N");
-    private static readonly string ProviderB = Guid.NewGuid().ToString("N");
+    private const string ProviderA = "11111111111111111111111111111111";
+    private const string ProviderB = "22222222222222222222222222222222";
     private static readonly IReadOnlyDictionary<string, string?> Labels =
         new Dictionary<string, string?>(StringComparer.Ordinal)
         {

--- a/tests/NzbWebDAV.Tests/Api/GetOverviewStatsProviderSeriesTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetOverviewStatsProviderSeriesTests.cs
@@ -1,0 +1,128 @@
+using NzbWebDAV.Api.Controllers.GetOverviewStats;
+using NzbWebDAV.Database.Models.Metrics;
+
+namespace NzbWebDAV.Tests.Api;
+
+public class GetOverviewStatsProviderSeriesTests
+{
+    private static readonly string ProviderA = Guid.NewGuid().ToString("N");
+    private static readonly string ProviderB = Guid.NewGuid().ToString("N");
+    private static readonly IReadOnlyDictionary<string, string?> Labels =
+        new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [ProviderA] = "Alpha",
+            [ProviderB] = "Beta",
+        };
+
+    private const long OneMinute = 60_000;
+    private const long OneHour = 3_600_000;
+    private const long OneDay = 86_400_000;
+
+    [Theory]
+    [InlineData(GetOverviewStatsRequest.OverviewWindow.Last1Hour, OneMinute, 60, false)]
+    [InlineData(GetOverviewStatsRequest.OverviewWindow.Last24Hours, 15 * OneMinute, 96, false)]
+    [InlineData(GetOverviewStatsRequest.OverviewWindow.Last7Days, OneHour, 168, false)]
+    [InlineData(GetOverviewStatsRequest.OverviewWindow.Last30Days, 6 * OneHour, 120, false)]
+    [InlineData(GetOverviewStatsRequest.OverviewWindow.AllTime, 7 * OneDay, 0, true)]
+    public void ResolveProviderSeriesGeometry_AlignsBucketsAndMarksTruncation(
+        GetOverviewStatsRequest.OverviewWindow window,
+        long expectedBucket,
+        int expectedCount,
+        bool truncated)
+    {
+        var nowMs = 1_700_000_000_000L;
+        var windowStart = window switch
+        {
+            GetOverviewStatsRequest.OverviewWindow.Last1Hour => nowMs - OneHour,
+            GetOverviewStatsRequest.OverviewWindow.Last24Hours => nowMs - OneDay,
+            GetOverviewStatsRequest.OverviewWindow.Last7Days => nowMs - 7 * OneDay,
+            GetOverviewStatsRequest.OverviewWindow.Last30Days => nowMs - 30 * OneDay,
+            _ => 0L,
+        };
+        var geometry = GetOverviewStatsController.ResolveProviderSeriesGeometry(window, windowStart, nowMs);
+
+        Assert.Equal(expectedBucket, geometry.BucketSize);
+        Assert.Equal(truncated, geometry.Truncated);
+        Assert.Equal(0, geometry.Start % expectedBucket);
+        Assert.Equal(0, geometry.End % expectedBucket);
+        Assert.True(geometry.End > geometry.Start);
+        if (expectedCount > 0)
+            Assert.Equal(expectedCount, (geometry.End - geometry.Start) / expectedBucket);
+        else
+            Assert.True(geometry.Start >= nowMs - 365 * OneDay - expectedBucket);
+    }
+
+    [Fact]
+    public void BuildProvidersFromMinutes_ZeroFillsAndIsolatesProviders()
+    {
+        var windowStart = 1_700_000_000_000L;
+        var minutes = new[]
+        {
+            (windowStart, ProviderA, 10L, 2_000_000L, 0L, 0L, 0L, 1_000L),
+            (windowStart + OneMinute, ProviderB, 10L, 1_000_000L, 0L, 0L, 0L, 1_000L),
+        };
+
+        var rows = GetOverviewStatsController.BuildProvidersFromMinutes(
+            minutes,
+            windowStart,
+            GetOverviewStatsRequest.OverviewWindow.Last1Hour,
+            Labels,
+            windowStart + OneHour);
+
+        var a = Assert.Single(rows, r => r.Provider == ProviderA);
+        var b = Assert.Single(rows, r => r.Provider == ProviderB);
+        var alignedStart = windowStart - windowStart % OneMinute;
+        Assert.Equal(60, a.SpeedSeries.Count);
+        Assert.Equal(60, b.SpeedSeries.Count);
+        Assert.Equal(alignedStart, a.SpeedSeries[0].Bucket);
+        Assert.Equal(2.0, a.SpeedSeries[0].SpeedMbPerSec);
+        Assert.Equal(2_000_000, a.SpeedSeries[0].BytesFetched);
+        Assert.Equal(0, a.SpeedSeries[1].SpeedMbPerSec);
+        Assert.Equal(0, b.SpeedSeries[0].SpeedMbPerSec);
+        Assert.Equal(1.0, b.SpeedSeries[1].SpeedMbPerSec);
+    }
+
+    [Fact]
+    public void BuildProvidersFromHourly_AllTimeClampsSparkAndOmitsLifetimeFromSeries()
+    {
+        var nowMs = 1_800_000_000_000L;
+        var recentHour = nowMs - OneHour;
+        recentHour -= recentHour % OneHour;
+        var hours = new[]
+        {
+            (recentHour, ProviderA, 10L, 2_000_000L, 0L, 0L, 0L, 1_000L),
+        };
+        var lifetime = new[]
+        {
+            new ProviderLifetimeTotal
+            {
+                Provider = ProviderA,
+                Articles = 99,
+                BytesFetched = 9_000_000,
+                Misses = 0,
+                Errors = 0,
+                Retries = 0,
+                SumDurationMs = 1_000,
+            },
+        };
+
+        var rows = GetOverviewStatsController.BuildProvidersFromHourly(
+            hours,
+            windowStart: 0,
+            bucketSize: OneHour,
+            nowMs,
+            Labels,
+            GetOverviewStatsRequest.OverviewWindow.AllTime,
+            lifetime);
+
+        var row = Assert.Single(rows);
+        Assert.Equal(109, row.Articles);
+        Assert.True(row.SpeedSpark.Count is > 0 and <= 60);
+        Assert.Contains(row.SpeedSpark, v => v > 0);
+        Assert.DoesNotContain(row.SpeedSeries, p => p.BytesFetched == 9_000_000);
+        Assert.Contains(row.SpeedSeries, p => p.BytesFetched == 2_000_000);
+        Assert.All(
+            row.SpeedSeries,
+            p => Assert.True(p.Bucket >= nowMs - 365 * OneDay - 7 * OneDay));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Metrics/ProviderCircuitOverviewEnricherTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/ProviderCircuitOverviewEnricherTests.cs
@@ -22,6 +22,10 @@ public class ProviderCircuitOverviewEnricherTests
                 Spark = [1, 2],
                 ErrorSpark = [0, 1],
                 RetrySpark = [2, 0],
+                SpeedSeries =
+                [
+                    new() { Bucket = 10, SpeedMbPerSec = 1.5, BytesFetched = 1500 },
+                ],
             },
         };
         var snapshots = new List<ProviderCircuitRuntimeSnapshot>
@@ -46,11 +50,16 @@ public class ProviderCircuitOverviewEnricherTests
         Assert.Equal(10, primary.Articles);
         Assert.Equal([0L, 1L], primary.ErrorSpark);
         Assert.Equal([2L, 0L], primary.RetrySpark);
+        var seriesPoint = Assert.Single(primary.SpeedSeries);
+        Assert.Equal(10, seriesPoint.Bucket);
+        Assert.Equal(1.5, seriesPoint.SpeedMbPerSec);
+        Assert.Equal(1500, seriesPoint.BytesFetched);
 
         var backup = enriched.Single(p => p.Provider == KeyB);
         Assert.Equal("closed", backup.CircuitState);
         Assert.Equal(0, backup.Articles);
         Assert.Equal("Backup", backup.Nickname);
         Assert.Equal(2, backup.ArticleMissCount);
+        Assert.Empty(backup.SpeedSeries);
     }
 }


### PR DESCRIPTION
## Summary
- Overview's provider scoreboard can open a timestamped effective-MB/s chart for one provider at a time (same metric as the MB/s column).
- Series geometry is 1h → 60×1min, 24h → 96×15min, 7d → 168×1h, 30d → 120×6h, and all-time → weekly buckets over the retained 365-day hourly horizon, marked truncated when that horizon clamps or folded lifetime totals exist.
- All-time sparklines now end-align on the current day so recent activity is visible instead of indexing from the Unix epoch. Lifetime totals still roll into row totals but never into series points.

Closes #946

## Test plan
- [x] `GetOverviewStatsProviderSeriesTests` — exact bucket counts, zero-fill/isolation, all-time spark clamp, lifetime bytes excluded from series
- [x] `ProviderCircuitOverviewEnricherTests` — `SpeedSeries` copied on existing rows; idle rows get `[]`
- [x] Overview frontend tests including chart-after-scroll and truncated caption
- [x] Frontend typecheck, lint, and production build
- [x] Full backend suite: 3666 passed, 14 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added provider speed-history charts to the overview dashboard.
  - Select a provider to view speed and fetched-byte trends across available time windows.
  - Added interactive hover, touch, keyboard navigation, tooltips, and responsive chart display.
  - Added messaging when historical data is limited or truncated, including all-time history limits.

- **Bug Fixes**
  - Preserved provider speed-history data when circuit-status details are applied.
  - Improved handling of missing providers and zero-activity time buckets.

- **Tests**
  - Added coverage for chart data, time-window boundaries, truncation, provider isolation, and data preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->