### PR TITLE
fix(usenet): STAT of missing articles no longer logs unclassified cache-cleanup failures

### DIFF
--- a/backend/Clients/Usenet/ArticleMissNegativeCache.cs
+++ b/backend/Clients/Usenet/ArticleMissNegativeCache.cs
@@ -54,6 +54,7 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
     private Task _persistenceLoop = Task.CompletedTask;
     private volatile bool _persistenceLoopStarted;
     private int _cleanupRunning;
+    private int _cleanupContinuationScheduled;
     private long _hits;
 
     private abstract record PersistenceWorkItem;
@@ -207,6 +208,12 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
         MarkMissingInMemory(key, at);
     }
 
+    /// <summary>
+    /// Test hook: invoked after each cleanup round while the single-flight is still
+    /// held, so marks added by the hook skip cleanup instead of recursing into it.
+    /// </summary>
+    internal Action? CleanupRoundCompletedForTests { get; set; }
+
     internal async Task MarkMissingAndPersistForTestsAsync(string key)
     {
         MarkMissing(key);
@@ -246,8 +253,7 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
         // The flight is released between rounds and the count re-checked, so marks
         // that skipped cleanup while another thread held the flight are handled by
         // the next round instead of waiting for a future MarkMissing. The round cap
-        // bounds the work done under a sustained mark storm; temporary over-cap is
-        // fine and is trimmed by a later call.
+        // bounds the work done under a sustained mark storm.
         for (var round = 0; round < MaxCleanupRounds; round++)
         {
             if (Interlocked.CompareExchange(ref _cleanupRunning, 1, 0) != 0)
@@ -256,6 +262,7 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
             try
             {
                 CleanupRound(maxEntries);
+                CleanupRoundCompletedForTests?.Invoke();
             }
             finally
             {
@@ -264,6 +271,32 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
 
             if (_missingAt.Count <= maxEntries) return;
         }
+
+        // Marks kept landing after each round's snapshot, so the loop is still over
+        // cap and every caller that added them skipped cleanup (the flight was
+        // held). Don't strand the cache over cap until some future MarkMissing —
+        // queue one coalesced continuation to keep trimming in the background.
+        ScheduleCleanupContinuation();
+    }
+
+    private void ScheduleCleanupContinuation()
+    {
+        if (Interlocked.CompareExchange(ref _cleanupContinuationScheduled, 1, 0) != 0)
+            return;
+        _ = Task.Run(() =>
+        {
+            // Re-arm before running, so a still-over-cap result can schedule the
+            // next coalesced continuation from inside Cleanup.
+            Interlocked.Exchange(ref _cleanupContinuationScheduled, 0);
+            try
+            {
+                Cleanup(_configManager.GetArticleMissCacheMaxEntries());
+            }
+            catch (Exception e) when (e is not OutOfMemoryException)
+            {
+                Log.Debug(e, "Article-miss cache cleanup continuation failed; a later mark retriggers cleanup.");
+            }
+        });
     }
 
     private void CleanupRound(int maxEntries)
@@ -271,10 +304,10 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
         var cutoff = DateTimeOffset.UtcNow - _configManager.GetArticleMissCacheTtl();
         // Weakly-consistent foreach — never LINQ OrderBy/ToArray on the live
         // ConcurrentDictionary (those use Count-then-CopyTo and race under writes).
+        // Enumeration only yields fully constructed nodes, so keys are never null.
         var snapshot = new List<KeyValuePair<string, DateTimeOffset>>(Math.Max(4, _missingAt.Count));
         foreach (var kv in _missingAt)
         {
-            if (kv.Key is null) continue;
             if (kv.Value < cutoff)
                 RemoveIfUnchanged(kv);
             else

--- a/backend/Clients/Usenet/ArticleMissNegativeCache.cs
+++ b/backend/Clients/Usenet/ArticleMissNegativeCache.cs
@@ -44,6 +44,7 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
 {
     private const int PersistenceQueueCapacity = 4096;
     private const int MaxPersistenceBatchSize = 256;
+    private const int MaxCleanupRounds = 8;
 
     private readonly ConfigManager _configManager;
     private readonly Func<DavDatabaseContext>? _contextFactory;
@@ -242,38 +243,57 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
     private void Cleanup(int maxEntries)
     {
         // Single-flight: a STAT storm must not start N concurrent O(n log n) sorts.
-        // A skipped cleanup is retried on a later MarkMissing; temporary over-cap is fine.
-        if (Interlocked.CompareExchange(ref _cleanupRunning, 1, 0) != 0)
-            return;
-
-        try
+        // The flight is released between rounds and the count re-checked, so marks
+        // that skipped cleanup while another thread held the flight are handled by
+        // the next round instead of waiting for a future MarkMissing. The round cap
+        // bounds the work done under a sustained mark storm; temporary over-cap is
+        // fine and is trimmed by a later call.
+        for (var round = 0; round < MaxCleanupRounds; round++)
         {
-            var cutoff = DateTimeOffset.UtcNow - _configManager.GetArticleMissCacheTtl();
-            // Weakly-consistent foreach — never LINQ OrderBy/ToArray on the live
-            // ConcurrentDictionary (those use Count-then-CopyTo and race under writes).
-            var snapshot = new List<KeyValuePair<string, DateTimeOffset>>(Math.Max(4, _missingAt.Count));
-            foreach (var kv in _missingAt)
+            if (Interlocked.CompareExchange(ref _cleanupRunning, 1, 0) != 0)
+                return;
+
+            try
             {
-                if (kv.Key is null) continue;
-                if (kv.Value < cutoff)
-                    _missingAt.TryRemove(kv.Key, out _);
-                else
-                    snapshot.Add(kv);
+                CleanupRound(maxEntries);
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _cleanupRunning, 0);
             }
 
-            var overflow = _missingAt.Count - maxEntries;
-            if (overflow <= 0) return;
-
-            snapshot.Sort(static (a, b) => a.Value.CompareTo(b.Value));
-            var toEvict = Math.Min(overflow, snapshot.Count);
-            for (var i = 0; i < toEvict; i++)
-                _missingAt.TryRemove(snapshot[i].Key, out _);
-        }
-        finally
-        {
-            Interlocked.Exchange(ref _cleanupRunning, 0);
+            if (_missingAt.Count <= maxEntries) return;
         }
     }
+
+    private void CleanupRound(int maxEntries)
+    {
+        var cutoff = DateTimeOffset.UtcNow - _configManager.GetArticleMissCacheTtl();
+        // Weakly-consistent foreach — never LINQ OrderBy/ToArray on the live
+        // ConcurrentDictionary (those use Count-then-CopyTo and race under writes).
+        var snapshot = new List<KeyValuePair<string, DateTimeOffset>>(Math.Max(4, _missingAt.Count));
+        foreach (var kv in _missingAt)
+        {
+            if (kv.Key is null) continue;
+            if (kv.Value < cutoff)
+                RemoveIfUnchanged(kv);
+            else
+                snapshot.Add(kv);
+        }
+
+        var overflow = _missingAt.Count - maxEntries;
+        if (overflow <= 0) return;
+
+        snapshot.Sort(static (a, b) => a.Value.CompareTo(b.Value));
+        var toEvict = Math.Min(overflow, snapshot.Count);
+        for (var i = 0; i < toEvict; i++)
+            RemoveIfUnchanged(snapshot[i]);
+    }
+
+    // Removes only when the timestamp still matches the snapshot, so a concurrent
+    // re-mark with a fresher timestamp is never evicted by a stale cleanup round.
+    private void RemoveIfUnchanged(KeyValuePair<string, DateTimeOffset> entry) =>
+        ((ICollection<KeyValuePair<string, DateTimeOffset>>)_missingAt).Remove(entry);
 
     private void EnqueueClear()
     {

--- a/backend/Clients/Usenet/ArticleMissNegativeCache.cs
+++ b/backend/Clients/Usenet/ArticleMissNegativeCache.cs
@@ -52,6 +52,7 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
     private CancellationTokenSource? _persistenceLoopCts;
     private Task _persistenceLoop = Task.CompletedTask;
     private volatile bool _persistenceLoopStarted;
+    private int _cleanupRunning;
     private long _hits;
 
     private abstract record PersistenceWorkItem;
@@ -226,21 +227,52 @@ public sealed class ArticleMissNegativeCache : IHostedService, IDisposable
     {
         _missingAt[key] = at;
         var maxEntries = _configManager.GetArticleMissCacheMaxEntries();
-        if (_missingAt.Count > maxEntries) Cleanup(maxEntries);
+        if (_missingAt.Count <= maxEntries) return;
+        try
+        {
+            Cleanup(maxEntries);
+        }
+        catch (Exception e) when (e is not OutOfMemoryException)
+        {
+            // The in-memory mark already succeeded; eviction must never fail STAT/BODY.
+            Log.Debug(e, "Article-miss cache cleanup failed; in-memory mark was retained.");
+        }
     }
 
     private void Cleanup(int maxEntries)
     {
-        var cutoff = DateTimeOffset.UtcNow - _configManager.GetArticleMissCacheTtl();
-        foreach (var kv in _missingAt)
-            if (kv.Value < cutoff) _missingAt.TryRemove(kv.Key, out _);
+        // Single-flight: a STAT storm must not start N concurrent O(n log n) sorts.
+        // A skipped cleanup is retried on a later MarkMissing; temporary over-cap is fine.
+        if (Interlocked.CompareExchange(ref _cleanupRunning, 1, 0) != 0)
+            return;
 
-        var overflow = _missingAt.Count - maxEntries;
-        if (overflow <= 0) return;
-        // Still over the cap after expiring stale rows — evict the oldest marks
-        // (approximate LRU) so runaway cardinality can't grow unbounded.
-        foreach (var kv in _missingAt.OrderBy(kv => kv.Value).Take(overflow))
-            _missingAt.TryRemove(kv.Key, out _);
+        try
+        {
+            var cutoff = DateTimeOffset.UtcNow - _configManager.GetArticleMissCacheTtl();
+            // Weakly-consistent foreach — never LINQ OrderBy/ToArray on the live
+            // ConcurrentDictionary (those use Count-then-CopyTo and race under writes).
+            var snapshot = new List<KeyValuePair<string, DateTimeOffset>>(Math.Max(4, _missingAt.Count));
+            foreach (var kv in _missingAt)
+            {
+                if (kv.Key is null) continue;
+                if (kv.Value < cutoff)
+                    _missingAt.TryRemove(kv.Key, out _);
+                else
+                    snapshot.Add(kv);
+            }
+
+            var overflow = _missingAt.Count - maxEntries;
+            if (overflow <= 0) return;
+
+            snapshot.Sort(static (a, b) => a.Value.CompareTo(b.Value));
+            var toEvict = Math.Min(overflow, snapshot.Count);
+            for (var i = 0; i < toEvict; i++)
+                _missingAt.TryRemove(snapshot[i].Key, out _);
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _cleanupRunning, 0);
+        }
     }
 
     private void EnqueueClear()

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleMissNegativeCacheTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleMissNegativeCacheTests.cs
@@ -146,11 +146,11 @@ public class ArticleMissNegativeCacheTests
             cache.MarkMissing(ArticleMissNegativeCache.BuildKey($"art-{i}", "p", null));
         });
 
-        // One extra sequential mark so a skipped single-flight cleanup can finish trim.
-        cache.MarkMissing(ArticleMissNegativeCache.BuildKey("art-final", "p", null));
-
+        // Cleanup re-checks the live count after releasing the single-flight, so once
+        // the parallel marks join, the last cleaner has trimmed to the cap without
+        // needing a final sequential mark.
         Assert.True(cache.Entries <= 100);
-        Assert.True(cache.IsMissing(ArticleMissNegativeCache.BuildKey("art-final", "p", null)));
+        Assert.True(cache.Entries > 0);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleMissNegativeCacheTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleMissNegativeCacheTests.cs
@@ -154,6 +154,49 @@ public class ArticleMissNegativeCacheTests
     }
 
     [Fact]
+    public async Task MaxEntries_RoundCapReachedOverCap_SchedulesCoalescedContinuation()
+    {
+        var config = CreateConfig(ttlSeconds: 300, maxEntries: 100);
+        var cache = new ArticleMissNegativeCache(config);
+
+        for (var i = 0; i < 100; i++)
+        {
+            cache.MarkMissingAtForTests(
+                ArticleMissNegativeCache.BuildKey($"seed-{i}", "p", null),
+                DateTimeOffset.UtcNow.AddMilliseconds(i));
+        }
+
+        // Every round lands a fresh mark after that round's snapshot (the hook runs
+        // while the single-flight is held, so the nested mark skips cleanup), so all
+        // eight rounds finish over cap and the round cap is reached.
+        var sabotage = 1;
+        var lateMarks = 0;
+        cache.CleanupRoundCompletedForTests = () =>
+        {
+            if (Volatile.Read(ref sabotage) == 0) return;
+            var n = Interlocked.Increment(ref lateMarks);
+            cache.MarkMissingAtForTests(
+                ArticleMissNegativeCache.BuildKey($"late-{n}", "p", null),
+                DateTimeOffset.UtcNow);
+        };
+
+        // The 101st mark pushes over the cap and runs the capped cleanup loop; the
+        // hook keeps every round over cap, so all eight rounds fire synchronously.
+        cache.MarkMissing(ArticleMissNegativeCache.BuildKey("trigger", "p", null));
+        Assert.True(Volatile.Read(ref lateMarks) >= 8);
+
+        // Once marks stop arriving, the scheduled continuation must drain the cache
+        // to the cap without any further MarkMissing call.
+        Interlocked.Exchange(ref sabotage, 0);
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
+        while (cache.Entries > 100 && DateTimeOffset.UtcNow < deadline)
+            await Task.Delay(10);
+
+        Assert.True(cache.Entries <= 100, $"continuation left {cache.Entries} entries");
+        Assert.True(cache.Entries > 0);
+    }
+
+    [Fact]
     public async Task PersistentCache_HydratesFreshMisses_AndPurgesExpiredRows()
     {
         await using var connection = new SqliteConnection("Data Source=:memory:");

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleMissNegativeCacheTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleMissNegativeCacheTests.cs
@@ -136,6 +136,24 @@ public class ArticleMissNegativeCacheTests
     }
 
     [Fact]
+    public void MaxEntries_ConcurrentMarksPastCap_DoesNotThrow()
+    {
+        var config = CreateConfig(ttlSeconds: 300, maxEntries: 100);
+        var cache = new ArticleMissNegativeCache(config);
+
+        Parallel.For(0, 8_000, i =>
+        {
+            cache.MarkMissing(ArticleMissNegativeCache.BuildKey($"art-{i}", "p", null));
+        });
+
+        // One extra sequential mark so a skipped single-flight cleanup can finish trim.
+        cache.MarkMissing(ArticleMissNegativeCache.BuildKey("art-final", "p", null));
+
+        Assert.True(cache.Entries <= 100);
+        Assert.True(cache.IsMissing(ArticleMissNegativeCache.BuildKey("art-final", "p", null)));
+    }
+
+    [Fact]
     public async Task PersistentCache_HydratesFreshMisses_AndPurgesExpiredRows()
     {
         await using var connection = new SqliteConnection("Data Source=:memory:");


### PR DESCRIPTION
## Summary
When many articles are missing at once, the article-miss cache trims oldest entries. That trim sorted the live dictionary with LINQ `OrderBy`, which races under concurrent STAT/BODY marks (Count-then-CopyTo). The resulting `ArgumentException` / `ArgumentNullException` leaked out of `MarkMissing` and was logged as an unclassified Usenet segment fetch failure — even though the provider had already returned a clean 430.

Cleanup now snapshots via weakly-consistent `foreach`, sorts the snapshot, single-flights eviction, and contains leftover exceptions so cache bookkeeping cannot fail a fetch.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~ArticleMissNegativeCache` (26 passed)
- Sequential cap eviction still keeps newest entries
- Concurrent `Parallel.For` of 8k marks past a 100-entry cap does not throw and trims to the cap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache cleanup reliability during concurrent activity.
  * Expired entries are removed safely, and excess entries are trimmed while preserving newly added cache results.
  * Cleanup failures no longer prevent successful cache updates.
  * Added follow-up cleanup to ensure the cache returns to its configured capacity.

* **Tests**
  * Added coverage for high-volume parallel cache updates, capacity enforcement, and continued cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->