### PR TITLE
fix(ui): connections counter no longer flashes a spinner on the queue page

### DIFF
--- a/frontend/app/root-revalidation.test.ts
+++ b/frontend/app/root-revalidation.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { ShouldRevalidateFunctionArgs } from "react-router";
+import { shouldRevalidate } from "./root-revalidation";
+
+function args(partial: {
+  current: string;
+  next: string;
+  formMethod?: ShouldRevalidateFunctionArgs["formMethod"];
+  defaultShouldRevalidate?: boolean;
+}): ShouldRevalidateFunctionArgs {
+  return {
+    currentUrl: new URL(`http://localhost${partial.current}`),
+    nextUrl: new URL(`http://localhost${partial.next}`),
+    currentParams: {},
+    nextParams: {},
+    defaultShouldRevalidate: partial.defaultShouldRevalidate ?? true,
+    ...(partial.formMethod !== undefined ? { formMethod: partial.formMethod } : {}),
+  };
+}
+
+describe("root shouldRevalidate", () => {
+  it("revalidates when crossing the login/onboarding layout boundary", () => {
+    expect(shouldRevalidate(args({ current: "/queue", next: "/login" }))).toBe(true);
+    expect(shouldRevalidate(args({ current: "/login", next: "/overview" }))).toBe(true);
+    expect(shouldRevalidate(args({ current: "/onboarding", next: "/queue" }))).toBe(true);
+  });
+
+  it("revalidates after settings POSTs", () => {
+    expect(
+      shouldRevalidate(args({ current: "/settings", next: "/settings", formMethod: "POST" })),
+    ).toBe(true);
+  });
+
+  it("skips root revalidation for queue POSTs", () => {
+    expect(shouldRevalidate(args({ current: "/queue", next: "/queue", formMethod: "POST" }))).toBe(
+      false,
+    );
+  });
+
+  it("skips same path and search revalidation", () => {
+    expect(shouldRevalidate(args({ current: "/queue", next: "/queue" }))).toBe(false);
+    expect(shouldRevalidate(args({ current: "/queue?qp=2", next: "/queue?qp=2" }))).toBe(false);
+    expect(shouldRevalidate(args({ current: "/health", next: "/health" }))).toBe(false);
+  });
+
+  it("revalidates when the path changes", () => {
+    expect(shouldRevalidate(args({ current: "/queue", next: "/overview" }))).toBe(true);
+  });
+
+  it("uses defaultShouldRevalidate when only search params change", () => {
+    expect(
+      shouldRevalidate(
+        args({
+          current: "/queue",
+          next: "/queue?qp=2",
+          defaultShouldRevalidate: true,
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldRevalidate(
+        args({
+          current: "/queue",
+          next: "/queue?qp=2",
+          defaultShouldRevalidate: false,
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/frontend/app/root-revalidation.ts
+++ b/frontend/app/root-revalidation.ts
@@ -1,0 +1,39 @@
+import type { ShouldRevalidateFunctionArgs } from "react-router";
+
+/** True for pages the root loader renders without the app layout. */
+export function isLayoutlessPath(pathname: string): boolean {
+  const path = pathname.replace(/\.data$/, "");
+  return path === "/login" || path === "/onboarding";
+}
+
+/**
+ * Skip root config re-fetches for routine mutations (queue deletes, toggles)
+ * and same-URL revalidation (queue websocket refresh, health/explore poll),
+ * but always revalidate when crossing the login/onboarding layout boundary
+ * (login/logout redirects change `useLayout`) and after settings/onboarding
+ * saves (which can change providers/watchdog config).
+ *
+ * Sidebar navigations to a different path still use `defaultShouldRevalidate`
+ * so session, update-check, and `hasUsenetProviders` stay current.
+ */
+export function shouldRevalidate({
+  currentUrl,
+  nextUrl,
+  formMethod,
+  defaultShouldRevalidate,
+}: ShouldRevalidateFunctionArgs) {
+  if (isLayoutlessPath(currentUrl.pathname) !== isLayoutlessPath(nextUrl.pathname)) {
+    return true;
+  }
+  if (formMethod && formMethod !== "GET") {
+    const fromSettingsOrOnboarding =
+      currentUrl.pathname.startsWith("/settings") || currentUrl.pathname.startsWith("/onboarding");
+    const toSettingsOrOnboarding =
+      nextUrl.pathname.startsWith("/settings") || nextUrl.pathname.startsWith("/onboarding");
+    return fromSettingsOrOnboarding || toSettingsOrOnboarding;
+  }
+  if (currentUrl.pathname === nextUrl.pathname && currentUrl.search === nextUrl.search) {
+    return false;
+  }
+  return defaultShouldRevalidate;
+}

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -8,7 +8,6 @@ import {
   useLocation,
   useNavigation,
   useRouteError,
-  type ShouldRevalidateFunctionArgs,
 } from "react-router";
 
 import "./app.css";
@@ -30,6 +29,8 @@ import { isOidcEnabled } from "../server/oidc.server";
 import { getServiceProvider } from "./utils/service-provider.server";
 import { isResetAdminPasswordSet } from "./utils/reset-admin-password.server";
 import { withUrlBase } from "~/utils/url-base";
+
+export { shouldRevalidate } from "./root-revalidation";
 
 export async function loader({ request }: Route.LoaderArgs) {
   const resetAdminPasswordSet = isResetAdminPasswordSet();
@@ -70,37 +71,6 @@ export async function loader({ request }: Route.LoaderArgs) {
         ?.configValue?.toLowerCase() !== "false",
     serviceProvider,
   };
-}
-
-/** True for pages the root loader renders without the app layout. */
-function isLayoutlessPath(pathname: string): boolean {
-  const path = pathname.replace(/\.data$/, "");
-  return path === "/login" || path === "/onboarding";
-}
-
-/**
- * Skip root config re-fetches for routine mutations (queue deletes, toggles),
- * but always revalidate when crossing the login/onboarding layout boundary
- * (login/logout redirects change `useLayout`) and after settings/onboarding
- * saves (which can change providers/watchdog config).
- */
-export function shouldRevalidate({
-  currentUrl,
-  nextUrl,
-  formMethod,
-  defaultShouldRevalidate,
-}: ShouldRevalidateFunctionArgs) {
-  if (isLayoutlessPath(currentUrl.pathname) !== isLayoutlessPath(nextUrl.pathname)) {
-    return true;
-  }
-  if (formMethod && formMethod !== "GET") {
-    const fromSettingsOrOnboarding =
-      currentUrl.pathname.startsWith("/settings") || currentUrl.pathname.startsWith("/onboarding");
-    const toSettingsOrOnboarding =
-      nextUrl.pathname.startsWith("/settings") || nextUrl.pathname.startsWith("/onboarding");
-    return fromSettingsOrOnboarding || toSettingsOrOnboarding;
-  }
-  return defaultShouldRevalidate;
 }
 
 function hasConfiguredUsenetProviders(configValue?: string): boolean {

--- a/frontend/app/routes/_index/components/live-usenet-connections/live-usenet-connections.test.tsx
+++ b/frontend/app/routes/_index/components/live-usenet-connections/live-usenet-connections.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LiveUsenetConnections } from "./live-usenet-connections";
+
+const { useWebsocketTopicMock } = vi.hoisted(() => ({
+  useWebsocketTopicMock: vi.fn(),
+}));
+
+vi.mock("~/utils/shared-websocket", () => ({
+  useWebsocketTopic: useWebsocketTopicMock,
+}));
+
+afterEach(() => {
+  cleanup();
+  useWebsocketTopicMock.mockReset();
+});
+
+describe("LiveUsenetConnections", () => {
+  it("shows a spinner only before the first cxs message", () => {
+    let onMessage: ((message: string) => void) | undefined;
+    useWebsocketTopicMock.mockImplementation(
+      (_topic: string, _kind: string, handler: (message: string) => void) => {
+        onMessage = handler;
+      },
+    );
+
+    render(<LiveUsenetConnections hasUsenetProviders />);
+
+    const widget = screen.getByLabelText("Usenet connections");
+    expect(widget.querySelector(".loading-spinner")).not.toBeNull();
+    expect(screen.getByText("Connecting")).toBeTruthy();
+
+    act(() => {
+      onMessage?.("0|1|1|3|20|2");
+    });
+
+    expect(screen.getByText("3/20")).toBeTruthy();
+    expect(screen.getByText("1 active · 2 warm")).toBeTruthy();
+    expect(widget.querySelector(".loading-spinner")).toBeNull();
+    expect(screen.queryByText("Connecting")).toBeNull();
+
+    act(() => {
+      onMessage?.("0|2|1|4|20|2");
+    });
+
+    expect(screen.getByText("4/20")).toBeTruthy();
+    expect(widget.querySelector(".loading-spinner")).toBeNull();
+    expect(screen.queryByText("Connecting")).toBeNull();
+  });
+
+  it("shows a dash when no providers are configured", () => {
+    render(<LiveUsenetConnections hasUsenetProviders={false} />);
+
+    expect(screen.getByText("—")).toBeTruthy();
+    expect(screen.getByText("No providers")).toBeTruthy();
+    expect(
+      screen.getByLabelText("Usenet connections").querySelector(".loading-spinner"),
+    ).toBeNull();
+    expect(useWebsocketTopicMock).toHaveBeenCalledWith(
+      "cxs",
+      "state",
+      expect.any(Function),
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+});

--- a/frontend/app/routes/_index/components/page-layout/page-layout.test.tsx
+++ b/frontend/app/routes/_index/components/page-layout/page-layout.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { PageLayout, type RequiredTopNavProps } from "./page-layout";
+
+afterEach(cleanup);
+
+function StatefulNav(_props: RequiredTopNavProps) {
+  const [count, setCount] = useState(0);
+  return (
+    <div>
+      <span data-testid="nav-count">{count}</span>
+      <button type="button" onClick={() => setCount((value) => value + 1)}>
+        increment nav
+      </button>
+    </div>
+  );
+}
+
+function Harness() {
+  const [tick, setTick] = useState(0);
+  return (
+    <>
+      <span data-testid="parent-tick">{tick}</span>
+      <button type="button" onClick={() => setTick((value) => value + 1)}>
+        rerender parent
+      </button>
+      <PageLayout
+        topNavComponent={(navProps) => <StatefulNav {...navProps} />}
+        leftNavChild={null}
+        bodyChild={null}
+      />
+    </>
+  );
+}
+
+describe("PageLayout top nav render prop", () => {
+  it("keeps nav state when the parent re-renders with a new render-prop identity", async () => {
+    const user = userEvent.setup();
+    const router = createMemoryRouter(
+      [
+        {
+          path: "*",
+          element: <Harness />,
+        },
+      ],
+      { initialEntries: ["/"] },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    await user.click(screen.getByRole("button", { name: "increment nav" }));
+    expect(screen.getByTestId("nav-count").textContent).toBe("1");
+
+    await user.click(screen.getByRole("button", { name: "rerender parent" }));
+    expect(screen.getByTestId("parent-tick").textContent).toBe("1");
+    expect(screen.getByTestId("nav-count").textContent).toBe("1");
+  });
+});

--- a/frontend/app/routes/_index/components/page-layout/page-layout.tsx
+++ b/frontend/app/routes/_index/components/page-layout/page-layout.tsx
@@ -31,11 +31,11 @@ export function PageLayout(props: PageLayoutProps) {
   return (
     <div className="flex h-dvh flex-col overflow-hidden bg-base-300 text-base-content">
       <div className="navbar z-40 h-16 min-h-16 shrink-0 border-b border-base-content/10 bg-base-200/70 px-0 backdrop-blur">
-        <props.topNavComponent
-          isHamburgerMenuOpen={isHamburgerMenuOpen}
-          onHamburgerMenuClick={onHamburgerMenuClick}
-          drawerToggleId={drawerToggleId}
-        />
+        {props.topNavComponent({
+          isHamburgerMenuOpen,
+          onHamburgerMenuClick,
+          drawerToggleId,
+        })}
       </div>
 
       {/* Override daisyUI drawer-side 100dvh when sticky under the navbar. */}

--- a/frontend/coverage-thresholds.json
+++ b/frontend/coverage-thresholds.json
@@ -1,6 +1,6 @@
 {
   "global": {
-    "branches": 21,
+    "branches": 24,
     "functions": 20,
     "lines": 25,
     "statements": 24


### PR DESCRIPTION
## Summary
- The Queue page’s websocket refresh was remounting the header Connections widget (inline nav render-prop used as a component type), which reset it to the connecting spinner whenever the live count updated — including on an empty queue.
- Invoke the layout nav render-prop as a callback so `TopNavigation` stays mounted, and skip the root loader on same-path+search revalidation (queue/health/explore refresh). Login/logout, settings saves, and real navigations still refetch root.

Clicking the current page in the sidebar no longer refetches root data; the child route still refreshes.

## Test plan
- [x] Frontend unit tests: PageLayout keeps nav state across parent re-renders; root `shouldRevalidate` cases; Connections spinner only before the first `cxs` message
- [x] `npm run typecheck` in `frontend/`
- [ ] Queue page with an empty queue: count may move with the warm pool, but must not swap to a spinner after first connect
- [ ] Queue with items / filtered views: table still refreshes on add/remove/status
- [ ] Settings → Usenet while the header is visible: provider live counts populate immediately
- [ ] Navigate Overview ↔ Queue: header must not flash a spinner; Settings Save still updates watchdog/providers; login/logout still works
- [ ] Health refresh / Explore poll: page data refreshes; header stays mounted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data refresh when navigating between regular pages and login or onboarding screens.
  - Ensured settings and queue updates refresh relevant page data reliably.
  - Prevented unnecessary refreshes when the URL remains unchanged or only search parameters change.
  - Preserved top-navigation state when the surrounding page updates.

- **Tests**
  - Added coverage for navigation refresh behavior, live connection loading and availability states, and page layout stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->