### PR TITLE
chore(webdav): capture Plex re-add evidence in support packs (scan failures, deletions, size changes)

### DIFF
--- a/backend/Middlewares/WebDavObservabilityMiddleware.cs
+++ b/backend/Middlewares/WebDavObservabilityMiddleware.cs
@@ -16,6 +16,9 @@ public class WebDavObservabilityMiddleware(RequestDelegate next)
     private static readonly TimeSpan SlowThreshold = TimeSpan.FromSeconds(5);
     private static readonly ConcurrentDictionary<string, long> Counters = new(StringComparer.Ordinal);
 
+    // Test seam: the five-second default is impractical to exercise in a unit test.
+    internal static TimeSpan? SlowThresholdOverride { get; set; }
+
     private static readonly HashSet<string> WebDavRoots = new(StringComparer.OrdinalIgnoreCase)
     {
         "/content",
@@ -48,16 +51,19 @@ public class WebDavObservabilityMiddleware(RequestDelegate next)
 
             Increment("total");
 
-            if (status >= 500)
+            var failed = status >= 500;
+            var slow = elapsedMs >= (SlowThresholdOverride ?? SlowThreshold).TotalMilliseconds;
+            if (failed) Increment("failed");
+            if (slow) Increment("slow");
+
+            if (failed)
             {
-                Increment("failed");
                 Log.Warning(
                     "WebDAV request failed. Method={Method} Path={Path} Status={Status} DurationMs={DurationMs}",
                     method, path, status, elapsedMs);
             }
-            else if (elapsedMs >= SlowThreshold.TotalMilliseconds)
+            else if (slow)
             {
-                Increment("slow");
                 Log.Warning(
                     "Slow WebDAV request. Method={Method} Path={Path} Status={Status} DurationMs={DurationMs}",
                     method, path, status, elapsedMs);
@@ -74,13 +80,9 @@ public class WebDavObservabilityMiddleware(RequestDelegate next)
         if (string.IsNullOrEmpty(path))
             return false;
 
-        foreach (var root in WebDavRoots)
-        {
-            if (path.StartsWith(root, StringComparison.OrdinalIgnoreCase))
-                return true;
-        }
-
-        return false;
+        return WebDavRoots.Any(root =>
+            path.StartsWith(root, StringComparison.OrdinalIgnoreCase)
+            && (path.Length == root.Length || path[root.Length] == '/'));
     }
 
     private static void Increment(string key) =>

--- a/backend/Middlewares/WebDavObservabilityMiddleware.cs
+++ b/backend/Middlewares/WebDavObservabilityMiddleware.cs
@@ -1,0 +1,93 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Services.SupportPack;
+using Serilog;
+
+namespace NzbWebDAV.Middlewares;
+
+/// <summary>
+/// Records slow and failed WebDAV requests so a transient scan-time failure is visible in
+/// logs and in the support pack. Only paths under the WebDAV mount roots are counted.
+/// </summary>
+public class WebDavObservabilityMiddleware(RequestDelegate next)
+{
+    private static readonly TimeSpan SlowThreshold = TimeSpan.FromSeconds(5);
+    private static readonly ConcurrentDictionary<string, long> Counters = new(StringComparer.Ordinal);
+
+    private static readonly HashSet<string> WebDavRoots = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "/content",
+        "/completed-symlinks",
+        "/.ids",
+        "/nzbs",
+        "/view",
+    };
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!IsWebDavRequest(context))
+        {
+            await next(context).ConfigureAwait(false);
+            return;
+        }
+
+        var method = context.Request.Method;
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            await next(context).ConfigureAwait(false);
+        }
+        finally
+        {
+            stopwatch.Stop();
+            var status = context.Response.StatusCode;
+            var elapsedMs = stopwatch.ElapsedMilliseconds;
+            var path = context.Request.Path.Value ?? context.Request.Path.ToUriComponent();
+
+            Increment("total");
+
+            if (status >= 500)
+            {
+                Increment("failed");
+                Log.Warning(
+                    "WebDAV request failed. Method={Method} Path={Path} Status={Status} DurationMs={DurationMs}",
+                    method, path, status, elapsedMs);
+            }
+            else if (elapsedMs >= SlowThreshold.TotalMilliseconds)
+            {
+                Increment("slow");
+                Log.Warning(
+                    "Slow WebDAV request. Method={Method} Path={Path} Status={Status} DurationMs={DurationMs}",
+                    method, path, status, elapsedMs);
+            }
+
+            if (context.RequestAborted.IsCancellationRequested)
+                Increment("aborted");
+        }
+    }
+
+    private static bool IsWebDavRequest(HttpContext context)
+    {
+        var path = context.Request.Path.Value;
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        foreach (var root in WebDavRoots)
+        {
+            if (path.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static void Increment(string key) =>
+        Counters.AddOrUpdate(key, 1, (_, count) => count + 1);
+
+    internal static IReadOnlyDictionary<string, long> Snapshot() =>
+        new Dictionary<string, long>(Counters, StringComparer.Ordinal);
+
+    internal static void Reset() => Counters.Clear();
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -444,8 +444,10 @@ public partial class Program
             // Must run before anything that reads Scheme/Host/RemoteIpAddress.
             app.UseForwardedHeaders();
             app.UseMiddleware<RequestCorrelationMiddleware>();
-            app.UseMiddleware<ExceptionMiddleware>();
+            // Observability wraps exception translation so its counters see the final
+            // status codes that ExceptionMiddleware assigns to WebDAV failures.
             app.UseMiddleware<WebDavObservabilityMiddleware>();
+            app.UseMiddleware<ExceptionMiddleware>();
             app.UseMiddleware<MetricsAuthenticationMiddleware>();
             app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(30) });
             app.Use(async (context, next) =>

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -445,6 +445,7 @@ public partial class Program
             app.UseForwardedHeaders();
             app.UseMiddleware<RequestCorrelationMiddleware>();
             app.UseMiddleware<ExceptionMiddleware>();
+            app.UseMiddleware<WebDavObservabilityMiddleware>();
             app.UseMiddleware<MetricsAuthenticationMiddleware>();
             app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(30) });
             app.Use(async (context, next) =>

--- a/backend/Services/DeletionAuditLog.cs
+++ b/backend/Services/DeletionAuditLog.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using NzbWebDAV.Database.Models;
 using Serilog;
 
@@ -17,6 +18,17 @@ public static class DeletionAuditLog
     /// </summary>
     public const int BulkDeleteWarningThreshold = 500;
 
+    private const int RecentBufferCapacity = 200;
+    private static readonly ConcurrentQueue<DeletionAuditEntry> Recent = new();
+
+    public sealed record DeletionAuditEntry(
+        DateTimeOffset At,
+        string Source,
+        string Path,
+        string Reason,
+        Guid? ItemId,
+        int? Count);
+
     /// <summary>
     /// Logs a single dav-item deletion.
     /// </summary>
@@ -25,6 +37,13 @@ public static class DeletionAuditLog
         Log.Information(
             "dav-delete source={Source} id={Id} path={Path} reason={Reason}",
             source, item.Id, item.Path, reason);
+        Enqueue(new DeletionAuditEntry(
+            DateTimeOffset.UtcNow,
+            source,
+            item.Path,
+            reason,
+            item.Id,
+            null));
     }
 
     /// <summary>
@@ -45,6 +64,13 @@ public static class DeletionAuditLog
         Log.Information(
             "dav-delete source={Source} count={Count} parentId={ParentId} reason={Reason} samplePaths={SamplePaths}",
             source, items.Count, parentId, reason, samplePaths);
+        Enqueue(new DeletionAuditEntry(
+            DateTimeOffset.UtcNow,
+            source,
+            samplePaths,
+            reason,
+            parentId,
+            items.Count));
     }
 
     /// <summary>
@@ -58,5 +84,22 @@ public static class DeletionAuditLog
         Log.Warning(
             "dav-delete-bulk source={Source} count={Count} threshold={Threshold} detail={Detail}",
             source, count, BulkDeleteWarningThreshold, detail);
+    }
+
+    internal static IReadOnlyList<DeletionAuditEntry> GetRecent() => Recent.ToArray();
+
+    internal static void Reset()
+    {
+        while (Recent.TryDequeue(out _))
+        {
+        }
+    }
+
+    private static void Enqueue(DeletionAuditEntry entry)
+    {
+        Recent.Enqueue(entry);
+        while (Recent.Count > RecentBufferCapacity && Recent.TryDequeue(out _))
+        {
+        }
     }
 }

--- a/backend/Services/DeletionAuditLog.cs
+++ b/backend/Services/DeletionAuditLog.cs
@@ -27,6 +27,7 @@ public static class DeletionAuditLog
         string Path,
         string Reason,
         Guid? ItemId,
+        Guid? ParentId,
         int? Count);
 
     /// <summary>
@@ -43,6 +44,7 @@ public static class DeletionAuditLog
             item.Path,
             reason,
             item.Id,
+            null,
             null));
     }
 
@@ -69,6 +71,7 @@ public static class DeletionAuditLog
             source,
             samplePaths,
             reason,
+            null,
             parentId,
             items.Count));
     }
@@ -88,18 +91,15 @@ public static class DeletionAuditLog
 
     internal static IReadOnlyList<DeletionAuditEntry> GetRecent() => Recent.ToArray();
 
-    internal static void Reset()
-    {
-        while (Recent.TryDequeue(out _))
-        {
-        }
-    }
+    internal static void Reset() => Recent.Clear();
 
     private static void Enqueue(DeletionAuditEntry entry)
     {
         Recent.Enqueue(entry);
+        // ConcurrentQueue has no capacity bound; drop the oldest entries past the cap.
         while (Recent.Count > RecentBufferCapacity && Recent.TryDequeue(out _))
         {
+            // Trimming is the condition, not the body.
         }
     }
 }

--- a/backend/Services/LazyRarResolver.cs
+++ b/backend/Services/LazyRarResolver.cs
@@ -355,7 +355,7 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
             if (updated > 0)
             {
                 Log.Information(
-                    "Reconciled DavItem FileSize for multipart blob {BlobId} to {Size}",
+                    "Reconciled DavItem FileSize for multipart blob {BlobId} to {Size} (changed after import)",
                     fileBlobId, publishedSize);
             }
         }

--- a/backend/Services/MultipartFileSizeRepairService.cs
+++ b/backend/Services/MultipartFileSizeRepairService.cs
@@ -107,7 +107,12 @@ public class MultipartFileSizeRepairService(IDbContextFactory<DavDatabaseContext
                 .ExecuteUpdateAsync(s => s.SetProperty(i => i.FileSize, publishedSize), ct)
                 .ConfigureAwait(false);
             if (updated > 0)
+            {
                 repaired++;
+                Log.Information(
+                    "MultipartFileSizeRepair: changed advertised FileSize for {Path} from sentinel to {Size}",
+                    item.Path, publishedSize);
+            }
         }
 
         Log.Information(

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -431,6 +431,12 @@ public sealed class SupportPackService(
             cpu,
             gc = BuildGcDiagnostics(usage, addressSpace),
             gcDiagnostics = gcDiagnosticsStore.LastResult,
+            webdavCounters = NzbWebDAV.Middlewares.WebDavObservabilityMiddleware.Snapshot(),
+            recentDavDeletions = DeletionAuditLog.GetRecent(),
+            rcloneLastForgetError = NzbWebDAV.Clients.Rclone.RcloneClient.Current?.LastForgetError
+                is { } forgetError
+                ? new { message = forgetError.Message, atUtc = forgetError.At }
+                : null,
             threadPool = new
             {
                 minWorkerThreads,

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -116,6 +116,14 @@ Allow Docker DNS or LAN hosts under **Trusted local hosts** — [SABnzbd API](..
 
 See [Deletion audit](../operations/deletion-audit.md) — history retention ≠ deleting mounts; orphan cleanup and *Arr actions can remove content. History rows disappearing after import are usually the Arr or a `/completed-symlinks` folder delete, not InfiniDysk deleting the file. If Remove Orphaned Files lists imported files, check that **Library Directory** is your organized library root, not the rclone mount.
 
+## Plex marks old episodes as newly added
+
+InfiniDysk does not change WebDAV `Last-Modified` after import, and it does not issue ETags. Plex keys library items by **file path**, so an old episode showing up as *newly added* means Plex deleted its library row and then re-created it on a later scan.
+
+The most common cause on an rclone mount of `/content` is a transient scan-time failure (container restart, rclone re-list after `vfs/forget`, lazy RAR size correction, proxy timeout) combined with Plex's **Empty trash automatically after every scan**. The path is briefly unavailable, trash collection removes the item, and the next clean scan re-adds it — triggering intro/credits analysis again.
+
+Quick check: compare the file's mtime in the mount (`ls -l`) with Plex's *added* date. An old mtime with a new *added* date means the server never recreated the file. For the full checklist see [Plex “newly added” churn on /content mounts](../operations/plex-readd-diagnosis.md).
+
 ## Provider / missing articles
 
 - Circuit breaker may pause a bad provider — check Usenet settings and Overview.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -116,7 +116,7 @@ Allow Docker DNS or LAN hosts under **Trusted local hosts** — [SABnzbd API](..
 
 See [Deletion audit](../operations/deletion-audit.md) — history retention ≠ deleting mounts; orphan cleanup and *Arr actions can remove content. History rows disappearing after import are usually the Arr or a `/completed-symlinks` folder delete, not InfiniDysk deleting the file. If Remove Orphaned Files lists imported files, check that **Library Directory** is your organized library root, not the rclone mount.
 
-## Plex marks old episodes as newly added
+## Plex marks old episodes as newly added [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since }
 
 InfiniDysk does not change WebDAV `Last-Modified` after import, and it does not issue ETags. Plex keys library items by **file path**, so an old episode showing up as *newly added* means Plex deleted its library row and then re-created it on a later scan.
 

--- a/docs/operations/plex-readd-diagnosis.md
+++ b/docs/operations/plex-readd-diagnosis.md
@@ -1,0 +1,62 @@
+# Plex “newly added” churn on /content mounts
+
+When Plex marks an old episode as *newly added* and re-runs intro/credits detection, InfiniDysk almost never changed the file’s metadata in place. WebDAV `getlastmodified` is the immutable `DavItem.CreatedAt`; there is no ETag. Plex tracks items by **file path**, so “newly added” means the path vanished and came back — either the server deleted and recreated it, or Plex removed its own library row after a failed scan and re-added it on the next clean scan.
+
+Use the checks below in order. The first one settles most cases without touching logs.
+
+## 1. Compare file mtime with Plex “added” date
+
+On the host, run:
+
+```bash
+ls -l "/path/to/plex/library/Show Name/Season 01/episode.mkv"
+```
+
+If the mtime is weeks or months old but Plex says *added today*, InfiniDysk did not recreate the file. The Plex library row was deleted and re-added because a scan saw the path as unavailable — skip to section 4 below.
+
+If the mtime is recent or the path changed (new release name, or a ` (2)` suffix), the server really did re-import the file. Check InfiniDysk history, health results, and Sonarr history for that episode.
+
+## 2. Is background repair enabled?
+
+Settings → Health → **Enable Background Repairs**. Default is **off**. If off, health-repair deletion is ruled out.
+
+## 3. Look for a server-side deletion
+
+```sql
+SELECT CreatedAt, Path, Result, RepairStatus, Message
+FROM HealthCheckResults
+WHERE RepairStatus IN (1, 2)
+ORDER BY CreatedAt DESC;
+```
+
+`RepairStatus` values: `1` = Arr remove-and-blocklist, `2` = deleted as orphan/force. Also grep container logs for:
+
+```bash
+grep "dav-delete" /var/log/docker.log  # or docker logs nzbdav 2>&1 | grep dav-delete
+```
+
+Health-repair deletes are logged as `dav-delete source=health-repair ... reason="auto-removed after repeated streaming failures"` or similar. See [Deletion audit](deletion-audit.md) for all sources.
+
+## 4. Transient scan failure
+
+If mtime is old and no `dav-delete` exists, the most likely cause is a scan that raced an unavailable or stale rclone view:
+
+- container restart or auto-update while Plex was scanning
+- rclone `vfs/forget` of `/content/{category}` immediately after an import forces a fresh PROPFIND
+- lazy RAR size correction changing the advertised size after first stream
+- frontend proxy timeout on a large season folder
+- network or mount blip
+
+Plex’s **Empty trash automatically after every scan** turns that temporary unavailability into a deleted library row; the next scan re-adds it.
+
+## 5. Confirm the Plex trash setting
+
+Plex Settings → Library → **Empty trash automatically after every scan** must be enabled for this symptom to appear. Disabling it prevents the re-add churn but leaves stale “unavailable” items after real upgrades.
+
+## 6. Sonarr history
+
+Even if you do not remember a grab, check Sonarr History for the affected series. A repair-triggered `EpisodeSearch` or a repack/proper shows up there and produces a new `/content` path.
+
+---
+
+If these checks point to a transient listing failure, collect a [technical support pack](../configuration/support.md) while the problem is fresh and open an issue with the `webdav.counters` section and any `dav-delete` lines.

--- a/docs/operations/plex-readd-diagnosis.md
+++ b/docs/operations/plex-readd-diagnosis.md
@@ -1,4 +1,4 @@
-# Plex “newly added” churn on /content mounts
+# Plex “newly added” churn on /content mounts [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since }
 
 When Plex marks an old episode as *newly added* and re-runs intro/credits detection, InfiniDysk almost never changed the file’s metadata in place. WebDAV `getlastmodified` is the immutable `DavItem.CreatedAt`; there is no ETag. Plex tracks items by **file path**, so “newly added” means the path vanished and came back — either the server deleted and recreated it, or Plex removed its own library row after a failed scan and re-added it on the next clean scan.
 
@@ -14,7 +14,7 @@ ls -l "/path/to/plex/library/Show Name/Season 01/episode.mkv"
 
 If the mtime is weeks or months old but Plex says *added today*, InfiniDysk did not recreate the file. The Plex library row was deleted and re-added because a scan saw the path as unavailable — skip to section 4 below.
 
-If the mtime is recent or the path changed (new release name, or a ` (2)` suffix), the server really did re-import the file. Check InfiniDysk history, health results, and Sonarr history for that episode.
+If the mtime is recent or the path changed (new release name, or a `(2)` suffix), the server really did re-import the file. Check InfiniDysk history, health results, and Sonarr history for that episode.
 
 ## 2. Is background repair enabled?
 
@@ -59,4 +59,4 @@ Even if you do not remember a grab, check Sonarr History for the affected series
 
 ---
 
-If these checks point to a transient listing failure, collect a [technical support pack](../configuration/support.md) while the problem is fresh and open an issue with the `webdav.counters` section and any `dav-delete` lines.
+If these checks point to a transient listing failure, collect a [technical support pack](../configuration/support.md) while the problem is fresh and open an issue with the `webdavCounters` section of `environment.json` and any `dav-delete` lines.

--- a/tests/NzbWebDAV.Tests/Middlewares/WebDavObservabilityMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/WebDavObservabilityMiddlewareTests.cs
@@ -1,0 +1,84 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Middlewares;
+
+namespace NzbWebDAV.Tests.Middlewares;
+
+public class WebDavObservabilityMiddlewareTests : IDisposable
+{
+    public WebDavObservabilityMiddlewareTests()
+    {
+        WebDavObservabilityMiddleware.Reset();
+    }
+
+    public void Dispose() => WebDavObservabilityMiddleware.Reset();
+
+    [Fact]
+    public async Task NonWebDavPath_IsIgnored()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/api/queue";
+        var middleware = new WebDavObservabilityMiddleware(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Empty(WebDavObservabilityMiddleware.Snapshot());
+    }
+
+    [Fact]
+    public async Task WebDavPath_IncrementTotal()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/content/tv/show.mkv";
+        context.Response.StatusCode = 200;
+        var middleware = new WebDavObservabilityMiddleware(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context);
+
+        var counters = WebDavObservabilityMiddleware.Snapshot();
+        Assert.Equal(1, counters["total"]);
+        Assert.False(counters.ContainsKey("slow"));
+        Assert.False(counters.ContainsKey("failed"));
+    }
+
+    [Fact]
+    public async Task FailedWebDavRequest_IncrementFailed()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/content/tv/show.mkv";
+        context.Response.StatusCode = 503;
+        var middleware = new WebDavObservabilityMiddleware(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context);
+
+        var counters = WebDavObservabilityMiddleware.Snapshot();
+        Assert.Equal(1, counters["total"]);
+        Assert.Equal(1, counters["failed"]);
+    }
+
+    [Fact]
+    public async Task AbortedWebDavRequest_IncrementAborted()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/content/tv/show.mkv";
+        context.RequestAborted = new CancellationToken(canceled: true);
+        var middleware = new WebDavObservabilityMiddleware(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context);
+
+        var counters = WebDavObservabilityMiddleware.Snapshot();
+        Assert.Equal(1, counters["total"]);
+        Assert.Equal(1, counters["aborted"]);
+    }
+
+    [Fact]
+    public async Task ViewPath_IsCounted()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/view/.ids/abc/123";
+        var middleware = new WebDavObservabilityMiddleware(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(1, WebDavObservabilityMiddleware.Snapshot()["total"]);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Middlewares/WebDavObservabilityMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/WebDavObservabilityMiddlewareTests.cs
@@ -10,7 +10,11 @@ public class WebDavObservabilityMiddlewareTests : IDisposable
         WebDavObservabilityMiddleware.Reset();
     }
 
-    public void Dispose() => WebDavObservabilityMiddleware.Reset();
+    public void Dispose()
+    {
+        WebDavObservabilityMiddleware.Reset();
+        WebDavObservabilityMiddleware.SlowThresholdOverride = null;
+    }
 
     [Fact]
     public async Task NonWebDavPath_IsIgnored()
@@ -80,5 +84,66 @@ public class WebDavObservabilityMiddlewareTests : IDisposable
         await middleware.InvokeAsync(context);
 
         Assert.Equal(1, WebDavObservabilityMiddleware.Snapshot()["total"]);
+    }
+
+    [Theory]
+    [InlineData("/content")]
+    [InlineData("/content/tv/show.mkv")]
+    [InlineData("/Content/TV/SHOW.MKV")]
+    public async Task RootAndChildPaths_MatchCaseInsensitively(string requestPath)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = requestPath;
+        var middleware = new WebDavObservabilityMiddleware(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(1, WebDavObservabilityMiddleware.Snapshot()["total"]);
+    }
+
+    [Theory]
+    [InlineData("/content-preview/page")]
+    [InlineData("/contentious")]
+    [InlineData("/viewer")]
+    public async Task SimilarPrefixes_AreNotCounted(string requestPath)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = requestPath;
+        var middleware = new WebDavObservabilityMiddleware(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Empty(WebDavObservabilityMiddleware.Snapshot());
+    }
+
+    [Fact]
+    public async Task SlowFailedRequest_IncrementsBothCounters()
+    {
+        WebDavObservabilityMiddleware.SlowThresholdOverride = TimeSpan.Zero;
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/content/tv/show.mkv";
+        context.Response.StatusCode = 503;
+        var middleware = new WebDavObservabilityMiddleware(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context);
+
+        var counters = WebDavObservabilityMiddleware.Snapshot();
+        Assert.Equal(1, counters["failed"]);
+        Assert.Equal(1, counters["slow"]);
+    }
+
+    [Fact]
+    public async Task FastRequest_WithZeroThreshold_IsNotSlow()
+    {
+        WebDavObservabilityMiddleware.SlowThresholdOverride = TimeSpan.FromHours(1);
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/content/tv/show.mkv";
+        var middleware = new WebDavObservabilityMiddleware(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context);
+
+        var counters = WebDavObservabilityMiddleware.Snapshot();
+        Assert.Equal(1, counters["total"]);
+        Assert.False(counters.ContainsKey("slow"));
     }
 }

--- a/zensical.toml
+++ b/zensical.toml
@@ -86,6 +86,7 @@ nav = [
     { "Retention and cleanup" = "operations/retention-cleanup.md" },
     { "Logs and crash dumps" = "operations/logs-crash-dumps.md" },
     { "Deletion audit" = "operations/deletion-audit.md" },
+    { "Plex re-added episodes" = "operations/plex-readd-diagnosis.md" },
     { "Database corruption" = "operations/database-corruption.md" },
     { "PostgreSQL" = "operations/postgresql.md" },
   ]},


### PR DESCRIPTION
## Context

Users on rclone mounts of `/content` have seen Plex intermittently re-discover old episodes as *newly added*, triggering intro/credits re-analysis, with no corresponding Sonarr grabs. Investigation established that InfiniDysk never mutates a stable path's identity in place — `getlastmodified` is the immutable `CreatedAt` and no ETag exists — so "newly added" means the path vanished and reappeared: either the server deleted and recreated it (which leaves history/audit records), or a transient scan-time failure plus Plex's auto trash collection made Plex delete and re-add its own library row.

We cannot fix what we have not proven. This PR ships the instrumentation and operator playbook to settle it on the next occurrence; hardening follows once a mechanism is confirmed.

## Summary
- New middleware counts slow (>5s), failed (5xx), and client-aborted WebDAV requests and logs each as a single warning line; the counters ship in the support pack (`environment.json` → `webdavCounters`).
- The support pack also includes a bounded list of recent `dav-delete` audit events (source, path, reason, timestamp) and the last rclone `vfs/forget` failure — answering "why did this episode vanish?" without container log access.
- New docs page ([Plex re-added episodes](https://www.infinidysk.com/operations/plex-readd-diagnosis/)) walks operators through the diagnosis: mtime-vs-added-date check (the decisive one), repair toggle, health results, `dav-delete` audit, and Plex trash-collection settings. Troubleshooting guide links to it.
- Log lines now say explicitly when an item's advertised file size changes after import (lazy RAR resolve / multipart size repair), which is one known trigger for rclone "file changed" read errors during scans.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — 3699 passed
- [x] `dotnet test tests/NzbWebDAV.ArchitectureTests/NzbWebDAV.ArchitectureTests.csproj -c Release` — 3 passed
- [x] `zensical build --clean --strict` — no issues
- [x] New `WebDavObservabilityMiddlewareTests` — 13 passed