### PR TITLE
fix(sab): failed API key warnings now identify the calling app

### DIFF
--- a/backend/Api/SabControllers/SabApiController.cs
+++ b/backend/Api/SabControllers/SabApiController.cs
@@ -47,6 +47,9 @@ public class SabApiController(
 {
     private static readonly LogThrottle AuthenticationFailureThrottle = new();
     private static readonly TimeSpan AuthenticationFailureLogInterval = TimeSpan.FromMinutes(5);
+    // Client-supplied and unbounded; the warning is held in the in-memory
+    // WarningLogBuffer/LogBufferSink, so it must be truncated before logging.
+    private const int MaxUserAgentLength = 200;
     private static readonly HashSet<string> KnownModes =
     [
         "version", "status", "get_cats", "get_config", "fullstatus", "server_stats", "warnings",
@@ -112,19 +115,25 @@ public class SabApiController(
                 string.Equals(configured, requestedCategory, StringComparison.OrdinalIgnoreCase))
             ?? "unknown";
         var source = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
-        // Source remains useful event context, but it must not be part of the
-        // process-lifetime throttle key: unauthenticated clients can generate
-        // an unbounded number of distinct remote addresses.
+        var userAgent = HttpContext.Request.Headers.UserAgent.ToString();
+        if (string.IsNullOrWhiteSpace(userAgent))
+            userAgent = "unknown";
+        else if (userAgent.Length > MaxUserAgentLength)
+            userAgent = userAgent[..MaxUserAgentLength];
+        // Source and user agent remain useful event context, but neither may be
+        // part of the process-lifetime throttle key: unauthenticated clients can
+        // generate an unbounded number of distinct values for both.
         var key = $"{mode}|{category}";
         if (!AuthenticationFailureThrottle.ShouldLog(key, AuthenticationFailureLogInterval, out var suppressed))
             return;
 
         Log.Warning(
-            "SAB API authentication rejected for mode {Mode}, category {Category}, source {Source}. " +
+            "SAB API authentication rejected for mode {Mode}, category {Category}, source {Source}, user agent {UserAgent}. " +
             "Update the configured API key; {SuppressedCount} matching failures were suppressed.",
             mode,
             category,
             source,
+            userAgent,
             suppressed);
     }
 

--- a/tests/NzbWebDAV.Tests/Api/SabPauseResumeTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabPauseResumeTests.cs
@@ -1,5 +1,7 @@
+using System.Net;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
 using NzbWebDAV.Api.Errors;
@@ -21,6 +23,9 @@ using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Tests.Database;
 using NzbWebDAV.Websocket;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
 
 namespace NzbWebDAV.Tests.Api;
 
@@ -290,6 +295,90 @@ public sealed class SabPauseResumeTests : IAsyncLifetime
         Assert.Equal("Invalid mode", ex.Message);
     }
 
+    [Fact]
+    public async Task HandleApiRequests_AuthFailure_LogsClientUserAgent()
+    {
+        // A unique category keeps the process-static auth-failure throttle key
+        // fresh for this test run.
+        var category = $"test-cat-{Guid.NewGuid():N}";
+        _configManager.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.ApiCategories, ConfigValue = category },
+        ]);
+
+        var previousEnvKey = Environment.GetEnvironmentVariable("FRONTEND_BACKEND_API_KEY");
+        Environment.SetEnvironmentVariable("FRONTEND_BACKEND_API_KEY", "test-env-key");
+        var sink = new CollectingSink();
+        var previousLogger = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        try
+        {
+            var context = new DefaultHttpContext();
+            context.Request.QueryString =
+                new QueryString($"?mode=queue&cat={category}&apikey=wrong-key");
+            context.Request.Headers.UserAgent = "Sonarr/4.0.16 (test)";
+            context.Connection.RemoteIpAddress = IPAddress.Parse("203.0.113.10");
+
+            var result = await CreateSabApiController(context).HandleApiRequests();
+
+            Assert.IsType<UnauthorizedObjectResult>(result);
+            var warning = Assert.Single(sink.Events, e =>
+                e.Level == LogEventLevel.Warning &&
+                e.MessageTemplate.Text.Contains(
+                    "SAB API authentication rejected", StringComparison.Ordinal));
+            Assert.Equal("Sonarr/4.0.16 (test)", PropertyText(warning, "UserAgent"));
+            Assert.Equal("queue", PropertyText(warning, "Mode"));
+            Assert.Equal(category, PropertyText(warning, "Category"));
+        }
+        finally
+        {
+            Log.Logger = previousLogger;
+            Environment.SetEnvironmentVariable("FRONTEND_BACKEND_API_KEY", previousEnvKey);
+        }
+    }
+
+    [Fact]
+    public async Task HandleApiRequests_AuthFailureWithoutUserAgent_LogsUnknown()
+    {
+        var category = $"test-cat-{Guid.NewGuid():N}";
+        _configManager.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.ApiCategories, ConfigValue = category },
+        ]);
+
+        var previousEnvKey = Environment.GetEnvironmentVariable("FRONTEND_BACKEND_API_KEY");
+        Environment.SetEnvironmentVariable("FRONTEND_BACKEND_API_KEY", "test-env-key");
+        var sink = new CollectingSink();
+        var previousLogger = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        try
+        {
+            var context = new DefaultHttpContext();
+            context.Request.QueryString =
+                new QueryString($"?mode=queue&cat={category}&apikey=wrong-key");
+
+            var result = await CreateSabApiController(context).HandleApiRequests();
+
+            Assert.IsType<UnauthorizedObjectResult>(result);
+            var warning = Assert.Single(sink.Events, e =>
+                e.Level == LogEventLevel.Warning &&
+                e.MessageTemplate.Text.Contains(
+                    "SAB API authentication rejected", StringComparison.Ordinal));
+            Assert.Equal("unknown", PropertyText(warning, "UserAgent"));
+        }
+        finally
+        {
+            Log.Logger = previousLogger;
+            Environment.SetEnvironmentVariable("FRONTEND_BACKEND_API_KEY", previousEnvKey);
+        }
+    }
+
 
     [Fact]
     public async Task PerJobPause_SetsPriorityPaused()
@@ -354,5 +443,32 @@ public sealed class SabPauseResumeTests : IAsyncLifetime
             Priority = priority,
             PostProcessing = QueueItem.PostProcessingOption.None
         };
+    }
+
+    private static string PropertyText(LogEvent logEvent, string name)
+    {
+        if (!logEvent.Properties.TryGetValue(name, out var value))
+            return "";
+        return value is ScalarValue { Value: { } raw }
+            ? raw.ToString() ?? ""
+            : value.ToString();
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events) return _events.ToArray();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events) _events.Add(logEvent);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- The throttled `SAB API authentication rejected` warning now includes the calling client's User-Agent header (e.g. `user agent Sonarr/4.0.16`), so operators can tell which misconfigured app is calling with a bad API key instead of only seeing a Docker-internal source IP.
- The value falls back to `unknown` when absent and is truncated to 200 chars, since it is client-supplied and the warning is held in the in-memory warning buffer that feeds support packs.
- Like the source IP, the user agent is deliberately kept out of the `mode|category` throttle key so unauthenticated clients cannot bypass throttling or grow the key map by rotating values. No frontend change: the proxy already forwards the original User-Agent untouched.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests -c Release --filter "FullyQualifiedName~HandleApiRequests_AuthFailure"` — 2 new tests pass (user agent logged; `unknown` fallback when header absent)
- [ ] PR CI: backend build + tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication-failure logs now include the client’s User-Agent when available.
  * User-Agent values are limited to 200 characters before being logged.
  * Missing User-Agent values are recorded as “unknown”.
  * Authentication throttling behavior remains unchanged.

* **Tests**
  * Added coverage for failed authentication requests with and without User-Agent information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->