### PR TITLE
fix(ui): overview stats stay a compact bar on tablets and wrap 3-wide on phones

### DIFF
--- a/frontend/app/routes/overview/components/live-tiles/live-tiles.tsx
+++ b/frontend/app/routes/overview/components/live-tiles/live-tiles.tsx
@@ -23,7 +23,7 @@ export function LiveTiles({ tiles }: LiveTilesProps) {
     <div
       role="region"
       aria-label="Live status"
-      className="stats stats-vertical w-full border border-base-content/10 bg-base-200 shadow lg:stats-horizontal"
+      className="stats w-full border border-base-content/10 bg-base-200 shadow max-sm:grid-flow-row max-sm:grid-cols-3 max-sm:gap-px max-sm:bg-base-content/10"
     >
       <Tile
         label="Active reads"
@@ -55,6 +55,7 @@ export function LiveTiles({ tiles }: LiveTilesProps) {
         value={tiles.errorsPerMinute.toString()}
         sub="hard failures / min"
         accent={tiles.errorsPerMinute > 0 ? "danger" : undefined}
+        className="max-sm:col-span-2"
       />
     </div>
   );
@@ -65,22 +66,30 @@ function Tile({
   value,
   sub,
   accent,
+  className,
 }: {
   label: string;
   value: string;
   sub?: string | undefined;
   accent?: "live" | "danger" | undefined;
+  className?: string | undefined;
 }) {
   const valueClass = accent === "live" ? "text-success" : accent === "danger" ? "text-error" : "";
   return (
-    <div className="stat">
+    <div
+      className={`stat px-3 py-2.5 sm:px-4 sm:py-4 lg:px-6 max-sm:border-e-0 max-sm:bg-base-200 ${className ?? ""}`}
+    >
       {accent && (
         <div className="stat-figure">
           <span className={`status ${accent === "live" ? "status-success" : "status-error"}`} />
         </div>
       )}
       <div className="stat-title">{label}</div>
-      <div className={`stat-value font-mono text-2xl md:text-3xl ${valueClass}`}>{value}</div>
+      <div
+        className={`stat-value font-mono text-lg sm:text-xl md:text-2xl lg:text-3xl ${valueClass}`}
+      >
+        {value}
+      </div>
       {sub && <div className="stat-desc">{sub}</div>}
     </div>
   );

--- a/frontend/app/routes/overview/components/live-tiles/live-tiles.tsx
+++ b/frontend/app/routes/overview/components/live-tiles/live-tiles.tsx
@@ -77,20 +77,20 @@ function Tile({
   const valueClass = accent === "live" ? "text-success" : accent === "danger" ? "text-error" : "";
   return (
     <div
-      className={`stat px-3 py-2.5 sm:px-4 sm:py-4 lg:px-6 max-sm:border-e-0 max-sm:bg-base-200 ${className ?? ""}`}
+      className={`stat px-3 py-2.5 sm:px-4 sm:py-4 lg:px-6 max-sm:min-w-0 max-sm:border-e-0 max-sm:bg-base-200 ${className ?? ""}`}
     >
       {accent && (
         <div className="stat-figure">
           <span className={`status ${accent === "live" ? "status-success" : "status-error"}`} />
         </div>
       )}
-      <div className="stat-title">{label}</div>
+      <div className="stat-title max-sm:whitespace-normal max-sm:break-words">{label}</div>
       <div
-        className={`stat-value font-mono text-lg sm:text-xl md:text-2xl lg:text-3xl ${valueClass}`}
+        className={`stat-value font-mono text-lg sm:text-xl md:text-2xl lg:text-3xl max-sm:whitespace-normal max-sm:break-words ${valueClass}`}
       >
         {value}
       </div>
-      {sub && <div className="stat-desc">{sub}</div>}
+      {sub && <div className="stat-desc max-sm:whitespace-normal max-sm:break-words">{sub}</div>}
     </div>
   );
 }

--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -533,10 +533,10 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
     ],
   );
 
-  // Below lg the stats bar stacks vertically; live reads matter more there,
-  // so Right now leads the stack. Edit mode keeps the canonical order so
-  // drag-and-drop stays consistent.
-  const mobileStack = useMediaQuery("(max-width: 1023px)");
+  // Below sm the stats bar wraps into a compact grid; live reads matter more
+  // there, so Right now leads the stack. Edit mode keeps the canonical order
+  // so drag-and-drop stays consistent.
+  const mobileStack = useMediaQuery("(max-width: 639px)");
   const visibleOrder = useMemo(() => {
     const filtered = order.filter((id) => {
       if (!loaderData.hasConfiguredIndexers && (id === "indexers" || id === "indexerApiUsage"))


### PR DESCRIPTION
## Summary
- The overview live stat bar (Active reads / Articles per s / Read throughput / Article RAM / Fetch errors) used to collapse into five full-width stacked rows below the `lg` breakpoint, wasting a lot of vertical space on tablets and phones.
- The bar now stays a single horizontal strip down to `sm` (640px), with value sizes stepping down (`text-xl` → `2xl` → `3xl`) so the row fits.
- Below `sm` it wraps into a compact 3-wide grid with tighter padding and hairline dividers; the fifth tile (Fetch errors) spans the remaining two columns of the last row.
- The "Right now" panel reorder breakpoint moves from `lg` to `sm` to match the new wrap point, so it still leads the page exactly when the bar is in its compact phone layout. Desktop (>= `lg`) appearance is unchanged.

## Test plan
- [x] Browser preview at 390px (3-wide grid, Right now on top), 700px and 900px (single horizontal bar), 1440px (unchanged desktop)
- [x] `npm run typecheck`, `npm run build`, `npm test` (771 tests) — all green
- [x] Prettier + eslint clean on changed files
- [ ] Reviewer: resize the overview page across the sm/lg breakpoints and confirm no horizontal clipping with real (non-zero) stats

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsive tile layouts for smaller screens.
  * Updated tile spacing, backgrounds, borders, and value sizing for clearer presentation.
  * Fetch errors now span both columns on compact layouts.
  * Refined mobile dashboard stacking behavior for better breakpoint consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->