### PR TITLE
chore(ci): label dev builds with build time (dev-YYMMDD.HHMM) instead of commit sha

### DIFF
--- a/.github/workflows/cut-prerelease.yml
+++ b/.github/workflows/cut-prerelease.yml
@@ -26,6 +26,7 @@ jobs:
       tag: ${{ steps.vars.outputs.tag }}
       sha: ${{ steps.vars.outputs.sha }}
       short_sha: ${{ steps.vars.outputs.short_sha }}
+      dev_label: ${{ steps.vars.outputs.dev_label }}
     steps:
       - id: vars
         env:
@@ -68,6 +69,7 @@ jobs:
           echo "tag=v${VERSION}-rc.${RC}" >> "$GITHUB_OUTPUT"
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
           echo "short_sha=${SHA:0:7}" >> "$GITHUB_OUTPUT"
+          echo "dev_label=dev-$(date -u +%y%m%d.%H%M)" >> "$GITHUB_OUTPUT"
 
   build:
     needs: resolve
@@ -101,7 +103,7 @@ jobs:
       tags: |
         ghcr.io/${{ github.repository }}:dev
         docker.io/infinidysk/infinidysk:dev
-      nzbdav_version: dev-${{ needs.resolve.outputs.short_sha }}
+      nzbdav_version: ${{ needs.resolve.outputs.dev_label }}
       checkout_ref: ${{ needs.resolve.outputs.sha }}
       dockerhub_username: infinidysk
     secrets:
@@ -120,6 +122,7 @@ jobs:
           RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
           RELEASE_SHA: ${{ needs.resolve.outputs.sha }}
           SHORT_SHA: ${{ needs.resolve.outputs.short_sha }}
+          DEV_LABEL: ${{ needs.resolve.outputs.dev_label }}
         run: |
           set -euo pipefail
           gh release create "$RELEASE_TAG" \
@@ -146,7 +149,7 @@ jobs:
               --prerelease
           fi
 
-          DEV_TITLE="Rolling :dev (dev-${SHORT_SHA})"
+          DEV_TITLE="Rolling :dev (${DEV_LABEL})"
           DEV_NOTES="Unversioned development snapshot from \`main\` at [\`${SHORT_SHA}\`](https://github.com/${{ github.repository }}/commit/${RELEASE_SHA}). Currently identical to release candidate [$RELEASE_TAG](https://github.com/${{ github.repository }}/releases/tag/$RELEASE_TAG)."
           if gh release view dev --repo "${{ github.repository }}" >/dev/null 2>&1; then
             gh release edit dev \

--- a/.github/workflows/refresh-dev.yml
+++ b/.github/workflows/refresh-dev.yml
@@ -13,9 +13,12 @@ jobs:
     permissions: {}
     outputs:
       short_sha: ${{ steps.sha.outputs.short_sha }}
+      dev_label: ${{ steps.sha.outputs.dev_label }}
     steps:
       - id: sha
-        run: echo "short_sha=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "short_sha=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+          echo "dev_label=dev-$(date -u +%y%m%d.%H%M)" >> "$GITHUB_OUTPUT"
 
   build:
     needs: resolve
@@ -27,7 +30,7 @@ jobs:
       tags: |
         ghcr.io/${{ github.repository }}:dev
         docker.io/infinidysk/infinidysk:dev
-      nzbdav_version: dev-${{ needs.resolve.outputs.short_sha }}
+      nzbdav_version: ${{ needs.resolve.outputs.dev_label }}
       dockerhub_username: infinidysk
     secrets:
       registry_token: ${{ secrets.GITHUB_TOKEN }}
@@ -44,9 +47,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_SHA: ${{ github.sha }}
           SHORT_SHA: ${{ needs.resolve.outputs.short_sha }}
+          DEV_LABEL: ${{ needs.resolve.outputs.dev_label }}
         run: |
           set -euo pipefail
-          ROLLING_TITLE="Rolling :dev (dev-${SHORT_SHA})"
+          ROLLING_TITLE="Rolling :dev (${DEV_LABEL})"
           ROLLING_NOTES="Unversioned development snapshot from \`main\` at [\`${SHORT_SHA}\`](https://github.com/${{ github.repository }}/commit/${RELEASE_SHA}). Not a release candidate — use for testing only."
           if gh release view dev --repo "${{ github.repository }}" >/dev/null 2>&1; then
             gh release edit dev \
@@ -86,6 +90,7 @@ jobs:
 
   announce-dev:
     needs:
+      - resolve
       - build
       - tag-dev
       - assets
@@ -99,6 +104,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHA: ${{ github.sha }}
           PREVIOUS_SHA: ${{ needs.tag-dev.outputs.previous_sha }}
+          DEV_LABEL: ${{ needs.resolve.outputs.dev_label }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -107,7 +113,6 @@ jobs:
             exit 1
           fi
 
-          SHORT_SHA="${SHA:0:7}"
           BASE_LABEL="Changes since last dev build"
           if [ -n "${PREVIOUS_SHA}" ] && [ "${PREVIOUS_SHA}" != "${SHA}" ]; then
             CHANGELOG=$(gh api "repos/${REPO}/compare/${PREVIOUS_SHA}...${SHA}" \
@@ -122,8 +127,8 @@ jobs:
             CHANGELOG="- (no new commits since last dev build)"
           fi
 
-          ANNOUNCEMENT_BODY=$(printf '🛠️ **Dev Branch Update** (version `dev-%s`)\nRelease and downloads: https://github.com/%s/releases/tag/dev\n\n%s\n%s' \
-            "${SHORT_SHA}" "${REPO}" "${BASE_LABEL}" "${CHANGELOG}")
+          ANNOUNCEMENT_BODY=$(printf '🛠️ **Dev Branch Update** (version `%s`)\nRelease and downloads: https://github.com/%s/releases/tag/dev\n\n%s\n%s' \
+            "${DEV_LABEL}" "${REPO}" "${BASE_LABEL}" "${CHANGELOG}")
 
           MAX_LEN=1900
           if [ "${#ANNOUNCEMENT_BODY}" -gt "${MAX_LEN}" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,14 @@ jobs:
       minor: ${{ steps.release.outputs.minor }}
       patch: ${{ steps.release.outputs.patch }}
       sha: ${{ steps.release.outputs.sha }}
+      dev_label: ${{ steps.vars.outputs.dev_label }}
     permissions:
       contents: write
       pull-requests: write
     steps:
+      - id: vars
+        run: echo "dev_label=dev-$(date -u +%y%m%d.%H%M)" >> "$GITHUB_OUTPUT"
+
       - name: Create release
         uses: googleapis/release-please-action@v5
         id: release
@@ -43,6 +47,7 @@ jobs:
       minor: ${{ steps.vars.outputs.minor }}
       patch: ${{ steps.vars.outputs.patch }}
       ref: ${{ steps.vars.outputs.ref }}
+      dev_label: ${{ steps.vars.outputs.dev_label }}
     steps:
       - name: Resolve version and tag
         id: vars
@@ -64,6 +69,7 @@ jobs:
           echo "minor=${MINOR}" >> "$GITHUB_OUTPUT"
           echo "patch=${PATCH}" >> "$GITHUB_OUTPUT"
           echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+          echo "dev_label=dev-$(date -u +%y%m%d.%H%M)" >> "$GITHUB_OUTPUT"
 
   deploy:
     if: github.event_name == 'push' && needs.release-please.outputs.release_created == 'true'
@@ -125,10 +131,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_SHA: ${{ needs.release-please.outputs.sha }}
           VERSION: v${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}.${{ needs.release-please.outputs.patch }}
+          DEV_LABEL: ${{ needs.release-please.outputs.dev_label }}
         run: |
           set -euo pipefail
           SHORT_SHA="${RELEASE_SHA:0:7}"
-          DEV_LABEL="dev-$(date -u +%y%m%d.%H%M)"
           ROLLING_TITLE="Rolling :dev (${DEV_LABEL})"
           ROLLING_NOTES="Unversioned development snapshot from \`main\` at [\`${SHORT_SHA}\`](https://github.com/${{ github.repository }}/commit/${RELEASE_SHA}). Currently identical to [$VERSION](https://github.com/${{ github.repository }}/releases/tag/$VERSION)."
           if gh release view dev --repo "${{ github.repository }}" >/dev/null 2>&1; then
@@ -206,11 +212,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_REF: ${{ needs.resolve-version.outputs.ref }}
+          DEV_LABEL: ${{ needs.resolve-version.outputs.dev_label }}
         run: |
           set -euo pipefail
           RELEASE_SHA=$(gh api "repos/${{ github.repository }}/commits/${RELEASE_REF}" --jq .sha)
           SHORT_SHA="${RELEASE_SHA:0:7}"
-          DEV_LABEL="dev-$(date -u +%y%m%d.%H%M)"
           ROLLING_TITLE="Rolling :dev (${DEV_LABEL})"
           ROLLING_NOTES="Unversioned development snapshot from \`main\` at [\`${SHORT_SHA}\`](https://github.com/${{ github.repository }}/commit/${RELEASE_SHA}). Currently identical to [$RELEASE_REF](https://github.com/${{ github.repository }}/releases/tag/$RELEASE_REF)."
           if gh release view dev --repo "${{ github.repository }}" >/dev/null 2>&1; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,8 @@ jobs:
         run: |
           set -euo pipefail
           SHORT_SHA="${RELEASE_SHA:0:7}"
-          ROLLING_TITLE="Rolling :dev (dev-${SHORT_SHA})"
+          DEV_LABEL="dev-$(date -u +%y%m%d.%H%M)"
+          ROLLING_TITLE="Rolling :dev (${DEV_LABEL})"
           ROLLING_NOTES="Unversioned development snapshot from \`main\` at [\`${SHORT_SHA}\`](https://github.com/${{ github.repository }}/commit/${RELEASE_SHA}). Currently identical to [$VERSION](https://github.com/${{ github.repository }}/releases/tag/$VERSION)."
           if gh release view dev --repo "${{ github.repository }}" >/dev/null 2>&1; then
             gh release edit dev \
@@ -209,7 +210,8 @@ jobs:
           set -euo pipefail
           RELEASE_SHA=$(gh api "repos/${{ github.repository }}/commits/${RELEASE_REF}" --jq .sha)
           SHORT_SHA="${RELEASE_SHA:0:7}"
-          ROLLING_TITLE="Rolling :dev (dev-${SHORT_SHA})"
+          DEV_LABEL="dev-$(date -u +%y%m%d.%H%M)"
+          ROLLING_TITLE="Rolling :dev (${DEV_LABEL})"
           ROLLING_NOTES="Unversioned development snapshot from \`main\` at [\`${SHORT_SHA}\`](https://github.com/${{ github.repository }}/commit/${RELEASE_SHA}). Currently identical to [$RELEASE_REF](https://github.com/${{ github.repository }}/releases/tag/$RELEASE_REF)."
           if gh release view dev --repo "${{ github.repository }}" >/dev/null 2>&1; then
             gh release edit dev \


### PR DESCRIPTION
## Summary

- Dev releases are now labeled `dev-{YYMMDD.HHMM}` (UTC, e.g. `dev-260825.1407`) instead of `dev-{commit}`.
- The label is computed once per workflow run in the `resolve` job of `refresh-dev.yml` and `cut-prerelease.yml` (and inline in `release.yml`'s dev-release jobs), so the baked-in `NZBDAV_VERSION`, the rolling `dev` release title, and the Discord announcement all show the same label.
- The commit SHA remains linked in the rolling release notes, and `NZBDAV_COMMIT_SHA` still bakes the real commit into the image, so traceability is unchanged.

## Test plan

- [x] YAML parses cleanly for all three edited workflows
- [x] Label format verified locally: `date -u +%y%m%d.%H%M` produces `260825.1415`-style output
- [ ] Run **Actions → Refresh :dev** after merge and confirm the image version, rolling release title, and Discord post all show the timestamped label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Development builds and rolling releases now use clear UTC timestamp-based labels (`dev-YYMMDD.HHMM`).
  * Development release announcements consistently display the matching timestamped label.
  * Automatic and manual development releases now follow the same labeling format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->