### PR TITLE
fix(usenet): stop skipping through incomplete files after every missing article

### DIFF
--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -1111,6 +1111,18 @@ public class MultiProviderNntpClient(
 
             if (walk.IsPureDefinitiveMiss)
             {
+                var fileName = FetchAttributionContext.Current?.FileName;
+                if (!ZeroFillLogLimiter.TryLog(fileName, out var suppressed))
+                    return;
+
+                if (suppressed > 0)
+                {
+                    Log.Warning(
+                        "Suppressed {SuppressedCount} additional unavailable-segment warnings for {FileName} in the previous 60 seconds.",
+                        suppressed,
+                        fileName);
+                }
+
                 Log.Warning(
                     "Usenet segment was unavailable from all eligible provider sources. " +
                     "Segment: {SegmentId}; File: {FileName}; Operation: {Operation}; " +
@@ -1118,7 +1130,7 @@ public class MultiProviderNntpClient(
                     "CachedSkips: {CachedSkips}; StorageGroupSkips: {StorageGroupSkips}; " +
                     "DurationMs: {DurationMs}",
                     segmentId,
-                    FetchAttributionContext.Current?.FileName,
+                    fileName,
                     LatencyNames.ToWireName(operation),
                     walk.EligibleProviders,
                     walk.Attempts,

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -38,6 +38,9 @@ public class Par2RepairService : BackgroundService
     private readonly ConcurrentDictionary<Guid, byte> _queuedOrRunning = new();
     private readonly ConcurrentDictionary<Guid, RepairFlight> _repairFlights = new();
     private readonly ConcurrentDictionary<string, byte> _pendingZeroFillPaths = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, ConcurrentQueue<(string Id, bool IsCorruption)>> _pendingSegmentIds =
+        new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<Guid, RetainedRepair> _retainedSegmentIds = new();
     private long _totalSucceeded;
     private long _totalFailed;
     private long _totalInfeasible;
@@ -83,26 +86,58 @@ public class Par2RepairService : BackgroundService
 
     internal int PendingZeroFillCount => _pendingZeroFillPaths.Count;
 
+    internal bool HasPendingZeroFillPath(string path) =>
+        _pendingZeroFillPaths.ContainsKey(path);
+
+    internal string[] PeekRetainedSegmentIdsForTests(Guid davItemId) =>
+        _retainedSegmentIds.TryGetValue(davItemId, out var retained)
+            ? retained.Ids.Keys.ToArray()
+            : [];
+
+    internal void ReleaseQueuedOrRunningForTests(Guid davItemId)
+    {
+        _queuedOrRunning.TryRemove(davItemId, out _);
+        if (_repairFlights.TryRemove(davItemId, out var flight))
+            flight.Completion.TrySetResult(false);
+    }
+
+    internal Task RequeueRetainedForTestsAsync(Guid davItemId, CancellationToken ct) =>
+        TryRequeueRetainedAsync(davItemId, ct);
+
     /// <summary>
     /// Synchronous, allocation-light entry point for streaming zero-fill events.
-    /// Runs on the playback hot path's failure branch: gate on config, dedup by
-    /// path, and hand off to the single background consumer. All DB work happens
-    /// in the consumer.
+    /// Runs on the playback hot path's failure branch: gate on config, accumulate
+    /// segment IDs per path, and arm at most one background item per path.
     /// </summary>
     public void ReportZeroFill(string path, string segmentId)
     {
-        if (!_configManager.IsPar2RepairEnabled()) return;
-        if (!_pendingZeroFillPaths.TryAdd(path, 0)) return;
-        if (!_zeroFillQueue.Writer.TryWrite(new ZeroFillEvent(path, segmentId)))
-            _pendingZeroFillPaths.TryRemove(path, out _);
+        if (!_configManager.IsPar2RepairEnabled() && !_configManager.IsDegradedToleranceEnabled())
+            return;
+        AccumulateAndArm(path, segmentId, isCorruption: false);
     }
 
     public void ReportCorruption(string path, string segmentId)
     {
         if (!_configManager.IsCorruptionTrackingEnabled()) return;
-        if (!_pendingZeroFillPaths.TryAdd(path, 0)) return;
-        if (!_zeroFillQueue.Writer.TryWrite(new ZeroFillEvent(path, segmentId, IsCorruption: true)))
-            _pendingZeroFillPaths.TryRemove(path, out _);
+        AccumulateAndArm(path, segmentId, isCorruption: true);
+    }
+
+    private void AccumulateAndArm(string path, string segmentId, bool isCorruption)
+    {
+        if (string.IsNullOrEmpty(path) || string.IsNullOrEmpty(segmentId))
+            return;
+
+        var ids = _pendingSegmentIds.GetOrAdd(
+            path,
+            static _ => new ConcurrentQueue<(string Id, bool IsCorruption)>());
+        ids.Enqueue((segmentId, isCorruption));
+        if (!_pendingZeroFillPaths.TryAdd(path, 0))
+            return;
+        if (_zeroFillQueue.Writer.TryWrite(new ZeroFillEvent(path, segmentId, isCorruption)))
+            return;
+
+        _pendingZeroFillPaths.TryRemove(path, out _);
+        _pendingSegmentIds.TryRemove(path, out _);
     }
 
     public virtual async Task EnqueueAsync(
@@ -111,15 +146,24 @@ public class Par2RepairService : BackgroundService
         CancellationToken ct = default)
     {
         if (!_configManager.IsPar2RepairEnabled()) return;
-        if (missingSegmentIds.Count == 0) return;
-        if (!await ShouldEnqueueAsync(davItem.Id, ct).ConfigureAwait(false)) return;
+        RetainSegmentIds(davItem.Id, davItem.Path, missingSegmentIds);
+        if (!await ShouldEnqueueAsync(davItem.Id, ct).ConfigureAwait(false))
+            return;
 
         if (!_queuedOrRunning.TryAdd(davItem.Id, 0))
             return;
 
+        var ids = DrainRetainedSegmentIds(davItem.Id);
+        if (ids.Length == 0)
+        {
+            _queuedOrRunning.TryRemove(davItem.Id, out _);
+            return;
+        }
+
         var flight = new RepairFlight();
         if (!_repairFlights.TryAdd(davItem.Id, flight))
         {
+            RetainSegmentIds(davItem.Id, davItem.Path, ids);
             _queuedOrRunning.TryRemove(davItem.Id, out _);
             return;
         }
@@ -127,10 +171,11 @@ public class Par2RepairService : BackgroundService
         var item = new RepairWorkItem(
             davItem.Id,
             davItem.Path,
-            missingSegmentIds.Distinct().ToArray(),
+            ids,
             flight);
         if (!_queue.Writer.TryWrite(item))
         {
+            RetainSegmentIds(davItem.Id, davItem.Path, ids);
             _queuedOrRunning.TryRemove(davItem.Id, out _);
             _repairFlights.TryRemove(new KeyValuePair<Guid, RepairFlight>(davItem.Id, flight));
             Log.Warning(
@@ -337,67 +382,103 @@ public class Par2RepairService : BackgroundService
             finally
             {
                 _pendingZeroFillPaths.TryRemove(evt.Path, out _);
+                TryRearmPendingZeroFill(evt.Path);
             }
         }
     }
 
     private async Task ProcessZeroFillEventAsync(ZeroFillEvent evt, CancellationToken ct)
     {
+        var reports = DrainPendingSegmentReports(evt.Path);
+        reports.Add((evt.SegmentId, evt.IsCorruption));
+
         await using var dbContext = CreateContext();
         var dbClient = new DavDatabaseClient(dbContext);
-        if (evt.IsCorruption)
+        var davItem = await dbContext.Items
+            .FirstOrDefaultAsync(x => x.Path == evt.Path, ct)
+            .ConfigureAwait(false);
+        if (davItem is null)
         {
-            await ProcessCorruptionEventAsync(dbContext, dbClient, evt, ct).ConfigureAwait(false);
+            Log.Debug("Playback repair trigger skipped; no DavItem at {Path}", evt.Path);
             return;
         }
 
-        var davItem = await dbClient.GetItemByPathAsync(evt.Path, ct).ConfigureAwait(false);
-        if (davItem != null)
-            await EnqueueAsync(davItem, [evt.SegmentId], ct).ConfigureAwait(false);
+        var nzbFile = await dbClient.GetDavNzbFileAsync(davItem, ct).ConfigureAwait(false);
+        if (nzbFile is null)
+        {
+            Log.Debug("Playback repair trigger skipped; no DavNzbFile payload for {Path}", evt.Path);
+            return;
+        }
+
+        var missingIds = new List<string>();
+        var corruptIds = new List<string>();
+        var missingIndices = new List<int>();
+        var corruptIndices = new List<int>();
+        foreach (var (segmentId, isCorruption) in reports)
+        {
+            var index = Array.IndexOf(nzbFile.SegmentIds, segmentId);
+            if (index < 0)
+            {
+                Log.Debug(
+                    "Playback repair trigger skipped unknown segment {SegmentId} for {Path}",
+                    segmentId,
+                    evt.Path);
+                continue;
+            }
+
+            if (isCorruption)
+            {
+                if (!_configManager.IsCorruptionTrackingEnabled())
+                    continue;
+                corruptIds.Add(segmentId);
+                corruptIndices.Add(index);
+            }
+            else
+            {
+                missingIds.Add(segmentId);
+                missingIndices.Add(index);
+            }
+        }
+
+        if (missingIndices.Count > 0 || corruptIndices.Count > 0)
+        {
+            await DavNzbFileBlobUpdater.MutateAsync(
+                davItem,
+                current =>
+                {
+                    if (missingIndices.Count > 0)
+                    {
+                        current.MissingSegmentIndices = UnionIndices(
+                            current.MissingSegmentIndices,
+                            missingIndices.ToArray());
+                    }
+
+                    if (corruptIndices.Count > 0)
+                    {
+                        current.CorruptSegmentIndices = UnionIndices(
+                            current.CorruptSegmentIndices,
+                            corruptIndices.ToArray());
+                    }
+
+                    return current;
+                },
+                fallback: nzbFile).ConfigureAwait(false);
+            await dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+
+        if (!_configManager.IsPar2RepairEnabled())
+            return;
+
+        var enqueueIds = missingIds.Concat(corruptIds).Distinct(StringComparer.Ordinal).ToArray();
+        if (enqueueIds.Length > 0)
+            await EnqueueAsync(davItem, enqueueIds, ct).ConfigureAwait(false);
     }
 
     internal Task ProcessCorruptionEventForTestsAsync(string path, string segmentId, CancellationToken ct) =>
         ProcessZeroFillEventAsync(new ZeroFillEvent(path, segmentId, IsCorruption: true), ct);
 
-    private async Task ProcessCorruptionEventAsync(
-        DavDatabaseContext dbContext,
-        DavDatabaseClient dbClient,
-        ZeroFillEvent evt,
-        CancellationToken ct)
-    {
-        if (!_configManager.IsCorruptionTrackingEnabled()) return;
-
-        var davItem = await dbContext.Items
-            .FirstOrDefaultAsync(x => x.Path == evt.Path, ct)
-            .ConfigureAwait(false);
-        if (davItem is null) return;
-
-        var nzbFile = await dbClient.GetDavNzbFileAsync(davItem, ct).ConfigureAwait(false);
-        if (nzbFile is null) return;
-
-        var index = Array.IndexOf(nzbFile.SegmentIds, evt.SegmentId);
-        if (index < 0) return;
-
-        await DavNzbFileBlobUpdater.MutateAsync(
-            davItem,
-            current =>
-            {
-                var existing = current.CorruptSegmentIndices ?? [];
-                if (existing.Contains(index))
-                    return current;
-                current.CorruptSegmentIndices = existing
-                    .Append(index)
-                    .Distinct()
-                    .OrderBy(i => i)
-                    .ToArray();
-                return current;
-            },
-            fallback: nzbFile).ConfigureAwait(false);
-        await dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
-
-        if (_configManager.IsPar2RepairEnabled())
-            await EnqueueAsync(davItem, [evt.SegmentId], ct).ConfigureAwait(false);
-    }
+    internal Task ProcessZeroFillEventForTestsAsync(string path, string segmentId, CancellationToken ct) =>
+        ProcessZeroFillEventAsync(new ZeroFillEvent(path, segmentId), ct);
 
     private async Task ProcessQueueItemAsync(RepairWorkItem item, CancellationToken ct)
     {
@@ -409,6 +490,7 @@ public class Par2RepairService : BackgroundService
         if (davItem == null)
         {
             _queuedOrRunning.TryRemove(item.DavItemId, out _);
+            _retainedSegmentIds.TryRemove(item.DavItemId, out _);
             CompleteFlight(item.DavItemId, item.Flight, false);
             return;
         }
@@ -443,6 +525,15 @@ public class Par2RepairService : BackgroundService
         finally
         {
             _repairFlights.TryRemove(new KeyValuePair<Guid, RepairFlight>(davItem.Id, flight));
+            try
+            {
+                if (!ct.IsCancellationRequested)
+                    await TryRequeueRetainedAsync(davItem.Id, ct).ConfigureAwait(false);
+            }
+            catch (Exception e) when (e is not OutOfMemoryException and not OperationCanceledException)
+            {
+                Log.Debug(e, "Failed to requeue retained PAR2 segment IDs for {Path}", davItem.Path);
+            }
         }
     }
 
@@ -1685,6 +1776,86 @@ public class Par2RepairService : BackgroundService
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public Task<bool> Task => Completion.Task;
+    }
+
+    private void RetainSegmentIds(Guid davItemId, string path, IEnumerable<string> segmentIds)
+    {
+        var retained = _retainedSegmentIds.GetOrAdd(
+            davItemId,
+            _ => new RetainedRepair { Path = path });
+        foreach (var id in segmentIds)
+        {
+            if (!string.IsNullOrEmpty(id))
+                retained.Ids.TryAdd(id, 0);
+        }
+    }
+
+    private string[] DrainRetainedSegmentIds(Guid davItemId)
+    {
+        if (!_retainedSegmentIds.TryRemove(davItemId, out var retained))
+            return [];
+        return retained.Ids.Keys.ToArray();
+    }
+
+    private async Task TryRequeueRetainedAsync(Guid davItemId, CancellationToken ct)
+    {
+        if (!_retainedSegmentIds.ContainsKey(davItemId))
+            return;
+
+        await using var dbContext = CreateContext();
+        var davItem = await dbContext.Items.AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == davItemId, ct)
+            .ConfigureAwait(false);
+        if (davItem is null)
+        {
+            _retainedSegmentIds.TryRemove(davItemId, out _);
+            return;
+        }
+
+        await EnqueueAsync(davItem, [], ct).ConfigureAwait(false);
+    }
+
+    private List<(string Id, bool IsCorruption)> DrainPendingSegmentReports(string path)
+    {
+        var drained = new List<(string Id, bool IsCorruption)>();
+        if (!_pendingSegmentIds.TryGetValue(path, out var queue))
+            return drained;
+
+        while (queue.TryDequeue(out var item))
+            drained.Add(item);
+        return drained;
+    }
+
+    private void TryRearmPendingZeroFill(string path)
+    {
+        if (!_pendingSegmentIds.TryGetValue(path, out var queue) || queue.IsEmpty)
+        {
+            _pendingSegmentIds.TryRemove(path, out _);
+            return;
+        }
+
+        if (!_pendingZeroFillPaths.TryAdd(path, 0))
+            return;
+
+        var segmentId = "";
+        var isCorruption = false;
+        if (queue.TryPeek(out var peek))
+        {
+            segmentId = peek.Id;
+            isCorruption = peek.IsCorruption;
+        }
+
+        if (_zeroFillQueue.Writer.TryWrite(new ZeroFillEvent(path, segmentId, isCorruption)))
+            return;
+
+        _pendingZeroFillPaths.TryRemove(path, out _);
+        _pendingSegmentIds.TryRemove(path, out _);
+    }
+
+    private sealed class RetainedRepair
+    {
+        public required string Path { get; init; }
+        public ConcurrentDictionary<string, byte> Ids { get; } = new(StringComparer.Ordinal);
     }
 
     private sealed record RepairWorkItem(

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -1783,11 +1783,8 @@ public class Par2RepairService : BackgroundService
         var retained = _retainedSegmentIds.GetOrAdd(
             davItemId,
             _ => new RetainedRepair { Path = path });
-        foreach (var id in segmentIds)
-        {
-            if (!string.IsNullOrEmpty(id))
-                retained.Ids.TryAdd(id, 0);
-        }
+        foreach (var id in segmentIds.Where(id => !string.IsNullOrEmpty(id)))
+            retained.Ids.TryAdd(id, 0);
     }
 
     private string[] DrainRetainedSegmentIds(Guid davItemId)
@@ -1813,6 +1810,13 @@ public class Par2RepairService : BackgroundService
         }
 
         await EnqueueAsync(davItem, [], ct).ConfigureAwait(false);
+
+        // A blocked requeue (failure cooldown, full queue, repair disabled) leaves no
+        // flight that could drain the retained entry, so it would sit for the process
+        // lifetime. Drop it: the blob's persisted MissingSegmentIndices remain the
+        // durable record and are unioned into any future repair job for the item.
+        if (!_queuedOrRunning.ContainsKey(davItemId))
+            _retainedSegmentIds.TryRemove(davItemId, out _);
     }
 
     private List<(string Id, bool IsCorruption)> DrainPendingSegmentReports(string path)
@@ -1837,12 +1841,15 @@ public class Par2RepairService : BackgroundService
         if (!_pendingZeroFillPaths.TryAdd(path, 0))
             return;
 
+        // Dequeue the head rather than peeking it: ProcessZeroFillEventAsync drains
+        // the queue and then appends the event payload, so a peeked head would be
+        // reported twice.
         var segmentId = "";
         var isCorruption = false;
-        if (queue.TryPeek(out var peek))
+        if (queue.TryDequeue(out var head))
         {
-            segmentId = peek.Id;
-            isCorruption = peek.IsCorruption;
+            segmentId = head.Id;
+            isCorruption = head.IsCorruption;
         }
 
         if (_zeroFillQueue.Writer.TryWrite(new ZeroFillEvent(path, segmentId, isCorruption)))

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -61,6 +61,20 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             ? 0
             : MaxCorruptionRetries;
 
+    private void ThrowIfPlaybackFailFast()
+    {
+        if (!PlaybackHoleTracker.ShouldFailFast(_fileName, out var exception))
+            return;
+        ExceptionDispatchInfo.Capture(
+            exception ?? new UsenetArticleNotFoundException(_segmentIds.Span[0])).Throw();
+    }
+
+    private SegmentDownloadResult ToDownloadResult(
+        DrainedSegment drained,
+        long estimate,
+        string segmentId) =>
+        SegmentDownloadResult.Success(drained.Stream, estimate, drained.ShortPadded, segmentId);
+
     /// <summary>
     /// Optional per-instance test hook invoked with the segment-boundary readiness sample,
     /// after it is taken and before the segment task is awaited. Production code never sets
@@ -573,6 +587,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         var lease = initialLease;
         try
         {
+            ThrowIfPlaybackFailFast();
             if (_knownMissingSegmentIndices?.Contains(segmentIndex) == true)
             {
                 var result = await DownloadKnownMissingSegment(
@@ -595,12 +610,12 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
                     await ThrowOnSegmentIdMismatchAsync(segmentId, bodyResponse).ConfigureAwait(false);
 #pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
-                    var stream = await DrainSegmentAsync(
+                    var drained = await DrainSegmentAsync(
 #pragma warning restore CA2000
                             bodyResponse.Stream!, segmentIndex, cancellationToken, lease, estimate)
                         .ConfigureAwait(false);
                     lease = null;
-                    return SegmentDownloadResult.Success(stream, estimate);
+                    return ToDownloadResult(drained, estimate, segmentId);
                 }
                 catch (UsenetArticleNotFoundException e)
                 {
@@ -715,6 +730,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         var lease = initialLease;
         try
         {
+            ThrowIfPlaybackFailFast();
             var local = await TryGetLocalSegmentAsync(segmentId, segmentIndex, lease, cancellationToken)
                 .ConfigureAwait(false);
             if (local is null)
@@ -767,9 +783,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 return null;
             }
 
-            return await DrainSegmentAsync(
+            return (await DrainSegmentAsync(
                     stream, segmentIndex, cancellationToken, lease, GetPlannedSegmentBytes(segmentIndex))
-                .ConfigureAwait(false);
+                .ConfigureAwait(false)).Stream;
         }
         catch
         {
@@ -805,15 +821,16 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         var lease = initialLease;
         try
         {
+            ThrowIfPlaybackFailFast();
             var response = await responseTask.ConfigureAwait(false);
             await ThrowOnSegmentIdMismatchAsync(segmentId, response).ConfigureAwait(false);
 #pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
-            var stream = await DrainSegmentAsync(
+            var drained = await DrainSegmentAsync(
 #pragma warning restore CA2000
                     response.Stream!, segmentIndex, cancellationToken, lease, estimate)
                 .ConfigureAwait(false);
             lease = null; // owned by BudgetedStream / buffer
-            return SegmentDownloadResult.Success(stream, estimate);
+            return ToDownloadResult(drained, estimate, segmentId);
         }
         catch (UsenetArticleNotFoundException e)
         {
@@ -942,12 +959,12 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                     }
                     await ThrowOnSegmentIdMismatchAsync(segmentId, response).ConfigureAwait(false);
 #pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
-                    var stream = await DrainSegmentAsync(
+                    var rescued = await DrainSegmentAsync(
 #pragma warning restore CA2000
                         response.Stream!, segmentIndex, cancellationToken, lease, GetPlannedSegmentBytes(segmentIndex))
                         .ConfigureAwait(false);
                     lease = null;
-                    return stream;
+                    return rescued.Stream;
                 }
                 catch (UsenetArticleNotFoundException)
                 {
@@ -1019,12 +1036,12 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                     }
                     await ThrowOnSegmentIdMismatchAsync(segmentId, response).ConfigureAwait(false);
 #pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
-                    var stream = await DrainSegmentAsync(
+                    var retried = await DrainSegmentAsync(
 #pragma warning restore CA2000
                         response.Stream!, segmentIndex, cancellationToken, lease, GetPlannedSegmentBytes(segmentIndex))
                         .ConfigureAwait(false);
                     lease = null;
-                    return stream;
+                    return retried.Stream;
                 }
                 catch (UsenetCorruptArticleException exception)
                 {
@@ -1098,12 +1115,12 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                         "Segment {PrimaryIndex} recovered via fallback MessageId {FallbackId} while reading {FileName}.",
                         segmentIndex, fallbackId, _fileName);
 #pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
-                    var stream = await DrainSegmentAsync(
+                    var drained = await DrainSegmentAsync(
 #pragma warning restore CA2000
                         bodyResponse.Stream!, segmentIndex, cancellationToken, lease, GetPlannedSegmentBytes(segmentIndex))
                         .ConfigureAwait(false);
                     lease = null;
-                    return stream;
+                    return drained.Stream;
                 }
                 catch (UsenetArticleNotFoundException)
                 {
@@ -1186,6 +1203,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         else
             Par2RepairTriggerSink.Current?.ReportZeroFill(_fileName, segmentId, segmentIndex, fill);
 
+        PlaybackHoleTracker.RecordHole(_fileName, segmentId, exception);
+
 #pragma warning disable CA2000 // gap-fill stream ownership transfers to the returned SegmentDownloadResult
         return SegmentDownloadResult.ZeroFill(
             CreateGapFillStream(fill, segmentIndex),
@@ -1248,7 +1267,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         return new TransientSegmentExhaustionException(message, failure);
     }
 
-    private async Task<Stream> DrainSegmentAsync(
+    private async Task<DrainedSegment> DrainSegmentAsync(
         Stream source,
         int segmentIndex,
         CancellationToken cancellationToken,
@@ -1285,8 +1304,11 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 StreamStallKind.BodyDrain,
                 Stopwatch.GetElapsedTime(drainStarted));
             var drained = buffer.Length;
+            var shortPadded = false;
             if (hasExactSize)
-                AlignDrainedSegment(buffer, segmentIndex, drained, exactSize);
+            {
+                shortPadded = AlignDrainedSegment(buffer, segmentIndex, drained, exactSize);
+            }
             else
                 _segmentSizes.RecordObservedSize(segmentIndex, drained);
 
@@ -1305,7 +1327,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 : new BudgetedStream(buffer, lease);
             ownsLease = false;
             buffer = null;
-            return result;
+            return new DrainedSegment(result, shortPadded);
         }
         catch
         {
@@ -1396,14 +1418,10 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         return await _budget.LeaseAsync(estimate, cancellationToken).ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Keeps a segment's contribution equal to its recorded length. Leaving either a
-    /// shortfall or an overrun would shift every following byte, so short bodies are
-    /// padded and long bodies are truncated to the recorded size.
-    /// </summary>
-    private void AlignDrainedSegment(PooledBufferStream buffer, int segmentIndex, long drained, long expected)
+    /// <returns>True when the body was short and padded to the recorded length.</returns>
+    private bool AlignDrainedSegment(PooledBufferStream buffer, int segmentIndex, long drained, long expected)
     {
-        if (drained == expected) return;
+        if (drained == expected) return false;
 
         if (drained > expected)
         {
@@ -1411,20 +1429,25 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 "Segment {SegmentIndex} of {FileName} decoded {Drained} bytes but was recorded as {Expected}. Truncating to keep offsets aligned.",
                 segmentIndex, _fileName, drained, expected);
             buffer.SetLength(expected);
-            return;
+            return false;
         }
 
         var shortfall = expected - drained;
+        var segmentId = _segmentIds.Span[segmentIndex];
+        var hole = new UsenetArticleNotFoundException(segmentId);
         ZeroFillLogLimiter.Write(
             "Segment {SegmentId} of {FileName} decoded {Bytes} bytes short of its recorded size. " +
             "Filling the gap to keep the rest of the file aligned.",
-            _segmentIds.Span[segmentIndex],
+            segmentId,
             _fileName,
             shortfall);
         if (MultiProviderNntpClient.CurrentReadSessionId is { } sessionId)
-            StreamTrace.TryZeroFill(sessionId, _segmentIds.Span[segmentIndex], shortfall);
+            StreamTrace.TryZeroFill(sessionId, segmentId, shortfall);
 
+        PlaybackHoleTracker.RecordHole(_fileName, segmentId, hole);
+        Par2RepairTriggerSink.Current?.ReportZeroFill(_fileName, segmentId, segmentIndex, shortfall);
         buffer.SetLength(expected);
+        return true;
     }
 
     public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
@@ -1499,7 +1522,26 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     {
         if (!result.IsZeroFill)
         {
+            if (result.IsShortPad)
+            {
+                _consecutiveZeroFills++;
+                if (_consecutiveZeroFills < GapFillLimits.MaxConsecutiveZeroFills
+                    && !PlaybackHoleTracker.ShouldFailFast(_fileName, out _))
+                    return result.Stream;
+
+                result.Stream.Dispose();
+                _cts.Cancel();
+                if (PlaybackHoleTracker.ShouldFailFast(_fileName, out var failFast)
+                    && failFast is not null)
+                {
+                    ExceptionDispatchInfo.Capture(failFast).Throw();
+                }
+
+                throw new UsenetArticleNotFoundException(result.SegmentId ?? _segmentIds.Span[0]);
+            }
+
             _consecutiveZeroFills = 0;
+            PlaybackHoleTracker.RecordGoodSegment(_fileName);
             return result.Stream;
         }
 
@@ -1513,7 +1555,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         if (MultiProviderNntpClient.CurrentReadSessionId is { } sessionId)
             StreamTrace.TryZeroFill(sessionId, result.SegmentId!, result.Bytes);
 
-        if (_consecutiveZeroFills < GapFillLimits.MaxConsecutiveZeroFills)
+        if (_consecutiveZeroFills < GapFillLimits.MaxConsecutiveZeroFills
+            && !PlaybackHoleTracker.ShouldFailFast(_fileName, out _))
             return result.Stream;
 
         result.Stream.Dispose();
@@ -1609,18 +1652,25 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         _cts.Dispose();
     }
 
+    private readonly record struct DrainedSegment(Stream Stream, bool ShortPadded);
+
     private sealed record SegmentDownloadResult(
         Stream Stream,
         long PlannedBytes = 0,
         string? MessageTemplate = null,
         string? SegmentId = null,
         long Bytes = 0,
-        Exception? Failure = null)
+        Exception? Failure = null,
+        bool IsShortPad = false)
     {
         public bool IsZeroFill => Failure is not null;
 
-        public static SegmentDownloadResult Success(Stream stream, long plannedBytes = 0) =>
-            new(stream, plannedBytes);
+        public static SegmentDownloadResult Success(
+            Stream stream,
+            long plannedBytes = 0,
+            bool isShortPad = false,
+            string? segmentId = null) =>
+            new(stream, plannedBytes, SegmentId: segmentId, IsShortPad: isShortPad);
 
         public static SegmentDownloadResult ZeroFill(
             Stream stream,

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -625,7 +625,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                     if (fallback is not null)
                     {
                         lease = null;
-                        return SegmentDownloadResult.Success(fallback, estimate);
+                        return ToDownloadResult(fallback.Value, estimate, segmentId);
                     }
 
                     if (_failFastOnFirstSegment && isFirstSegment)
@@ -653,7 +653,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                         if (fallback is not null)
                         {
                             lease = null;
-                            return SegmentDownloadResult.Success(fallback, estimate);
+                            return ToDownloadResult(fallback.Value, estimate, segmentId);
                         }
 
                         if (_failFastOnFirstSegment && isFirstSegment)
@@ -739,7 +739,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             if (local is not null)
             {
                 lease = null;
-                return SegmentDownloadResult.Success(local, estimate);
+                return ToDownloadResult(local.Value, estimate, segmentId);
             }
 
             var missing = new UsenetArticleNotFoundException(segmentId);
@@ -763,7 +763,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         }
     }
 
-    private async Task<Stream?> TryGetLocalSegmentAsync(
+    private async Task<DrainedSegment?> TryGetLocalSegmentAsync(
         string segmentId,
         int segmentIndex,
         ArticleByteLease? lease,
@@ -783,9 +783,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 return null;
             }
 
-            return (await DrainSegmentAsync(
+            return await DrainSegmentAsync(
                     stream, segmentIndex, cancellationToken, lease, GetPlannedSegmentBytes(segmentIndex))
-                .ConfigureAwait(false)).Stream;
+                .ConfigureAwait(false);
         }
         catch
         {
@@ -794,7 +794,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         }
     }
 
-    private async Task<Stream?> TryGetLocalFallbackSegmentsAsync(
+    private async Task<DrainedSegment?> TryGetLocalFallbackSegmentsAsync(
         int segmentIndex,
         ArticleByteLease? lease,
         CancellationToken cancellationToken)
@@ -839,7 +839,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             if (fallback is not null)
             {
                 lease = null;
-                return SegmentDownloadResult.Success(fallback, estimate);
+                return ToDownloadResult(fallback.Value, estimate, segmentId);
             }
 
             if (_failFastOnFirstSegment && isFirstSegment) throw;
@@ -853,11 +853,11 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         {
             try
             {
-                var stream = await RetryCorruptSegmentAsync(
+                var retried = await RetryCorruptSegmentAsync(
                         segmentId, segmentIndex, e, lease, cancellationToken)
                     .ConfigureAwait(false);
                 lease = null;
-                return SegmentDownloadResult.Success(stream, estimate);
+                return ToDownloadResult(retried, estimate, segmentId);
             }
             catch (UsenetCorruptArticleException persistent)
             {
@@ -885,7 +885,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             // dropped socket takes out unrelated segments with it. Re-request this
             // segment on its own first, which is what gives provider failover and the
             // streaming-timeout retries a chance before any data is degraded.
-            Stream? rescued;
+            DrainedSegment? rescued;
             try
             {
                 rescued = await TryRescueSegmentAsync(
@@ -907,7 +907,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             }
 
             if (rescued is not null)
-                return SegmentDownloadResult.Success(rescued, estimate);
+                return ToDownloadResult(rescued.Value, estimate, segmentId);
 
             if (_failFastOnFirstSegment && isFirstSegment) throw;
             throw CreateTransientSegmentFailure(segmentId, segmentIndex, e);
@@ -924,7 +924,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     /// if rescue confirms the article is genuinely missing, so the caller can gap-fill
     /// rather than treating it as a transient transport failure.
     /// </summary>
-    private async Task<Stream?> TryRescueSegmentAsync(
+    private async Task<DrainedSegment?> TryRescueSegmentAsync(
         string segmentId,
         int segmentIndex,
         Exception batchFailure,
@@ -964,7 +964,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                         response.Stream!, segmentIndex, cancellationToken, lease, GetPlannedSegmentBytes(segmentIndex))
                         .ConfigureAwait(false);
                     lease = null;
-                    return rescued.Stream;
+                    return rescued;
                 }
                 catch (UsenetArticleNotFoundException)
                 {
@@ -1000,7 +1000,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         UsenetDecodedBodyResponse response) =>
         SegmentResponseValidator.ThrowOnSegmentIdMismatchAsync(segmentId, response);
 
-    private async Task<Stream> RetryCorruptSegmentAsync(
+    private async Task<DrainedSegment> RetryCorruptSegmentAsync(
         string segmentId,
         int segmentIndex,
         UsenetCorruptArticleException initialFailure,
@@ -1041,7 +1041,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                         response.Stream!, segmentIndex, cancellationToken, lease, GetPlannedSegmentBytes(segmentIndex))
                         .ConfigureAwait(false);
                     lease = null;
-                    return retried.Stream;
+                    return retried;
                 }
                 catch (UsenetCorruptArticleException exception)
                 {
@@ -1054,7 +1054,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             if (fallback is not null)
             {
                 lease = null;
-                return fallback;
+                return fallback.Value;
             }
 
             ExceptionDispatchInfo.Capture(failure).Throw();
@@ -1073,7 +1073,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     /// attempts; on success ownership transfers to the returned stream, on miss
     /// the caller still owns the lease.
     /// </summary>
-    private async Task<Stream?> TryFallbackSegmentsAsync(
+    private async Task<DrainedSegment?> TryFallbackSegmentsAsync(
         int segmentIndex,
         ArticleByteLease? existingLease,
         CancellationToken cancellationToken)
@@ -1120,7 +1120,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                         bodyResponse.Stream!, segmentIndex, cancellationToken, lease, GetPlannedSegmentBytes(segmentIndex))
                         .ConfigureAwait(false);
                     lease = null;
-                    return drained.Stream;
+                    return drained;
                 }
                 catch (UsenetArticleNotFoundException)
                 {
@@ -1434,18 +1434,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
         var shortfall = expected - drained;
         var segmentId = _segmentIds.Span[segmentIndex];
-        var hole = new UsenetArticleNotFoundException(segmentId);
-        ZeroFillLogLimiter.Write(
-            "Segment {SegmentId} of {FileName} decoded {Bytes} bytes short of its recorded size. " +
-            "Filling the gap to keep the rest of the file aligned.",
-            segmentId,
-            _fileName,
-            shortfall);
-        if (MultiProviderNntpClient.CurrentReadSessionId is { } sessionId)
-            StreamTrace.TryZeroFill(sessionId, segmentId, shortfall);
-
-        PlaybackHoleTracker.RecordHole(_fileName, segmentId, hole);
-        Par2RepairTriggerSink.Current?.ReportZeroFill(_fileName, segmentId, segmentIndex, shortfall);
+        SegmentHoleReporter.ReportShortDecode(_fileName, segmentId, segmentIndex, shortfall);
         buffer.SetLength(expected);
         return true;
     }

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Exceptions;
@@ -308,8 +309,17 @@ public class NzbFileStream(
         return null;
     }
 
+    private void ThrowIfPlaybackFailFast()
+    {
+        if (!PlaybackHoleTracker.ShouldFailFast(fileName ?? "", out var exception))
+            return;
+        ExceptionDispatchInfo.Capture(
+            exception ?? new UsenetArticleNotFoundException(fileSegmentIds[0])).Throw();
+    }
+
     private async Task<Stream> GetFileStream(long rangeStart, CancellationToken cancellationToken)
     {
+        ThrowIfPlaybackFailFast();
         if (rangeStart == 0) return GetMultiSegmentStream(0, failFastOnFirstSegment: true, cancellationToken);
         if (!IsKnownMissingSegment(foundSegment: null, rangeStart) && !ShouldUseDirectRangePath())
         {
@@ -354,13 +364,17 @@ public class NzbFileStream(
 
     private bool IsKnownMissingSegment(InterpolationSearch.Result? foundSegment, long rangeStart)
     {
-        if (_knownMissingSegmentIndices is null || _segmentByteRanges is null) return false;
+        if (_segmentByteRanges is null) return false;
         var segment = foundSegment ?? InterpolationSearch.Find(
             rangeStart,
             new LongRange(0, _segmentByteRanges.Length),
             new LongRange(0, fileSize),
             guess => _segmentByteRanges[guess]);
-        return _knownMissingSegmentIndices.Contains(segment.FoundIndex);
+        if (_knownMissingSegmentIndices?.Contains(segment.FoundIndex) == true)
+            return true;
+        if ((uint)segment.FoundIndex >= (uint)fileSegmentIds.Length)
+            return false;
+        return PlaybackHoleTracker.IsKnownMissingSegment(fileName ?? "", fileSegmentIds[segment.FoundIndex]);
     }
 
     private const int MaxSeekGuessCorrection = 3;
@@ -571,6 +585,16 @@ public class NzbFileStream(
             .Where(index => index >= firstSegmentIndex)
             .Select(index => index - firstSegmentIndex)
             .ToHashSet();
+        var trackerIds = PlaybackHoleTracker.SnapshotMissingSegmentIds(fileName ?? "");
+        if (trackerIds is { Count: > 0 })
+        {
+            knownMissing ??= [];
+            for (var i = firstSegmentIndex; i < fileSegmentIds.Length; i++)
+            {
+                if (trackerIds.Contains(fileSegmentIds[i]))
+                    knownMissing.Add(i - firstSegmentIndex);
+            }
+        }
 
         return MultiSegmentStream.CreateFirstSegmentHybrid(
             segmentIds,

--- a/backend/Streams/PlaybackHoleTracker.cs
+++ b/backend/Streams/PlaybackHoleTracker.cs
@@ -76,22 +76,44 @@ internal static class PlaybackHoleTracker
 
     public static bool IsKnownMissingSegment(string? path, string segmentId)
     {
-        if (!IsTrackablePath(path) || string.IsNullOrEmpty(segmentId))
-            return false;
-        if (!Files.TryGetValue(path!, out var state))
-            return false;
+        var known = false;
+        var now = Clock.GetUtcNow();
+        if (IsTrackablePath(path) && !string.IsNullOrEmpty(segmentId)
+            && Files.TryGetValue(path!, out var state))
+        {
+            lock (state)
+            {
+                // Missing-segment memory must not outlive provider recovery: after a
+                // PAR2 repair or backfill the same path would otherwise keep being
+                // served zero bytes until an unrelated 256th RecordHole sweeps.
+                if (IsStale(state, now))
+                    Files.TryRemove(path!, out _);
+                else
+                    known = state.MissingSegmentIds.Contains(segmentId);
+            }
+        }
 
-        lock (state)
-            return state.MissingSegmentIds.Contains(segmentId);
+        MaybeCleanup(now);
+        return known;
     }
 
     public static HashSet<string>? SnapshotMissingSegmentIds(string? path)
     {
-        if (!IsTrackablePath(path) || !Files.TryGetValue(path!, out var state))
-            return null;
+        HashSet<string>? snapshot = null;
+        var now = Clock.GetUtcNow();
+        if (IsTrackablePath(path) && Files.TryGetValue(path!, out var state))
+        {
+            lock (state)
+            {
+                if (IsStale(state, now))
+                    Files.TryRemove(path!, out _);
+                else if (state.MissingSegmentIds.Count > 0)
+                    snapshot = [.. state.MissingSegmentIds];
+            }
+        }
 
-        lock (state)
-            return state.MissingSegmentIds.Count == 0 ? null : [..state.MissingSegmentIds];
+        MaybeCleanup(now);
+        return snapshot;
     }
 
     /// <summary>
@@ -101,6 +123,10 @@ internal static class PlaybackHoleTracker
     /// </summary>
     private static bool IsTrackablePath(string? path) =>
         !string.IsNullOrEmpty(path) && path[0] == '/';
+
+    // Caller must hold the state lock.
+    private static bool IsStale(FileState state, DateTimeOffset now) =>
+        now - state.LastEventUtc >= CleanupThreshold;
 
     private static void Prune(FileState state, DateTimeOffset now)
     {

--- a/backend/Streams/PlaybackHoleTracker.cs
+++ b/backend/Streams/PlaybackHoleTracker.cs
@@ -1,0 +1,142 @@
+using System.Collections.Concurrent;
+
+namespace NzbWebDAV.Streams;
+
+/// <summary>
+/// Process-wide memory of playback-discovered holes so rclone's abort-and-retry
+/// cannot reset the consecutive-miss counter by opening a new HTTP range.
+/// </summary>
+internal static class PlaybackHoleTracker
+{
+    internal static readonly TimeSpan ConsecutiveWindow = TimeSpan.FromSeconds(30);
+    internal static readonly TimeSpan CleanupThreshold = TimeSpan.FromMinutes(5);
+
+    private static readonly ConcurrentDictionary<string, FileState> Files =
+        new(StringComparer.Ordinal);
+    private static int _callCount;
+
+    internal static TimeProvider Clock { get; set; } = TimeProvider.System;
+
+    internal static void ResetForTests()
+    {
+        Files.Clear();
+        Clock = TimeProvider.System;
+        Volatile.Write(ref _callCount, 0);
+    }
+
+    public static void RecordHole(string? path, string segmentId, Exception exception)
+    {
+        if (!IsTrackablePath(path) || string.IsNullOrEmpty(segmentId))
+            return;
+
+        var now = Clock.GetUtcNow();
+        var state = Files.GetOrAdd(path!, static _ => new FileState());
+        lock (state)
+        {
+            Prune(state, now);
+            state.LastEventUtc = now;
+            state.HoleTimes.Add(now);
+            state.MissingSegmentIds.Add(segmentId);
+            state.LastException = exception;
+        }
+
+        MaybeCleanup(now);
+    }
+
+    public static void RecordGoodSegment(string? path)
+    {
+        if (!IsTrackablePath(path) || !Files.TryGetValue(path!, out var state))
+            return;
+
+        var now = Clock.GetUtcNow();
+        lock (state)
+        {
+            state.HoleTimes.Clear();
+            state.LastEventUtc = now;
+            state.LastException = null;
+        }
+    }
+
+    public static bool ShouldFailFast(string? path, out Exception? exception)
+    {
+        exception = null;
+        if (!IsTrackablePath(path) || !Files.TryGetValue(path!, out var state))
+            return false;
+
+        var now = Clock.GetUtcNow();
+        lock (state)
+        {
+            Prune(state, now);
+            if (state.HoleTimes.Count < GapFillLimits.MaxConsecutiveZeroFills)
+                return false;
+            exception = state.LastException;
+            return true;
+        }
+    }
+
+    public static bool IsKnownMissingSegment(string? path, string segmentId)
+    {
+        if (!IsTrackablePath(path) || string.IsNullOrEmpty(segmentId))
+            return false;
+        if (!Files.TryGetValue(path!, out var state))
+            return false;
+
+        lock (state)
+            return state.MissingSegmentIds.Contains(segmentId);
+    }
+
+    public static HashSet<string>? SnapshotMissingSegmentIds(string? path)
+    {
+        if (!IsTrackablePath(path) || !Files.TryGetValue(path!, out var state))
+            return null;
+
+        lock (state)
+            return state.MissingSegmentIds.Count == 0 ? null : [..state.MissingSegmentIds];
+    }
+
+    /// <summary>
+    /// Production playback keys the tracker by the DAV path (always rooted at '/').
+    /// Basenames used by existing stream tests stay off the process-wide map so
+    /// parallel cases cannot accumulate each other's holes.
+    /// </summary>
+    private static bool IsTrackablePath(string? path) =>
+        !string.IsNullOrEmpty(path) && path[0] == '/';
+
+    private static void Prune(FileState state, DateTimeOffset now)
+    {
+        var cutoff = now - ConsecutiveWindow;
+        var holeTimes = state.HoleTimes;
+        var write = 0;
+        for (var read = 0; read < holeTimes.Count; read++)
+        {
+            if (holeTimes[read] >= cutoff)
+                holeTimes[write++] = holeTimes[read];
+        }
+
+        if (write < holeTimes.Count)
+            holeTimes.RemoveRange(write, holeTimes.Count - write);
+    }
+
+    private static void MaybeCleanup(DateTimeOffset now)
+    {
+        if (Interlocked.Increment(ref _callCount) % 256 != 0)
+            return;
+
+        foreach (var entry in Files)
+        {
+            lock (entry.Value)
+            {
+                if (now - entry.Value.LastEventUtc >= CleanupThreshold)
+                    Files.TryRemove(entry.Key, out _);
+            }
+        }
+    }
+
+    private sealed class FileState
+    {
+        public DateTimeOffset LastEventUtc { get; set; }
+        public Exception? LastException { get; set; }
+        public List<DateTimeOffset> HoleTimes { get; } = [];
+        public HashSet<string> MissingSegmentIds { get; } = new(StringComparer.Ordinal);
+    }
+}

--- a/backend/Streams/SegmentHoleReporter.cs
+++ b/backend/Streams/SegmentHoleReporter.cs
@@ -1,0 +1,35 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Services.Repair;
+using NzbWebDAV.Services.StreamTrace;
+
+namespace NzbWebDAV.Streams;
+
+/// <summary>
+/// Shared reporting for a segment that decoded short of its recorded size: one
+/// coalesced warning, one stream-trace event, one tracked playback hole, and one
+/// PAR2 repair trigger, so the buffered and unbuffered streams cannot drift apart.
+/// </summary>
+internal static class SegmentHoleReporter
+{
+    public static UsenetArticleNotFoundException ReportShortDecode(
+        string fileName,
+        string segmentId,
+        int segmentIndex,
+        long shortfall)
+    {
+        var hole = new UsenetArticleNotFoundException(segmentId);
+        ZeroFillLogLimiter.Write(
+            "Segment {SegmentId} of {FileName} decoded {Bytes} bytes short of its recorded size. " +
+            "Filling the gap to keep the rest of the file aligned.",
+            segmentId,
+            fileName,
+            shortfall);
+        if (MultiProviderNntpClient.CurrentReadSessionId is { } sessionId)
+            StreamTrace.TryZeroFill(sessionId, segmentId, shortfall);
+
+        PlaybackHoleTracker.RecordHole(fileName, segmentId, hole);
+        Par2RepairTriggerSink.Current?.ReportZeroFill(fileName, segmentId, segmentIndex, shortfall);
+        return hole;
+    }
+}

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -233,18 +233,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
             if (TryGetRemainingExactBytes(out remainingExact) && remainingExact > 0)
             {
                 var shortId = _segmentIds.Span[_openSegmentIndex];
-                var hole = new UsenetArticleNotFoundException(shortId);
-                ZeroFillLogLimiter.Write(
-                    "Segment {SegmentId} of {FileName} decoded {Bytes} bytes short of its recorded size. " +
-                    "Filling the gap to keep the rest of the file aligned.",
-                    shortId,
-                    _fileName,
-                    remainingExact);
-                if (MultiProviderNntpClient.CurrentReadSessionId is { } sessionId)
-                    StreamTrace.TryZeroFill(sessionId, shortId, remainingExact);
-
-                PlaybackHoleTracker.RecordHole(_fileName, shortId, hole);
-                Par2RepairTriggerSink.Current?.ReportZeroFill(
+                var hole = SegmentHoleReporter.ReportShortDecode(
                     _fileName, shortId, _openSegmentIndex, remainingExact);
                 _consecutiveZeroFills++;
                 _openSegmentHole = true;
@@ -645,6 +634,10 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
             catch (UsenetArticleNotFoundException)
             {
                 await DisposeBodyStreamAsync(fallbackStream).ConfigureAwait(false);
+                // A playback fail-fast raised by FetchBodyAsync must escape instead of
+                // walking every fallback ID and recording an extra hole per attempt.
+                if (PlaybackHoleTracker.ShouldFailFast(_fileName, out var failFast) && failFast is not null)
+                    ExceptionDispatchInfo.Capture(failFast).Throw();
             }
             catch (UsenetCorruptArticleException)
             {

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -34,6 +34,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
     private long _pendingPadBytes;
     private int _consecutiveZeroFills;
     private bool _openSegmentFromLiveFetch;
+    private bool _openSegmentHole;
     private bool _hasProbedByte;
     private byte _probedByte;
     private bool _disposed;
@@ -118,6 +119,8 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
                     continue;
                 }
 
+                ThrowIfPlaybackFailFast();
+
                 Stream? fetched = null;
                 try
                 {
@@ -130,7 +133,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
                     fetched = null;
                     _openSegmentIndex = segmentIndex;
                     _openSegmentFromLiveFetch = true;
-                    _consecutiveZeroFills = 0;
+                    _openSegmentHole = false;
                 }
                 catch (UsenetArticleNotFoundException e)
                 {
@@ -142,7 +145,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
                         _stream = fallback;
                         _openSegmentIndex = segmentIndex;
                         _openSegmentFromLiveFetch = true;
-                        _consecutiveZeroFills = 0;
+                        _openSegmentHole = false;
                     }
                     else
                     {
@@ -229,14 +232,26 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
             // starts at the offset the rest of the file expects.
             if (TryGetRemainingExactBytes(out remainingExact) && remainingExact > 0)
             {
+                var shortId = _segmentIds.Span[_openSegmentIndex];
+                var hole = new UsenetArticleNotFoundException(shortId);
                 ZeroFillLogLimiter.Write(
                     "Segment {SegmentId} of {FileName} decoded {Bytes} bytes short of its recorded size. " +
                     "Filling the gap to keep the rest of the file aligned.",
-                    _segmentIds.Span[_openSegmentIndex],
+                    shortId,
                     _fileName,
                     remainingExact);
                 if (MultiProviderNntpClient.CurrentReadSessionId is { } sessionId)
-                    StreamTrace.TryZeroFill(sessionId, _segmentIds.Span[_openSegmentIndex], remainingExact);
+                    StreamTrace.TryZeroFill(sessionId, shortId, remainingExact);
+
+                PlaybackHoleTracker.RecordHole(_fileName, shortId, hole);
+                Par2RepairTriggerSink.Current?.ReportZeroFill(
+                    _fileName, shortId, _openSegmentIndex, remainingExact);
+                _consecutiveZeroFills++;
+                _openSegmentHole = true;
+                var cap = _consecutiveZeroFills >= GapFillLimits.MaxConsecutiveZeroFills;
+                var trackerFail = PlaybackHoleTracker.ShouldFailFast(_fileName, out var failFast);
+                if (cap || trackerFail)
+                    ExceptionDispatchInfo.Capture(failFast ?? hole).Throw();
 
                 _pendingPadBytes = remainingExact;
                 continue;
@@ -281,6 +296,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         string segmentId,
         CancellationToken cancellationToken)
     {
+        ThrowIfPlaybackFailFast();
         var local = await TryGetLocalSegmentAsync(segmentId, segmentIndex, cancellationToken)
             .ConfigureAwait(false)
             ?? await TryGetLocalFallbackAsync(segmentIndex, cancellationToken).ConfigureAwait(false);
@@ -289,7 +305,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
             _stream = local;
             _openSegmentIndex = segmentIndex;
             _openSegmentFromLiveFetch = false;
-            _consecutiveZeroFills = 0;
+            _openSegmentHole = false;
             return;
         }
 
@@ -363,9 +379,16 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         if (_openSegmentIndex >= 0
             && !_segmentSizes.TryGetExactSize(_openSegmentIndex, out _))
             _segmentSizes.RecordObservedSize(_openSegmentIndex, _openSegmentBytes);
+        if (!_openSegmentHole)
+        {
+            _consecutiveZeroFills = 0;
+            PlaybackHoleTracker.RecordGoodSegment(_fileName);
+        }
+
         _openSegmentIndex = -1;
         _pendingPadBytes = 0;
         _openSegmentFromLiveFetch = false;
+        _openSegmentHole = false;
         _hasProbedByte = false;
         await DisposeOpenBodyAsync().ConfigureAwait(false);
     }
@@ -431,7 +454,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
             _stream = fallback;
             _openSegmentIndex = segmentIndex;
             _openSegmentFromLiveFetch = true;
-            _consecutiveZeroFills = 0;
+            _openSegmentHole = false;
             return;
         }
 
@@ -543,7 +566,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         _stream = stream;
         _openSegmentIndex = segmentIndex;
         _openSegmentFromLiveFetch = true;
-        _consecutiveZeroFills = 0;
+        _openSegmentHole = false;
     }
 
     private void ApplyZeroFill(
@@ -554,6 +577,8 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         bool isCorruption)
     {
         _consecutiveZeroFills++;
+        _openSegmentHole = true;
+        PlaybackHoleTracker.RecordHole(_fileName, segmentId, cause);
         var template = isCorruption
             ? "Article {SegmentId} persistently corrupt while reading {FileName}. Filling the {Bytes}-byte gap to preserve later file offsets."
             : "Article {SegmentId} missing on all providers while reading {FileName}. Filling the {Bytes}-byte gap to preserve later file offsets.";
@@ -564,9 +589,11 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
             Par2RepairTriggerSink.ReportCorruption(_fileName, segmentId);
         else
             Par2RepairTriggerSink.Current?.ReportZeroFill(_fileName, segmentId, segmentIndex, fill);
-        if (_consecutiveZeroFills >= GapFillLimits.MaxConsecutiveZeroFills)
+        var cap = _consecutiveZeroFills >= GapFillLimits.MaxConsecutiveZeroFills;
+        var trackerFail = PlaybackHoleTracker.ShouldFailFast(_fileName, out var failFast);
+        if (cap || trackerFail)
         {
-            ExceptionDispatchInfo.Capture(cause).Throw();
+            ExceptionDispatchInfo.Capture(failFast ?? cause).Throw();
             throw cause;
         }
 
@@ -638,6 +665,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         string segmentId,
         CancellationToken cancellationToken)
     {
+        ThrowIfPlaybackFailFast();
         using (FetchAttributionContext.Begin(_fileName))
         {
             return await _usenetClient.DecodedBodyAsync(segmentId, cancellationToken)
@@ -682,6 +710,14 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
             ArrayPool<byte>.Shared.Return(buffer);
             await DisposeBodyStreamAsync(stream).ConfigureAwait(false);
         }
+    }
+
+    private void ThrowIfPlaybackFailFast()
+    {
+        if (!PlaybackHoleTracker.ShouldFailFast(_fileName, out var exception))
+            return;
+        ExceptionDispatchInfo.Capture(
+            exception ?? new UsenetArticleNotFoundException(_segmentIds.Span[0])).Throw();
     }
 
     private void ThrowIfDisposed()

--- a/backend/Streams/ZeroFillLogLimiter.cs
+++ b/backend/Streams/ZeroFillLogLimiter.cs
@@ -39,8 +39,10 @@ internal static class ZeroFillLogLimiter
         if (string.IsNullOrEmpty(baseName) || baseName == "unknown")
             return true;
 
+        // Key on the complete attributed path: same-named files in different
+        // directories must not share one suppression window.
         var now = DateTime.UtcNow;
-        var key = baseName.Normalize(NormalizationForm.FormC);
+        var key = fileName.Normalize(NormalizationForm.FormC);
         var state = Windows.GetOrAdd(key, static _ => new WindowState());
         var shouldLog = false;
 

--- a/backend/Streams/ZeroFillLogLimiter.cs
+++ b/backend/Streams/ZeroFillLogLimiter.cs
@@ -6,8 +6,9 @@ using Serilog;
 namespace NzbWebDAV.Streams;
 
 /// <summary>
-/// Coalesces gap-fill warnings by file so a release with many unavailable
-/// articles cannot flood the application log.
+/// Coalesces per-file warnings so a release with many unavailable articles
+/// cannot flood the application log. Prefetch-miss and gap-fill warnings share
+/// the same window so one file cannot emit both at full rate.
 /// </summary>
 internal static class ZeroFillLogLimiter
 {
@@ -17,23 +18,31 @@ internal static class ZeroFillLogLimiter
     private static readonly TimeSpan CleanupThreshold = TimeSpan.FromMinutes(5);
     private static int _callCount;
 
-    /// <param name="context">
-    /// Optional diagnostic detail appended as its own property, so a warning explains
-    /// which part of which file fell short without needing a second log line.
-    /// </param>
-    public static void Write(
-        string messageTemplate,
-        string segmentId,
-        string fileName,
-        long bytes,
-        Exception? exception = null,
-        string? context = null)
+    internal static void ResetForTests()
     {
+        Windows.Clear();
+        Volatile.Write(ref _callCount, 0);
+    }
+
+    /// <summary>
+    /// Returns true when this file should emit a warning. <paramref name="suppressed"/>
+    /// is the count hidden during the previous window (0 on the first emission).
+    /// Unattributed files always log so queue/STAT noise is not silently dropped.
+    /// </summary>
+    public static bool TryLog(string? fileName, out int suppressed)
+    {
+        suppressed = 0;
+        if (string.IsNullOrEmpty(fileName) || fileName == "unknown")
+            return true;
+
+        var baseName = Path.GetFileName(fileName);
+        if (string.IsNullOrEmpty(baseName) || baseName == "unknown")
+            return true;
+
         var now = DateTime.UtcNow;
-        var key = fileName.Normalize(NormalizationForm.FormC);
+        var key = baseName.Normalize(NormalizationForm.FormC);
         var state = Windows.GetOrAdd(key, static _ => new WindowState());
         var shouldLog = false;
-        var suppressed = 0;
 
         lock (state)
         {
@@ -50,29 +59,44 @@ internal static class ZeroFillLogLimiter
             }
         }
 
-        if (shouldLog)
-        {
-            if (suppressed > 0)
-            {
-                Log.Warning(
-                    "Suppressed {SuppressedCount} additional gap-fill warnings for {FileName} in the previous 60 seconds.",
-                    suppressed,
-                    fileName);
-            }
-
-            var template = context is null ? messageTemplate : messageTemplate + " {Context}";
-            object?[] values = context is null
-                ? [segmentId, fileName, bytes]
-                : [segmentId, fileName, bytes, context];
-
-            if (exception is null)
-                Log.Warning(template, values);
-            else
-                exception.LogWarningKnownOrStack(template, values);
-        }
-
         if (Interlocked.Increment(ref _callCount) % 256 == 0)
             Cleanup(now);
+
+        return shouldLog;
+    }
+
+    /// <param name="context">
+    /// Optional diagnostic detail appended as its own property, so a warning explains
+    /// which part of which file fell short without needing a second log line.
+    /// </param>
+    public static void Write(
+        string messageTemplate,
+        string segmentId,
+        string fileName,
+        long bytes,
+        Exception? exception = null,
+        string? context = null)
+    {
+        if (!TryLog(fileName, out var suppressed))
+            return;
+
+        if (suppressed > 0)
+        {
+            Log.Warning(
+                "Suppressed {SuppressedCount} additional gap-fill warnings for {FileName} in the previous 60 seconds.",
+                suppressed,
+                fileName);
+        }
+
+        var template = context is null ? messageTemplate : messageTemplate + " {Context}";
+        object?[] values = context is null
+            ? [segmentId, fileName, bytes]
+            : [segmentId, fileName, bytes, context];
+
+        if (exception is null)
+            Log.Warning(template, values);
+        else
+            exception.LogWarningKnownOrStack(template, values);
     }
 
     private static void Cleanup(DateTime now)

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTerminalMissLoggingTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTerminalMissLoggingTests.cs
@@ -272,6 +272,7 @@ public sealed class MultiProviderNntpClientTerminalMissLoggingTests
     public async Task SharedPumpMiss_IncludesFileAttribution()
     {
         const string segmentId = "shared-pump@terminal-miss";
+        var fileName = $"shared-pump-{Guid.NewGuid():N}.mkv";
         var events = await CaptureLogsAsync(async () =>
         {
             using var nntp = TwoThrowingProviders();
@@ -283,10 +284,10 @@ public sealed class MultiProviderNntpClientTerminalMissLoggingTests
                 failFastOnFirstSegment: false,
                 usePipelinedBodyRequests: false,
                 CancellationToken.None,
-                fileName: "movie.mkv",
+                fileName: fileName,
                 exactSegmentSizes: new long[] { 8 });
             await using var entry = new SharedStreamEntry(
-                "/content/movie.mkv",
+                $"/content/{fileName}",
                 0,
                 8,
                 64,
@@ -310,13 +311,14 @@ public sealed class MultiProviderNntpClientTerminalMissLoggingTests
         });
 
         var warning = Assert.Single(events, e => IsMissWarningFor(e, segmentId));
-        Assert.Equal("movie.mkv", PropertyText(warning, "FileName"));
+        Assert.Equal(fileName, PropertyText(warning, "FileName"));
     }
 
     [Fact]
     public async Task PlaybackZeroFill_DoesNotDuplicateTheTerminalMissWarning()
     {
         const string segmentId = "zero-fill@terminal-miss";
+        var fileName = $"zero-fill-{Guid.NewGuid():N}.mkv";
         var events = await CaptureLogsAsync(async () =>
         {
             using var nntp = TwoThrowingProviders();
@@ -328,7 +330,7 @@ public sealed class MultiProviderNntpClientTerminalMissLoggingTests
                 failFastOnFirstSegment: false,
                 usePipelinedBodyRequests: false,
                 CancellationToken.None,
-                fileName: "movie.mkv",
+                fileName: fileName,
                 exactSegmentSizes: new long[] { 8 });
             var buffer = new byte[8];
             _ = await stream.ReadAsync(buffer);

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.ExceptionServices;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -625,6 +626,26 @@ public class ExceptionMiddlewareTests
         var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
         var middleware = CreateMiddleware(
             _ => throw new UsenetArticleNotFoundException(segmentId));
+
+        await middleware.InvokeAsync(context);
+
+        var ex = Assert.Throws<UsenetArticleNotFoundException>(
+            () => HealthCheckService.CheckCachedMissingSegmentIds([segmentId]));
+        Assert.Equal(segmentId, ex.SegmentId);
+    }
+
+    [Fact]
+    public async Task CapturedFailFastRethrow_WithDavItem_StillSeedsQueueFailFastCache()
+    {
+        var segmentId = $"<{Guid.NewGuid():N}@test>";
+        var captured = new UsenetArticleNotFoundException(segmentId);
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var middleware = CreateMiddleware(_ =>
+        {
+            ExceptionDispatchInfo.Capture(captured).Throw();
+            return Task.CompletedTask;
+        });
 
         await middleware.InvokeAsync(context);
 

--- a/tests/NzbWebDAV.Tests/Services/Repair/DavNzbFileCorruptionRecordTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/DavNzbFileCorruptionRecordTests.cs
@@ -186,6 +186,41 @@ public sealed class DavNzbFileCorruptionRecordTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task RequeueRetained_DropsRetainedIdsWhenItemIsCoolingDown()
+    {
+        var segments = NewSegmentIds(3);
+        var (item, _) = await AddFileAsync(segments);
+        var service = new Par2RepairService(_config, null!, new RepairPatchStore(Path.Join(_configRoot, "patches-cooldown"), 1024 * 1024));
+
+        await service.EnqueueAsync(item, [segments[0]], CancellationToken.None);
+        await service.EnqueueAsync(item, [segments[1]], CancellationToken.None);
+        Assert.NotEmpty(service.PeekRetainedSegmentIdsForTests(item.Id));
+
+        service.ReleaseQueuedOrRunningForTests(item.Id);
+        await using (var context = new DavDatabaseContext())
+        {
+            context.Par2RepairJobs.Add(new Par2RepairJob
+            {
+                Id = Guid.NewGuid(),
+                DavItemId = item.Id,
+                Path = item.Path,
+                State = Par2RepairJob.RepairJobState.Failed,
+                CreatedAt = DateTimeOffset.UtcNow.AddHours(-1),
+                CompletedAt = DateTimeOffset.UtcNow.AddHours(-1),
+                Attempts = 1,
+                NextAttemptAt = DateTimeOffset.UtcNow.AddHours(1),
+            });
+            await context.SaveChangesAsync();
+        }
+
+        await service.RequeueRetainedForTestsAsync(item.Id, CancellationToken.None);
+
+        // The cooldown blocks the requeue and no flight remains to drain the entry;
+        // the persisted blob indices stay the durable record for a future repair.
+        Assert.Empty(service.PeekRetainedSegmentIdsForTests(item.Id));
+    }
+
+    [Fact]
     public async Task HealthReplaceMutation_PreservesCorruptRecord()
     {
         var segments = NewSegmentIds(3);

--- a/tests/NzbWebDAV.Tests/Services/Repair/DavNzbFileCorruptionRecordTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/DavNzbFileCorruptionRecordTests.cs
@@ -129,6 +129,63 @@ public sealed class DavNzbFileCorruptionRecordTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Consumer_UnionsZeroFillSegmentIdsAndPersistsMissingIndices()
+    {
+        var segments = NewSegmentIds(4);
+        var (item, _) = await AddFileAsync(segments, missing: [1]);
+        var service = new RecordingEnqueuePar2RepairService(_config, Path.Join(_configRoot, "patches-zf-union"));
+
+        service.ReportZeroFill(item.Path, segments[2]);
+        service.ReportZeroFill(item.Path, segments[0]);
+        await service.ProcessZeroFillEventForTestsAsync(item.Path, segments[2], CancellationToken.None);
+
+        var blob = await ReadCurrentBlobAsync(item.Id);
+        Assert.Equal([0, 1, 2], blob.MissingSegmentIndices!);
+        var enqueued = Assert.Single(service.Enqueued);
+        Assert.Contains(segments[0], enqueued);
+        Assert.Contains(segments[2], enqueued);
+        Assert.DoesNotContain(segments[1], enqueued);
+    }
+
+    [Fact]
+    public async Task Consumer_UnionsCorruptionSegmentIdsOnOnePath()
+    {
+        var segments = NewSegmentIds(3);
+        var (item, _) = await AddFileAsync(segments);
+        var service = new RecordingEnqueuePar2RepairService(_config, Path.Join(_configRoot, "patches-corr-union"));
+
+        service.ReportCorruption(item.Path, segments[0]);
+        service.ReportCorruption(item.Path, segments[2]);
+        await service.ProcessCorruptionEventForTestsAsync(item.Path, segments[0], CancellationToken.None);
+
+        var blob = await ReadCurrentBlobAsync(item.Id);
+        Assert.Equal([0, 2], blob.CorruptSegmentIndices!);
+        var enqueued = Assert.Single(service.Enqueued);
+        Assert.Contains(segments[0], enqueued);
+        Assert.Contains(segments[2], enqueued);
+    }
+
+    [Fact]
+    public async Task EnqueueAsync_RetainsIdsWhenAJobIsAlreadyQueuedAndRequeuesAfterRelease()
+    {
+        var segments = NewSegmentIds(3);
+        var (item, _) = await AddFileAsync(segments);
+        var service = new Par2RepairService(_config, null!, new RepairPatchStore(Path.Join(_configRoot, "patches-retain"), 1024 * 1024));
+
+        await service.EnqueueAsync(item, [segments[0]], CancellationToken.None);
+        await service.EnqueueAsync(item, [segments[1], segments[2]], CancellationToken.None);
+
+        var retained = service.PeekRetainedSegmentIdsForTests(item.Id);
+        Assert.Contains(segments[1], retained);
+        Assert.Contains(segments[2], retained);
+
+        service.ReleaseQueuedOrRunningForTests(item.Id);
+        await service.RequeueRetainedForTestsAsync(item.Id, CancellationToken.None);
+
+        Assert.Empty(service.PeekRetainedSegmentIdsForTests(item.Id));
+    }
+
+    [Fact]
     public async Task HealthReplaceMutation_PreservesCorruptRecord()
     {
         var segments = NewSegmentIds(3);

--- a/tests/NzbWebDAV.Tests/Streams/KnownCorruptFastPathTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/KnownCorruptFastPathTests.cs
@@ -231,7 +231,7 @@ public class KnownCorruptFastPathTests
             Assert.Equal(new byte[fill], outputB.ToArray());
             Assert.Equal(1, clientA.BodyRequestCount);
             Assert.Equal(1, clientB.BodyRequestCount);
-            Assert.Equal(1, service.PendingZeroFillCount);
+            Assert.True(service.HasPendingZeroFillPath(path));
         }
         finally
         {

--- a/tests/NzbWebDAV.Tests/Streams/KnownMissingFastPathTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/KnownMissingFastPathTests.cs
@@ -7,6 +7,7 @@ using NzbWebDAV.Tests.Fakes;
 
 namespace NzbWebDAV.Tests.Streams;
 
+[Collection(nameof(PlaybackHoleTrackerCollection))]
 public class KnownMissingFastPathTests
 {
     [Theory]
@@ -191,4 +192,54 @@ public class KnownMissingFastPathTests
         Assert.Equal(new byte[3], destination);
         Assert.Equal(0, client.BodyRequestCounts.GetValueOrDefault(ids[1]));
     }
+
+    [Fact]
+    public async Task ThirdConsecutiveMiss_SecondStreamFailsFastWithZeroBodyRequests()
+    {
+        PlaybackHoleTracker.ResetForTests();
+        var path = $"/view/fail-fast-{Guid.NewGuid():N}.mkv";
+        var ids = new[] { "miss-a@test", "miss-b@test", "miss-c@test", "miss-d@test" };
+        var sizes = new long[] { 5, 5, 5, 5 };
+        try
+        {
+            var first = new FakeNntpClient(new Dictionary<string, byte[]>());
+            await using (var stream = CreateGapFillStream(ids, first, path, sizes, articleBufferSize: 4))
+            {
+                await Assert.ThrowsAsync<UsenetArticleNotFoundException>(
+                    async () => await stream.CopyToAsync(Stream.Null));
+            }
+
+            Assert.True(first.BodyRequestCount > 0);
+            Assert.True(PlaybackHoleTracker.ShouldFailFast(path, out var stored));
+            Assert.IsType<UsenetArticleNotFoundException>(stored);
+
+            var second = new FakeNntpClient(new Dictionary<string, byte[]>());
+            await using var stream2 = CreateGapFillStream(ids, second, path, sizes, articleBufferSize: 4);
+            await Assert.ThrowsAsync<UsenetArticleNotFoundException>(
+                async () => await stream2.CopyToAsync(Stream.Null));
+
+            Assert.Equal(0, second.BodyRequestCount);
+        }
+        finally
+        {
+            PlaybackHoleTracker.ResetForTests();
+        }
+    }
+
+    private static Stream CreateGapFillStream(
+        string[] ids,
+        INntpClient client,
+        string path,
+        long[] sizes,
+        int articleBufferSize) =>
+        MultiSegmentStream.Create(
+            ids.AsMemory(),
+            client,
+            articleBufferSize,
+            estimatedSegmentSize: 5,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            CancellationToken.None,
+            fileName: path,
+            exactSegmentSizes: sizes);
 }

--- a/tests/NzbWebDAV.Tests/Streams/PlaybackHoleTrackerCollection.cs
+++ b/tests/NzbWebDAV.Tests/Streams/PlaybackHoleTrackerCollection.cs
@@ -1,0 +1,7 @@
+namespace NzbWebDAV.Tests.Streams;
+
+/// <summary>
+/// Serializes tests that read or reset the process-wide <c>PlaybackHoleTracker</c>.
+/// </summary>
+[CollectionDefinition(nameof(PlaybackHoleTrackerCollection))]
+public sealed class PlaybackHoleTrackerCollection;

--- a/tests/NzbWebDAV.Tests/Streams/PlaybackHoleTrackerTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/PlaybackHoleTrackerTests.cs
@@ -79,6 +79,22 @@ public sealed class PlaybackHoleTrackerTests : IDisposable
     }
 
     [Fact]
+    public void StaleEntries_ExpireOnReadWithoutFurtherHoles()
+    {
+        var path = $"/view/stale-read-{Guid.NewGuid():N}.mkv";
+        var clock = new ManualTimeProvider();
+        PlaybackHoleTracker.Clock = clock;
+        var miss = new UsenetArticleNotFoundException("stale@test");
+        PlaybackHoleTracker.RecordHole(path, "stale@test", miss);
+        Assert.True(PlaybackHoleTracker.IsKnownMissingSegment(path, "stale@test"));
+
+        clock.Advance(PlaybackHoleTracker.CleanupThreshold + TimeSpan.FromSeconds(1));
+
+        Assert.False(PlaybackHoleTracker.IsKnownMissingSegment(path, "stale@test"));
+        Assert.Null(PlaybackHoleTracker.SnapshotMissingSegmentIds(path));
+    }
+
+    [Fact]
     public void BasenameFileNames_AreNotTracked()
     {
         var miss = new UsenetArticleNotFoundException("movie@test");

--- a/tests/NzbWebDAV.Tests/Streams/PlaybackHoleTrackerTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/PlaybackHoleTrackerTests.cs
@@ -1,0 +1,101 @@
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Streams;
+
+namespace NzbWebDAV.Tests.Streams;
+
+[Collection(nameof(PlaybackHoleTrackerCollection))]
+public sealed class PlaybackHoleTrackerTests : IDisposable
+{
+    public PlaybackHoleTrackerTests() => PlaybackHoleTracker.ResetForTests();
+
+    public void Dispose() => PlaybackHoleTracker.ResetForTests();
+
+    [Fact]
+    public void ThreeConsecutiveHoles_FailFast_TwoIsolatedHolesDoNot()
+    {
+        var path = $"/view/isolated-{Guid.NewGuid():N}.mkv";
+        var miss = new UsenetArticleNotFoundException("a@test");
+        PlaybackHoleTracker.RecordHole(path, "a@test", miss);
+        PlaybackHoleTracker.RecordHole(path, "b@test", miss);
+        Assert.False(PlaybackHoleTracker.ShouldFailFast(path, out _));
+
+        PlaybackHoleTracker.RecordHole(path, "c@test", miss);
+        Assert.True(PlaybackHoleTracker.ShouldFailFast(path, out var stored));
+        Assert.Same(miss, stored);
+        Assert.True(PlaybackHoleTracker.IsKnownMissingSegment(path, "b@test"));
+    }
+
+    [Fact]
+    public void GoodSegment_ResetsConsecutiveWindow()
+    {
+        var path = $"/view/reset-{Guid.NewGuid():N}.mkv";
+        var miss = new UsenetArticleNotFoundException("a@test");
+        PlaybackHoleTracker.RecordHole(path, "a@test", miss);
+        PlaybackHoleTracker.RecordHole(path, "b@test", miss);
+        PlaybackHoleTracker.RecordGoodSegment(path);
+        PlaybackHoleTracker.RecordHole(path, "c@test", miss);
+        PlaybackHoleTracker.RecordHole(path, "d@test", miss);
+
+        Assert.False(PlaybackHoleTracker.ShouldFailFast(path, out _));
+        Assert.True(PlaybackHoleTracker.IsKnownMissingSegment(path, "a@test"));
+    }
+
+    [Fact]
+    public void SlidingWindow_ExpiresOldHoles()
+    {
+        var path = $"/view/window-{Guid.NewGuid():N}.mkv";
+        var clock = new ManualTimeProvider();
+        PlaybackHoleTracker.Clock = clock;
+        var miss = new UsenetArticleNotFoundException("a@test");
+        PlaybackHoleTracker.RecordHole(path, "a@test", miss);
+        PlaybackHoleTracker.RecordHole(path, "b@test", miss);
+        PlaybackHoleTracker.RecordHole(path, "c@test", miss);
+        Assert.True(PlaybackHoleTracker.ShouldFailFast(path, out _));
+
+        clock.Advance(PlaybackHoleTracker.ConsecutiveWindow + TimeSpan.FromSeconds(1));
+        Assert.False(PlaybackHoleTracker.ShouldFailFast(path, out _));
+        Assert.True(PlaybackHoleTracker.IsKnownMissingSegment(path, "a@test"));
+    }
+
+    [Fact]
+    public void StaleEntries_AreEvictedOnPeriodicCleanup()
+    {
+        var stale = $"/view/stale-{Guid.NewGuid():N}.mkv";
+        var clock = new ManualTimeProvider();
+        PlaybackHoleTracker.Clock = clock;
+        var miss = new UsenetArticleNotFoundException("stale@test");
+        PlaybackHoleTracker.RecordHole(stale, "stale@test", miss);
+        clock.Advance(PlaybackHoleTracker.CleanupThreshold + TimeSpan.FromSeconds(1));
+
+        for (var i = 0; i < 255; i++)
+        {
+            PlaybackHoleTracker.RecordHole(
+                $"/view/other-{Guid.NewGuid():N}.mkv",
+                "other@test",
+                miss);
+        }
+
+        Assert.False(PlaybackHoleTracker.IsKnownMissingSegment(stale, "stale@test"));
+    }
+
+    [Fact]
+    public void BasenameFileNames_AreNotTracked()
+    {
+        var miss = new UsenetArticleNotFoundException("movie@test");
+        PlaybackHoleTracker.RecordHole("movie.mkv", "movie@test", miss);
+        PlaybackHoleTracker.RecordHole("movie.mkv", "movie2@test", miss);
+        PlaybackHoleTracker.RecordHole("movie.mkv", "movie3@test", miss);
+
+        Assert.False(PlaybackHoleTracker.ShouldFailFast("movie.mkv", out _));
+        Assert.False(PlaybackHoleTracker.IsKnownMissingSegment("movie.mkv", "movie@test"));
+    }
+
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _utcNow = DateTimeOffset.UtcNow;
+
+        public void Advance(TimeSpan delta) => _utcNow += delta;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+    }
+}

--- a/tests/NzbWebDAV.Tests/Streams/UnbufferedShortDecodeHoleTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/UnbufferedShortDecodeHoleTests.cs
@@ -1,0 +1,96 @@
+using System.Text;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.Fakes;
+
+namespace NzbWebDAV.Tests.Streams;
+
+[Collection(nameof(PlaybackHoleTrackerCollection))]
+public sealed class UnbufferedShortDecodeHoleTests : IDisposable
+{
+    public UnbufferedShortDecodeHoleTests() => PlaybackHoleTracker.ResetForTests();
+
+    public void Dispose() => PlaybackHoleTracker.ResetForTests();
+
+    [Fact]
+    public async Task ShortDecodePadding_RecordsHoleAndDoesNotFailFastAlone()
+    {
+        var path = $"/view/short-decode-{Guid.NewGuid():N}.mkv";
+        const string shortId = "short@test";
+        const string okId = "ok@test";
+        var client = new FakeNntpClient(
+            new Dictionary<string, byte[]>
+            {
+                [shortId] = "ab"u8.ToArray(),
+                [okId] = "cdef"u8.ToArray(),
+            });
+        await using var stream = new UnbufferedMultiSegmentStream(
+            new[] { shortId, okId }.AsMemory(),
+            client,
+            estimatedSegmentSize: 5,
+            fileName: path,
+            exactSegmentSizes: new long[] { 5, 4 });
+        using var output = new MemoryStream();
+
+        await stream.CopyToAsync(output);
+
+        Assert.Equal("ab\0\0\0cdef", Encoding.ASCII.GetString(output.ToArray()));
+        Assert.True(PlaybackHoleTracker.IsKnownMissingSegment(path, shortId));
+        Assert.False(PlaybackHoleTracker.ShouldFailFast(path, out _));
+        Assert.Equal(1, client.BodyRequestCounts[shortId]);
+        Assert.Equal(1, client.BodyRequestCounts[okId]);
+    }
+
+    [Fact]
+    public async Task ThreeConsecutiveShortDecodes_FailFast()
+    {
+        var path = $"/view/short-cap-{Guid.NewGuid():N}.mkv";
+        var ids = new[] { "s0@test", "s1@test", "s2@test" };
+        var client = new FakeNntpClient(
+            ids.ToDictionary(id => id, _ => "x"u8.ToArray(), StringComparer.Ordinal));
+        await using var stream = new UnbufferedMultiSegmentStream(
+            ids.AsMemory(),
+            client,
+            estimatedSegmentSize: 5,
+            fileName: path,
+            exactSegmentSizes: new long[] { 5, 5, 5 });
+
+        await Assert.ThrowsAsync<UsenetArticleNotFoundException>(
+            async () => await stream.CopyToAsync(Stream.Null));
+
+        Assert.True(PlaybackHoleTracker.ShouldFailFast(path, out var stored));
+        Assert.IsType<UsenetArticleNotFoundException>(stored);
+    }
+
+    [Fact]
+    public async Task ShortDecode_CountsTowardCrossRangeFailFast()
+    {
+        var path = $"/view/short-range-{Guid.NewGuid():N}.mkv";
+        var ids = new[] { "s0@test", "s1@test", "s2@test" };
+        var first = new FakeNntpClient(
+            ids.ToDictionary(id => id, _ => "x"u8.ToArray(), StringComparer.Ordinal));
+        await using (var stream = new UnbufferedMultiSegmentStream(
+                         ids.AsMemory(),
+                         first,
+                         estimatedSegmentSize: 5,
+                         fileName: path,
+                         exactSegmentSizes: new long[] { 5, 5, 5 }))
+        {
+            await Assert.ThrowsAsync<UsenetArticleNotFoundException>(
+                async () => await stream.CopyToAsync(Stream.Null));
+        }
+
+        var second = new FakeNntpClient(
+            ids.ToDictionary(id => id, _ => "x"u8.ToArray(), StringComparer.Ordinal));
+        await using var stream2 = new UnbufferedMultiSegmentStream(
+            ids.AsMemory(),
+            second,
+            estimatedSegmentSize: 5,
+            fileName: path,
+            exactSegmentSizes: new long[] { 5, 5, 5 });
+
+        await Assert.ThrowsAsync<UsenetArticleNotFoundException>(
+            async () => await stream2.CopyToAsync(Stream.Null));
+        Assert.Equal(0, second.BodyRequestCount);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Streams/ZeroFillLogLimiterTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/ZeroFillLogLimiterTests.cs
@@ -1,0 +1,29 @@
+using NzbWebDAV.Streams;
+
+namespace NzbWebDAV.Tests.Streams;
+
+public sealed class ZeroFillLogLimiterTests : IDisposable
+{
+    public ZeroFillLogLimiterTests() => ZeroFillLogLimiter.ResetForTests();
+
+    public void Dispose() => ZeroFillLogLimiter.ResetForTests();
+
+    [Fact]
+    public void TryLog_CoalescesRepeatsPerFile()
+    {
+        var path = $"/view/limit-{Guid.NewGuid():N}.mkv";
+        Assert.True(ZeroFillLogLimiter.TryLog(path, out var firstSuppressed));
+        Assert.Equal(0, firstSuppressed);
+        Assert.False(ZeroFillLogLimiter.TryLog(path, out _));
+        Assert.False(ZeroFillLogLimiter.TryLog(path, out _));
+    }
+
+    [Fact]
+    public void TryLog_AlwaysAllowsUnattributedAndUnknown()
+    {
+        Assert.True(ZeroFillLogLimiter.TryLog(null, out _));
+        Assert.True(ZeroFillLogLimiter.TryLog("", out _));
+        Assert.True(ZeroFillLogLimiter.TryLog("unknown", out _));
+        Assert.True(ZeroFillLogLimiter.TryLog("unknown", out _));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Streams/ZeroFillLogLimiterTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/ZeroFillLogLimiterTests.cs
@@ -30,7 +30,9 @@ public sealed class ZeroFillLogLimiterTests : IDisposable
     [Fact]
     public void TryLog_DistinctPathsWithSameFileName_EachLogOnce()
     {
-        var name = $"movie-{Guid.NewGuid():N}.mkv";
+        // Fixed name: this class runs sequentially and resets the limiter per test,
+        // so a deterministic fixture cannot leak windows between runs.
+        const string name = "movie-same-name-distinct-dirs.mkv";
         Assert.True(ZeroFillLogLimiter.TryLog($"/view/a/{name}", out _));
         Assert.True(ZeroFillLogLimiter.TryLog($"/view/b/{name}", out _));
         Assert.False(ZeroFillLogLimiter.TryLog($"/view/a/{name}", out _));

--- a/tests/NzbWebDAV.Tests/Streams/ZeroFillLogLimiterTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/ZeroFillLogLimiterTests.cs
@@ -26,4 +26,14 @@ public sealed class ZeroFillLogLimiterTests : IDisposable
         Assert.True(ZeroFillLogLimiter.TryLog("unknown", out _));
         Assert.True(ZeroFillLogLimiter.TryLog("unknown", out _));
     }
+
+    [Fact]
+    public void TryLog_DistinctPathsWithSameFileName_EachLogOnce()
+    {
+        var name = $"movie-{Guid.NewGuid():N}.mkv";
+        Assert.True(ZeroFillLogLimiter.TryLog($"/view/a/{name}", out _));
+        Assert.True(ZeroFillLogLimiter.TryLog($"/view/b/{name}", out _));
+        Assert.False(ZeroFillLogLimiter.TryLog($"/view/a/{name}", out _));
+        Assert.False(ZeroFillLogLimiter.TryLog($"/view/b/{name}", out _));
+    }
 }


### PR DESCRIPTION
## Summary
- Fail a playback range after 3 consecutive all-provider misses on the same DAV path within 30 seconds, even when rclone aborts and opens a new HTTP range (the previous per-stream gap-fill counter reset to 0 each time).
- Persist missing segment indices discovered during playback so later ranges skip NNTP for those articles, and enqueue the **union** of PAR2 segment IDs (including IDs that arrived while a repair job was already running).
- Coalesce per-file “unavailable from all providers” warnings so a swiss-cheese remux cannot flood the warning ring.

Isolated 1–2 hole files still gap-fill and can be PAR2-repaired. Dead first-segment / unknown-length behavior is unchanged.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (3674 passed, 14 skipped)
- [x] Cross-range fail-fast: second `MultiSegmentStream` for the same path issues **zero** BODY requests after 3 consecutive misses
- [x] Isolated holes do not fail-fast; a good segment resets the consecutive window; sliding 30s window expires old misses
- [x] Unbuffered short-decode padding records a hole and counts toward fail-fast
- [x] Two `ReportZeroFill` / `ReportCorruption` IDs on one path both persist and both appear in `EnqueueAsync`
- [x] IDs dropped while a PAR2 job is queued are retained and requeued after release
- [x] Fail-fast rethrow of `UsenetArticleNotFoundException` still seeds the queue fail-fast cache when `DavItem` is on the context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Playback Reliability**
  * Playback now detects repeated missing, corrupt, or incomplete segments sooner and fails fast when recovery is unlikely.
  * Missing and short segments are tracked consistently across streams and playback ranges, including zero-filled segments.
  * Repair processing combines segment reports and retains affected segments for follow-up recovery.

* **Logging**
  * Repeated unavailable-segment warnings are rate-limited per file, with suppressed warning counts reported clearly.
  * Short-segment warnings and recovery events now provide more consistent playback diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->