### PR TITLE
fix(queue): large NZBs up to 256 MiB no longer rejected during import

### DIFF
--- a/backend/Api/Errors/NzbInputLimits.cs
+++ b/backend/Api/Errors/NzbInputLimits.cs
@@ -2,14 +2,14 @@ namespace NzbWebDAV.Api.Errors;
 
 /// <summary>
 /// Bounded NZB ingest limits. Defaults are high enough for legitimate large
-/// releases (selected above current accepted fixtures) and are enforced before
-/// a queue item is inserted.
+/// releases (selected above current accepted fixtures and real-world reports,
+/// e.g. #1176) and are enforced before a queue item is inserted.
 /// </summary>
 public sealed class NzbInputLimits
 {
     public static NzbInputLimits Default { get; } = new();
 
-    public int MaxXmlBytes { get; init; } = 64 * 1024 * 1024;
+    public int MaxXmlBytes { get; init; } = 256 * 1024 * 1024;
     public int MaxFiles { get; init; } = 10_000;
     public int MaxTotalSegments { get; init; } = 500_000;
     public int MaxNameLength { get; init; } = 255;

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -239,7 +239,8 @@ public partial class Program
             // initialize webapp
             var builder = WebApplication.CreateBuilder(args);
             var apiDocsEnabled = AdminOpenApiExtensions.IsEnabled(builder.Environment);
-            var maxRequestBodySize = EnvironmentUtil.GetLongVariable("MAX_REQUEST_BODY_SIZE") ?? 100 * 1024 * 1024;
+            // Default headroom covers the 256 MiB NZB ingest cap plus multipart overhead.
+            var maxRequestBodySize = EnvironmentUtil.GetLongVariable("MAX_REQUEST_BODY_SIZE") ?? 300 * 1024 * 1024;
             builder.WebHost.ConfigureKestrel(options => options.Limits.MaxRequestBodySize = maxRequestBodySize);
             builder.Host.UseSerilog();
             builder.Services.Configure<HostOptions>(options =>

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -103,7 +103,7 @@ or restrict backend capabilities when enforcement is required.
 | `DOTNET_GCRegionSize` | runtime default | .NET SOH region size; hexadecimal bytes |
 | `DOTNET_GCConserveMemory` | `0` | .NET heap-conservation level (0–9) |
 | `DOTNET_gcServer` | image default (`1`) | Enables (`1`) or disables (`0`) server GC |
-| `MAX_REQUEST_BODY_SIZE` | 100 MiB | Max request body bytes |
+| `MAX_REQUEST_BODY_SIZE` | 300 MiB | Max request body bytes |
 | `QUEUE_ITEM_STUCK_MINUTES` [since 1.1.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0){ .nzbdav-since } | `5` | Minutes without queue progress before the stuck-item watchdog pauses and cancels the worker |
 | `NZBDAV_VERSION` | `0.0.0` | Reported app version |
 | `DOTNET_DbgEnableMiniDump` | off | Opt-in crash dumps — [Logs](../operations/logs-crash-dumps.md) |

--- a/tests/NzbWebDAV.Tests/Api/NzbInputValidatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/NzbInputValidatorTests.cs
@@ -104,6 +104,23 @@ public class NzbInputValidatorTests
     }
 
     [Fact]
+    public void AcceptsDocumentAbove64MiB()
+    {
+        // Regression for #1176: padding via an XML comment keeps the document
+        // valid without tripping the subject or segment limits.
+        var padding = new string('a', 65 * 1024 * 1024);
+        var xml = $"<nzb><!-- {padding} --><file subject=\"file-1\"><segments>" +
+                  "<segment bytes=\"15\" number=\"1\">id@example</segment>" +
+                  "</segments></file></nzb>";
+        using var stream = Bytes(xml);
+
+        var bytes = NzbInputValidator.ValidateAndSumSegmentBytes(stream, NzbInputLimits.Default);
+
+        Assert.True(stream.Length > 64 * 1024 * 1024);
+        Assert.Equal(15, bytes);
+    }
+
+    [Fact]
     public void AcceptsSubjectBeyondFilenameLimit()
     {
         var subject = new string('a', 600);


### PR DESCRIPTION
## Summary

- Fixes #1176 — manual uploads of NZBs over 64 MiB failed with `400 "The NZB document exceeds the maximum allowed size."` because `NzbInputLimits.Default.MaxXmlBytes` was hard-coded at 64 MiB; the reporter's ~69 MB NZB (and its `.nzb.gz` variant, since the cap measures decompressed bytes) both exceeded it.
- Raises the default cap to 256 MiB, following the raise-only precedent of #1097 (segments) and #1160 (subjects), and adds a regression test covering a document above the old cap.
- Raises the Kestrel `MaxRequestBodySize` default from 100 MiB to 300 MiB so UI/proxied uploads can actually reach the new cap (multipart framing adds overhead beyond the file bytes); `MAX_REQUEST_BODY_SIZE` still overrides it, and the env-var docs are updated.

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~NzbInputValidatorTests"` — 11/11 pass, including the new >64 MiB regression test
- [x] Full backend suite locally — 3714 passed, 0 failed, 15 skipped (Postgres/symlink real-ops skips are environmental)
- [ ] CI: full backend suite via `ci.yml`
- [ ] Manual: upload a ~69 MB NZB via the web UI and confirm it imports