### PR TITLE
chore(docs): document connection warming and the header Connections indicator

### DIFF
--- a/docs/configuration/streaming.md
+++ b/docs/configuration/streaming.md
@@ -42,7 +42,7 @@ is saturated.
 | Streaming Segment Retries | `usenet.streaming-segment-retries` | `3` | Fresh-connection retries after timeout, 0–5 |
 | Article Buffer Size | `usenet.article-buffer-size` | `40` | Articles buffered ahead per stream |
 | In-flight article budget (MiB) [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since } | `usenet.in-flight-article-budget-mb` | auto | Host-wide decoded-byte cap. Auto uses 25% of the detected managed-heap ceiling, clamped to 64–8192 MiB; explicit values also range from 64–8192 MiB |
-| Idle connection timeout | `usenet.idle-connection-timeout-seconds` | `60` | Close unused connections after 15–300 seconds |
+| Idle connection timeout | `usenet.idle-connection-timeout-seconds` | `60` | Close unused connections after 15–300 seconds; also sets the [connection warming](../features/connection-warming.md) sweep and keepalive cadence |
 | Batched article downloads | `usenet.pipelined-body-requests` | on | Fetch WebDAV BODY requests in small batches |
 | Streaming batch width [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since } | `usenet.streaming-body-batch-width` | `4` | Maximum articles per BODY batch (1–8) |
 | Container-aware gap fill [since 0.10.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.10.0){ .nzbdav-since } | `usenet.container-aware-fill` | on | Experimental MPEG-TS null-packet fill for confirmed gaps |

--- a/docs/configuration/usenet.md
+++ b/docs/configuration/usenet.md
@@ -55,6 +55,22 @@ Run Auto-tune before enabling queue pipelining. WebDAV streaming batching is a *
 
 See [NNTP pipelining](../features/nntp-pipelining.md) and [Multi-provider](../features/multi-provider.md).
 
+## Warm connections [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since }
+
+Each pooled provider keeps a small floor of pre-connected, authenticated NNTP sockets
+ready so playback and queue work skip the connect/TLS/login handshake after idle
+periods. Warm sockets count against the provider's connection limit but never hold
+download permits. See [Connection warming](../features/connection-warming.md) for the
+mechanics and the header indicator.
+
+| Control | Config key | Default | Effect |
+|---------|------------|---------|--------|
+| Warm connections | `usenet.warm-connections.enabled` | on | Keep pre-connected sockets ready per provider |
+| Warm floor | `usenet.warm-connections.floor` | auto | Idle sockets kept ready per provider; auto derives one sixth of Max Connections, clamped to 1–8 |
+
+Changes take effect on the next provider save or restart — connection pools are not
+rebuilt when these keys change alone.
+
 ## Article-miss negative cache [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since }
 
 After a provider (or [storage group](../features/multi-provider.md)) reports a definitive article miss

--- a/docs/features/connection-warming.md
+++ b/docs/features/connection-warming.md
@@ -1,0 +1,51 @@
+# Connection warming
+
+Connection warming [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since } keeps a small number of pre-connected, authenticated NNTP sockets standing by on each pooled provider. Playback and queue work borrow one instantly instead of paying the TCP + TLS + login handshake first — which is most of the wait between pressing play and the first bytes moving after an idle period.
+
+## How it works
+
+Each pooled provider gets a **warm floor**: a target count of idle, ready-to-use connections. By default the floor is derived from the provider's **Max Connections** — roughly one sixth of it, at least 1 and at most 8.
+
+```mermaid
+flowchart TD
+  pool["Warm floor: idle authenticated NNTP connections"]
+  borrow["Playback / queue borrow"] -->|"no handshake wait"| pool
+  sweep["Sweeper runs every idle-timeout / 2"] --> ping["DATE ping keeps warm sockets fresh"]
+  ping -->|"stale socket"| refill["Dispose and refill floor"]
+  refill --> pool
+  sweep --> reap["Idle connections above the floor are reaped"]
+```
+
+- A background sweeper runs every half of the [idle connection timeout](../configuration/streaming.md) (default: every 30 seconds). It refills the floor when sockets were lost and reaps idle connections **only above the floor** — warm connections are never closed just for being idle.
+- Before a provider's own idle timeout can drop a warm socket, the sweeper pings it with a lightweight NNTP `DATE` command. A failed ping means the socket went stale; it is disposed and the floor refills.
+- Warm connections never hold download permits, so the full configured connection width stays available to real work.
+- If a provider is unreachable at startup, warming does not spin or block startup — the next sweep retries. When InfiniDysk learns that a provider's real connection limit is lower than configured, the floor shrinks with it.
+
+## What you see in the header
+
+The **Connections** indicator in the top navigation shows pooled-provider totals, updated live (about five times per second):
+
+- `5/50` — live connections across pooled providers versus their combined maximum.
+- `2 active · 3 warm` — connections currently transferring versus idle warm ones. The warm part only appears while at least one warm connection is standing by.
+- Hovering explains: *"Warm connections are pre-connected to your Usenet providers so playback can start faster."*
+
+Other states: a spinner with **Connecting** until the first update arrives, **Reconnecting** while the live UI connection recovers from a brief drop, and `—` / **No providers** when no Usenet provider is configured. The indicator is hidden on narrow screens. Backup-only providers are excluded from the totals.
+
+**Settings → Usenet** shows the same live counts on each provider card.
+
+## Tuning
+
+| Setting | Config key | Default | Effect |
+|---------|------------|---------|--------|
+| Warm connections | `usenet.warm-connections.enabled` | on | Keep a small pool of pre-connected sockets per provider |
+| Warm floor | `usenet.warm-connections.floor` | auto | Idle sockets kept ready per provider; auto derives one sixth of Max Connections, clamped to 1–8 |
+
+There is no settings-UI toggle; set the keys as [headless environment variables](../configuration/headless.md) (`NZBDAV_CONFIG__USENET__WARM_CONNECTIONS__ENABLED` / `NZBDAV_CONFIG__USENET__WARM_CONNECTIONS__FLOOR`). Changes take effect on the next provider save or restart — connection pools are not rebuilt when these keys change alone.
+
+## Cost and trade-offs
+
+- Warm sockets are real connections and count against the provider plan's connection limit, even while idle.
+- Keepalive traffic is negligible: one tiny `DATE` exchange per warm socket per sweep.
+- On very small plans or [memory-constrained hosts](../operations/memory-constrained-hosts.md), lower the floor or disable warming entirely.
+
+[Usenet](../configuration/usenet.md) · [NNTP pipelining](nntp-pipelining.md) · [Streaming and seeking](streaming-seeking.md)

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -16,6 +16,7 @@ InfiniDysk combines a virtual filesystem, Usenet streaming stack, and automation
 -   [Watchtower](watchtower.md)
 -   [Warden, Watchdog, Preflight](warden-watchdog-preflight.md)
 -   [NNTP pipelining](nntp-pipelining.md)
+-   [Connection warming](connection-warming.md)
 -   [SABnzbd API](sab-api.md)
 
 </div>

--- a/docs/operations/memory-constrained-hosts.md
+++ b/docs/operations/memory-constrained-hosts.md
@@ -72,8 +72,8 @@ glibc-specific; the shipped Alpine image uses musl and does not use
 - Lower provider **Max connections** and explicit download/queue connection
   limits before reducing buffers. NNTP I/O is asynchronous; it does not create
   a dedicated OS thread per socket.
-- Disable warm connections or shorten the idle timeout if many pooled sockets
-  are unnecessary.
+- Disable [warm connections](../features/connection-warming.md) or shorten the
+  idle timeout if many pooled sockets are unnecessary.
 - Lower **Streaming body batch width** and set an explicit **In-flight article
   budget** to reduce active decoded-pipe retention.
 - `DOTNET_GCRetainVM=0` is already the .NET default; setting it does not shrink

--- a/zensical.toml
+++ b/zensical.toml
@@ -47,6 +47,7 @@ nav = [
     { "Watchtower" = "features/watchtower.md" },
     { "Warden, Watchdog, Preflight" = "features/warden-watchdog-preflight.md" },
     { "NNTP pipelining" = "features/nntp-pipelining.md" },
+    { "Connection warming" = "features/connection-warming.md" },
     { "SABnzbd API" = "features/sab-api.md" },
   ]},
   { "Configuration" = [


### PR DESCRIPTION
## Summary
- New **Features → Connection warming** page: how the per-provider warm floor works (default on, floor ≈ max/6 clamped 1–8), the sweeper + NNTP `DATE` keepalive loop, and what users see in the header (`live/max`, "N active · M warm", Connecting/Reconnecting states)
- Documents the `usenet.warm-connections.enabled` / `usenet.warm-connections.floor` keys on the Usenet configuration page, including that changes apply on the next provider save or restart
- Cross-links from the streaming idle-timeout row and the memory-constrained hosts guide; adds nav entry and Features index card

## Test plan
- [x] `zensical build --clean --strict` passes with no issues
- [ ] CI docs workflow green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive guidance for NNTP connection warming, including configuration, behavior, resource usage, monitoring, and operational trade-offs.
  - Documented warm connections in the Usenet configuration guide.
  - Clarified how idle connection timeouts affect warming sweeps and keepalive timing.
  - Added connection warming to the feature index and documentation navigation.
  - Updated memory-constrained host guidance with a direct link to the new feature documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->