### PR TITLE
chore(ci): Discord release announcements rewritten as user-friendly summaries

### DIFF
--- a/.github/scripts/summarize-release-notes.sh
+++ b/.github/scripts/summarize-release-notes.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Summarize conventional-commit release notes into user-friendly Discord
+# announcement text via the OpenAI chat completions API.
+#
+# Input:  raw notes on stdin (one conventional-commit subject per line).
+# Args:   --type stable|rc|dev   release channel, for prompt context
+#         --version <tag>        version/tag, for prompt context
+# Env:    OPENAI_API_KEY (required; absence exits 1 with an Actions notice)
+#         OPENAI_MODEL   (optional; default gpt-5-mini)
+#
+# Output: summarized notes on stdout. Every failure exits non-zero with empty
+# stdout so callers can fall back to posting the raw commit list.
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 --type stable|rc|dev --version <tag> < raw-notes" >&2
+}
+
+fail() {
+  echo "::notice::$1 Falling back to raw release notes." >&2
+  exit 1
+}
+
+TYPE=""
+VERSION=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --type) TYPE="${2:-}"; shift 2 ;;
+    --version) VERSION="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+case "$TYPE" in
+  stable|rc|dev) ;;
+  *) echo "--type must be stable, rc, or dev" >&2; usage; exit 2 ;;
+esac
+[[ -n "$VERSION" ]] || { echo "--version is required" >&2; usage; exit 2; }
+
+if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+  echo "::notice::OPENAI_API_KEY is not set; skipping LLM release-notes summary." >&2
+  exit 1
+fi
+
+MODEL="${OPENAI_MODEL:-gpt-5-mini}"
+MAX_INPUT_CHARS=8000
+MAX_OUTPUT_CHARS=1500
+
+NOTES=$(cat)
+NOTES="${NOTES:0:${MAX_INPUT_CHARS}}"
+if [[ -z "${NOTES//[[:space:]]/}" ]]; then
+  fail "No release notes provided on stdin."
+fi
+
+case "$TYPE" in
+  stable) CHANNEL_DESC="a stable release announced to all users" ;;
+  rc) CHANNEL_DESC="a release candidate announced to testers" ;;
+  dev) CHANNEL_DESC="a rolling development snapshot announced to testers" ;;
+esac
+
+SYSTEM_PROMPT=$(cat <<'EOF'
+You write Discord release announcements for InfiniDysk, a WebDAV server that mounts NZB documents as a virtual filesystem and streams content directly from Usenet, acting as a drop-in SABnzbd download client for Sonarr, Radarr, and similar tools. Your readers run the Docker image and have no knowledge of the codebase.
+
+You are given conventional-commit messages (feat/fix/chore with scopes). Rewrite them as release notes for end users.
+
+Rules:
+- Group changes into short bold-labeled sections: **New**, **Improved**, **Fixed**, and **Before you upgrade** (only when breaking changes or required upgrade actions are present).
+- Describe what the user will notice or be able to do, never what code changed. Drop type(scope): prefixes, commit hashes, PR numbers, and issue references.
+- Omit chore/ci/docs/test commits and dependency bumps with no user-visible effect.
+- Use only Discord-supported markdown: **bold**, *italic*, __underline__, ~~strikethrough~~, - bullets, > quotes, inline `code`, masked links [label](url). Never use tables, images, HTML tags, task lists, # headings, or horizontal rules.
+- No @mentions.
+- Keep the whole output under 1200 characters.
+- Output only the release notes: no preamble, no sign-off, no code fences.
+EOF
+)
+
+USER_PROMPT=$(printf 'This is %s (version %s).\n\nCommits:\n%s' "$CHANNEL_DESC" "$VERSION" "$NOTES")
+
+PAYLOAD=$(jq -n \
+  --arg model "$MODEL" \
+  --arg system "$SYSTEM_PROMPT" \
+  --arg user "$USER_PROMPT" \
+  '{model: $model, messages: [{role: "system", content: $system}, {role: "user", content: $user}], max_completion_tokens: 2000}')
+
+if ! RESPONSE=$(curl --fail-with-body -sS --max-time 60 \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${OPENAI_API_KEY}" \
+  -d "$PAYLOAD" \
+  "https://api.openai.com/v1/chat/completions"); then
+  fail "OpenAI summarization request failed."
+fi
+
+if ! SUMMARY=$(jq -r '.choices[0].message.content // empty' <<< "$RESPONSE"); then
+  fail "Could not parse the OpenAI response."
+fi
+
+# Defensive cleanup in case the model wraps the notes in a code fence.
+SUMMARY=$(printf '%s\n' "$SUMMARY" | sed -e '1{/^```/d;}' -e '${/^```$/d;}')
+SUMMARY="${SUMMARY#"${SUMMARY%%[![:space:]]*}"}"
+SUMMARY="${SUMMARY%"${SUMMARY##*[![:space:]]}"}"
+
+[[ -n "$SUMMARY" ]] || fail "OpenAI returned an empty summary."
+(( ${#SUMMARY} <= MAX_OUTPUT_CHARS )) || fail "Summary exceeded ${MAX_OUTPUT_CHARS} characters (${#SUMMARY})."
+if grep -qE '</?[a-zA-Z][^>]*>' <<< "$SUMMARY"; then
+  fail "Summary contained HTML tags, which Discord does not render."
+fi
+if grep -qE '^[[:space:]]*\|.*\|' <<< "$SUMMARY"; then
+  fail "Summary contained a markdown table, which Discord does not render."
+fi
+
+printf '%s\n' "$SUMMARY"

--- a/.github/workflows/cut-prerelease.yml
+++ b/.github/workflows/cut-prerelease.yml
@@ -202,9 +202,14 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
       - name: Post release candidate to Discord
         env:
           DISCORD_DEVELOPMENT_WEBHOOK_URL: ${{ secrets.DISCORD_DEVELOPMENT_WEBHOOK_URL }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
           SHA: ${{ needs.resolve.outputs.sha }}
@@ -231,8 +236,18 @@ jobs:
             CHANGELOG="- (no new commits since last release candidate)"
           fi
 
-          ANNOUNCEMENT_BODY=$(printf '🧪 **Release Candidate Available** (`%s`)\nRelease and downloads: https://github.com/%s/releases/tag/%s\n\n%s\n%s' \
-            "${RELEASE_TAG}" "${REPO}" "${RELEASE_TAG}" "${BASE_LABEL}" "${CHANGELOG}")
+          SUMMARY=""
+          if [ "${CHANGELOG}" != "- (no new commits since last release candidate)" ] \
+            && [ "${CHANGELOG}" != "- No previous release candidate to compare" ]; then
+            SUMMARY=$(printf '%s\n' "${CHANGELOG}" | bash .github/scripts/summarize-release-notes.sh --type rc --version "${RELEASE_TAG}" || true)
+          fi
+          if [ -n "${SUMMARY}" ]; then
+            ANNOUNCEMENT_BODY=$(printf '🧪 **Release Candidate Available** (`%s`)\nRelease and downloads: https://github.com/%s/releases/tag/%s\n\n%s' \
+              "${RELEASE_TAG}" "${REPO}" "${RELEASE_TAG}" "${SUMMARY}")
+          else
+            ANNOUNCEMENT_BODY=$(printf '🧪 **Release Candidate Available** (`%s`)\nRelease and downloads: https://github.com/%s/releases/tag/%s\n\n%s\n%s' \
+              "${RELEASE_TAG}" "${REPO}" "${RELEASE_TAG}" "${BASE_LABEL}" "${CHANGELOG}")
+          fi
 
           MAX_LEN=1900
           if [ "${#ANNOUNCEMENT_BODY}" -gt "${MAX_LEN}" ]; then

--- a/.github/workflows/refresh-dev.yml
+++ b/.github/workflows/refresh-dev.yml
@@ -93,9 +93,14 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
       - name: Post :dev refresh to Discord
         env:
           DISCORD_DEVELOPMENT_WEBHOOK_URL: ${{ secrets.DISCORD_DEVELOPMENT_WEBHOOK_URL }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHA: ${{ github.sha }}
           PREVIOUS_SHA: ${{ needs.tag-dev.outputs.previous_sha }}
@@ -122,8 +127,18 @@ jobs:
             CHANGELOG="- (no new commits since last dev build)"
           fi
 
-          ANNOUNCEMENT_BODY=$(printf '🛠️ **Dev Branch Update** (version `dev-%s`)\nRelease and downloads: https://github.com/%s/releases/tag/dev\n\n%s\n%s' \
-            "${SHORT_SHA}" "${REPO}" "${BASE_LABEL}" "${CHANGELOG}")
+          SUMMARY=""
+          if [ "${CHANGELOG}" != "- (no new commits since last dev build)" ] \
+            && [ "${CHANGELOG}" != "- No previous dev build to compare" ]; then
+            SUMMARY=$(printf '%s\n' "${CHANGELOG}" | bash .github/scripts/summarize-release-notes.sh --type dev --version "dev-${SHORT_SHA}" || true)
+          fi
+          if [ -n "${SUMMARY}" ]; then
+            ANNOUNCEMENT_BODY=$(printf '🛠️ **Dev Branch Update** (version `dev-%s`)\nRelease and downloads: https://github.com/%s/releases/tag/dev\n\n%s' \
+              "${SHORT_SHA}" "${REPO}" "${SUMMARY}")
+          else
+            ANNOUNCEMENT_BODY=$(printf '🛠️ **Dev Branch Update** (version `dev-%s`)\nRelease and downloads: https://github.com/%s/releases/tag/dev\n\n%s\n%s' \
+              "${SHORT_SHA}" "${REPO}" "${BASE_LABEL}" "${CHANGELOG}")
+          fi
 
           MAX_LEN=1900
           if [ "${#ANNOUNCEMENT_BODY}" -gt "${MAX_LEN}" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,6 +347,8 @@ jobs:
       - name: Post announcement to Discord
         env:
           DISCORD_ANNOUNCEMENTS_WEBHOOK_URL: ${{ secrets.DISCORD_ANNOUNCEMENTS_WEBHOOK_URL }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
           VERSION: ${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}.${{ needs.release-please.outputs.patch }}
         run: |
           set -euo pipefail
@@ -369,7 +371,13 @@ jobs:
             -e 's/ \(\[[0-9a-f]+\]\(https:\/\/github\.com\/[^)]+\/commit\/[^)]+\)\)//g' \
             -e 's/, closes \[#[0-9]+\]\(https:\/\/github\.com\/[^)]+\/issues\/[0-9]+\)//g')
 
-          ANNOUNCEMENT_BODY=$(printf '🚀 **New Release: Version [%s]**%s' "${VERSION}" "${RELEASE_NOTES}")
+          SUMMARY=$(printf '%s' "${RELEASE_NOTES}" | bash .github/scripts/summarize-release-notes.sh --type stable --version "v${VERSION}" || true)
+          if [ -n "${SUMMARY}" ]; then
+            ANNOUNCEMENT_BODY=$(printf '🚀 **New Release: Version [%s]**\n%s\n\n[Full changelog](https://github.com/%s/releases/tag/v%s)' \
+              "${VERSION}" "${SUMMARY}" "${GITHUB_REPOSITORY}" "${VERSION}")
+          else
+            ANNOUNCEMENT_BODY=$(printf '🚀 **New Release: Version [%s]**%s' "${VERSION}" "${RELEASE_NOTES}")
+          fi
 
           # Discord content is limited to 2000 characters.
           MAX_LEN=1900

--- a/.github/workflows/test-discord-announcements.yml
+++ b/.github/workflows/test-discord-announcements.yml
@@ -7,6 +7,11 @@ on:
         description: Message to post to the announcements Discord channel
         required: true
         type: string
+      summarize:
+        description: Treat the message as conventional commits, summarize with the LLM, and post to the development channel instead
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -15,14 +20,31 @@ jobs:
   test-announcements-webhook:
     runs-on: ubuntu-latest
     steps:
-      - name: Post test message to Discord announcements
+      - name: Checkout repository
+        if: ${{ inputs.summarize }}
+        uses: actions/checkout@v7
+
+      - name: Post test message to Discord
         env:
           DISCORD_ANNOUNCEMENTS_WEBHOOK_URL: ${{ secrets.DISCORD_ANNOUNCEMENTS_WEBHOOK_URL }}
+          DISCORD_DEVELOPMENT_WEBHOOK_URL: ${{ secrets.DISCORD_DEVELOPMENT_WEBHOOK_URL }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
           MESSAGE: ${{ inputs.message }}
+          SUMMARIZE: ${{ inputs.summarize }}
         run: |
           set -euo pipefail
-          if [ -z "${DISCORD_ANNOUNCEMENTS_WEBHOOK_URL}" ]; then
-            echo "DISCORD_ANNOUNCEMENTS_WEBHOOK_URL secret is not set" >&2
+          WEBHOOK_URL="${DISCORD_ANNOUNCEMENTS_WEBHOOK_URL}"
+          if [ "${SUMMARIZE}" = "true" ]; then
+            WEBHOOK_URL="${DISCORD_DEVELOPMENT_WEBHOOK_URL}"
+            if ! SUMMARY=$(printf '%s' "${MESSAGE}" | bash .github/scripts/summarize-release-notes.sh --type dev --version "test"); then
+              echo "LLM summarization failed; nothing was posted." >&2
+              exit 1
+            fi
+            MESSAGE="${SUMMARY}"
+          fi
+          if [ -z "${WEBHOOK_URL}" ]; then
+            echo "Discord webhook URL secret for the selected channel is not set" >&2
             exit 1
           fi
           if [ -z "${MESSAGE}" ]; then
@@ -33,4 +55,4 @@ jobs:
           ESCAPED_BODY=$(printf '%s' "$MESSAGE" | jq -Rsa .)
           curl --fail-with-body -sS -H "Content-Type: application/json" \
             -d "{\"content\": ${ESCAPED_BODY}, \"flags\": 4}" \
-            "$DISCORD_ANNOUNCEMENTS_WEBHOOK_URL"
+            "$WEBHOOK_URL"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,9 +400,9 @@ Skip this handoff if there are no local changes and nothing to push or PR. Do no
 | `ci.yml` | PRs and pushes to `main` | Frontend lint/typecheck/build/tests + backend build/tests |
 | `docs.yml` | PRs and pushes to `main` | Zensical docs build (`zensical build --clean --strict`); deploys to GitHub Pages on `main` |
 | `codeql.yml` | PRs, pushes to `main`, and weekly schedule | CodeQL security analysis for C#, TypeScript, and GitHub Actions |
-| `refresh-dev.yml` | Manual `workflow_dispatch` | Publishes `ghcr.io/.../infinidysk:dev`, builds Linux archives, creates/updates the rolling `dev` GitHub pre-release, and moves the git `dev` tag to that commit (unversioned snapshot) |
-| `cut-prerelease.yml` | Manual `workflow_dispatch` | Creates numbered and rolling `rc` GitHub Pre-releases with Linux archives; pushes versioned RC tags to every registry and rolling `:rc`/`:dev` tags to canonical GHCR and Docker Hub; refreshes the rolling `dev` pre-release with the RC's archives; moves git `rc` and `dev` tags (`dev` first, so `rc` is never ahead of `dev`); announces to development Discord |
-| `release.yml` | Push to `main` | release-please versioning; publishes Linux archives and stable Docker tags to every registry, plus `dev` and `rc` tags to canonical GHCR and Docker Hub; refreshes the rolling `dev` pre-release; moves git `dev` and `rc` tags (`dev` first); deletes versioned `v*-rc.*` pre-releases and their image tags |
+| `refresh-dev.yml` | Manual `workflow_dispatch` | Publishes `ghcr.io/.../infinidysk:dev`, builds Linux archives, creates/updates the rolling `dev` GitHub pre-release, and moves the git `dev` tag to that commit (unversioned snapshot); announces LLM-summarized changes to the development Discord |
+| `cut-prerelease.yml` | Manual `workflow_dispatch` | Creates numbered and rolling `rc` GitHub Pre-releases with Linux archives; pushes versioned RC tags to every registry and rolling `:rc`/`:dev` tags to canonical GHCR and Docker Hub; refreshes the rolling `dev` pre-release with the RC's archives; moves git `rc` and `dev` tags (`dev` first, so `rc` is never ahead of `dev`); announces LLM-summarized changes to the development Discord |
+| `release.yml` | Push to `main` | release-please versioning; publishes Linux archives and stable Docker tags to every registry, plus `dev` and `rc` tags to canonical GHCR and Docker Hub; refreshes the rolling `dev` pre-release; moves git `dev` and `rc` tags (`dev` first); deletes versioned `v*-rc.*` pre-releases and their image tags; announces LLM-summarized release notes to the announcements Discord |
 | `release.yml` | Manual `workflow_dispatch` | Republishes Linux archives and stable Docker tags to every registry, plus `dev` and `rc` tags to canonical GHCR and Docker Hub, for an existing version; refreshes the rolling `dev` pre-release; moves git `dev` and `rc` tags (`dev` first); deletes versioned `v*-rc.*` pre-releases and their image tags |
 | `promote-lts.yml` | Manual `workflow_dispatch` | Moves git `lts` and GHCR `:lts` to an existing published version (no rebuild) |
 | `performance.yml` | Nightly cron (`17 5 * * *`) + `workflow_dispatch` | Streaming and SAB API report compare (deterministic + floored timing envelopes); optional re-baseline PR |
@@ -412,6 +412,8 @@ Skip this handoff if there are no local changes and nothing to push or PR. Do no
 | `move-movable-tag.yml` | Reusable (called by refresh-dev/cut-prerelease/release) | Force-moves a movable git tag (`dev`, `rc`, …) to a given commit |
 
 Docker image builds are shared via the reusable workflow. Branch and dependabot image pipelines were removed — PRs are validated by `ci.yml` instead of publishing throwaway images.
+
+Discord announcements in `release.yml`, `cut-prerelease.yml`, and `refresh-dev.yml` run the raw conventional-commit notes through `.github/scripts/summarize-release-notes.sh` (OpenAI chat completions) to post user-friendly summaries; the script enforces Discord's markdown subset and 2000-character cap. When the `OPENAI_API_KEY` secret is unset or the API call fails, the announcement falls back to the previous raw commit list. `OPENAI_MODEL` (repo variable, default `gpt-5-mini`) overrides the model. Use the **Test Discord Announcements** workflow with `summarize=true` to dry-run the summarizer against the development channel.
 
 ## Releases
 


### PR DESCRIPTION
## Summary
- Adds `.github/scripts/summarize-release-notes.sh`, a shared helper that sends raw conventional-commit notes to the OpenAI chat completions API and returns user-friendly release notes (grouped by New / Improved / Fixed / Before you upgrade) written in Discord's supported markdown subset and sized to stay under the 2000-character webhook cap.
- `release.yml`, `cut-prerelease.yml`, and `refresh-dev.yml` announcements now post the LLM summary (with a changelog/release link); any failure — missing `OPENAI_API_KEY`, API error, empty or off-contract output (HTML/tables/too long) — falls back to the exact raw-commit-list behavior we post today. No-new-commits placeholders skip the API call entirely.
- Extends **Test Discord Announcements** with a `summarize` input that dry-runs the summarizer against the development channel, so prompt tuning doesn't require cutting a release.

## Required setup
- Add the `OPENAI_API_KEY` repo secret (without it, announcements behave exactly as today).
- Optionally set the `OPENAI_MODEL` repo variable to override the default `gpt-5-mini`.

## Test plan
- [x] `bash -n` on the new script; YAML-parse all four workflows; `bash -n` on each modified `run:` block
- [x] Local dry-runs: missing key, empty stdin, invalid args, and a real 401 from a bogus key all exit non-zero with empty stdout (fallback verified)
- [ ] After merge + adding `OPENAI_API_KEY`: run **Test Discord Announcements** with `summarize=true` and confirm the summary lands in the development channel
- [ ] Watch the next **Refresh :dev** run for the real end-to-end path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release announcements now include concise, user-friendly summaries when available.
  - Development, prerelease, and production announcements can include generated highlights alongside links to full changelogs.
  - Announcement testing now supports optionally previewing summarized release notes.

- **Bug Fixes**
  - Announcements retain the existing changelog format when summaries cannot be generated, ensuring releases continue to publish reliably.

- **Documentation**
  - Added guidance for release-note summaries, formatting limits, fallback behavior, and testing announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->