### PR TITLE
chore(dumb): expose a database contract file for SQLite-to-PostgreSQL migrators

### DIFF
--- a/backend/Database/DatabaseContractWriter.cs
+++ b/backend/Database/DatabaseContractWriter.cs
@@ -1,0 +1,179 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Config;
+using Serilog;
+
+namespace NzbWebDAV.Database;
+
+/// <summary>
+/// Writes a machine-readable database contract (<c>db-contract.json</c>) to CONFIG_PATH
+/// after migration events, so external migrators (e.g. DUMB's SQLite-to-PostgreSQL
+/// migrator) can pin against the exact applied migration history instead of
+/// reverse-engineering schema identity from __EFMigrationsHistory, backup manifests,
+/// or the app version. The top-level fields describe the main database; the
+/// <c>databases</c> map carries every database the runtime owns.
+/// </summary>
+internal static class DatabaseContractWriter
+{
+    internal const string ContractVersion = "infinidysk-db-v1";
+    internal const string ContractFileName = "db-contract.json";
+
+    // Runtime tables that are not part of the stable schema. RemoveUnlinkedFilesTask
+    // recreates TMP_LINKED_FILES on every orphan-cleanup pass, and TMP_LINKED_FILES_UNIQUE
+    // can be stranded when a run dies between CREATE and RENAME.
+    private static readonly string[] MainTransientObjects = ["TMP_LINKED_FILES", "TMP_LINKED_FILES_UNIQUE"];
+
+    // Test seams (same pattern as UsenetMigrationStore).
+    internal static Func<DavDatabaseContext> MainContextFactory { get; set; } =
+        static () => new DavDatabaseContext();
+
+    internal static Func<MetricsDbContext> MetricsContextFactory { get; set; } =
+        static () => new MetricsDbContext();
+
+    internal static Func<UsenetMigrationDbContext> UsenetMigrationContextFactory { get; set; } =
+        static () => new UsenetMigrationDbContext();
+
+    internal static Func<string> UsenetMigrationDatabaseFilePath { get; set; } =
+        static () => UsenetMigrationDbContext.DatabaseFilePath;
+
+    internal static Func<string> ContractFilePath { get; set; } =
+        static () => Path.Join(DavDatabaseContext.ConfigPath, ContractFileName);
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+
+    /// <summary>
+    /// Writes the contract file. Never throws: the contract is informational and must
+    /// not block startup or the usenet-migration wizard.
+    /// </summary>
+    public static async Task WriteAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            await WriteCoreAsync(ct).ConfigureAwait(false);
+        }
+        catch (Exception e) when (e is not OutOfMemoryException)
+        {
+            Log.Warning("Could not write database contract file to {Path}: {Reason}", ContractFilePath(), e.Message);
+            Log.Debug(e, "Database contract write failure stack");
+        }
+    }
+
+    private static async Task WriteCoreAsync(CancellationToken ct)
+    {
+        var provider = DatabaseProviderConfig.IsPostgres ? "postgres" : "sqlite";
+
+        DatabaseContractEntry main;
+        await using (var context = MainContextFactory())
+            main = await ReadEntryAsync(context, provider, MainTransientObjects, ct).ConfigureAwait(false);
+
+        DatabaseContractEntry metrics;
+        await using (var context = MetricsContextFactory())
+            metrics = await ReadEntryAsync(context, "sqlite", [], ct).ConfigureAwait(false);
+
+        // The usenet-migration ledger is created lazily by UsenetMigrationStore, which
+        // treats file existence as meaningful state — never create it as a side effect.
+        var usenetMigration = new DatabaseContractEntry("sqlite", null, 0, null, []);
+        if (File.Exists(UsenetMigrationDatabaseFilePath()))
+        {
+            await using var context = UsenetMigrationContextFactory();
+            usenetMigration = await ReadEntryAsync(context, "sqlite", [], ct).ConfigureAwait(false);
+        }
+
+        var contract = new DatabaseContract(
+            ContractVersion,
+            ConfigManager.AppVersion,
+            DateTime.UtcNow.ToString("O"),
+            main.Provider,
+            main.TerminalMigration,
+            main.MigrationCount,
+            main.MigrationHistoryHash,
+            main.TransientObjects,
+            new Dictionary<string, DatabaseContractEntry>
+            {
+                ["main"] = main,
+                ["metrics"] = metrics,
+                ["usenetMigration"] = usenetMigration,
+            });
+
+        WriteFileAtomically(ContractFilePath(), JsonSerializer.Serialize(contract, SerializerOptions));
+    }
+
+    private static async Task<DatabaseContractEntry> ReadEntryAsync(
+        DbContext context,
+        string provider,
+        string[] transientObjects,
+        CancellationToken ct)
+    {
+        var applied = await context.Database.GetAppliedMigrationsAsync(ct).ConfigureAwait(false);
+        var sorted = applied.OrderBy(id => id, StringComparer.Ordinal).ToList();
+        return new DatabaseContractEntry(
+            provider,
+            sorted.LastOrDefault(),
+            sorted.Count,
+            ComputeHistoryHash(sorted),
+            transientObjects);
+    }
+
+    private static string ComputeHistoryHash(IReadOnlyCollection<string> sortedMigrationIds)
+    {
+        var payload = string.Join('\n', sortedMigrationIds);
+        return "sha256:" + Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(payload))).ToLowerInvariant();
+    }
+
+    private static void WriteFileAtomically(string finalPath, string json)
+    {
+        var directory = Path.GetDirectoryName(finalPath)!;
+
+        foreach (var stale in Directory.EnumerateFiles(directory, "db-contract.*.tmp"))
+        {
+            try
+            {
+                File.Delete(stale);
+            }
+            catch
+            {
+                // best effort — stale temp files from a crashed write.
+            }
+        }
+
+        // Replace-by-rename only needs write permission on the directory, so a
+        // root-owned db-contract.json left by a previous install can never block an
+        // upgrade or reinstall. The temp file is chmodded before the rename so the
+        // contract is world-readable (DUMB may read it as another user) from the
+        // moment it appears at the final path.
+        var tempPath = Path.Join(directory, $"db-contract.{Guid.NewGuid():N}.tmp");
+        File.WriteAllText(tempPath, json, new UTF8Encoding(false));
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(tempPath,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite |
+                UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+        }
+
+        File.Move(tempPath, finalPath, overwrite: true);
+    }
+
+    private sealed record DatabaseContractEntry(
+        string Provider,
+        string? TerminalMigration,
+        int MigrationCount,
+        string? MigrationHistoryHash,
+        string[] TransientObjects);
+
+    private sealed record DatabaseContract(
+        string Contract,
+        string AppVersion,
+        string GeneratedAtUtc,
+        string Provider,
+        string? TerminalMigration,
+        int MigrationCount,
+        string? MigrationHistoryHash,
+        string[] TransientObjects,
+        Dictionary<string, DatabaseContractEntry> Databases);
+}

--- a/backend/Database/DatabaseContractWriter.cs
+++ b/backend/Database/DatabaseContractWriter.cs
@@ -27,7 +27,9 @@ internal static class DatabaseContractWriter
 
     // Test seams (same pattern as UsenetMigrationStore).
     internal static Func<DavDatabaseContext> MainContextFactory { get; set; } =
-        static () => new DavDatabaseContext();
+        static () => DatabaseProviderConfig.IsPostgres
+            ? new PostgresDavDatabaseContext()
+            : new DavDatabaseContext();
 
     internal static Func<MetricsDbContext> MetricsContextFactory { get; set; } =
         static () => new MetricsDbContext();
@@ -136,7 +138,11 @@ internal static class DatabaseContractWriter
             {
                 File.Delete(stale);
             }
-            catch
+            catch (IOException)
+            {
+                // best effort — stale temp files from a crashed write.
+            }
+            catch (UnauthorizedAccessException)
             {
                 // best effort — stale temp files from a crashed write.
             }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -131,6 +131,9 @@ public partial class Program
             if (args.Contains("--db-migration"))
             {
                 await RunDatabaseMigrationsAsync(args).ConfigureAwait(false);
+                await DatabaseContractWriter
+                    .WriteAsync(SigtermUtil.GetCancellationToken())
+                    .ConfigureAwait(false);
                 return;
             }
 
@@ -150,6 +153,12 @@ public partial class Program
             await using var metricsBootstrap = new MetricsDbContext();
             await StartupDatabaseMigrator
                 .RunAsync(databaseContext, metricsBootstrap, startupCancellationToken)
+                .ConfigureAwait(false);
+
+            // Refresh the machine-readable database contract so external migrators
+            // (DUMB) can pin against the applied migration history.
+            await DatabaseContractWriter
+                .WriteAsync(startupCancellationToken)
                 .ConfigureAwait(false);
 
             // Surface database corruption as one clear event with recovery guidance,

--- a/backend/UsenetMigration/UsenetMigrationStore.cs
+++ b/backend/UsenetMigration/UsenetMigrationStore.cs
@@ -52,6 +52,10 @@ public sealed class UsenetMigrationStore : IDisposable
     internal Action ClearSqlitePools { get; set; } =
         static () => SqliteConnection.ClearAllPools();
 
+    /// <summary>Refreshes db-contract.json after the ledger is (re)created. Overridable in tests.</summary>
+    internal Func<CancellationToken, Task> WriteDatabaseContract { get; set; } =
+        static ct => DatabaseContractWriter.WriteAsync(ct);
+
     private readonly SemaphoreSlim _databaseInitialization = new(1, 1);
     private bool _databaseInitialized;
 
@@ -89,6 +93,10 @@ public sealed class UsenetMigrationStore : IDisposable
                 RecreateDatabaseFiles();
                 await MigrateAndCreateSessionAsync(ct).ConfigureAwait(false);
             }
+
+            // The ledger was just migrated (or recreated) — refresh the on-disk
+            // database contract so external migrators see it. Non-fatal.
+            await WriteDatabaseContract(ct).ConfigureAwait(false);
 
             Volatile.Write(ref _databaseInitialized, true);
         }

--- a/docs/operations/postgresql.md
+++ b/docs/operations/postgresql.md
@@ -25,6 +25,53 @@ use `/config/db.sqlite` unchanged.
 Only the main operational store uses PostgreSQL. `metrics.sqlite`, `warden.db`,
 and `usenet-migration.db` remain in `/config`.
 
+## Database contract file [since 1.2.6](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.6){ .nzbdav-since }
+
+The runtime writes a machine-readable database contract to
+`/config/db-contract.json` after every successful migration pass (startup and
+`--db-migration`) and whenever the usenet-migration ledger is created. External
+migrators — such as [DUMB](https://dumbarr.com/)'s SQLite-to-PostgreSQL
+migrator — can pin against this contract instead of reverse-engineering schema
+identity from `__EFMigrationsHistory`, backup manifests, or the app version.
+
+The file is world-readable (`0644`) and replaced atomically on each write, so
+readers never observe a partial document and upgrades or reinstalls running as
+a different user can always overwrite it.
+
+```json
+{
+  "contract": "infinidysk-db-v1",
+  "appVersion": "1.2.6",
+  "generatedAtUtc": "2026-08-25T19:00:00.0000000Z",
+  "provider": "sqlite",
+  "terminalMigration": "20260824143000_Add-Generated-Symlink-Metadata",
+  "migrationCount": 51,
+  "migrationHistoryHash": "sha256:…",
+  "transientObjects": ["TMP_LINKED_FILES", "TMP_LINKED_FILES_UNIQUE"],
+  "databases": {
+    "main": { "provider": "sqlite", "terminalMigration": "…", "migrationCount": 51, "migrationHistoryHash": "sha256:…", "transientObjects": ["TMP_LINKED_FILES", "TMP_LINKED_FILES_UNIQUE"] },
+    "metrics": { "provider": "sqlite", "terminalMigration": "…", "migrationCount": 12, "migrationHistoryHash": "sha256:…", "transientObjects": [] },
+    "usenetMigration": { "provider": "sqlite", "terminalMigration": null, "migrationCount": 0, "migrationHistoryHash": null, "transientObjects": [] }
+  }
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `contract` | Stable contract identifier (`infinidysk-db-v1`); bumped only when the contract shape or semantics change. Pin against this. |
+| `appVersion` | Running InfiniDysk version. Informational only — the binary and the database can be on different schemas, so do not use it as a schema proxy. |
+| `generatedAtUtc` | When the contract was written. |
+| `provider` | Main database provider: `sqlite` or `postgres`. |
+| `terminalMigration` | Newest applied EF migration id on the main database. |
+| `migrationCount` | Number of applied migrations on the main database. |
+| `migrationHistoryHash` | `sha256:` hex fingerprint of the full applied migration history (ordinal-sorted ids joined with `\n`) — not just the tip. |
+| `transientObjects` | Runtime tables that may exist but are not part of the stable schema (e.g. `TMP_LINKED_FILES` from unlinked-file cleanup). Exclude these when comparing schemas. |
+| `databases` | Per-database entries (`main`, `metrics`, `usenetMigration`) with the same five fields. The top-level fields mirror `databases.main`. |
+
+The `usenetMigration` ledger is created lazily; until it exists, its entry
+reports `terminalMigration: null`, `migrationCount: 0`, and
+`migrationHistoryHash: null`.
+
 ## Backups
 
 The Settings backup page continues to back up the SQLite auxiliary stores, but

--- a/tests/NzbWebDAV.Tests/Database/DatabaseContractWriterCollection.cs
+++ b/tests/NzbWebDAV.Tests/Database/DatabaseContractWriterCollection.cs
@@ -1,0 +1,11 @@
+namespace NzbWebDAV.Tests.Database;
+
+/// <summary>
+/// Serializes tests that mutate DatabaseContractWriter's process-wide static
+/// factories and paths, so a seam saved in one test class is never the mutated
+/// value left behind by another.
+/// </summary>
+[CollectionDefinition(nameof(DatabaseContractWriterCollection), DisableParallelization = true)]
+public sealed class DatabaseContractWriterCollection
+{
+}

--- a/tests/NzbWebDAV.Tests/Database/DatabaseContractWriterTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DatabaseContractWriterTests.cs
@@ -10,6 +10,7 @@ using NzbWebDAV.Database.MigrationHelpers;
 
 namespace NzbWebDAV.Tests.Database;
 
+[Collection(nameof(DatabaseContractWriterCollection))]
 public sealed class DatabaseContractWriterTests : IAsyncLifetime
 {
     private readonly string _root = Path.Join(Path.GetTempPath(), $"nzbdav-contract-{Guid.NewGuid():N}");

--- a/tests/NzbWebDAV.Tests/Database/DatabaseContractWriterTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DatabaseContractWriterTests.cs
@@ -1,0 +1,249 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+
+namespace NzbWebDAV.Tests.Database;
+
+public sealed class DatabaseContractWriterTests : IAsyncLifetime
+{
+    private readonly string _root = Path.Join(Path.GetTempPath(), $"nzbdav-contract-{Guid.NewGuid():N}");
+    private readonly string _mainPath;
+    private readonly string _metricsPath;
+    private readonly string _ledgerPath;
+    private readonly string _contractPath;
+
+    private DbContextOptions<DavDatabaseContext> _mainOptions = null!;
+    private DbContextOptions<MetricsDbContext> _metricsOptions = null!;
+    private DbContextOptions<UsenetMigrationDbContext> _ledgerOptions = null!;
+
+    private Func<DavDatabaseContext> _previousMainFactory = null!;
+    private Func<MetricsDbContext> _previousMetricsFactory = null!;
+    private Func<UsenetMigrationDbContext> _previousLedgerFactory = null!;
+    private Func<string> _previousLedgerFilePath = null!;
+    private Func<string> _previousContractFilePath = null!;
+
+    public DatabaseContractWriterTests()
+    {
+        _mainPath = Path.Join(_root, "db.sqlite");
+        _metricsPath = Path.Join(_root, "metrics.sqlite");
+        _ledgerPath = Path.Join(_root, "usenet-migration.db");
+        _contractPath = Path.Join(_root, "db-contract.json");
+    }
+
+    public async Task InitializeAsync()
+    {
+        Directory.CreateDirectory(_root);
+
+        _mainOptions = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_mainPath};Pooling=False")
+            .AddInterceptors(new SqliteMainDbPragmas())
+            .ReplaceService<IMigrationsSqlGenerator, SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _metricsOptions = new DbContextOptionsBuilder<MetricsDbContext>()
+            .UseSqlite($"Data Source={_metricsPath};Pooling=False")
+            .AddInterceptors(new SqliteMetricsPragmas())
+            .ReplaceService<IMigrationsSqlGenerator, SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _ledgerOptions = new DbContextOptionsBuilder<UsenetMigrationDbContext>()
+            .UseSqlite($"Data Source={_ledgerPath};Pooling=False")
+            .AddInterceptors(new SqliteUsenetMigrationPragmas())
+            .Options;
+
+        _previousMainFactory = DatabaseContractWriter.MainContextFactory;
+        _previousMetricsFactory = DatabaseContractWriter.MetricsContextFactory;
+        _previousLedgerFactory = DatabaseContractWriter.UsenetMigrationContextFactory;
+        _previousLedgerFilePath = DatabaseContractWriter.UsenetMigrationDatabaseFilePath;
+        _previousContractFilePath = DatabaseContractWriter.ContractFilePath;
+
+        DatabaseContractWriter.MainContextFactory = () => new DavDatabaseContext(_mainOptions);
+        DatabaseContractWriter.MetricsContextFactory = () => new MetricsDbContext(_metricsOptions);
+        DatabaseContractWriter.UsenetMigrationContextFactory = () => new UsenetMigrationDbContext(_ledgerOptions);
+        DatabaseContractWriter.UsenetMigrationDatabaseFilePath = () => _ledgerPath;
+        DatabaseContractWriter.ContractFilePath = () => _contractPath;
+
+        await using (var main = new DavDatabaseContext(_mainOptions))
+            await main.Database.MigrateAsync();
+        await using (var metrics = new MetricsDbContext(_metricsOptions))
+            await metrics.Database.MigrateAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        DatabaseContractWriter.MainContextFactory = _previousMainFactory;
+        DatabaseContractWriter.MetricsContextFactory = _previousMetricsFactory;
+        DatabaseContractWriter.UsenetMigrationContextFactory = _previousLedgerFactory;
+        DatabaseContractWriter.UsenetMigrationDatabaseFilePath = _previousLedgerFilePath;
+        DatabaseContractWriter.ContractFilePath = _previousContractFilePath;
+
+        SqliteConnection.ClearAllPools();
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // best effort — temp files.
+        }
+
+        await Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task WriteAsync_WritesContractMatchingAppliedHistory()
+    {
+        var mainApplied = await GetAppliedMigrationsAsync(new DavDatabaseContext(_mainOptions));
+        var metricsApplied = await GetAppliedMigrationsAsync(new MetricsDbContext(_metricsOptions));
+
+        await DatabaseContractWriter.WriteAsync();
+
+        using var doc = await ReadContractAsync();
+        var root = doc.RootElement;
+
+        Assert.Equal("infinidysk-db-v1", root.GetProperty("contract").GetString());
+        Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("appVersion").GetString()));
+        Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("generatedAtUtc").GetString()));
+        Assert.Equal("sqlite", root.GetProperty("provider").GetString());
+        Assert.Equal(mainApplied.Last(), root.GetProperty("terminalMigration").GetString());
+        Assert.Equal(mainApplied.Count, root.GetProperty("migrationCount").GetInt32());
+        Assert.Equal(ExpectedHash(mainApplied), root.GetProperty("migrationHistoryHash").GetString());
+        Assert.Equal(
+            new[] { "TMP_LINKED_FILES", "TMP_LINKED_FILES_UNIQUE" },
+            root.GetProperty("transientObjects").Deserialize<string[]>());
+
+        var databases = root.GetProperty("databases");
+
+        var main = databases.GetProperty("main");
+        Assert.Equal("sqlite", main.GetProperty("provider").GetString());
+        Assert.Equal(mainApplied.Last(), main.GetProperty("terminalMigration").GetString());
+        Assert.Equal(mainApplied.Count, main.GetProperty("migrationCount").GetInt32());
+        Assert.Equal(ExpectedHash(mainApplied), main.GetProperty("migrationHistoryHash").GetString());
+        Assert.Equal(2, main.GetProperty("transientObjects").GetArrayLength());
+
+        var metrics = databases.GetProperty("metrics");
+        Assert.Equal("sqlite", metrics.GetProperty("provider").GetString());
+        Assert.Equal(metricsApplied.Last(), metrics.GetProperty("terminalMigration").GetString());
+        Assert.Equal(metricsApplied.Count, metrics.GetProperty("migrationCount").GetInt32());
+        Assert.Equal(ExpectedHash(metricsApplied), metrics.GetProperty("migrationHistoryHash").GetString());
+        Assert.Equal(0, metrics.GetProperty("transientObjects").GetArrayLength());
+
+        var ledger = databases.GetProperty("usenetMigration");
+        Assert.Equal("sqlite", ledger.GetProperty("provider").GetString());
+        Assert.Equal(JsonValueKind.Null, ledger.GetProperty("terminalMigration").ValueKind);
+        Assert.Equal(0, ledger.GetProperty("migrationCount").GetInt32());
+        Assert.Equal(JsonValueKind.Null, ledger.GetProperty("migrationHistoryHash").ValueKind);
+        Assert.Equal(0, ledger.GetProperty("transientObjects").GetArrayLength());
+
+        // The writer must not create the lazily-initialized ledger as a side effect.
+        Assert.False(File.Exists(_ledgerPath));
+    }
+
+    [Fact]
+    public async Task WriteAsync_ProducesDeterministicHistoryHash()
+    {
+        await DatabaseContractWriter.WriteAsync();
+        string? first;
+        using (var doc = await ReadContractAsync())
+            first = doc.RootElement.GetProperty("migrationHistoryHash").GetString();
+
+        await DatabaseContractWriter.WriteAsync();
+        string? second;
+        using (var doc = await ReadContractAsync())
+            second = doc.RootElement.GetProperty("migrationHistoryHash").GetString();
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public async Task WriteAsync_WritesWorldReadableFile_AndOverwritesReadOnlyLeftover()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        const UnixFileMode expected =
+            UnixFileMode.UserRead | UnixFileMode.UserWrite |
+            UnixFileMode.GroupRead | UnixFileMode.OtherRead;
+
+        await DatabaseContractWriter.WriteAsync();
+        Assert.Equal(expected, File.GetUnixFileMode(_contractPath));
+
+        // A restrictive leftover from a previous install (possibly owned by another
+        // user) must not block the rewrite: replace-by-rename only needs directory
+        // write permission, and the new file is 0644 again afterwards.
+        File.SetUnixFileMode(_contractPath,
+            UnixFileMode.UserRead | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+        await DatabaseContractWriter.WriteAsync();
+
+        Assert.Equal(expected, File.GetUnixFileMode(_contractPath));
+        using var doc = await ReadContractAsync();
+        Assert.Equal("infinidysk-db-v1", doc.RootElement.GetProperty("contract").GetString());
+    }
+
+    [Fact]
+    public async Task WriteAsync_CleansUpStaleTempFiles()
+    {
+        var stale = Path.Join(_root, "db-contract.deadbeef.tmp");
+        await File.WriteAllTextAsync(stale, "junk");
+
+        await DatabaseContractWriter.WriteAsync();
+
+        Assert.False(File.Exists(stale));
+        Assert.Empty(Directory.GetFiles(_root, "db-contract.*.tmp"));
+        Assert.True(File.Exists(_contractPath));
+    }
+
+    [Fact]
+    public async Task WriteAsync_PopulatesUsenetMigrationSection_WhenLedgerExists()
+    {
+        List<string> ledgerApplied;
+        await using (var context = new UsenetMigrationDbContext(_ledgerOptions))
+        {
+            await context.Database.MigrateAsync();
+            ledgerApplied = await GetAppliedMigrationsAsync(context);
+        }
+
+        await DatabaseContractWriter.WriteAsync();
+
+        using var doc = await ReadContractAsync();
+        var ledger = doc.RootElement.GetProperty("databases").GetProperty("usenetMigration");
+        Assert.Equal("sqlite", ledger.GetProperty("provider").GetString());
+        Assert.Equal(ledgerApplied.Last(), ledger.GetProperty("terminalMigration").GetString());
+        Assert.Equal(ledgerApplied.Count, ledger.GetProperty("migrationCount").GetInt32());
+        Assert.Equal(ExpectedHash(ledgerApplied), ledger.GetProperty("migrationHistoryHash").GetString());
+        Assert.Equal(0, ledger.GetProperty("transientObjects").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task WriteAsync_NeverThrows_WhenContractCannotBeWritten()
+    {
+        var unreachable = Path.Join(_root, "missing-dir", "db-contract.json");
+        DatabaseContractWriter.ContractFilePath = () => unreachable;
+
+        await DatabaseContractWriter.WriteAsync();
+
+        Assert.False(File.Exists(unreachable));
+    }
+
+    private async Task<JsonDocument> ReadContractAsync() =>
+        JsonDocument.Parse(await File.ReadAllTextAsync(_contractPath));
+
+    private static async Task<List<string>> GetAppliedMigrationsAsync(DbContext context)
+    {
+        await using (context)
+        {
+            return (await context.Database.GetAppliedMigrationsAsync())
+                .OrderBy(id => id, StringComparer.Ordinal)
+                .ToList();
+        }
+    }
+
+    private static string ExpectedHash(IEnumerable<string> appliedMigrationIds)
+    {
+        var payload = string.Join('\n', appliedMigrationIds.OrderBy(id => id, StringComparer.Ordinal));
+        return "sha256:" + Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(payload))).ToLowerInvariant();
+    }
+}

--- a/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
@@ -23,6 +23,7 @@ using NzbWebDAV.Websocket;
 
 namespace NzbWebDAV.Tests.Database;
 
+[Collection(nameof(DatabaseContractWriterCollection))]
 public sealed class PostgresMigrationTests
 {
     [SkippableFact]

--- a/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
@@ -1,6 +1,8 @@
 using System.Data.Common;
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.AspNetCore.Http;
 using Npgsql;
 using NzbWebDAV.Api.Controllers.GetOverviewStats;
@@ -9,6 +11,8 @@ using NzbWebDAV.Api.SabControllers.GetQueue;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Services;
@@ -229,6 +233,98 @@ public sealed class PostgresMigrationTests
         finally
         {
             await ExecuteAsync(adminConnection, $"DROP SCHEMA IF EXISTS \"{schema}\" CASCADE");
+        }
+    }
+
+    [SkippableFact]
+    public async Task DatabaseContractWriter_ReadsMainHistoryFromPostgres()
+    {
+        Skip.IfNot(
+            DatabaseProviderConfig.IsPostgres,
+            "PostgreSQL migration tests require DATABASE_PROVIDER=postgres.");
+
+        // The default factory must route to the PostgreSQL migration context.
+        await using (var probe = DatabaseContractWriter.MainContextFactory())
+            Assert.IsType<PostgresDavDatabaseContext>(probe);
+
+        var schema = $"nzbdav_contract_{Guid.NewGuid():N}";
+        var connectionString = DatabaseProviderConfig.PostgresConnectionString;
+        await using var adminConnection = new NpgsqlConnection(connectionString);
+        await adminConnection.OpenAsync();
+        await ExecuteAsync(adminConnection, $"CREATE SCHEMA \"{schema}\"");
+
+        var configRoot = Path.Join(Path.GetTempPath(), $"nzbdav-contract-pg-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(configRoot);
+        var contractPath = Path.Join(configRoot, "db-contract.json");
+
+        var previousMainFactory = DatabaseContractWriter.MainContextFactory;
+        var previousMetricsFactory = DatabaseContractWriter.MetricsContextFactory;
+        var previousLedgerFilePath = DatabaseContractWriter.UsenetMigrationDatabaseFilePath;
+        var previousContractFilePath = DatabaseContractWriter.ContractFilePath;
+
+        try
+        {
+            var scopedConnectionString = new NpgsqlConnectionStringBuilder(connectionString)
+            {
+                SearchPath = schema
+            }.ConnectionString;
+            var mainOptions = new DbContextOptionsBuilder<PostgresDavDatabaseContext>()
+                .UseNpgsql(scopedConnectionString)
+                .Options;
+
+            List<string> applied;
+            await using (var context = new PostgresDavDatabaseContext(mainOptions))
+            {
+                await context.Database.MigrateAsync().WaitAsync(TimeSpan.FromSeconds(30));
+                applied = (await context.Database.GetAppliedMigrationsAsync())
+                    .OrderBy(id => id, StringComparer.Ordinal)
+                    .ToList();
+            }
+
+            var metricsOptions = new DbContextOptionsBuilder<MetricsDbContext>()
+                .UseSqlite($"Data Source={Path.Join(configRoot, "metrics.sqlite")};Pooling=False")
+                .AddInterceptors(new SqliteMetricsPragmas())
+                .ReplaceService<
+                    IMigrationsSqlGenerator,
+                    SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            await using (var metrics = new MetricsDbContext(metricsOptions))
+                await metrics.Database.MigrateAsync();
+
+            DatabaseContractWriter.MainContextFactory = () => new PostgresDavDatabaseContext(mainOptions);
+            DatabaseContractWriter.MetricsContextFactory = () => new MetricsDbContext(metricsOptions);
+            DatabaseContractWriter.UsenetMigrationDatabaseFilePath =
+                () => Path.Join(configRoot, "usenet-migration.db");
+            DatabaseContractWriter.ContractFilePath = () => contractPath;
+
+            await DatabaseContractWriter.WriteAsync();
+
+            using var doc = JsonDocument.Parse(await File.ReadAllTextAsync(contractPath));
+            var root = doc.RootElement;
+            Assert.Equal("postgres", root.GetProperty("provider").GetString());
+            Assert.Equal(applied.Last(), root.GetProperty("terminalMigration").GetString());
+            Assert.Equal(applied.Count, root.GetProperty("migrationCount").GetInt32());
+
+            var main = root.GetProperty("databases").GetProperty("main");
+            Assert.Equal("postgres", main.GetProperty("provider").GetString());
+            Assert.Equal(applied.Last(), main.GetProperty("terminalMigration").GetString());
+            Assert.Equal(applied.Count, main.GetProperty("migrationCount").GetInt32());
+        }
+        finally
+        {
+            DatabaseContractWriter.MainContextFactory = previousMainFactory;
+            DatabaseContractWriter.MetricsContextFactory = previousMetricsFactory;
+            DatabaseContractWriter.UsenetMigrationDatabaseFilePath = previousLedgerFilePath;
+            DatabaseContractWriter.ContractFilePath = previousContractFilePath;
+            await ExecuteAsync(adminConnection, $"DROP SCHEMA IF EXISTS \"{schema}\" CASCADE");
+            try
+            {
+                Directory.Delete(configRoot, recursive: true);
+            }
+            catch (IOException)
+            {
+                // best effort — temp files.
+            }
         }
     }
 

--- a/tests/NzbWebDAV.Tests/UsenetMigration/MigrationTestHarness.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/MigrationTestHarness.cs
@@ -46,7 +46,11 @@ internal sealed class MigrationTestHarness : IAsyncDisposable
             .ReplaceService<IMigrationsSqlGenerator, SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
             .Options;
 
-        Store = new UsenetMigrationStore { ContextFactory = MigFactory };
+        Store = new UsenetMigrationStore
+        {
+            ContextFactory = MigFactory,
+            WriteDatabaseContract = static _ => Task.CompletedTask,
+        };
     }
 
     public static async Task<MigrationTestHarness> CreateAsync()

--- a/tests/NzbWebDAV.Tests/UsenetMigration/UsenetMigrationStoreTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/UsenetMigrationStoreTests.cs
@@ -32,6 +32,7 @@ public class UsenetMigrationStoreTests
         var store = new UsenetMigrationStore
         {
             ContextFactory = () => new UsenetMigrationDbContext(options),
+            WriteDatabaseContract = static _ => Task.CompletedTask,
         };
 
         try
@@ -74,6 +75,7 @@ public class UsenetMigrationStoreTests
             ContextFactory = () => new UsenetMigrationDbContext(options),
             DatabaseFilePath = () => databasePath,
             DatabaseFileExists = () => File.Exists(databasePath),
+            WriteDatabaseContract = static _ => Task.CompletedTask,
         };
 
         try


### PR DESCRIPTION
## Summary

- Writes a machine-readable database contract to `/config/db-contract.json` after every migration event (startup migrations, standalone `--db-migration`, and lazy creation/recreation of the usenet-migration ledger), so DUMB's SQLite-to-PostgreSQL migrator can pin against a stable runtime-owned contract instead of reverse-engineering `__EFMigrationsHistory`, backup manifests, or the app version.
- The contract carries a stable id (`infinidysk-db-v1`), provider, terminal migration, applied count, a `sha256` fingerprint of the full applied history, and known transient objects (`TMP_LINKED_FILES`, `TMP_LINKED_FILES_UNIQUE`) — top-level for the main database plus a `databases` map covering main, metrics, and usenet-migration.
- The file is world-readable (`0644`) and replaced atomically via temp-file + rename, so readers never see a partial document and a differently-owned leftover from a previous install can never block an upgrade or reinstall. Writes are best-effort and never block startup or the migration wizard.

Closes #1150

## Test plan

- [x] New `DatabaseContractWriterTests` (6 tests): contract shape against real migrated SQLite databases, hash determinism, 0644 permissions, overwrite of a read-only leftover, stale temp cleanup, lazily-created ledger handling, never-throws guarantee
- [x] Full backend suite: `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release` — 3713 passed, 0 failed
- [x] Docs build: `zensical build --clean --strict` — clean
- [x] Manual smoke: `NzbWebDAV --db-migration` against a temp CONFIG_PATH produced the expected `db-contract.json` with mode 0644
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic generation of a machine-readable database contract after database migrations.
  * Contract includes migration history, database metadata, application version, timestamps, and optional Usenet migration details.
  * Contract updates are written safely and do not block startup when recoverable errors occur.

* **Documentation**
  * Added operational documentation for `/config/db-contract.json`, including its format, permissions, contents, and update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->