### PR TITLE
chore(ci): post Discord release announcement only after all artifacts publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,8 +330,11 @@ jobs:
     needs:
       - release-please
       - deploy
+      - assets
+      - publish-dev-release
       - tag-dev
       - tag-rc
+      - cleanup-prereleases
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- The Release workflow's `announce` job now also waits for `assets` (Linux archives attached to the GitHub release), `publish-dev-release` (rolling `:dev` pre-release refresh), and `cleanup-prereleases` (versioned RC release/image-tag deletion).
- Previously it only waited on the Docker image push and the movable `dev`/`rc` tags, so the Discord announcement could go out while the GitHub release still had no downloadable archives and before RC cleanup finished.
- The Discord notification is now the very last job in the Release workflow; message content is unchanged.

## Test plan
- [x] `release.yml` parses as valid YAML and every `needs` entry resolves to an existing job
- [ ] Confirm on the next release run (Actions graph) that `announce` starts only after all other jobs complete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release announcements now wait for asset preparation, development publishing, and prerelease cleanup to complete.
  * Improved release workflow coordination for more reliable announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->