### PR TITLE
fix(queue): NZBs with long Usenet subjects no longer rejected during import

### DIFF
--- a/backend/Api/Errors/NzbInputLimits.cs
+++ b/backend/Api/Errors/NzbInputLimits.cs
@@ -13,5 +13,12 @@ public sealed class NzbInputLimits
     public int MaxFiles { get; init; } = 10_000;
     public int MaxTotalSegments { get; init; } = 500_000;
     public int MaxNameLength { get; init; } = 255;
+
+    /// <summary>
+    /// Cap on the NZB <c>&lt;file subject&gt;</c> attribute. Subjects are Usenet
+    /// header lines (index prefix, quoted filename, yEnc part counts), not
+    /// filenames, so they routinely exceed <see cref="MaxNameLength"/>.
+    /// </summary>
+    public int MaxSubjectLength { get; init; } = 1024;
     public int MaxMessageIdLength { get; init; } = 248;
 }

--- a/backend/Models/Nzb/NzbInputValidator.cs
+++ b/backend/Models/Nzb/NzbInputValidator.cs
@@ -63,8 +63,12 @@ public static class NzbInputValidator
                     }
 
                     var subject = reader.GetAttribute("subject") ?? string.Empty;
-                    if (subject.Length > limits.MaxNameLength)
-                        errors.Add("nzb", "An NZB file subject exceeds the maximum name length.");
+                    if (subject.Length > limits.MaxSubjectLength)
+                    {
+                        errors.Add(
+                            "nzb",
+                            $"An NZB file subject exceeds the maximum length ({limits.MaxSubjectLength}).");
+                    }
 
                     totalBytes = AddSegmentBytesOrThrow(
                         totalBytes,

--- a/backend/Utils/PathSanitizer.cs
+++ b/backend/Utils/PathSanitizer.cs
@@ -82,7 +82,12 @@ public static class PathSanitizer
         }
 
         var sanitized = sb.ToString();
-        return string.IsNullOrEmpty(sanitized) ? "untitled" : TruncateToMaxComponentLength(sanitized);
+        if (string.IsNullOrEmpty(sanitized))
+            return "untitled";
+
+        // Truncation trims trailing dots/spaces, which can empty an over-long component.
+        sanitized = TruncateToMaxComponentLength(sanitized);
+        return string.IsNullOrEmpty(sanitized) ? "untitled" : sanitized;
     }
 
     // DavItem.Name is HasMaxLength(255); 240 leaves headroom for " (xxxxx)" duplicate suffixes.

--- a/backend/Utils/PathSanitizer.cs
+++ b/backend/Utils/PathSanitizer.cs
@@ -51,22 +51,13 @@ public static class PathSanitizer
         if (string.IsNullOrEmpty(sanitized))
             return "untitled";
 
-        var extension = Path.GetExtension(sanitized);
         var stem = Path.GetFileNameWithoutExtension(sanitized);
         if (WindowsReservedNames.Contains(stem))
             sanitized = "_" + sanitized;
 
-        if (sanitized.Length > 240)
+        if (sanitized.Length > MaxComponentLength)
         {
-            if (extension.Length > 0 && extension.Length < 240)
-            {
-                var maxStem = 240 - extension.Length;
-                sanitized = sanitized[..maxStem].TrimEnd('.', ' ') + extension;
-            }
-            else
-            {
-                sanitized = sanitized[..240].TrimEnd('.', ' ');
-            }
+            sanitized = TruncateToMaxComponentLength(sanitized);
 
             if (string.IsNullOrEmpty(sanitized))
                 return "untitled";
@@ -77,6 +68,7 @@ public static class PathSanitizer
 
     /// <summary>
     /// Minimal sanitization when Windows-safe paths are disabled: only '/' and NUL.
+    /// Still length-capped so a sanitized name can never overflow DavItem.Name (255).
     /// </summary>
     private static string SanitizeMinimal(string name)
     {
@@ -90,7 +82,30 @@ public static class PathSanitizer
         }
 
         var sanitized = sb.ToString();
-        return string.IsNullOrEmpty(sanitized) ? "untitled" : sanitized;
+        return string.IsNullOrEmpty(sanitized) ? "untitled" : TruncateToMaxComponentLength(sanitized);
+    }
+
+    // DavItem.Name is HasMaxLength(255); 240 leaves headroom for " (xxxxx)" duplicate suffixes.
+    private const int MaxComponentLength = 240;
+
+    private static string TruncateToMaxComponentLength(string name)
+    {
+        if (name.Length <= MaxComponentLength)
+            return name;
+
+        var extension = Path.GetExtension(name);
+        string truncated;
+        if (extension.Length > 0 && extension.Length < MaxComponentLength)
+        {
+            var maxStem = MaxComponentLength - extension.Length;
+            truncated = name[..maxStem].TrimEnd('.', ' ') + extension;
+        }
+        else
+        {
+            truncated = name[..MaxComponentLength].TrimEnd('.', ' ');
+        }
+
+        return truncated;
     }
 
     public static string SanitizeComponentWithLog(string original)

--- a/tests/NzbWebDAV.Tests/Api/AddFileRequestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AddFileRequestTests.cs
@@ -45,6 +45,17 @@ public class AddFileRequestTests
         Assert.Contains("filename", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void ResolveFileName_RejectsFilenamePastMaxNameLength()
+    {
+        var longName = new string('a', 252) + ".nzb";
+
+        var ex = Assert.Throws<ApiValidationException>(() => AddFileRequest.ResolveFileName(longName, null));
+
+        Assert.True(ex.Errors.ContainsKey("nzbname"));
+        Assert.Contains("maximum name length", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Theory]
     [InlineData("release.nzb", "release.nzb")]
     [InlineData("release", "release.nzb")]

--- a/tests/NzbWebDAV.Tests/Api/NzbInputValidatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/NzbInputValidatorTests.cs
@@ -103,6 +103,36 @@ public class NzbInputValidatorTests
         Assert.DoesNotContain("aaaa", ex.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void AcceptsSubjectBeyondFilenameLimit()
+    {
+        var subject = new string('a', 600);
+        var xml = $"<nzb><file subject=\"{subject}\"><segments>" +
+                  "<segment bytes=\"15\" number=\"1\">id@example</segment>" +
+                  "</segments></file></nzb>";
+        using var stream = Bytes(xml);
+
+        var bytes = NzbInputValidator.ValidateAndSumSegmentBytes(stream, NzbInputLimits.Default);
+
+        Assert.Equal(15, bytes);
+    }
+
+    [Fact]
+    public void RejectsSubjectPastLimitWithLimit()
+    {
+        var subject = new string('a', 1025);
+        var xml = $"<nzb><file subject=\"{subject}\"><segments>" +
+                  "<segment bytes=\"15\" number=\"1\">id@example</segment>" +
+                  "</segments></file></nzb>";
+        using var stream = Bytes(xml);
+
+        var ex = Assert.Throws<ApiValidationException>(
+            () => NzbInputValidator.ValidateAndSumSegmentBytes(stream, NzbInputLimits.Default));
+
+        Assert.Contains("subject", ex.Errors["nzb"][0], StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("1024", ex.Errors["nzb"][0], StringComparison.Ordinal);
+    }
+
     private static string BuildNzb(int fileCount, int segmentsPerFile, long segmentBytes = 15)
     {
         var builder = new StringBuilder("<nzb>");

--- a/tests/NzbWebDAV.Tests/Utils/PathSanitizerTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/PathSanitizerTests.cs
@@ -97,6 +97,20 @@ public class PathSanitizerTests
     }
 
     [Fact]
+    public void SanitizeComponent_WhenDisabled_TruncationToEmptyBecomesUntitled()
+    {
+        PathSanitizer.SetWindowsSafePathsEnabled(false);
+        try
+        {
+            Assert.Equal("untitled", PathSanitizer.SanitizeComponent(new string(' ', 241)));
+        }
+        finally
+        {
+            PathSanitizer.SetWindowsSafePathsEnabled(true);
+        }
+    }
+
+    [Fact]
     public void GetJobName_SanitizesWindowsInvalidCharacters()
     {
         Assert.Equal("Show_ Title_", FilenameUtil.GetJobName("Show: Title?.nzb"));

--- a/tests/NzbWebDAV.Tests/Utils/PathSanitizerTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/PathSanitizerTests.cs
@@ -80,6 +80,23 @@ public class PathSanitizerTests
     }
 
     [Fact]
+    public void SanitizeComponent_WhenDisabled_StillTruncatesToComponentLimit()
+    {
+        PathSanitizer.SetWindowsSafePathsEnabled(false);
+        try
+        {
+            var stem = new string('a', 300);
+            var result = PathSanitizer.SanitizeComponent(stem + ".mkv");
+            Assert.True(result.Length <= 240);
+            Assert.EndsWith(".mkv", result);
+        }
+        finally
+        {
+            PathSanitizer.SetWindowsSafePathsEnabled(true);
+        }
+    }
+
+    [Fact]
     public void GetJobName_SanitizesWindowsInvalidCharacters()
     {
         Assert.Equal("Show_ Title_", FilenameUtil.GetJobName("Show: Title?.nzb"));

--- a/tests/NzbWebDAV.Tests/Utils/PathSanitizerTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/PathSanitizerTests.cs
@@ -82,32 +82,16 @@ public class PathSanitizerTests
     [Fact]
     public void SanitizeComponent_WhenDisabled_StillTruncatesToComponentLimit()
     {
-        PathSanitizer.SetWindowsSafePathsEnabled(false);
-        try
-        {
-            var stem = new string('a', 300);
-            var result = PathSanitizer.SanitizeComponent(stem + ".mkv");
-            Assert.True(result.Length <= 240);
-            Assert.EndsWith(".mkv", result);
-        }
-        finally
-        {
-            PathSanitizer.SetWindowsSafePathsEnabled(true);
-        }
+        var stem = new string('a', 300);
+        var result = PathSanitizer.SanitizeComponent(stem + ".mkv", windowsSafe: false);
+        Assert.True(result.Length <= 240);
+        Assert.EndsWith(".mkv", result);
     }
 
     [Fact]
     public void SanitizeComponent_WhenDisabled_TruncationToEmptyBecomesUntitled()
     {
-        PathSanitizer.SetWindowsSafePathsEnabled(false);
-        try
-        {
-            Assert.Equal("untitled", PathSanitizer.SanitizeComponent(new string(' ', 241)));
-        }
-        finally
-        {
-            PathSanitizer.SetWindowsSafePathsEnabled(true);
-        }
+        Assert.Equal("untitled", PathSanitizer.SanitizeComponent(new string(' ', 241), windowsSafe: false));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Splits the shared 255-char ingest limit: `<file subject>` attributes now allow up to 1024 chars (`MaxSubjectLength`), while the SAB NZB filename gate stays at 255 (`MaxNameLength`). Long scene names (e.g. dual-episode releases via Prowlarr) were rejected with "An NZB file subject exceeds the maximum name length." even though the raw subject is only stored in the unbounded NZB XML blob — never in a length-limited column — and downstream queue processing already truncates derived filenames.
- The validation error now names the limit, matching the count/limit style from #1097.
- Hardens `PathSanitizer.SanitizeMinimal` (Windows-safe paths off) with the same 240-char extension-preserving truncation as the Windows-safe path, so a long subject-derived name can never overflow `DavItem.Name` (255) at insert time.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` (3663 passed, 14 skipped)
- [x] New: validator accepts a 600-char subject, rejects at 1025 with the limit in the message
- [x] New: sanitizer truncates to <=240 with extension preserved when Windows-safe paths are off
- [x] New: 256-char NZB filename still rejected (proves the limit split)
- [ ] Manual: retry a previously rejected long-subject release from Prowlarr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable 1,024-character limit for NZB file subjects.
  * Improved handling of long filenames with a consistent 240-character limit, preserving extensions where possible.

* **Bug Fixes**
  * Validation errors now report the applicable subject-length limit.
  * Sanitized names now handle trailing spaces and periods consistently and fall back to “untitled” when needed.

* **Tests**
  * Added coverage for filename rejection, subject-length boundaries, and extension-preserving truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->