### PR TITLE
fix(ui): live file reads are now full-width rows in the Overview stack

### DIFF
--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.test.tsx
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.test.tsx
@@ -1,12 +1,195 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { LiveReadsPanel } from "./live-reads-panel";
+import type { ActiveRead } from "~/clients/backend-client.server";
+import { LiveReadsPanel, LiveReadsPanelContent, type LiveReadRow } from "./live-reads-panel";
+
+function fixtureRead(
+  id: string,
+  fileName: string,
+  path: string,
+  currentOffset: number,
+  fileSize: number,
+  clientUserAgent: string,
+  clientIp: string,
+  providers: ActiveRead["providers"],
+  overrides?: { startedMinutesAgo?: number; bytesRead?: number; bytesFetched?: number },
+): ActiveRead {
+  const now = Date.now();
+  return {
+    id,
+    fileName,
+    path,
+    startedAt: now - (overrides?.startedMinutesAgo ?? 20) * 60_000,
+    lastActivityAt: now,
+    bytesRead: overrides?.bytesRead ?? currentOffset,
+    bytesFetched: overrides?.bytesFetched ?? 0,
+    currentOffset,
+    fileSize,
+    clientUserAgent,
+    clientIp,
+    providers,
+  };
+}
+
+function historyAround(rate: number, samples = 45): number[] {
+  return Array.from({ length: samples }, (_, i) =>
+    Math.max(0, rate * (0.72 + 0.55 * Math.abs(Math.sin(i / 4)))),
+  );
+}
+
+const fixtureRows: LiveReadRow[] = [
+  {
+    read: fixtureRead(
+      "a1b2c3d4-0001-4000-8000-000000000001",
+      "The.Prestige.2006.1080p.BluRay.x264-GRP.mkv",
+      "/completed-symlinks/movies/The.Prestige.2006.1080p.BluRay.x264-GRP.mkv",
+      3_200_000_000,
+      8_400_000_000,
+      "Plex/1.107.0",
+      "192.168.1.20",
+      [
+        { host: "news.eweka.nl", nickname: "Eweka", segments: 41 },
+        { host: "news.newshosting.com", nickname: "Newshosting", segments: 18 },
+      ],
+      { startedMinutesAgo: 84, bytesFetched: 3_800_000_000 },
+    ),
+    rate: 7_200_000,
+    history: historyAround(7_200_000),
+  },
+  {
+    read: fixtureRead(
+      "a1b2c3d4-0002-4000-8000-000000000002",
+      "The.Last.of.Us.S01E03.1080p.WEB-DL.DDP5.1.H.264-GRP.mkv",
+      "/completed-symlinks/tv/The.Last.of.Us.S01E03.1080p.WEB-DL.DDP5.1.H.264-GRP.mkv",
+      412_000_000,
+      1_100_000_000,
+      "Infuse/8.0",
+      "192.168.1.34",
+      [{ host: "news.eweka.nl", nickname: "Eweka", segments: 22 }],
+      { startedMinutesAgo: 20, bytesFetched: 600_000_000 },
+    ),
+    rate: 4_100_000,
+    history: historyAround(4_100_000),
+  },
+  {
+    read: fixtureRead(
+      "a1b2c3d4-0003-4000-8000-000000000003",
+      "Dune.Part.Two.2024.2160p.WEB-DL.DDP5.1.Atmos.H.265-GRP.mkv",
+      "/completed-symlinks/movies/Dune.Part.Two.2024.2160p.WEB-DL.DDP5.1.Atmos.H.265-GRP.mkv",
+      1_100_000_000,
+      3_800_000_000,
+      "VLC/3.0.20",
+      "192.168.1.51",
+      [
+        { host: "news.newshosting.com", nickname: "Newshosting", segments: 17 },
+        { host: "news.usenetserver.com", nickname: "UsenetServer", segments: 9 },
+      ],
+      { startedMinutesAgo: 33, bytesRead: 2_900_000_000, bytesFetched: 2_950_000_000 },
+    ),
+    rate: 2_800_000,
+    history: historyAround(2_800_000),
+  },
+  {
+    read: fixtureRead(
+      "a1b2c3d4-0004-4000-8000-000000000004",
+      "Severance.S02E01.2160p.ATVP.WEB-DL.DDP5.1.H.265-GRP.mkv",
+      "/completed-symlinks/tv/Severance.S02E01.2160p.ATVP.WEB-DL.DDP5.1.H.265-GRP.mkv",
+      218_000_000,
+      890_000_000,
+      "rclone/1.68",
+      "192.168.1.10",
+      [{ host: "news.usenetserver.com", nickname: "UsenetServer", segments: 13 }],
+      { startedMinutesAgo: 5, bytesFetched: 300_000_000 },
+    ),
+    rate: 1_900_000,
+    history: historyAround(1_900_000),
+  },
+  {
+    read: fixtureRead(
+      "a1b2c3d4-0005-4000-8000-000000000005",
+      "9f2c7a1e4b.mkv",
+      "/completed-symlinks/movies/Interstellar.2014.1080p.BluRay.x264-GRP/9f2c7a1e4b.mkv",
+      900_000_000,
+      5_200_000_000,
+      "Kodi/21.0",
+      "192.168.1.64",
+      [{ host: "news.eweka.nl", nickname: "Eweka", segments: 30 }],
+      { startedMinutesAgo: 12, bytesFetched: 1_200_000_000 },
+    ),
+    rate: 5_400_000,
+    history: historyAround(5_400_000),
+  },
+];
 
 describe("LiveReadsPanel", () => {
-  it("keeps the dashboard rail visible when there are no active reads", () => {
+  it("renders the empty state when there are no active reads", () => {
     const markup = renderToStaticMarkup(<LiveReadsPanel />);
 
     expect(markup).toContain("Right now");
     expect(markup).toContain("No files are being read right now.");
+  });
+
+  it("renders each active read as a full-width row", () => {
+    const markup = renderToStaticMarkup(<LiveReadsPanelContent rows={fixtureRows} />);
+
+    expect(markup).toContain("5 active");
+    expect(markup).toContain("The.Prestige.2006.1080p.BluRay.x264-GRP.mkv");
+    expect(markup).toContain("Severance.S02E01.2160p.ATVP.WEB-DL.DDP5.1.H.265-GRP.mkv");
+    // Speed, progress, and computed time left
+    expect(markup).toContain("7.2 MB/s");
+    expect(markup).toContain("3.2 GB");
+    expect(markup).toContain("/ 8.4 GB");
+    expect(markup).toContain("12m left");
+    expect(markup).toContain("6m left");
+    // Meta line: client, provider badges, session id
+    expect(markup).toContain("Plex");
+    expect(markup).toContain("192.168.1.20");
+    expect(markup).toContain("Eweka");
+    expect(markup).toContain("a1b2c3d4");
+  });
+
+  it("labels media rows with MOVIE / EPISODE badges", () => {
+    const markup = renderToStaticMarkup(<LiveReadsPanelContent rows={fixtureRows} />);
+
+    expect(markup.match(/MOVIE/g)).toHaveLength(3);
+    expect(markup.match(/EPISODE/g)).toHaveLength(2);
+  });
+
+  it("renders a speed sparkline per row", () => {
+    const markup = renderToStaticMarkup(<LiveReadsPanelContent rows={fixtureRows} />);
+
+    expect(markup.match(/<svg/g)?.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("shows session age and Usenet-fetched bytes in the meta line", () => {
+    const markup = renderToStaticMarkup(<LiveReadsPanelContent rows={fixtureRows} />);
+
+    expect(markup).toContain("1h 24m in");
+    expect(markup).toContain("5m in");
+    expect(markup).toContain("fetched 3.8 GB");
+  });
+
+  it("notes total bytes served when the player is scrubbing", () => {
+    const markup = renderToStaticMarkup(<LiveReadsPanelContent rows={fixtureRows} />);
+
+    // Dune row: 2.9 GB served vs 1.1 GB current position.
+    expect(markup).toContain("2.9 GB served");
+    // Linear rows (bytesRead == currentOffset) get no such note.
+    expect(markup.match(/served</g)).toHaveLength(1);
+  });
+
+  it("falls back to the release folder name for obfuscated file names", () => {
+    const markup = renderToStaticMarkup(<LiveReadsPanelContent rows={fixtureRows} />);
+
+    expect(markup).toContain("Interstellar.2014.1080p.BluRay.x264-GRP.mkv");
+    expect(markup).not.toContain("9f2c7a1e4b.mkv</span>");
+  });
+
+  it("renders an em dash for time left when the rate stalls", () => {
+    const stalled: LiveReadRow[] = [{ ...fixtureRows[0]!, rate: 0 }];
+    const markup = renderToStaticMarkup(<LiveReadsPanelContent rows={stalled} />);
+
+    expect(markup).toContain("—");
+    expect(markup).not.toContain("left</span>");
   });
 });

--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
@@ -1,25 +1,85 @@
 import { useEffect, useRef, useState } from "react";
 import type { ActiveRead, ActiveReadsMessage } from "~/clients/backend-client.server";
-import { formatBytes } from "../../utils/format";
+import { formatBytes, formatSessionAge, formatTimeLeft } from "../../utils/format";
+import { mediaTypeFromFileName } from "../../utils/media-type";
+import { displayNameForRead } from "../../utils/display-name";
 import { clientIdentityTooltip, clientLabelFromUserAgent } from "~/utils/client-label";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
 import { Tooltip } from "~/components/ui";
+import { Sparkline } from "../provider-scoreboard/provider-scoreboard";
 
 const TOPIC_ACTIVE_READS = "ar";
 
+export type LiveReadRow = {
+  read: ActiveRead;
+  /** Smoothed download rate in bytes/sec. */
+  rate: number;
+  /** Recent rate samples (one per broadcast tick) for the sparkline. */
+  history: number[];
+};
+
+// The broadcaster ticks once per second; 60 samples ≈ the last minute.
+const HISTORY_LIMIT = 60;
+
 /**
- * Live "right now" panel — reads cards refreshed via the ActiveReads WS topic.
- * Keeps an empty state when no reads are active so the dashboard rail is stable.
- * When `paused`, the subscription is disabled so layout edit borders stay stable.
+ * Live "right now" panel — full-width rows refreshed via the ActiveReads WS
+ * topic. Keeps an empty state when no reads are active so the dashboard stack
+ * stays stable. When `paused`, the subscription is disabled so layout edit
+ * borders stay stable.
  */
 export function LiveReadsPanel({ paused = false }: { paused?: boolean }) {
-  const [reads, setReads] = useState<ActiveRead[]>([]);
+  const [rows, setRows] = useState<LiveReadRow[]>([]);
+  // Track previous bytesRead per session for live MiB/s computation.
+  const prevRef = useRef<Map<string, { bytes: number; at: number; rate: number }>>(new Map());
+  // Per-session rate samples for the sparkline, keyed by session id.
+  const historyRef = useRef<Map<string, number[]>>(new Map());
+
+  useWebsocketTopic(
+    TOPIC_ACTIVE_READS,
+    "state",
+    (message) => {
+      try {
+        // ActiveReads websocket topic payload shape (backend contract)
+        const payload = JSON.parse(message) as ActiveReadsMessage;
+        const now = Date.now();
+        const prev = prevRef.current;
+        const next = new Map<string, { bytes: number; at: number; rate: number }>();
+        const nextHistory = new Map<string, number[]>();
+        const nextRows: LiveReadRow[] = [];
+        for (const r of payload.reads ?? []) {
+          const old = prev.get(r.id);
+          let rate = old?.rate ?? 0;
+          if (old && now > old.at) {
+            const dt = (now - old.at) / 1000;
+            const db = r.bytesRead - old.bytes;
+            if (dt > 0 && db >= 0) {
+              const instant = db / dt;
+              rate = old.rate * 0.4 + instant * 0.6;
+            }
+          }
+          next.set(r.id, { bytes: r.bytesRead, at: now, rate });
+          const history = [...(historyRef.current.get(r.id) ?? []), rate].slice(-HISTORY_LIMIT);
+          nextHistory.set(r.id, history);
+          nextRows.push({ read: r, rate, history });
+        }
+        prevRef.current = next;
+        historyRef.current = nextHistory;
+        setRows(nextRows);
+      } catch {
+        /* ignore */
+      }
+    },
+    { enabled: !paused },
+  );
+
+  return <LiveReadsPanelContent rows={rows} />;
+}
+
+export function LiveReadsPanelContent({ rows }: { rows: LiveReadRow[] }) {
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [copyNotice, setCopyNotice] = useState<{ seq: number; text: string } | null>(null);
   const copySeqRef = useRef(0);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Track previous bytesRead per session for live MiB/s computation.
-  const prevRef = useRef<Map<string, { bytes: number; at: number; rate: number }>>(new Map());
 
   useEffect(() => {
     return () => {
@@ -43,47 +103,15 @@ export function LiveReadsPanel({ paused = false }: { paused?: boolean }) {
     }, 1500);
   };
 
-  useWebsocketTopic(
-    TOPIC_ACTIVE_READS,
-    "state",
-    (message) => {
-      try {
-        // ActiveReads websocket topic payload shape (backend contract)
-        const payload = JSON.parse(message) as ActiveReadsMessage;
-        const now = Date.now();
-        const prev = prevRef.current;
-        const next = new Map<string, { bytes: number; at: number; rate: number }>();
-        for (const r of payload.reads ?? []) {
-          const old = prev.get(r.id);
-          let rate = old?.rate ?? 0;
-          if (old && now > old.at) {
-            const dt = (now - old.at) / 1000;
-            const db = r.bytesRead - old.bytes;
-            if (dt > 0 && db >= 0) {
-              const instant = db / dt;
-              rate = old.rate * 0.4 + instant * 0.6;
-            }
-          }
-          next.set(r.id, { bytes: r.bytesRead, at: now, rate });
-        }
-        prevRef.current = next;
-        setReads(payload.reads ?? []);
-      } catch {
-        /* ignore */
-      }
-    },
-    { enabled: !paused },
-  );
-
   return (
-    <section className="card w-full min-w-0 border border-base-content/10 bg-base-100 shadow-sm xl:h-full">
+    <section className="card w-full min-w-0 border border-base-content/10 bg-base-100 shadow-sm">
       <div className="card-body gap-3 p-4">
         <div className="flex items-center gap-2.5">
           <span className="status status-success animate-pulse" aria-hidden="true" />
           <h3 className="card-title m-0 text-base">Right now</h3>
-          {reads.length > 0 && (
+          {rows.length > 0 && (
             <span className="badge badge-ghost badge-sm ml-auto font-mono tabular-nums">
-              {reads.length} active
+              {rows.length} active
             </span>
           )}
         </div>
@@ -92,102 +120,24 @@ export function LiveReadsPanel({ paused = false }: { paused?: boolean }) {
           {copyNotice?.text ?? ""}
         </div>
 
-        {reads.length === 0 ? (
+        {rows.length === 0 ? (
           <p className="m-0 text-sm text-base-content/50">
             No files are being read right now. Open a mounted file to see live progress here.
           </p>
         ) : (
-          <ul className="list w-full p-0">
-            {reads.map((r) => {
-              const meta = prevRef.current.get(r.id);
-              const rate = meta?.rate ?? 0;
-              // Use the latest read position (what the player is requesting
-              // right now) — not cumulative bytes transferred — so the bar
-              // reflects actual playback location, immune to seeks/replays.
-              const pct =
-                r.fileSize && r.fileSize > 0
-                  ? Math.min(100, (r.currentOffset / r.fileSize) * 100)
-                  : null;
-              return (
-                <li key={r.id} className="list-row px-0">
-                  <div className="list-col-grow min-w-0 gap-2">
-                    <Tooltip content={r.path}>
-                      <span className="block truncate text-sm font-medium text-base-content">
-                        {r.fileName || lastSegment(r.path)}
-                      </span>
-                    </Tooltip>
-                    <Tooltip content={clientIdentityTooltip(r.clientUserAgent, r.clientIp) ?? ""}>
-                      <span className="block truncate text-xs text-base-content/50">
-                        {clientLabelFromUserAgent(r.clientUserAgent)}
-                        {r.clientIp ? (
-                          <span className="font-mono text-base-content/40"> · {r.clientIp}</span>
-                        ) : null}
-                      </span>
-                    </Tooltip>
-                    <Tooltip content={`Copy session id: ${r.id}`}>
-                      <button
-                        type="button"
-                        className="btn btn-link btn-xs h-auto min-h-0 px-0 font-mono"
-                        aria-label={`Copy session id: ${r.id}${
-                          copiedId === r.id ? " (copied)" : ""
-                        }`}
-                        onClick={() => {
-                          void copySessionId(r.id);
-                        }}
-                      >
-                        {copiedId === r.id ? "Copied" : shortSessionId(r.id)}
-                      </button>
-                    </Tooltip>
-                    {pct !== null ? (
-                      <progress
-                        className="progress progress-success h-1 w-full"
-                        value={pct}
-                        max={100}
-                      />
-                    ) : (
-                      <span
-                        className="loading loading-bars loading-sm text-success"
-                        role="status"
-                        aria-label="Loading progress"
-                      />
-                    )}
-                    <div className="flex items-baseline justify-between font-mono text-xs tabular-nums">
-                      <span className="font-medium text-base-content">
-                        {r.fileSize ? (
-                          <>
-                            at {formatBytes(r.currentOffset)}{" "}
-                            <span className="font-normal text-base-content/50">
-                              / {formatBytes(r.fileSize)}
-                            </span>
-                          </>
-                        ) : (
-                          <>at {formatBytes(r.currentOffset)}</>
-                        )}
-                      </span>
-                      <span className="font-medium text-base-content">{formatBytes(rate)}/s</span>
-                    </div>
-                    {r.providers.length > 0 && (
-                      <div className="flex min-w-0 flex-wrap gap-1">
-                        {r.providers.slice(0, 6).map((p, i) => {
-                          const label = p.nickname?.trim() || p.host;
-                          return (
-                            <Tooltip
-                              key={`${p.host}-${i}`}
-                              content={`${label} (${p.host}): ${p.segments} segments`}
-                            >
-                              <span className="badge badge-ghost badge-sm gap-1.5 font-mono tabular-nums">
-                                <span className="max-w-[8rem] truncate">{label}</span>
-                                <span className="font-medium">{p.segments}</span>
-                              </span>
-                            </Tooltip>
-                          );
-                        })}
-                      </div>
-                    )}
-                  </div>
-                </li>
-              );
-            })}
+          <ul className="m-0 w-full list-none divide-y divide-base-content/10 p-0">
+            {rows.map(({ read, rate, history }) => (
+              <ReadRow
+                key={read.id}
+                read={read}
+                rate={rate}
+                history={history}
+                copied={copiedId === read.id}
+                onCopySessionId={(id) => {
+                  void copySessionId(id);
+                }}
+              />
+            ))}
           </ul>
         )}
       </div>
@@ -195,9 +145,135 @@ export function LiveReadsPanel({ paused = false }: { paused?: boolean }) {
   );
 }
 
-function lastSegment(path: string): string {
-  const idx = path.lastIndexOf("/");
-  return idx >= 0 ? path.slice(idx + 1) : path;
+function ReadRow({
+  read: r,
+  rate,
+  history,
+  copied,
+  onCopySessionId,
+}: {
+  read: ActiveRead;
+  rate: number;
+  history: number[];
+  copied: boolean;
+  onCopySessionId: (id: string) => void;
+}) {
+  const display = displayNameForRead(r.fileName, r.path);
+  const mediaType = mediaTypeFromFileName(display.name);
+  // Use the latest read position (what the player is requesting right now) —
+  // not cumulative bytes transferred — so the bar reflects actual playback
+  // location, immune to seeks/replays.
+  const pct =
+    r.fileSize && r.fileSize > 0 ? Math.min(100, (r.currentOffset / r.fileSize) * 100) : null;
+  const timeLeft = r.fileSize
+    ? formatTimeLeft(Math.max(0, r.fileSize - r.currentOffset), rate)
+    : null;
+  const sessionAge = formatSessionAge(r.startedAt);
+  const bytesFetched = r.bytesFetched ?? 0;
+  // Total bytes served well past the current position means the player is
+  // re-reading ranges (scrubbing / replaying), not streaming linearly.
+  const scrubbing = r.bytesRead > r.currentOffset + Math.max(64_000_000, r.currentOffset * 0.2);
+
+  return (
+    <li className="flex flex-col gap-1.5 py-3 first:pt-0 last:pb-0">
+      <div className="flex flex-col gap-1.5 lg:flex-row lg:items-center lg:gap-x-4">
+        <div className="flex min-w-0 items-center gap-2 lg:flex-1">
+          {mediaType && (
+            <span
+              className={`badge badge-sm shrink-0 ${
+                mediaType === "movie" ? "badge-primary" : "badge-secondary"
+              }`}
+            >
+              {mediaType === "movie" ? "MOVIE" : "EPISODE"}
+            </span>
+          )}
+          <Tooltip
+            className="min-w-0 flex-1"
+            content={display.isReleaseFallback ? `${r.path}\n(obfuscated file name)` : r.path}
+          >
+            <span className="block truncate text-sm font-medium text-base-content">
+              {display.name}
+            </span>
+          </Tooltip>
+        </div>
+        <div className="flex shrink-0 flex-wrap items-center gap-x-4 gap-y-1 font-mono text-xs tabular-nums">
+          {history.length >= 2 && (
+            <span className="hidden sm:block">
+              <Sparkline values={history} tone="success" />
+            </span>
+          )}
+          <span className="font-medium text-success">{formatBytes(rate)}/s</span>
+          <span className="font-medium text-base-content">
+            {formatBytes(r.currentOffset)}
+            {r.fileSize ? (
+              <span className="font-normal text-base-content/50"> / {formatBytes(r.fileSize)}</span>
+            ) : null}
+          </span>
+          <span className="text-base-content/50">{timeLeft ?? "—"}</span>
+        </div>
+      </div>
+
+      {pct !== null ? (
+        <progress className="progress progress-success h-1 w-full" value={pct} max={100} />
+      ) : (
+        <span
+          className="loading loading-bars loading-sm text-success"
+          role="status"
+          aria-label="Loading progress"
+        />
+      )}
+
+      <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-base-content/50">
+        <Tooltip content={clientIdentityTooltip(r.clientUserAgent, r.clientIp) ?? ""}>
+          <span className="truncate">
+            {clientLabelFromUserAgent(r.clientUserAgent)}
+            {r.clientIp ? (
+              <span className="font-mono text-base-content/40"> · {r.clientIp}</span>
+            ) : null}
+          </span>
+        </Tooltip>
+        {sessionAge && <span>{sessionAge}</span>}
+        {bytesFetched > 0 && (
+          <Tooltip content="Bytes pulled from Usenet for this session, including readahead">
+            <span className="font-mono tabular-nums">fetched {formatBytes(bytesFetched)}</span>
+          </Tooltip>
+        )}
+        {scrubbing && (
+          <Tooltip content="Total bytes served to the player, including seeks and replays">
+            <span className="font-mono tabular-nums">{formatBytes(r.bytesRead)} served</span>
+          </Tooltip>
+        )}
+        {r.providers.length > 0 && (
+          <span className="flex min-w-0 flex-wrap gap-1">
+            {r.providers.slice(0, 6).map((p, i) => {
+              const label = p.nickname?.trim() || p.host;
+              return (
+                <Tooltip
+                  key={`${p.host}-${i}`}
+                  content={`${label} (${p.host}): ${p.segments} segments`}
+                >
+                  <span className="badge badge-ghost badge-sm gap-1.5 font-mono tabular-nums">
+                    <span className="max-w-[8rem] truncate">{label}</span>
+                    <span className="font-medium">{p.segments}</span>
+                  </span>
+                </Tooltip>
+              );
+            })}
+          </span>
+        )}
+        <Tooltip content={`Copy session id: ${r.id}`}>
+          <button
+            type="button"
+            className="btn btn-link btn-xs h-auto min-h-0 px-0 font-mono"
+            aria-label={`Copy session id: ${r.id}${copied ? " (copied)" : ""}`}
+            onClick={() => onCopySessionId(r.id)}
+          >
+            {copied ? "Copied" : shortSessionId(r.id)}
+          </button>
+        </Tooltip>
+      </div>
+    </li>
+  );
 }
 
 function shortSessionId(id: string): string {

--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -45,6 +45,7 @@ import { SectionLoadError } from "./components/section-load-error/section-load-e
 import { Icon, Tooltip } from "~/components/ui";
 import { backendClient, type ArrHealthResponse } from "~/clients/backend-client.server";
 import { useRowOrder } from "./utils/use-row-order";
+import { useMediaQuery } from "~/utils/use-media-query";
 import { hasConfiguredIndexers } from "./utils/has-configured-indexers";
 import { hasConfiguredArrs, isArrHealthEnabled } from "./utils/has-configured-arrs";
 import {
@@ -73,6 +74,7 @@ const WINDOWS: { value: OverviewWindow; label: string }[] = [
 
 const DEFAULT_ROW_ORDER = [
   "liveTiles",
+  "rightNow",
   "throughput",
   "providers",
   "activity",
@@ -370,6 +372,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
   const rowContent = useMemo<Record<string, ReactNode>>(
     () => ({
       liveTiles: <LiveTiles tiles={liveTiles} />,
+      rightNow: <LiveReadsPanel paused={editMode} />,
       throughput:
         windowError && !windowLoaded ? (
           <SectionLoadError label="activity" onRetry={() => setWindowRetry((n) => n + 1)} />
@@ -512,6 +515,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
     }),
     [
       liveTiles,
+      editMode,
       stats,
       window,
       isLongWindow,
@@ -529,16 +533,28 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
     ],
   );
 
-  const visibleOrder = useMemo(
-    () =>
-      order.filter((id) => {
-        if (!loaderData.hasConfiguredIndexers && (id === "indexers" || id === "indexerApiUsage"))
-          return false;
-        if (!loaderData.hasConfiguredArrs && id === "arrHealth") return false;
-        return true;
-      }),
-    [loaderData.hasConfiguredIndexers, loaderData.hasConfiguredArrs, order],
-  );
+  // Below lg the stats bar stacks vertically; live reads matter more there,
+  // so Right now leads the stack. Edit mode keeps the canonical order so
+  // drag-and-drop stays consistent.
+  const mobileStack = useMediaQuery("(max-width: 1023px)");
+  const visibleOrder = useMemo(() => {
+    const filtered = order.filter((id) => {
+      if (!loaderData.hasConfiguredIndexers && (id === "indexers" || id === "indexerApiUsage"))
+        return false;
+      if (!loaderData.hasConfiguredArrs && id === "arrHealth") return false;
+      return true;
+    });
+    if (!mobileStack || editMode) return filtered;
+    const idx = filtered.indexOf("rightNow");
+    if (idx <= 0) return filtered;
+    return ["rightNow", ...filtered.slice(0, idx), ...filtered.slice(idx + 1)];
+  }, [
+    loaderData.hasConfiguredIndexers,
+    loaderData.hasConfiguredArrs,
+    order,
+    mobileStack,
+    editMode,
+  ]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
@@ -639,28 +655,20 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
         </div>
       )}
 
-      <div
-        id="overview-dashboard"
-        className="grid min-w-0 grid-cols-1 items-start gap-4 xl:grid-cols-[minmax(0,1fr)_20rem]"
-      >
-        <aside className="flex w-full min-w-0 xl:col-start-2 xl:row-start-1 xl:sticky xl:top-4 xl:max-h-[calc(100vh-2rem)]">
-          <LiveReadsPanel paused={editMode} />
-        </aside>
-        <div className="flex min-w-0 flex-col gap-4 xl:col-start-1 xl:row-start-1">
-          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
-            <SortableContext items={visibleOrder} strategy={verticalListSortingStrategy}>
-              {visibleOrder.map((id) => {
-                const content = rowContent[id];
-                if (!content) return null;
-                return (
-                  <SortableRow key={id} id={id} editMode={editMode}>
-                    {content}
-                  </SortableRow>
-                );
-              })}
-            </SortableContext>
-          </DndContext>
-        </div>
+      <div id="overview-dashboard" className="flex min-w-0 flex-col gap-4">
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+          <SortableContext items={visibleOrder} strategy={verticalListSortingStrategy}>
+            {visibleOrder.map((id) => {
+              const content = rowContent[id];
+              if (!content) return null;
+              return (
+                <SortableRow key={id} id={id} editMode={editMode}>
+                  {content}
+                </SortableRow>
+              );
+            })}
+          </SortableContext>
+        </DndContext>
       </div>
     </div>
   );

--- a/frontend/app/routes/overview/utils/display-name.test.ts
+++ b/frontend/app/routes/overview/utils/display-name.test.ts
@@ -44,4 +44,15 @@ describe("displayNameForRead", () => {
     const result = displayNameForRead("9f2c7a1e4b.mkv", "/.ids/9f2c7a1e-4b2c");
     expect(result).toEqual({ name: "9f2c7a1e4b.mkv", isReleaseFallback: false });
   });
+
+  it("keeps the obfuscated leaf for root-level or empty paths", () => {
+    expect(displayNameForRead("9f2c7a1e4b.mkv", "/9f2c7a1e4b.mkv")).toEqual({
+      name: "9f2c7a1e4b.mkv",
+      isReleaseFallback: false,
+    });
+    expect(displayNameForRead("9f2c7a1e4b.mkv", "")).toEqual({
+      name: "9f2c7a1e4b.mkv",
+      isReleaseFallback: false,
+    });
+  });
 });

--- a/frontend/app/routes/overview/utils/display-name.test.ts
+++ b/frontend/app/routes/overview/utils/display-name.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { displayNameForRead, isProbablyObfuscated } from "./display-name";
+
+describe("isProbablyObfuscated", () => {
+  it("flags classic obfuscated names", () => {
+    expect(isProbablyObfuscated("b082fa0beaa644d3aa01045d5b8d0b36.mkv")).toBe(true);
+    expect(isProbablyObfuscated("abc.xyz.a4c567edbcbf27.mkv")).toBe(true);
+    expect(isProbablyObfuscated("9f2c7a1e4b.mkv")).toBe(true);
+  });
+
+  it("passes clear release names through", () => {
+    expect(isProbablyObfuscated("The.Prestige.2006.1080p.BluRay.x264-GRP.mkv")).toBe(false);
+    expect(isProbablyObfuscated("Severance.S02E01.2160p.ATVP.WEB-DL.DDP5.1.H.265-GRP.mkv")).toBe(
+      false,
+    );
+    expect(isProbablyObfuscated("Some Movie (1999) 720p.mkv")).toBe(false);
+  });
+});
+
+describe("displayNameForRead", () => {
+  it("keeps clear leaf names", () => {
+    const result = displayNameForRead(
+      "The.Prestige.2006.1080p.BluRay.x264-GRP.mkv",
+      "/completed-symlinks/movies/The.Prestige.2006.1080p.BluRay.x264-GRP.mkv",
+    );
+    expect(result).toEqual({
+      name: "The.Prestige.2006.1080p.BluRay.x264-GRP.mkv",
+      isReleaseFallback: false,
+    });
+  });
+
+  it("falls back to the release folder for obfuscated leaves", () => {
+    const result = displayNameForRead(
+      "9f2c7a1e4b.mkv",
+      "/completed-symlinks/movies/Interstellar.2014.1080p.BluRay.x264-GRP/9f2c7a1e4b.mkv",
+    );
+    expect(result).toEqual({
+      name: "Interstellar.2014.1080p.BluRay.x264-GRP.mkv",
+      isReleaseFallback: true,
+    });
+  });
+
+  it("keeps the obfuscated leaf when the path has no useful parent", () => {
+    const result = displayNameForRead("9f2c7a1e4b.mkv", "/.ids/9f2c7a1e-4b2c");
+    expect(result).toEqual({ name: "9f2c7a1e4b.mkv", isReleaseFallback: false });
+  });
+});

--- a/frontend/app/routes/overview/utils/display-name.ts
+++ b/frontend/app/routes/overview/utils/display-name.ts
@@ -48,7 +48,8 @@ export function displayNameForRead(fileName: string, path: string): DisplayName 
 
   const segments = path.split("/").filter(Boolean);
   const parent = segments.length >= 2 ? segments[segments.length - 2]! : "";
-  if (IGNORED_PARENTS.has(parent.toLowerCase())) return { name: leaf, isReleaseFallback: false };
+  if (parent === "" || IGNORED_PARENTS.has(parent.toLowerCase()))
+    return { name: leaf, isReleaseFallback: false };
 
   const ext = leaf.includes(".") ? leaf.slice(leaf.lastIndexOf(".")) : "";
   return { name: parent + ext, isReleaseFallback: true };

--- a/frontend/app/routes/overview/utils/display-name.ts
+++ b/frontend/app/routes/overview/utils/display-name.ts
@@ -1,0 +1,66 @@
+/**
+ * Display-name resolution for active reads. The queue deobfuscates most
+ * video files at import time, but when an obfuscated leaf survives (e.g.
+ * "b082fa0beaa644d3aa01045d5b8d0b36.mkv") the release folder in the WebDAV
+ * path is a far more useful label than the leaf.
+ */
+
+// Structural mount roots that are never useful as display names.
+const IGNORED_PARENTS = new Set(["content", "nzbs", ".ids", "completed-symlinks"]);
+
+/**
+ * Port of the backend's ObfuscationUtil.IsProbablyObfuscated (itself a port
+ * of sabnzbd's deobfuscate_filenames heuristic). Keep the two in sync.
+ */
+export function isProbablyObfuscated(fileName: string): boolean {
+  const base = fileName.replace(/\.[^.]*$/, "");
+
+  // Certainly obfuscated
+  if (/^[a-f0-9]{32}$/.test(base)) return true;
+  if (/^[a-f0-9.]{40,}$/.test(base)) return true;
+  if (/[a-f0-9]{30}/.test(base) && (base.match(/\[\w+\]/g) ?? []).length >= 2) return true;
+  if (/^abc\.xyz/.test(base)) return true;
+
+  // Signals of a typical, clear name
+  const decimals = countChars(base, (c) => c >= "0" && c <= "9");
+  const upper = countChars(base, (c) => c >= "A" && c <= "Z");
+  const lower = countChars(base, (c) => c >= "a" && c <= "z");
+  const spacesDots = countChars(base, (c) => c === " " || c === "." || c === "_");
+
+  if (upper >= 2 && lower >= 2 && spacesDots >= 1) return false;
+  if (spacesDots >= 3) return false;
+  if (upper + lower >= 4 && decimals >= 4 && spacesDots >= 1) return false;
+  if (base.length > 0 && base[0]! >= "A" && base[0]! <= "Z" && lower > 2 && upper / lower <= 0.25)
+    return false;
+
+  return true;
+}
+
+export type DisplayName = {
+  name: string;
+  /** True when the name comes from the release folder because the leaf is obfuscated. */
+  isReleaseFallback: boolean;
+};
+
+export function displayNameForRead(fileName: string, path: string): DisplayName {
+  const leaf = fileName || lastPathSegment(path);
+  if (!isProbablyObfuscated(leaf)) return { name: leaf, isReleaseFallback: false };
+
+  const segments = path.split("/").filter(Boolean);
+  const parent = segments.length >= 2 ? segments[segments.length - 2]! : "";
+  if (IGNORED_PARENTS.has(parent.toLowerCase())) return { name: leaf, isReleaseFallback: false };
+
+  const ext = leaf.includes(".") ? leaf.slice(leaf.lastIndexOf(".")) : "";
+  return { name: parent + ext, isReleaseFallback: true };
+}
+
+export function lastPathSegment(path: string): string {
+  const idx = path.lastIndexOf("/");
+  return idx >= 0 ? path.slice(idx + 1) : path;
+}
+
+function countChars(value: string, predicate: (char: string) => boolean): number {
+  let count = 0;
+  for (const char of value) if (predicate(char)) count++;
+  return count;
+}

--- a/frontend/app/routes/overview/utils/format.test.ts
+++ b/frontend/app/routes/overview/utils/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatDurationMs } from "./format";
+import { formatDurationMs, formatSessionAge, formatTimeLeft } from "./format";
 
 describe("formatDurationMs", () => {
   it("renders em dash for missing or invalid values", () => {
@@ -16,5 +16,38 @@ describe("formatDurationMs", () => {
     expect(formatDurationMs(10_800_000)).toBe("3h");
     expect(formatDurationMs(3_660_000)).toBe("1h 1m");
     expect(formatDurationMs(60_000)).toBe("1m");
+  });
+});
+
+describe("formatTimeLeft", () => {
+  it("returns null when the estimate is meaningless", () => {
+    expect(formatTimeLeft(1_000, 0)).toBeNull();
+    expect(formatTimeLeft(1_000, -5)).toBeNull();
+    expect(formatTimeLeft(1_000, Number.NaN)).toBeNull();
+    expect(formatTimeLeft(-1, 100)).toBeNull();
+  });
+
+  it("formats sub-minute, minute, and hour estimates", () => {
+    expect(formatTimeLeft(59 * 100, 100)).toBe("<1m left");
+    expect(formatTimeLeft(5_200_000_000, 7_200_000)).toBe("12m left");
+    expect(formatTimeLeft(672_000_000, 1_900_000)).toBe("6m left");
+    expect(formatTimeLeft(84 * 60 * 1_000, 1_000)).toBe("1h 24m left");
+    expect(formatTimeLeft(2 * 3_600 * 1_000, 1_000)).toBe("2h 0m left");
+  });
+});
+
+describe("formatSessionAge", () => {
+  const now = 1_800_000_000_000;
+
+  it("renders empty for missing or invalid starts", () => {
+    expect(formatSessionAge(null, now)).toBe("");
+    expect(formatSessionAge(undefined, now)).toBe("");
+    expect(formatSessionAge(Number.NaN, now)).toBe("");
+  });
+
+  it("formats fresh, minute, and hour ages", () => {
+    expect(formatSessionAge(now - 30_000, now)).toBe("just started");
+    expect(formatSessionAge(now - 20 * 60_000, now)).toBe("20m in");
+    expect(formatSessionAge(now - 65 * 60_000, now)).toBe("1h 5m in");
   });
 });

--- a/frontend/app/routes/overview/utils/format.ts
+++ b/frontend/app/routes/overview/utils/format.ts
@@ -38,6 +38,38 @@ export function formatDurationMs(ms: number | null | undefined): string {
   return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
 }
 
+/**
+ * Estimated time until a read reaches end-of-file at its current rate.
+ * Returns null when the estimate is meaningless (unknown size, stalled rate).
+ */
+export function formatTimeLeft(remainingBytes: number, rateBytesPerSec: number): string | null {
+  if (
+    !isFinite(remainingBytes) ||
+    !isFinite(rateBytesPerSec) ||
+    rateBytesPerSec <= 0 ||
+    remainingBytes < 0
+  ) {
+    return null;
+  }
+  const seconds = remainingBytes / rateBytesPerSec;
+  if (seconds < 60) return "<1m left";
+  const totalMinutes = Math.round(seconds / 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return hours > 0 ? `${hours}h ${minutes}m left` : `${totalMinutes}m left`;
+}
+
+/** Age of a live read session: "just started", "24m in", "1h 5m in". */
+export function formatSessionAge(startedAtMs: number | null | undefined, now = Date.now()): string {
+  if (startedAtMs == null || !Number.isFinite(startedAtMs)) return "";
+  const ageSeconds = Math.max(0, Math.round((now - startedAtMs) / 1000));
+  if (ageSeconds < 60) return "just started";
+  const totalMinutes = Math.floor(ageSeconds / 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return hours > 0 ? `${hours}h ${minutes}m in` : `${totalMinutes}m in`;
+}
+
 export function formatTimeAgo(ms: number | null | undefined, now = Date.now()): string {
   if (ms == null || !Number.isFinite(ms)) return "—";
   const age = Math.max(0, Math.round((now - ms) / 1000));

--- a/frontend/app/routes/overview/utils/media-type.test.ts
+++ b/frontend/app/routes/overview/utils/media-type.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { mediaTypeFromFileName } from "./media-type";
+
+describe("mediaTypeFromFileName", () => {
+  it("classifies season-episode tokens as episodes", () => {
+    expect(mediaTypeFromFileName("The.Last.of.Us.S01E03.1080p.WEB-DL.DDP5.1.H.264-GRP.mkv")).toBe(
+      "episode",
+    );
+    expect(mediaTypeFromFileName("Severance.S02E01.2160p.ATVP.WEB-DL.DDP5.1.H.265-GRP.mkv")).toBe(
+      "episode",
+    );
+    expect(mediaTypeFromFileName("Some Show s2e11 720p.mkv")).toBe("episode");
+    expect(mediaTypeFromFileName("Some.Show.1x02.1080p.mkv")).toBe("episode");
+  });
+
+  it("classifies year-plus-quality names as movies", () => {
+    expect(mediaTypeFromFileName("The.Prestige.2006.1080p.BluRay.x264-GRP.mkv")).toBe("movie");
+    expect(
+      mediaTypeFromFileName("Dune.Part.Two.2024.2160p.WEB-DL.DDP5.1.Atmos.H.265-GRP.mkv"),
+    ).toBe("movie");
+    expect(mediaTypeFromFileName("Some Movie (1999) 720p.mkv")).toBe("movie");
+  });
+
+  it("does not mistake codec tokens for episode markers", () => {
+    expect(mediaTypeFromFileName("Movie.Title.2010.BluRay.x264-GRP.mkv")).toBe("movie");
+  });
+
+  it("returns null for names that do not look like media", () => {
+    expect(mediaTypeFromFileName("backup-2024-01-01.zip")).toBeNull();
+    expect(mediaTypeFromFileName("README.txt")).toBeNull();
+    expect(mediaTypeFromFileName("2006.mkv")).toBeNull();
+  });
+});

--- a/frontend/app/routes/overview/utils/media-type.ts
+++ b/frontend/app/routes/overview/utils/media-type.ts
@@ -1,0 +1,21 @@
+export type MediaType = "movie" | "episode";
+
+// "S01E03" / "s2e11" season-episode tokens, delimited so codec names like
+// "x264" never match.
+const EPISODE_PATTERN = /(?:^|[\s._-])s\d{1,2}e\d{1,2}(?:[\s._-]|$)/i;
+// "1x02" season-x-episode tokens.
+const EPISODE_ALT_PATTERN = /(?:^|[\s._-])\d{1,2}x\d{2}(?:[\s._-]|$)/;
+const YEAR_PATTERN = /(?:^|[\s._([-])(19\d{2}|20\d{2})(?:[\s._)\]-]|$)/;
+const QUALITY_PATTERN =
+  /\b(480p|576p|720p|1080p|2160p|4320p|blu[-. ]?ray|bdrip|web[-. ]?dl|webrip|hdrip|hdtv|dvdrip|remux)\b/i;
+
+/**
+ * Best-effort media classification from a release-style file name, used for
+ * the Right Now row badge. Returns null when the name doesn't look like
+ * media — non-media files get no badge rather than a wrong one.
+ */
+export function mediaTypeFromFileName(fileName: string): MediaType | null {
+  if (EPISODE_PATTERN.test(fileName) || EPISODE_ALT_PATTERN.test(fileName)) return "episode";
+  if (YEAR_PATTERN.test(fileName) && QUALITY_PATTERN.test(fileName)) return "movie";
+  return null;
+}

--- a/frontend/app/routes/overview/utils/use-row-order.test.ts
+++ b/frontend/app/routes/overview/utils/use-row-order.test.ts
@@ -38,6 +38,12 @@ describe("mergeRowOrder", () => {
     expect(mergeRowOrder(DEFAULT, ["liveTiles"])).toEqual([...DEFAULT]);
   });
 
+  it("dedupes repeated saved ids, keeping the first occurrence", () => {
+    expect(
+      mergeRowOrder(DEFAULT, ["providers", "liveTiles", "providers", "rightNow", "throughput"]),
+    ).toEqual(["providers", "liveTiles", "rightNow", "throughput"]);
+  });
+
   it("ignores non-array or malformed saved values", () => {
     expect(mergeRowOrder(DEFAULT, "nope")).toEqual([...DEFAULT]);
     expect(

--- a/frontend/app/routes/overview/utils/use-row-order.test.ts
+++ b/frontend/app/routes/overview/utils/use-row-order.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { mergeRowOrder } from "./use-row-order";
+
+const DEFAULT = ["liveTiles", "rightNow", "throughput", "providers"] as const;
+
+describe("mergeRowOrder", () => {
+  it("returns the default order when there is no saved layout", () => {
+    expect(mergeRowOrder(DEFAULT, null)).toEqual([...DEFAULT]);
+  });
+
+  it("keeps the saved relative order", () => {
+    expect(mergeRowOrder(DEFAULT, ["providers", "liveTiles", "rightNow", "throughput"])).toEqual([
+      "providers",
+      "liveTiles",
+      "rightNow",
+      "throughput",
+    ]);
+  });
+
+  it("drops saved ids that no longer exist", () => {
+    expect(
+      mergeRowOrder(DEFAULT, ["providers", "retired", "liveTiles", "rightNow", "throughput"]),
+    ).toEqual(["providers", "liveTiles", "rightNow", "throughput"]);
+  });
+
+  it("inserts a new row at its default position instead of appending it", () => {
+    // A saved layout from before the rightNow row existed still places it
+    // directly under liveTiles.
+    expect(mergeRowOrder(DEFAULT, ["providers", "liveTiles", "throughput"])).toEqual([
+      "providers",
+      "liveTiles",
+      "rightNow",
+      "throughput",
+    ]);
+  });
+
+  it("appends a new row when none of its default-successors are saved", () => {
+    expect(mergeRowOrder(DEFAULT, ["liveTiles"])).toEqual([...DEFAULT]);
+  });
+
+  it("ignores non-array or malformed saved values", () => {
+    expect(mergeRowOrder(DEFAULT, "nope")).toEqual([...DEFAULT]);
+    expect(
+      mergeRowOrder(DEFAULT, [1, {}, "liveTiles", "rightNow", "throughput", "providers"]),
+    ).toEqual([...DEFAULT]);
+  });
+});

--- a/frontend/app/routes/overview/utils/use-row-order.ts
+++ b/frontend/app/routes/overview/utils/use-row-order.ts
@@ -2,6 +2,29 @@ import { useCallback, useEffect, useState } from "react";
 
 const STORAGE_KEY = "overview-row-order";
 
+/**
+ * Merge a saved layout with the default row order. Saved rows keep their
+ * relative order; rows the saved layout doesn't know about (newly shipped
+ * widgets) are spliced in at their default position — before the first
+ * default-successor present in the saved layout — instead of being dumped
+ * at the bottom. Unknown saved ids are dropped.
+ */
+export function mergeRowOrder(defaultOrder: readonly string[], saved: unknown): string[] {
+  const known = new Set(defaultOrder);
+  const merged = Array.isArray(saved)
+    ? saved.filter((id: unknown): id is string => typeof id === "string" && known.has(id))
+    : [];
+  for (const id of defaultOrder) {
+    if (merged.includes(id)) continue;
+    const anchor = defaultOrder
+      .slice(defaultOrder.indexOf(id) + 1)
+      .find((successor) => merged.includes(successor));
+    if (anchor === undefined) merged.push(id);
+    else merged.splice(merged.indexOf(anchor), 0, id);
+  }
+  return merged;
+}
+
 export function useRowOrder(defaultOrder: readonly string[]) {
   const [order, setOrder] = useState<string[]>(() => [...defaultOrder]);
 
@@ -9,14 +32,7 @@ export function useRowOrder(defaultOrder: readonly string[]) {
     try {
       const raw = globalThis.localStorage?.getItem(STORAGE_KEY);
       if (!raw) return;
-      const saved: unknown = JSON.parse(raw);
-      if (!Array.isArray(saved)) return;
-      const known = new Set(defaultOrder);
-      const kept = saved.filter(
-        (id: unknown): id is string => typeof id === "string" && known.has(id),
-      );
-      const missing = defaultOrder.filter((id) => !kept.includes(id));
-      setOrder([...kept, ...missing]);
+      setOrder(mergeRowOrder(defaultOrder, JSON.parse(raw)));
     } catch {
       /* ignore corrupt storage */
     }

--- a/frontend/app/routes/overview/utils/use-row-order.ts
+++ b/frontend/app/routes/overview/utils/use-row-order.ts
@@ -11,8 +11,14 @@ const STORAGE_KEY = "overview-row-order";
  */
 export function mergeRowOrder(defaultOrder: readonly string[], saved: unknown): string[] {
   const known = new Set(defaultOrder);
+  const seen = new Set<string>();
   const merged = Array.isArray(saved)
-    ? saved.filter((id: unknown): id is string => typeof id === "string" && known.has(id))
+    ? saved.filter(
+        (id: unknown): id is string =>
+          // Known string ids only, first occurrence wins — a corrupt saved
+          // layout with duplicates must not produce duplicate React keys.
+          typeof id === "string" && known.has(id) && !seen.has(id) && (seen.add(id), true),
+      )
     : [];
   for (const id of defaultOrder) {
     if (merged.includes(id)) continue;

--- a/frontend/app/utils/use-media-query.ts
+++ b/frontend/app/utils/use-media-query.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+/** SSR-safe media query hook. */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(
+    () => typeof window !== "undefined" && window.matchMedia(query).matches,
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const onChange = () => setMatches(mql.matches);
+    onChange();
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, [query]);
+
+  return matches;
+}

--- a/frontend/app/utils/use-media-query.ts
+++ b/frontend/app/utils/use-media-query.ts
@@ -1,10 +1,9 @@
 import { useEffect, useState } from "react";
 
-/** SSR-safe media query hook. */
+/** SSR-safe media query hook. Initial render is always `false` so server and
+ * client markup match; the effect syncs the real value after mount. */
 export function useMediaQuery(query: string): boolean {
-  const [matches, setMatches] = useState(
-    () => typeof window !== "undefined" && window.matchMedia(query).matches,
-  );
+  const [matches, setMatches] = useState(false);
 
   useEffect(() => {
     const mql = window.matchMedia(query);

--- a/frontend/coverage-thresholds.json
+++ b/frontend/coverage-thresholds.json
@@ -1,9 +1,9 @@
 {
   "global": {
     "branches": 24,
-    "functions": 20,
-    "lines": 25,
-    "statements": 24
+    "functions": 23,
+    "lines": 28,
+    "statements": 27
   },
   "globs": {
     "app/clients/**": {


### PR DESCRIPTION
## Summary

- The **Right now** card moved out of the narrow right rail (now removed) into the main Overview stack as a full-width row directly under the stats bar — and on phone-sized screens it leads the stack above the stats bar.
- Each active read is now a full-width, providers-style row: media-type badge (MOVIE/EPISODE), title, a live rate sparkline, speed, progress, and computed time left, with a muted meta line showing client + IP, session age, Usenet-fetched bytes, a scrubbing indicator when a player re-reads ranges, provider badges, and the session-id copy button.
- Files with obfuscated names (e.g. `9f2c7a1e4b.mkv`) now display their release folder name instead, using a frontend port of the backend's SABnzbd-style obfuscation heuristic.
- Existing custom dashboard layouts get the new row inserted right after the stats bar instead of appended at the bottom.

## Test plan

- [x] `npm run lint`, `npm run typecheck`, `npm run format:check`, `npm run build`, `npm test` (769 tests, incl. new coverage for the row rendering, media-type classifier, obfuscation fallback, time-left formatting, and row-order merge)
- [x] Verified live on a local dev server at 390px / 900px / 1500px: titles truncate without overlapping stats, mobile hoists Right now above the stats bar, desktop keeps it under the stats bar
- [x] Empty state unchanged when nothing is being read

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the live reads panel with responsive rows, media labels, progress, time remaining, rate sparklines, session age, byte totals, provider badges, and session-ID copying.
  * Added clearer display names when filenames are obfuscated.
  * Added movie and episode media-type labels.
  * Added responsive dashboard ordering, placing live reads prominently on smaller screens.
  * Improved saved dashboard layout handling when widgets are added or removed.

* **Bug Fixes**
  * Improved handling of stalled or invalid read rates and session times.
  * Added safer responsive behavior across server-rendered and client-rendered views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->