### PR TITLE
fix(queue): large imports of missing or corrupt Usenet articles no longer grind the server

### DIFF
--- a/backend/Api/SabControllers/RemoveFromHistory/RemoveFromHistoryController.cs
+++ b/backend/Api/SabControllers/RemoveFromHistory/RemoveFromHistoryController.cs
@@ -39,28 +39,7 @@ public class RemoveFromHistoryController(
                     ct: request.CancellationToken)
                 .ConfigureAwait(false);
         }
-        try
-        {
-            await dbClient.Ctx.SaveChangesAsync(request.CancellationToken).ConfigureAwait(false);
-        }
-        catch (DbUpdateConcurrencyException ex) when (ex.Entries.All(e => e.Entity is HistoryItem))
-        {
-            // Ignore concurrently deleted history rows, then retry the surviving batch.
-            var vanishedIds = ex.Entries
-                .Select(e => ((HistoryItem)e.Entity).Id)
-                .ToHashSet();
-
-            foreach (var entry in ex.Entries)
-                entry.State = EntityState.Detached;
-
-            var cleanupEntries = dbClient.Ctx.ChangeTracker.Entries<HistoryCleanupItem>()
-                .Where(e => e.State == EntityState.Added && vanishedIds.Contains(e.Entity.Id))
-                .ToList();
-            foreach (var entry in cleanupEntries)
-                entry.State = EntityState.Detached;
-
-            await dbClient.Ctx.SaveChangesAsync(request.CancellationToken).ConfigureAwait(false);
-        }
+        await dbClient.SaveHistoryRemovalAsync(request.CancellationToken).ConfigureAwait(false);
         _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemRemoved, string.Join(",", ids));
         return new RemoveFromHistoryResponse() { Status = true };
     }

--- a/backend/Clients/RadarrSonarr/ArrInstanceBackoff.cs
+++ b/backend/Clients/RadarrSonarr/ArrInstanceBackoff.cs
@@ -1,0 +1,105 @@
+using System.Collections.Concurrent;
+using System.Net.Sockets;
+
+namespace NzbWebDAV.Clients.RadarrSonarr;
+
+/// <summary>
+/// Per-host exponential backoff for Arr instance polls. When an instance starts
+/// timing out or refusing connections (an overloaded or dying peer), polling it on
+/// the fixed cadence just adds work to a host that cannot answer. After
+/// <see cref="FailureThreshold"/> consecutive reachability failures the instance is
+/// considered "in backoff" and callers should skip non-essential polls until
+/// <see cref="GetRemainingBackoff"/> elapses. Any successful call resets the counter.
+///
+/// Only reachability failures (timeout, socket EAGAIN/refused/unreachable) count —
+/// a 4xx/5xx response means the host is alive and answering, so it does not back off.
+/// </summary>
+public sealed class ArrInstanceBackoff
+{
+    internal const int FailureThreshold = 2;
+    private static readonly TimeSpan MinBackoff = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan MaxBackoff = TimeSpan.FromMinutes(10);
+
+    private sealed class State
+    {
+        public int ConsecutiveFailures;
+        public DateTimeOffset BackoffUntil;
+    }
+
+    private readonly ConcurrentDictionary<string, State> _byHost = new(StringComparer.OrdinalIgnoreCase);
+    private readonly TimeProvider _timeProvider;
+
+    public ArrInstanceBackoff(TimeProvider? timeProvider = null)
+    {
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    private static string Key(string host) => host.TrimEnd('/').ToLowerInvariant();
+
+    /// <summary>True while the host is within its current backoff window.</summary>
+    public bool IsInBackoff(string host)
+    {
+        if (!_byHost.TryGetValue(Key(host), out var state)) return false;
+        lock (state)
+            return state.ConsecutiveFailures >= FailureThreshold && _timeProvider.GetUtcNow() < state.BackoffUntil;
+    }
+
+    /// <summary>Remaining backoff for the host, or zero if not backing off.</summary>
+    public TimeSpan GetRemainingBackoff(string host)
+    {
+        if (!_byHost.TryGetValue(Key(host), out var state)) return TimeSpan.Zero;
+        lock (state)
+        {
+            if (state.ConsecutiveFailures < FailureThreshold) return TimeSpan.Zero;
+            var remaining = state.BackoffUntil - _timeProvider.GetUtcNow();
+            return remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero;
+        }
+    }
+
+    public void RecordSuccess(string host)
+    {
+        if (!_byHost.TryGetValue(Key(host), out var state)) return;
+        lock (state)
+        {
+            state.ConsecutiveFailures = 0;
+            state.BackoffUntil = default;
+        }
+    }
+
+    /// <summary>
+    /// Record a failure. Only reachability failures advance the backoff counter;
+    /// other exceptions are ignored so a live-but-erroring host keeps its cadence.
+    /// </summary>
+    public void RecordFailure(string host, Exception exception)
+    {
+        if (!IsReachabilityFailure(exception)) return;
+        var state = _byHost.GetOrAdd(Key(host), _ => new State());
+        lock (state)
+        {
+            state.ConsecutiveFailures++;
+            if (state.ConsecutiveFailures < FailureThreshold) return;
+            var backoff = ComputeBackoff(state.ConsecutiveFailures);
+            state.BackoffUntil = _timeProvider.GetUtcNow() + backoff;
+        }
+    }
+
+    private static TimeSpan ComputeBackoff(int consecutiveFailures)
+    {
+        var steps = Math.Min(consecutiveFailures - FailureThreshold, 10);
+        var backoff = TimeSpan.FromTicks(MinBackoff.Ticks << steps);
+        return backoff > MaxBackoff ? MaxBackoff : backoff;
+    }
+
+    internal static bool IsReachabilityFailure(Exception exception)
+    {
+        // A per-call timeout surfaces as TaskCanceledException/OperationCanceledException
+        // whose token is the linked call token, not the shutdown token.
+        if (exception is OperationCanceledException) return true;
+        for (var e = exception; e is not null; e = e.InnerException)
+        {
+            if (e is SocketException) return true;
+            if (e is HttpRequestException httpEx && httpEx.StatusCode is null) return true;
+        }
+        return false;
+    }
+}

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -673,6 +673,7 @@ public class MultiProviderNntpClient(
                     {
                         stopwatch.Stop();
                         walk.NoteException(e);
+                        MarkCachedMissingOnThrownMiss(e, segmentId, provider, missingGroups);
                         var reason = ClassifyAndRecordFailure(
                             provider.MetricsKey, e, stopwatch.ElapsedMilliseconds,
                             priorMisses?.Count ?? 0, traceRange,
@@ -905,6 +906,7 @@ public class MultiProviderNntpClient(
             {
                 stopwatch.Stop();
                 walk.NoteException(e);
+                MarkCachedMissingOnThrownMiss(e, segmentId, provider, missingGroups);
                 var reason = ClassifyAndRecordFailure(
                     provider.MetricsKey, e, stopwatch.ElapsedMilliseconds, attemptIndex,
                     traceRange, operation, segmentId);
@@ -1055,6 +1057,7 @@ public class MultiProviderNntpClient(
             {
                 stopwatch.Stop();
                 walk.NoteException(e);
+                MarkCachedMissingOnThrownMiss(e, articleId, provider, missingGroups);
                 var reason = ClassifyAndRecordFailure(
                     provider.MetricsKey, e, stopwatch.ElapsedMilliseconds, attemptIndex,
                     traceRange, operation, articleId);
@@ -1092,6 +1095,26 @@ public class MultiProviderNntpClient(
     private void MarkCachedMissing(SegmentId segmentId, MultiConnectionNntpClient provider)
     {
         articleMissCache?.MarkMissing(CacheKey(segmentId, provider));
+    }
+
+    /// <summary>
+    /// Production <see cref="BaseNntpClient"/> throws <see cref="UsenetArticleNotFoundException"/>
+    /// on 430 instead of returning a response object. The response-object path already
+    /// marks the miss cache; this keeps the throw path in the retry/fallback loop
+    /// consistent. The initial batch primary 430 must not mark, so the intentional
+    /// re-probe is not skipped by its own cache entry.
+    /// </summary>
+    private void MarkCachedMissingOnThrownMiss(
+        Exception exception,
+        SegmentId? segmentId,
+        MultiConnectionNntpClient provider,
+        HashSet<string> missingGroups)
+    {
+        if (segmentId is not { } id) return;
+        if (ClassifyException(exception) != SegmentFetch.FetchStatus.Missing) return;
+        var group = NormalizeStorageGroup(provider.StorageGroup);
+        if (group.Length > 0) missingGroups.Add(group);
+        MarkCachedMissing(id, provider);
     }
 
     private static string CacheKey(SegmentId segmentId, MultiConnectionNntpClient provider) =>

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1273,6 +1273,24 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
             .ToHashSet();
     }
 
+    private static readonly HashSet<string> DefaultMediaReadinessCategories =
+        new(StringComparer.OrdinalIgnoreCase) { "tv", "movies", "movie", "series" };
+
+    /// <summary>
+    /// Categories whose media outputs get a BODY-level head/tail readiness probe before
+    /// SAB reports completion. Always includes the explicit article-existence categories;
+    /// when ensure-importable-video is enabled, the common media categories are included
+    /// too so a short-decoded or unseekable file fails into history before Arr/rclone
+    /// reads it, rather than after.
+    /// </summary>
+    public HashSet<string> GetMediaReadinessCategories()
+    {
+        var categories = GetEnsureArticleExistenceCategories();
+        if (IsEnsureImportableMediaEnabled())
+            categories.UnionWith(DefaultMediaReadinessCategories);
+        return categories;
+    }
+
     public string GetArticleExistenceCheckMode()
     {
         var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiArticleExistenceCheckMode));

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1274,7 +1274,7 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
     }
 
     private static readonly HashSet<string> DefaultMediaReadinessCategories =
-        new(StringComparer.OrdinalIgnoreCase) { "tv", "movies", "movie", "series" };
+        new(StringComparer.OrdinalIgnoreCase) { "tv", "movies", "movie", "series", "audio" };
 
     /// <summary>
     /// Categories whose media outputs get a BODY-level head/tail readiness probe before

--- a/backend/Database/BlobStore.cs
+++ b/backend/Database/BlobStore.cs
@@ -44,8 +44,8 @@ public static class BlobStore
         CancellationToken cancellationToken = default)
         => Current.WriteBlob(id, stream, cancellationToken);
 
-    public static Task WriteBlob<T>(Guid id, T blob)
-        => Current.WriteBlob(id, blob);
+    public static Task WriteBlob<T>(Guid id, T blob, CancellationToken cancellationToken = default)
+        => Current.WriteBlob(id, blob, cancellationToken);
 
     public static Stream? ReadBlob(Guid id)
         => Current.ReadBlob(id);

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -565,11 +565,17 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
     /// same history row or a duplicate <see cref="HistoryCleanupItem"/> insert as
     /// success. Two SAB remove-from-history calls can otherwise collide on the
     /// cleanup primary key after both have staged the same id.
+    ///
+    /// SQLite's EF provider issues one modification command per batch, so a
+    /// colliding delete of N ids can surface N separate concurrency (or unique)
+    /// exceptions. The retry budget is therefore the number of pending entries,
+    /// plus one for the successful save — not a fixed attempt count.
     /// </summary>
     public async Task SaveHistoryRemovalAsync(CancellationToken ct = default)
     {
+        var maxAttempts = CountPendingSaveEntries() + 1;
         DbUpdateException? last = null;
-        for (var attempt = 0; attempt < 3; attempt++)
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
         {
             try
             {
@@ -579,7 +585,10 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
             catch (DbUpdateConcurrencyException ex) when (ex.Entries.All(e => e.Entity is HistoryItem))
             {
                 last = ex;
+                var pendingBefore = CountPendingSaveEntries();
                 DetachVanishedHistory(ex);
+                if (CountPendingSaveEntries() >= pendingBefore)
+                    throw;
             }
             catch (DbUpdateException ex) when (TryDetachDuplicateCleanup(ex))
             {
@@ -590,6 +599,10 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
         if (last is not null)
             throw last;
     }
+
+    private int CountPendingSaveEntries() =>
+        Ctx.ChangeTracker.Entries()
+            .Count(e => e.State is EntityState.Added or EntityState.Deleted or EntityState.Modified);
 
     private void DetachVanishedHistory(DbUpdateConcurrencyException ex)
     {

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -548,6 +548,9 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
             .Select(x => x.Id)
             .ToHashSetAsync(ct)
             .ConfigureAwait(false);
+        alreadyPending.UnionWith(Ctx.ChangeTracker.Entries<HistoryCleanupItem>()
+            .Where(e => e.State == EntityState.Added)
+            .Select(e => e.Entity.Id));
         Ctx.HistoryCleanupItems.AddRange(removed
             .Where(x => !alreadyPending.Contains(x.Id))
             .Select(x => new HistoryCleanupItem
@@ -555,6 +558,68 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
                 Id = x.Id,
                 DeleteMountedFiles = deleteFiles
             }));
+    }
+
+    /// <summary>
+    /// Commits a history-removal change set, treating a concurrent delete of the
+    /// same history row or a duplicate <see cref="HistoryCleanupItem"/> insert as
+    /// success. Two SAB remove-from-history calls can otherwise collide on the
+    /// cleanup primary key after both have staged the same id.
+    /// </summary>
+    public async Task SaveHistoryRemovalAsync(CancellationToken ct = default)
+    {
+        DbUpdateException? last = null;
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+                return;
+            }
+            catch (DbUpdateConcurrencyException ex) when (ex.Entries.All(e => e.Entity is HistoryItem))
+            {
+                last = ex;
+                DetachVanishedHistory(ex);
+            }
+            catch (DbUpdateException ex) when (TryDetachDuplicateCleanup(ex))
+            {
+                last = ex;
+            }
+        }
+
+        if (last is not null)
+            throw last;
+    }
+
+    private void DetachVanishedHistory(DbUpdateConcurrencyException ex)
+    {
+        var vanishedIds = ex.Entries
+            .Select(e => ((HistoryItem)e.Entity).Id)
+            .ToHashSet();
+
+        foreach (var entry in ex.Entries)
+            entry.State = EntityState.Detached;
+
+        foreach (var entry in Ctx.ChangeTracker.Entries<HistoryCleanupItem>()
+                     .Where(e => e.State == EntityState.Added && vanishedIds.Contains(e.Entity.Id))
+                     .ToList())
+        {
+            entry.State = EntityState.Detached;
+        }
+    }
+
+    private static bool TryDetachDuplicateCleanup(DbUpdateException ex)
+    {
+        if (!ex.IsUniqueConstraintException())
+            return false;
+
+        var cleanup = ex.Entries.Where(e => e.Entity is HistoryCleanupItem).ToList();
+        if (cleanup.Count == 0)
+            return false;
+
+        foreach (var entry in cleanup)
+            entry.State = EntityState.Detached;
+        return true;
     }
 
     public sealed record DavSubtreeDeleteEntry(

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -582,11 +582,12 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
                 await Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
                 return;
             }
-            catch (DbUpdateConcurrencyException ex) when (ex.Entries.All(e => e.Entity is HistoryItem))
+            catch (DbUpdateConcurrencyException ex) when (
+                ex.Entries.All(e => e.Entity is HistoryItem or DavItem))
             {
                 last = ex;
                 var pendingBefore = CountPendingSaveEntries();
-                DetachVanishedHistory(ex);
+                DetachVanishedEntries(ex);
                 if (CountPendingSaveEntries() >= pendingBefore)
                     throw;
             }
@@ -604,17 +605,22 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
         Ctx.ChangeTracker.Entries()
             .Count(e => e.State is EntityState.Added or EntityState.Deleted or EntityState.Modified);
 
-    private void DetachVanishedHistory(DbUpdateConcurrencyException ex)
+    private void DetachVanishedEntries(DbUpdateConcurrencyException ex)
     {
-        var vanishedIds = ex.Entries
-            .Select(e => ((HistoryItem)e.Entity).Id)
+        var vanishedHistoryIds = ex.Entries
+            .Select(e => e.Entity)
+            .OfType<HistoryItem>()
+            .Select(item => item.Id)
             .ToHashSet();
 
         foreach (var entry in ex.Entries)
             entry.State = EntityState.Detached;
 
+        if (vanishedHistoryIds.Count == 0)
+            return;
+
         foreach (var entry in Ctx.ChangeTracker.Entries<HistoryCleanupItem>()
-                     .Where(e => e.State == EntityState.Added && vanishedIds.Contains(e.Entity.Id))
+                     .Where(e => e.State == EntityState.Added && vanishedHistoryIds.Contains(e.Entity.Id))
                      .ToList())
         {
             entry.State = EntityState.Detached;

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -496,11 +496,7 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
 
             Ctx.Items.RemoveRange(davItems);
             Ctx.HistoryItems.RemoveRange(historyItems);
-            Ctx.HistoryCleanupItems.AddRange(historyItems.Select(x => new HistoryCleanupItem
-            {
-                Id = x.Id,
-                DeleteMountedFiles = deleteFiles
-            }));
+            await AddCleanupItemsIdempotentAsync(historyItems, deleteFiles, ct).ConfigureAwait(false);
         }
         else
         {
@@ -523,11 +519,7 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
             }
 
             Ctx.HistoryItems.RemoveRange(existing);
-            Ctx.HistoryCleanupItems.AddRange(existing.Select(x => new HistoryCleanupItem
-            {
-                Id = x.Id,
-                DeleteMountedFiles = deleteFiles
-            }));
+            await AddCleanupItemsIdempotentAsync(existing, deleteFiles, ct).ConfigureAwait(false);
         }
 
         await CascadeWatchdogEntriesAsync(
@@ -535,6 +527,34 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
             contentGroupKeys: groupKeys,
             ct: ct,
             excludeHistoryIds: ids).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Adds a HistoryCleanupItem for each removed history row, skipping ids that already
+    /// have a pending cleanup row. A concurrent RemoveFromHistory (or a retry while the
+    /// previous cleanup row is still pending) would otherwise collide on the primary key
+    /// and 500 the SAB call; a duplicate cleanup request is already satisfied, so it is
+    /// treated as success.
+    /// </summary>
+    private async Task AddCleanupItemsIdempotentAsync(
+        List<HistoryItem> removed,
+        bool deleteFiles,
+        CancellationToken ct)
+    {
+        if (removed.Count == 0) return;
+        var removedIds = removed.Select(x => x.Id).ToList();
+        var alreadyPending = await Ctx.HistoryCleanupItems
+            .Where(x => removedIds.Contains(x.Id))
+            .Select(x => x.Id)
+            .ToHashSetAsync(ct)
+            .ConfigureAwait(false);
+        Ctx.HistoryCleanupItems.AddRange(removed
+            .Where(x => !alreadyPending.Contains(x.Id))
+            .Select(x => new HistoryCleanupItem
+            {
+                Id = x.Id,
+                DeleteMountedFiles = deleteFiles
+            }));
     }
 
     public sealed record DavSubtreeDeleteEntry(

--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -1002,11 +1002,11 @@ public class DavDatabaseContext : DbContext
         {
             // save blobs to blob-store
             foreach (var blobNzbFile in BlobNzbFiles)
-                await BlobStore.WriteBlob(blobNzbFile.Id, blobNzbFile).ConfigureAwait(false);
+                await BlobStore.WriteBlob(blobNzbFile.Id, blobNzbFile, cancellationToken).ConfigureAwait(false);
             foreach (var blobRarFile in BlobRarFiles)
-                await BlobStore.WriteBlob(blobRarFile.Id, blobRarFile).ConfigureAwait(false);
+                await BlobStore.WriteBlob(blobRarFile.Id, blobRarFile, cancellationToken).ConfigureAwait(false);
             foreach (var blobMultipartFile in BlobMultipartFiles)
-                await BlobStore.WriteBlob(blobMultipartFile.Id, blobMultipartFile).ConfigureAwait(false);
+                await BlobStore.WriteBlob(blobMultipartFile.Id, blobMultipartFile, cancellationToken).ConfigureAwait(false);
 
             // save db changes
             var addedOrRemovedDavItems = GetAddedOrRemovedDavItems();

--- a/backend/Database/FileBlobStore.cs
+++ b/backend/Database/FileBlobStore.cs
@@ -84,6 +84,8 @@ public sealed class FileBlobStore : IBlobStore, IDisposable
             await using (var fileStream = OpenBlobWrite(tempPath))
             await using (var compressionStream = new CompressionStream(fileStream, CompressionLevel))
             {
+                // CPU-bound serialization may finish before the token is observed;
+                // ThrowIfCancellationRequested and temp-file cleanup still honor it.
                 await MemoryPackSerializer.SerializeAsync(compressionStream, blob, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             }

--- a/backend/Database/FileBlobStore.cs
+++ b/backend/Database/FileBlobStore.cs
@@ -73,8 +73,9 @@ public sealed class FileBlobStore : IBlobStore, IDisposable
         }
     }
 
-    public async Task WriteBlob<T>(Guid id, T blob)
+    public async Task WriteBlob<T>(Guid id, T blob, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var blobPath = GetBlobPath(id);
         var tempPath = blobPath + ".tmp";
         var committed = false;
@@ -83,8 +84,10 @@ public sealed class FileBlobStore : IBlobStore, IDisposable
             await using (var fileStream = OpenBlobWrite(tempPath))
             await using (var compressionStream = new CompressionStream(fileStream, CompressionLevel))
             {
-                await MemoryPackSerializer.SerializeAsync(compressionStream, blob).ConfigureAwait(false);
+                await MemoryPackSerializer.SerializeAsync(compressionStream, blob, cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
             }
+            cancellationToken.ThrowIfCancellationRequested();
 
             CommitBlobWrite(blobPath, tempPath);
             committed = true;

--- a/backend/Database/IBlobStore.cs
+++ b/backend/Database/IBlobStore.cs
@@ -11,7 +11,7 @@ public interface IBlobStore
 {
     [OverloadResolutionPriority(1)]
     Task WriteBlob(Guid id, Stream stream, CancellationToken cancellationToken = default);
-    Task WriteBlob<T>(Guid id, T blob);
+    Task WriteBlob<T>(Guid id, T blob, CancellationToken cancellationToken = default);
     Stream? ReadBlob(Guid id);
     Task<T?> ReadBlob<T>(Guid id);
     void Delete(Guid id);

--- a/backend/Exceptions/PersistentUsenetCorruptionException.cs
+++ b/backend/Exceptions/PersistentUsenetCorruptionException.cs
@@ -1,0 +1,20 @@
+namespace NzbWebDAV.Exceptions;
+
+/// <summary>
+/// The same yEnc CRC pair was confirmed on at least two providers. Retrying the
+/// queue item cannot recover the segment — the article itself is corrupt.
+/// </summary>
+public sealed class PersistentUsenetCorruptionException(
+    string segmentId,
+    uint actualCrc,
+    uint expectedCrc,
+    Exception? innerException = null)
+    : NonRetryableDownloadException(
+        $"Segment {segmentId} failed yEnc CRC identically on multiple providers " +
+        $"(actual {actualCrc:x8}, expected {expectedCrc:x8}).",
+        innerException)
+{
+    public string SegmentId { get; } = segmentId;
+    public uint ActualCrc { get; } = actualCrc;
+    public uint ExpectedCrc { get; } = expectedCrc;
+}

--- a/backend/Exceptions/UsenetCorruptArticleException.cs
+++ b/backend/Exceptions/UsenetCorruptArticleException.cs
@@ -1,3 +1,6 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
 namespace NzbWebDAV.Exceptions;
 
 public sealed class UsenetCorruptArticleException(
@@ -8,6 +11,28 @@ public sealed class UsenetCorruptArticleException(
         $"Provider {providerKey} returned corrupt yEnc data for segment {segmentId}.",
         innerException)
 {
+    private static readonly Regex CrcPairPattern = new(
+        @"The decoded yEnc CRC32 was ([0-9a-f]{8}), but the trailer expected ([0-9a-f]{8})\.",
+        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     public string SegmentId { get; } = segmentId;
     public string ProviderKey { get; } = providerKey;
+
+    public bool TryGetCrcPair(out uint actualCrc, out uint expectedCrc)
+    {
+        actualCrc = 0;
+        expectedCrc = 0;
+        for (var current = InnerException; current != null; current = current.InnerException)
+        {
+            var match = CrcPairPattern.Match(current.Message);
+            if (!match.Success) continue;
+            if (!uint.TryParse(match.Groups[1].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out actualCrc))
+                continue;
+            if (!uint.TryParse(match.Groups[2].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out expectedCrc))
+                continue;
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/backend/Extensions/ExceptionExtensions.cs
+++ b/backend/Extensions/ExceptionExtensions.cs
@@ -150,6 +150,12 @@ public static class ExceptionExtensions
             return true;
         }
 
+        if (exception.IsTransientDatabaseException())
+        {
+            reason = exception.GetBaseException().Message;
+            return true;
+        }
+
         string? found = null;
         for (var current = exception; current != null; current = current.InnerException)
         {

--- a/backend/Extensions/ExceptionExtensions.cs
+++ b/backend/Extensions/ExceptionExtensions.cs
@@ -25,8 +25,8 @@ public static class ExceptionExtensions
     /// <summary>
     /// True when the exception chain contains SQLITE_CORRUPT (primary result code 11),
     /// meaning the database file itself is damaged. Transient busy/locked errors
-    /// (codes 5/6/8/13) are deliberately excluded: corruption never heals on retry,
-    /// while busy/locked conditions do.
+    /// (codes 5/6) and disk errors (codes 8/13) are deliberately excluded: corruption
+    /// never heals on retry, while those conditions are classified separately.
     /// </summary>
     public static bool IsDatabaseCorruptionException(this Exception exception)
     {
@@ -75,21 +75,40 @@ public static class ExceptionExtensions
     }
 
     /// <summary>
-    /// True for write contention that can be retried by the caller's next sweep.
-    /// PostgreSQL reports concurrent serialization/deadlock failures by SQLSTATE.
+    /// True for write contention that can be retried by the caller's next sweep
+    /// (SQLITE_BUSY / SQLITE_LOCKED). SQLITE_READONLY (8) and SQLITE_FULL (13) are
+    /// operator-facing disk errors that do not heal on retry — see
+    /// <see cref="IsKnownSqliteDiskException"/>. PostgreSQL reports concurrent
+    /// serialization/deadlock failures by SQLSTATE.
     /// </summary>
     public static bool IsTransientDatabaseException(this Exception exception)
     {
         for (var current = exception; current != null; current = current.InnerException)
         {
             if (current is SqliteException sqlite
-                && sqlite.SqliteErrorCode is 5 or 6 or 8 or 13)
+                && sqlite.SqliteErrorCode is 5 or 6)
                 return true;
 
             if (current is PostgresException postgres
                 && postgres.SqlState is PostgresErrorCodes.SerializationFailure
                     or PostgresErrorCodes.DeadlockDetected
                     or PostgresErrorCodes.LockNotAvailable)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// True for SQLITE_READONLY (8) and SQLITE_FULL (13). These are known
+    /// operator errors (disk full, read-only mount) that should log as a single
+    /// line without a stack, but must not be retried as transient contention.
+    /// </summary>
+    public static bool IsKnownSqliteDiskException(this Exception exception)
+    {
+        for (var current = exception; current != null; current = current.InnerException)
+        {
+            if (current is SqliteException sqlite && sqlite.SqliteErrorCode is 8 or 13)
                 return true;
         }
 
@@ -150,7 +169,7 @@ public static class ExceptionExtensions
             return true;
         }
 
-        if (exception.IsTransientDatabaseException())
+        if (exception.IsTransientDatabaseException() || exception.IsKnownSqliteDiskException())
         {
             reason = exception.GetBaseException().Message;
             return true;

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -403,6 +403,7 @@ public partial class Program
                 .AddSingleton<LiveStatsBroadcaster>()
                 .AddHostedService(sp => sp.GetRequiredService<LiveStatsBroadcaster>())
                 .AddSingleton<ArrReplacementSearchBudget>()
+                .AddSingleton<NzbWebDAV.Clients.RadarrSonarr.ArrInstanceBackoff>()
                 .AddHostedService<HealthCheckService>()
                 .AddHostedService<HealthCheckRetentionService>()
                 .AddHostedService<ArrMonitoringService>()

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -841,6 +841,7 @@ public class QueueItemProcessor(
             dbClient.Ctx.SuppressAutomaticRcloneVfsForget = true;
             try
             {
+                _stageReporter("finalize-commit");
                 await dbClient.Ctx.SaveChangesAsync(finalizeCt).ConfigureAwait(false);
             }
             finally
@@ -898,7 +899,6 @@ public class QueueItemProcessor(
         await finalizeLock.WaitAsync(waitCt).ConfigureAwait(false);
         try
         {
-            _stageReporter("finalize-commit");
             await action().ConfigureAwait(false);
         }
         finally

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -513,7 +513,10 @@ public class QueueItemProcessor(
             if (configManager.IsEnsureImportableMediaEnabled())
                 new EnsureImportableMediaValidator(dbClient).ThrowIfValidationFails();
 
-            if (healthCheckCategories.Contains(queueItem.Category.ToLowerInvariant()))
+            // BODY readiness runs for the explicit health-check categories and, when
+            // ensure-importable-video is on, for the common media categories — so a
+            // short-decoded or unseekable file fails into history before Arr/rclone.
+            if (configManager.GetMediaReadinessCategories().Contains(queueItem.Category.ToLowerInvariant()))
             {
                 await RunStageAsync(
                     "import-readiness",

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -72,7 +72,7 @@ public class QueueItemProcessor(
     }
 
     private const int MaxProviderRetryAttempts = 20;
-    private static readonly TimeSpan StageWarningInterval = TimeSpan.FromMinutes(15);
+    private static readonly TimeSpan StageWarningInterval = TimeSpan.FromMinutes(2);
 
     /// <summary>
     /// Set by the queue's stuck watchdog when this worker's cancellation should
@@ -206,8 +206,10 @@ public class QueueItemProcessor(
                 queueItem.PauseUntil = DateTime.Now + backoff;
                 dbClient.Ctx.QueueItems.Attach(queueItem);
                 dbClient.Ctx.Entry(queueItem).Property(x => x.PauseUntil).IsModified = true;
-                await WithFinalizeLockAsync(() => dbClient.Ctx.SaveChangesAsync(ct))
-                    .ConfigureAwait(false);
+                // Retry persistence is a single-row PauseUntil write. It must not join
+                // the finalize convoy — a worker blocked in readiness/blob I/O would
+                // otherwise pin every provider-retry for the process.
+                await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
                 _ = websocketManager.SendMessage(WebsocketTopic.QueueItemStatus, $"{queueItem.Id}|Queued");
             }
             catch (Exception ex) when (ex is DbUpdateException or InvalidOperationException)
@@ -892,9 +894,11 @@ public class QueueItemProcessor(
         }
 
         var waitCt = cancellationToken ?? ct;
+        _stageReporter("finalize-lock-wait");
         await finalizeLock.WaitAsync(waitCt).ConfigureAwait(false);
         try
         {
+            _stageReporter("finalize-commit");
             await action().ConfigureAwait(false);
         }
         finally

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -882,7 +882,11 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
             _configManager, _websocketManager, _providerUsageTracker,
             _watchdogLog, _sourceTracker, progressHook, _retryAttempts,
             _finalizeLock, cts.Token,
-            stageReporter: stage => inProgressQueueItem.CurrentStage = stage
+            stageReporter: stage =>
+            {
+                inProgressQueueItem.CurrentStage = stage;
+                inProgressQueueItem.StageStartedAtUtc = DateTime.UtcNow;
+            }
         )
         {
             // The stuck watchdog flips this flag on the final stall attempt; the
@@ -1255,10 +1259,17 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
         int ProgressPercentage,
         bool IsPrimary,
         TimeSpan? Eta = null,
-        double BytesPerSecond = 0);
+        double BytesPerSecond = 0,
+        string CurrentStage = "",
+        long StageAgeMs = 0,
+        long SemaphoreWaitMilliseconds = 0);
 
-    private static InProgressQueueItemSnapshot ToSnapshot(InProgressQueueItem item) =>
-        new(
+    private static InProgressQueueItemSnapshot ToSnapshot(InProgressQueueItem item)
+    {
+        var stageAgeMs = item.StageStartedAtUtc is { } started
+            ? Math.Max(0, (long)(DateTime.UtcNow - started).TotalMilliseconds)
+            : 0;
+        return new(
             item.QueueItem,
             item.ProgressPercentage,
             item.IsPrimary,
@@ -1266,7 +1277,11 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
                 item.BytesPerSecond,
                 item.ProgressPercentage,
                 item.QueueItem.TotalSegmentBytes),
-            item.BytesPerSecond);
+            item.BytesPerSecond,
+            item.CurrentStage,
+            stageAgeMs,
+            item.QueueDownloadContext.SemaphoreWaitMilliseconds);
+    }
 
     private sealed class InProgressQueueItem
     {
@@ -1281,6 +1296,7 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
         /// processors). Set by the processor; read by the stuck watchdog.
         /// </summary>
         public string CurrentStage { get; set; } = string.Empty;
+        public DateTime? StageStartedAtUtc { get; set; }
         public Task ProcessingTask { get; set; } = null!;
         public TaskCompletionSource CompletionSignal { get; init; } = null!;
         public CancellationTokenSource CancellationTokenSource { get; init; } = null!;

--- a/backend/Services/ArrHealthService.cs
+++ b/backend/Services/ArrHealthService.cs
@@ -212,6 +212,8 @@ public sealed class ArrHealthService : BackgroundService
         {
             var queueStatus = await CallAsync(callCt => client.GetQueueStatusAsync(callCt), ct).ConfigureAwait(false);
             var queue = await CallAsync(callCt => client.GetQueueAsync(callCt), ct).ConfigureAwait(false);
+            // Arr answered; clear reachability backoff before local DB/history work.
+            _backoff.RecordSuccess(details.Host);
 
             await using var dav = DavContextFactory();
             await using var metrics = MetricsContextFactory();
@@ -244,7 +246,6 @@ public sealed class ArrHealthService : BackgroundService
                 ? ArrInstanceHealthStatus.Degraded
                 : ArrInstanceHealthStatus.Healthy;
 
-            _backoff.RecordSuccess(details.Host);
             RecordSuccess(new ArrHealthSnapshot
             {
                 InstanceKey = key,

--- a/backend/Services/ArrHealthService.cs
+++ b/backend/Services/ArrHealthService.cs
@@ -31,6 +31,7 @@ public sealed class ArrHealthService : BackgroundService
     ];
 
     private readonly ConfigManager _configManager;
+    private readonly ArrInstanceBackoff _backoff;
     private readonly SemaphoreSlim _cycleGate = new(1, 1);
     private readonly object _snapshotLock = new();
     private readonly Dictionary<string, ArrHealthSnapshot> _snapshots = new(StringComparer.Ordinal);
@@ -46,9 +47,11 @@ public sealed class ArrHealthService : BackgroundService
 
     public ArrHealthService(
         ConfigManager configManager,
-        IDbContextFactory<DavDatabaseContext>? dbContextFactory = null)
+        IDbContextFactory<DavDatabaseContext>? dbContextFactory = null,
+        ArrInstanceBackoff? backoff = null)
     {
         _configManager = configManager;
+        _backoff = backoff ?? new ArrInstanceBackoff();
         DavContextFactory = dbContextFactory is null
             ? static () => new DavDatabaseContext()
             : dbContextFactory.CreateDbContext;
@@ -181,6 +184,19 @@ public sealed class ArrHealthService : BackgroundService
     {
         var key = ArrConfig.MakeInstanceKey(appType, details.Host);
         var displayName = string.IsNullOrWhiteSpace(details.Name) ? details.Host : details.Name;
+
+        // Skip a host that is timing out or refusing connections until its backoff
+        // elapses — polling a dying peer on the fixed cadence only adds load it cannot
+        // serve. The last-known snapshot stays in place so the UI keeps showing it.
+        if (_backoff.IsInBackoff(details.Host))
+        {
+            Log.Debug(
+                "Arr health poll for {Host} skipped; instance is in backoff for {Remaining}",
+                details.Host,
+                _backoff.GetRemainingBackoff(details.Host));
+            return;
+        }
+
         ArrClient client;
         try
         {
@@ -228,6 +244,7 @@ public sealed class ArrHealthService : BackgroundService
                 ? ArrInstanceHealthStatus.Degraded
                 : ArrInstanceHealthStatus.Healthy;
 
+            _backoff.RecordSuccess(details.Host);
             RecordSuccess(new ArrHealthSnapshot
             {
                 InstanceKey = key,
@@ -254,6 +271,7 @@ public sealed class ArrHealthService : BackgroundService
         catch (Exception e) when (e is not OutOfMemoryException)
         {
             e.LogWarningKnownOrStack("Arr health poll failed for {Host}", details.Host);
+            _backoff.RecordFailure(details.Host, e);
             RecordFailure(key, appType, details.Host, displayName, e);
         }
     }

--- a/backend/Services/ArrMonitoringService.cs
+++ b/backend/Services/ArrMonitoringService.cs
@@ -18,11 +18,16 @@ public class ArrMonitoringService : BackgroundService
 {
     private readonly ConfigManager _configManager;
     private readonly ArrReplacementSearchBudget _replacementSearchBudget;
+    private readonly ArrInstanceBackoff _backoff;
 
-    public ArrMonitoringService(ConfigManager configManager, ArrReplacementSearchBudget replacementSearchBudget)
+    public ArrMonitoringService(
+        ConfigManager configManager,
+        ArrReplacementSearchBudget replacementSearchBudget,
+        ArrInstanceBackoff? backoff = null)
     {
         _configManager = configManager;
         _replacementSearchBudget = replacementSearchBudget;
+        _backoff = backoff ?? new ArrInstanceBackoff();
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -61,11 +66,23 @@ public class ArrMonitoringService : BackgroundService
         // the buffer support packs are built from, so detail goes to Debug and the pass
         // reports one Warning per release and action.
         var resolutions = new List<(string? Title, ArrConfig.QueueAction Action, string Reason, string IdentitySource)>();
+
+        // Skip a host that is timing out or refusing connections until its backoff elapses.
+        if (_backoff.IsInBackoff(client.Host))
+        {
+            Log.Debug(
+                "Arr queue monitoring for {Host} skipped; instance is in backoff for {Remaining}",
+                client.Host,
+                _backoff.GetRemainingBackoff(client.Host));
+            return;
+        }
+
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
         timeout.CancelAfter(TimeSpan.FromSeconds(20));
         try
         {
             var queueStatus = await client.GetQueueStatusAsync(timeout.Token).ConfigureAwait(false);
+            _backoff.RecordSuccess(client.Host);
             if (queueStatus is { Warnings: false, UnknownWarnings: false }) return;
             var queue = await client.GetQueueAsync(timeout.Token).ConfigureAwait(false);
             var stuckRecords = GetActionableStuckRecords(queue, arrConfig.QueueRules);
@@ -84,10 +101,12 @@ public class ArrMonitoringService : BackgroundService
         catch (OperationCanceledException) when (timeout.IsCancellationRequested)
         {
             Log.Warning("Arr queue monitoring timed out after 20 seconds for {Host}", client.Host);
+            _backoff.RecordFailure(client.Host, new TimeoutException("Arr queue monitoring timed out."));
         }
         catch (Exception e) when (e is HttpRequestException { InnerException: System.Net.Sockets.SocketException })
         {
             Log.Debug(e, "Could not reach Arr instance {Host} for queue monitoring", client.Host);
+            _backoff.RecordFailure(client.Host, e);
         }
         catch (Exception e) when (e is not OutOfMemoryException)
         {

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -65,6 +65,7 @@ public class HealthCheckService : BackgroundService
 
     private readonly ConfigManager _configManager;
     private readonly ArrReplacementSearchBudget _replacementSearchBudget;
+    private readonly ArrInstanceBackoff _arrBackoff;
     private readonly UsenetStreamingClient _usenetClient;
     private readonly WebsocketManager _websocketManager;
     private readonly BenchmarkGate _benchmarkGate;
@@ -92,11 +93,13 @@ public class HealthCheckService : BackgroundService
         RepairPatchStore repairPatchStore,
         ArrReplacementSearchBudget replacementSearchBudget,
         IDbContextFactory<DavDatabaseContext>? dbContextFactory = null,
-        TimeProvider? timeProvider = null
+        TimeProvider? timeProvider = null,
+        ArrInstanceBackoff? arrBackoff = null
     )
     {
         _configManager = configManager;
         _replacementSearchBudget = replacementSearchBudget;
+        _arrBackoff = arrBackoff ?? new ArrInstanceBackoff();
         _usenetClient = usenetClient;
         _websocketManager = websocketManager;
         _benchmarkGate = benchmarkGate;
@@ -1507,7 +1510,8 @@ public class HealthCheckService : BackgroundService
         string symlinkOrStrmPath,
         Guid? downloadId,
         CancellationToken ct,
-        Func<ArrClient, IReadOnlyList<string>, bool>? shouldRequestSearch = null)
+        Func<ArrClient, IReadOnlyList<string>, bool>? shouldRequestSearch = null,
+        ArrInstanceBackoff? arrBackoff = null)
     {
         // Track whether a no-owner result is authoritative enough to explain to the operator.
         // Neither outcome permits deletion: a successful-but-incomplete library/Arr view is
@@ -1518,14 +1522,29 @@ public class HealthCheckService : BackgroundService
         {
             ct.ThrowIfCancellationRequested();
 
+            // Skip the root-folder query for an instance that is timing out or refusing
+            // connections — it cannot answer, and asking only adds load to a dying peer.
+            // Treat it like an unreachable instance so repair defers rather than deletes.
+            if (arrBackoff is not null && arrBackoff.IsInBackoff(arrClient.Host))
+            {
+                anInstanceFailed = true;
+                Log.Debug(
+                    "Health-check repair: skipping root-folder query for {Host}; instance is in backoff for {Remaining}",
+                    arrClient.Host,
+                    arrBackoff.GetRemainingBackoff(arrClient.Host));
+                continue;
+            }
+
             List<ArrRootFolder> rootFolders;
             try
             {
                 rootFolders = await arrClient.GetRootFolders(ct).ConfigureAwait(false);
+                arrBackoff?.RecordSuccess(arrClient.Host);
             }
             catch (Exception e) when (e is HttpRequestException or TaskCanceledException or InvalidOperationException)
             {
                 anInstanceFailed = true;
+                arrBackoff?.RecordFailure(arrClient.Host, e);
                 LogArrRepairFailure(
                     e,
                     "Health-check repair: could not query root folders from {Host}",
@@ -1869,7 +1888,8 @@ public class HealthCheckService : BackgroundService
                         .Select(identity => $"{arrClient.Host.TrimEnd('/').ToLowerInvariant()}|{identity}")
                         .ToArray(),
                     arrConfig.EffectiveQueueReplacementSearchLimit(),
-                    arrConfig.EffectiveQueueReplacementSearchWindow())).ConfigureAwait(false);
+                    arrConfig.EffectiveQueueReplacementSearchWindow()),
+                _arrBackoff).ConfigureAwait(false);
 
             if (arrDecision != ArrLinkedRepairDecision.DeferNoMatchingMediaItem)
                 _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);

--- a/backend/Services/Metrics/MetricsRetentionService.cs
+++ b/backend/Services/Metrics/MetricsRetentionService.cs
@@ -61,10 +61,12 @@ public class MetricsRetentionService(ConfigManager configManager) : BackgroundSe
         }
     }
 
+    internal const int SegmentFetchDeleteBatchSize = 50_000;
+    private const int IncrementalVacuumPages = 4_000;
+
     internal static async Task SweepAsync(MetricsDbContext db, long nowMs, TimeSpan fetchTtl)
     {
-        await db.Database.ExecuteSqlRawAsync(
-            "DELETE FROM SegmentFetches WHERE At < {0}", Cutoff(nowMs, fetchTtl)).ConfigureAwait(false);
+        await DeleteSegmentFetchesInBatchesAsync(db, Cutoff(nowMs, fetchTtl)).ConfigureAwait(false);
         await db.Database.ExecuteSqlRawAsync(
             "DELETE FROM MetricEvents WHERE At < {0}", Cutoff(nowMs, EventTtl)).ConfigureAwait(false);
         await db.Database.ExecuteSqlRawAsync(
@@ -82,7 +84,30 @@ public class MetricsRetentionService(ConfigManager configManager) : BackgroundSe
             "DELETE FROM ArrImportEvents WHERE ImportedAtMs < {0}", Cutoff(nowMs, ArrImportEventTtl))
             .ConfigureAwait(false);
 
-        await db.Database.ExecuteSqlRawAsync("PRAGMA incremental_vacuum;").ConfigureAwait(false);
+        await db.Database.ExecuteSqlRawAsync($"PRAGMA incremental_vacuum({IncrementalVacuumPages});")
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Rowid-batched DELETE so a multi-GB SegmentFetches sweep cannot hold the
+    /// write lock past MetricsWriter's 5s busy_timeout. Matches
+    /// <see cref="OverviewStatsReset.WipeProviderAsync"/>.
+    /// </summary>
+    private static async Task DeleteSegmentFetchesInBatchesAsync(MetricsDbContext db, long cutoff)
+    {
+        var batchSize = Math.Max(1, SegmentFetchDeleteBatchSize);
+        int batch;
+        do
+        {
+            batch = await db.Database.ExecuteSqlRawAsync(
+                """
+                DELETE FROM SegmentFetches WHERE rowid IN
+                    (SELECT rowid FROM SegmentFetches WHERE At < {0} LIMIT {1})
+                """,
+                new object[] { cutoff, batchSize }).ConfigureAwait(false);
+            if (batch > 0)
+                await Task.Yield();
+        } while (batch > 0);
     }
 
     private static async Task FoldAndPruneProviderHourlyAsync(MetricsDbContext db, long cutoff)

--- a/backend/Services/Metrics/MetricsWriter.cs
+++ b/backend/Services/Metrics/MetricsWriter.cs
@@ -347,16 +347,22 @@ public class MetricsWriter : BackgroundService
 
             await db.SaveChangesAsync().ConfigureAwait(false);
             await tx.CommitAsync().ConfigureAwait(false);
-
-            var completed = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-            Interlocked.Exchange(ref _lastFlushLagMs, (long)(DateTime.UtcNow - started).TotalMilliseconds);
-            Interlocked.Exchange(ref _lastSuccessfulFlushAtMs, completed);
-            Interlocked.Exchange(ref _lastFlushError, null);
+            RecordFlushSuccess(started);
         }
         catch (Exception ex) when (ex is not OutOfMemoryException)
         {
+            if (ex.IsTransientDatabaseException()
+                && Volatile.Read(ref _resetGeneration) == generation
+                && Volatile.Read(ref _resetting) == 0
+                && await TryFlushBatchAsync(fetches, events, sessions, failoverMisses).ConfigureAwait(false))
+            {
+                RecordFlushSuccess(started);
+                return;
+            }
+
             // Only requeue if this flush still belongs to the current generation.
             // A reset that started mid-flush must not resurrect wiped rows.
+            var queuedRows = fetches.Count + events.Count + sessions.Count + failoverMisses.Count;
             if (Volatile.Read(ref _resetGeneration) == generation && Volatile.Read(ref _resetting) == 0)
             {
                 Requeue(_fetches, fetches);
@@ -365,14 +371,59 @@ public class MetricsWriter : BackgroundService
                 Requeue(_failoverMisses, failoverMisses);
             }
             Interlocked.Exchange(ref _lastFlushError, ex.GetBaseException().Message);
+            if (ex.IsTransientDatabaseException())
+            {
+                Log.Warning(
+                    "MetricsWriter flush deferred. QueuedRows={QueuedRows} Reason: {Reason}",
+                    queuedRows,
+                    ex.GetBaseException().Message);
+                return;
+            }
+
             throw;
         }
     }
 
+    private async Task<bool> TryFlushBatchAsync(
+        List<SegmentFetch> fetches,
+        List<MetricEvent> events,
+        List<ReadSession> sessions,
+        List<FailoverMiss> failoverMisses)
+    {
+        try
+        {
+            await Task.Delay(250).ConfigureAwait(false);
+            await using var db = _contextFactory();
+            await using var tx = await db.Database.BeginTransactionAsync().ConfigureAwait(false);
+            if (fetches.Count > 0) db.SegmentFetches.AddRange(fetches);
+            if (events.Count > 0) db.MetricEvents.AddRange(events);
+            if (sessions.Count > 0) db.ReadSessions.AddRange(sessions);
+            if (failoverMisses.Count > 0) db.FailoverMisses.AddRange(failoverMisses);
+            await db.SaveChangesAsync().ConfigureAwait(false);
+            await tx.CommitAsync().ConfigureAwait(false);
+            return true;
+        }
+        catch (Exception retryEx) when (retryEx is not OutOfMemoryException)
+        {
+            Log.Debug(retryEx, "MetricsWriter busy retry failed");
+            return false;
+        }
+    }
+
+    private void RecordFlushSuccess(DateTime started)
+    {
+        var completed = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        Interlocked.Exchange(ref _lastFlushLagMs, (long)(DateTime.UtcNow - started).TotalMilliseconds);
+        Interlocked.Exchange(ref _lastSuccessfulFlushAtMs, completed);
+        Interlocked.Exchange(ref _lastFlushError, null);
+    }
+
     private static List<T> Drain<T>(ConcurrentQueue<T> q)
     {
-        var list = new List<T>(Math.Min(q.Count, FlushThreshold * 2));
-        while (q.TryDequeue(out var item)) list.Add(item);
+        var cap = FlushThreshold * 2;
+        var list = new List<T>(Math.Min(q.Count, cap));
+        while (list.Count < cap && q.TryDequeue(out var item))
+            list.Add(item);
         return list;
     }
 

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -871,14 +871,15 @@ public class Par2RepairService : BackgroundService
             catch (OverflowException)
             {
                 await PersistDiscoveredDamageAsync(davItem, nzbFile, accessor, ct).ConfigureAwait(false);
-                return RepairExecutionResult.NotFeasible("PAR2 working-set estimate overflowed.");
+                return RepairExecutionResult.NotFeasible("PAR2 working-set estimate overflowed.", bytesRead);
             }
 
             if (workingSetBytes > maxMemoryBytes)
             {
                 await PersistDiscoveredDamageAsync(davItem, nzbFile, accessor, ct).ConfigureAwait(false);
                 return RepairExecutionResult.NotFeasible(
-                    $"PAR2 working set {workingSetBytes} bytes exceeds memory cap.");
+                    $"PAR2 working set {workingSetBytes} bytes exceeds memory cap.",
+                    bytesRead);
             }
 
             Interlocked.Exchange(ref _activeEstimatedWorkingSetBytes, workingSetBytes);
@@ -888,7 +889,8 @@ public class Par2RepairService : BackgroundService
             {
                 await PersistDiscoveredDamageAsync(davItem, nzbFile, accessor, ct).ConfigureAwait(false);
                 return RepairExecutionResult.NotFeasible(
-                    $"Recovery set size {releaseBytes} bytes exceeds release cap.");
+                    $"Recovery set size {releaseBytes} bytes exceeds release cap.",
+                    bytesRead);
             }
 
             var missingSliceIndices = unavailableSlices.OrderBy(x => x).ToList();
@@ -909,7 +911,8 @@ public class Par2RepairService : BackgroundService
             {
                 await PersistDiscoveredDamageAsync(davItem, nzbFile, accessor, ct).ConfigureAwait(false);
                 return RepairExecutionResult.NotFeasible(
-                    $"Need {missingSliceIndices.Count} recovery slices but only collected {recoverySlices.Count}.");
+                    $"Need {missingSliceIndices.Count} recovery slices but only collected {recoverySlices.Count}.",
+                    bytesRead);
             }
 
             var reconstructor = new Par2Reconstructor();
@@ -928,13 +931,17 @@ public class Par2RepairService : BackgroundService
             {
                 PrometheusMetrics.Current?.RecordPar2ValidationFailure("slice");
                 await PersistDiscoveredDamageAsync(davItem, nzbFile, accessor, ct).ConfigureAwait(false);
-                return RepairExecutionResult.Failed(reconstruction.FailureReason ?? "Reconstruction failed.");
+                return RepairExecutionResult.Failed(
+                    reconstruction.FailureReason ?? "Reconstruction failed.",
+                    bytesRead);
             }
 
             if (patchTargets.Count == 0)
             {
                 await PersistDiscoveredDamageAsync(davItem, nzbFile, accessor, ct).ConfigureAwait(false);
-                return RepairExecutionResult.NotFeasible("No missing or corrupt segments were confirmed during PAR2 repair.");
+                return RepairExecutionResult.NotFeasible(
+                    "No missing or corrupt segments were confirmed during PAR2 repair.",
+                    bytesRead);
             }
 
             SetRepairPhase("assembling-patches", maxMemoryBytes);
@@ -958,7 +965,7 @@ public class Par2RepairService : BackgroundService
             {
                 PrometheusMetrics.Current?.RecordPar2ValidationFailure("file");
                 await PersistDiscoveredDamageAsync(davItem, nzbFile, accessor, ct).ConfigureAwait(false);
-                return RepairExecutionResult.Failed(md5Reason);
+                return RepairExecutionResult.Failed(md5Reason, bytesRead);
             }
 
             _patchStore.CommitPatches(
@@ -975,7 +982,7 @@ public class Par2RepairService : BackgroundService
         catch (Par2MemoryCapExceededException e)
         {
             await PersistDiscoveredDamageAsync(davItem, nzbFile, accessor, ct).ConfigureAwait(false);
-            return RepairExecutionResult.NotFeasible(e.Message);
+            return RepairExecutionResult.NotFeasible(e.Message, bytesRead);
         }
     }
 
@@ -1932,8 +1939,8 @@ public class Par2RepairService : BackgroundService
         public static RepairExecutionResult NotFeasible(string reason, long bytesRead = 0)
             => new(false, true, reason, bytesRead, 0, 0);
 
-        public static RepairExecutionResult Failed(string reason)
-            => new(false, false, reason, 0, 0, 0);
+        public static RepairExecutionResult Failed(string reason, long bytesRead = 0)
+            => new(false, false, reason, bytesRead, 0, 0);
     }
 
     private sealed class SliceSegmentAccessor

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -613,12 +613,15 @@ public class Par2RepairService : BackgroundService
                 ? Par2RepairJob.RepairJobState.Infeasible
                 : Par2RepairJob.RepairJobState.Failed;
             job.CompletedAt = DateTimeOffset.UtcNow;
+            job.BytesRead = result.BytesRead;
             job.FailureReason = result.FailureReason;
             job.NextAttemptAt = DateTimeOffset.UtcNow +
                                 TimeSpan.FromHours(_configManager.GetPar2FailureCooldownHours());
             await PersistJobAsync(job, ct).ConfigureAwait(false);
             PrometheusMetrics.Current?.RecordPar2RepairJob(result.IsInfeasible ? "infeasible" : "failed");
             PrometheusMetrics.Current?.ObservePar2RepairDuration(stopwatch.Elapsed);
+            if (result.BytesRead > 0)
+                Interlocked.Add(ref _totalBytesRead, result.BytesRead);
             if (result.IsInfeasible) Interlocked.Increment(ref _totalInfeasible);
             else Interlocked.Increment(ref _totalFailed);
             Log.Warning(
@@ -761,6 +764,17 @@ public class Par2RepairService : BackgroundService
         if (unavailableSlices.Count == 0)
             return RepairExecutionResult.NotFeasible("Missing or corrupt segments do not map to PAR2 slices.");
 
+        var maxMissingSlices = _configManager.GetPar2MaxMissingSlices();
+        if (unavailableSlices.Count > maxMissingSlices)
+        {
+            Log.Warning(
+                "PAR2 repair targeting {Path} infeasible before discovery. " +
+                "Initial={Initial} Discovered={Discovered} Cap={Cap} BytesRead={BytesRead} Elapsed={Elapsed}",
+                davItem.Path, unavailableSlices.Count, 0, maxMissingSlices, 0L, TimeSpan.Zero);
+            return RepairExecutionResult.NotFeasible(
+                $"Missing slice count {unavailableSlices.Count} exceeds cap {maxMissingSlices}.");
+        }
+
         var fetchConcurrency = _configManager.GetPar2FetchConcurrency();
         using var fetchGate = new SemaphoreSlim(fetchConcurrency, fetchConcurrency);
         var bytesRead = 0L;
@@ -803,9 +817,13 @@ public class Par2RepairService : BackgroundService
 
         try
         {
-            await DiscoverUnavailableSourcesAsync(
-                    accessor, sliceMap, targetIfsc, unavailableSegments, unavailableSlices, ct)
+            var initialUnavailableSlices = unavailableSlices.Count;
+            var discoveryWatch = Stopwatch.StartNew();
+            var exceededCap = await DiscoverUnavailableSourcesAsync(
+                    accessor, sliceMap, targetIfsc, unavailableSegments, unavailableSlices,
+                    maxMissingSlices, ct)
                 .ConfigureAwait(false);
+            discoveryWatch.Stop();
 
             var discoveredMissing = accessor.MissingSegmentIndices.Except(persistedMissing).Except(requested.Select(x => x.Index)).Count();
             var discoveredCorrupt = accessor.CorruptSegmentIndices.Except(persistedCorrupt).Except(requested.Select(x => x.Index)).Count();
@@ -821,12 +839,21 @@ public class Par2RepairService : BackgroundService
                 discoveredCorrupt,
                 unavailableSlices.Count);
 
-            var maxMissingSlices = _configManager.GetPar2MaxMissingSlices();
-            if (unavailableSlices.Count > maxMissingSlices)
+            if (exceededCap || unavailableSlices.Count > maxMissingSlices)
             {
                 await PersistDiscoveredDamageAsync(davItem, nzbFile, accessor, ct).ConfigureAwait(false);
+                Log.Warning(
+                    "PAR2 repair targeting {Path} infeasible after discovery. " +
+                    "Initial={Initial} Discovered={Discovered} Cap={Cap} BytesRead={BytesRead} Elapsed={Elapsed}",
+                    davItem.Path,
+                    initialUnavailableSlices,
+                    unavailableSlices.Count,
+                    maxMissingSlices,
+                    bytesRead,
+                    discoveryWatch.Elapsed);
                 return RepairExecutionResult.NotFeasible(
-                    $"Missing slice count {unavailableSlices.Count} exceeds cap {maxMissingSlices}.");
+                    $"Missing slice count {unavailableSlices.Count} exceeds cap {maxMissingSlices}.",
+                    bytesRead);
             }
 
             var patchTargets = SegmentsOverlappingSlices(sliceMap, unavailableSlices, segmentIds);
@@ -952,12 +979,13 @@ public class Par2RepairService : BackgroundService
         }
     }
 
-    private static async Task DiscoverUnavailableSourcesAsync(
+    private static async Task<bool> DiscoverUnavailableSourcesAsync(
         SliceSegmentAccessor accessor,
         Par2FileSliceMap sliceMap,
         IfscPacket targetIfsc,
         HashSet<int> unavailableSegments,
         HashSet<int> unavailableSlices,
+        int maxMissingSlices,
         CancellationToken ct)
     {
         var expanded = true;
@@ -967,6 +995,8 @@ public class Par2RepairService : BackgroundService
             expanded = false;
             accessor.BeginSequentialPass();
             AbsorbAccessorDiscoveries(accessor, sliceMap, unavailableSegments, unavailableSlices, ref expanded);
+            if (unavailableSlices.Count > maxMissingSlices)
+                return true;
 
             for (var local = 0; local < sliceMap.SliceCount; local++)
             {
@@ -981,8 +1011,12 @@ public class Par2RepairService : BackgroundService
                 expanded |= (assembled is null ||
                              !Par2Reconstructor.VerifySliceChecksum(assembled, targetIfsc.Slices[local]))
                             && unavailableSlices.Add(globalSlice);
+                if (unavailableSlices.Count > maxMissingSlices)
+                    return true;
             }
         }
+
+        return false;
     }
 
     private static void AbsorbAccessorDiscoveries(
@@ -1895,8 +1929,8 @@ public class Par2RepairService : BackgroundService
         public static RepairExecutionResult Succeeded(long bytesRead, int slices, int segmentsCommitted)
             => new(true, false, null, bytesRead, slices, segmentsCommitted);
 
-        public static RepairExecutionResult NotFeasible(string reason)
-            => new(false, true, reason, 0, 0, 0);
+        public static RepairExecutionResult NotFeasible(string reason, long bytesRead = 0)
+            => new(false, true, reason, bytesRead, 0, 0);
 
         public static RepairExecutionResult Failed(string reason)
             => new(false, false, reason, 0, 0, 0);

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -13,6 +13,7 @@ using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Logging;
 using NzbWebDAV.Services.Diagnostics;
 using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Queue;
 using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Streams;
 using NzbWebDAV.Utils;
@@ -35,7 +36,8 @@ public sealed class SupportPackService(
     GcDiagnosticsStore gcDiagnosticsStore,
     Repair.Par2RepairService par2RepairService,
     Repair.RepairPatchStore repairPatchStore,
-    ConcurrentReadTracker? concurrentReadTracker = null)
+    ConcurrentReadTracker? concurrentReadTracker = null,
+    IQueueCoordinator? queueCoordinator = null)
 {
     private const long MinuteMs = 60_000;
     private const long HourMs = 60 * MinuteMs;
@@ -231,6 +233,11 @@ public sealed class SupportPackService(
         debug-level install can push older events out of it. logs/warnings.log keeps
         the last 500 warnings and errors separately for that reason - check it first
         when the main log looks like it only contains routine activity.
+
+        environment.json → queue.inProgress lists every in-flight import with its
+        current stage, how long that stage has been running, and cumulative queue
+        semaphore wait. Use it to tell NNTP work apart from finalize-lock wait,
+        metadata blob writes, or the SQLite commit.
 
         environment.json reports CPU and GC pause figures, thread pool occupancy, and
         per-provider connection-pool state with lifetime churn. Read cpu.rolling and
@@ -459,6 +466,7 @@ public sealed class SupportPackService(
                 availableFreeSpaceBytes = drive.IsReady ? drive.AvailableFreeSpace : (long?)null,
             },
             par2Repair = BuildPar2RepairDiagnostics(),
+            queue = BuildQueueDiagnostics(),
             streamTracing = new
             {
                 enabled = streamTracing.Enabled,
@@ -695,6 +703,34 @@ public sealed class SupportPackService(
         {
             Log.Debug(e, "Support pack: could not read the process thread count");
             return null;
+        }
+    }
+
+    private object BuildQueueDiagnostics()
+    {
+        try
+        {
+            var items = queueCoordinator?.GetInProgressQueueItems() ?? [];
+            return new
+            {
+                inProgressCount = items.Count,
+                inProgress = items.Select(item => new
+                {
+                    id = item.QueueItem.Id,
+                    jobName = item.QueueItem.JobName,
+                    category = item.QueueItem.Category,
+                    isPrimary = item.IsPrimary,
+                    progressPercentage = item.ProgressPercentage,
+                    currentStage = item.CurrentStage,
+                    stageAgeMs = item.StageAgeMs,
+                    semaphoreWaitMs = item.SemaphoreWaitMilliseconds,
+                }).ToList(),
+            };
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            Log.Debug(ex, "Support pack: could not snapshot in-progress queue items");
+            return new { inProgressCount = 0, inProgress = Array.Empty<object>(), unavailable = true };
         }
     }
 

--- a/backend/Services/UsenetFileToBlobstoreMigrationService.cs
+++ b/backend/Services/UsenetFileToBlobstoreMigrationService.cs
@@ -98,7 +98,7 @@ public class UsenetFileToBlobstoreMigrationService(
                 var davItem = await GetDavItem(getFileToMigrateId(fileToMigrate), dbContext, ct).ConfigureAwait(false);
                 dbContext.Entry(fileToMigrate).State = EntityState.Detached;
                 setFileToMigrateNewId(fileToMigrate);
-                await BlobStore.WriteBlob(getFileToMigrateId(fileToMigrate), fileToMigrate).ConfigureAwait(false);
+                await BlobStore.WriteBlob(getFileToMigrateId(fileToMigrate), fileToMigrate, ct).ConfigureAwait(false);
                 try
                 {
                     // database changes

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -596,6 +596,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 return result;
             }
 
+            var persistent = new PersistentCorruptionTracker();
             for (var attempt = 0; ; attempt++)
             {
                 try
@@ -645,6 +646,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 }
                 catch (UsenetCorruptArticleException e) when (!cancellationToken.IsCancellationRequested)
                 {
+                    persistent.NoteOrThrow(e);
                     if (attempt >= GetCorruptionRetryLimit(segmentId))
                     {
                         var fallback = await TryFallbackSegmentsAsync(
@@ -687,7 +689,10 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                     OomDiagnostics.LogHeapStateOnOom(oom, "segment body retry");
                     throw;
                 }
-                catch (Exception e) when (!cancellationToken.IsCancellationRequested && e is not OutOfMemoryException)
+                catch (Exception e) when (
+                    !cancellationToken.IsCancellationRequested
+                    && e is not OutOfMemoryException
+                    && e is not PersistentUsenetCorruptionException)
                 {
                     if (attempt < MaxBodyRetries)
                     {
@@ -878,7 +883,10 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             OomDiagnostics.LogHeapStateOnOom(oom, "pipelined segment batch");
             throw;
         }
-        catch (Exception e) when (!cancellationToken.IsCancellationRequested && e is not OutOfMemoryException)
+        catch (Exception e) when (
+            !cancellationToken.IsCancellationRequested
+            && e is not OutOfMemoryException
+            && e is not PersistentUsenetCorruptionException)
         {
             // A failure inside a pipelined batch says nothing about whether the article
             // can be fetched at all: the batch shares one connection, so a stall or a
@@ -932,6 +940,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         CancellationToken cancellationToken)
     {
         var lease = existingLease;
+        var persistent = new PersistentCorruptionTracker();
+        if (batchFailure is UsenetCorruptArticleException corruptBatch)
+            persistent.NoteOrThrow(corruptBatch);
         try
         {
             for (var attempt = 1; attempt <= MaxBodyRetries; attempt++)
@@ -970,17 +981,28 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 {
                     throw;
                 }
+                catch (PersistentUsenetCorruptionException)
+                {
+                    throw;
+                }
+                catch (UsenetCorruptArticleException e)
+                {
+                    persistent.NoteOrThrow(e);
+                    Log.Debug(e, "Individual rescue of segment {SegmentId} failed (attempt {Attempt}).",
+                        segmentId, attempt);
+                }
                 catch (OutOfMemoryException oom)
                 {
                     OomDiagnostics.LogHeapStateOnOom(oom, "individual segment rescue");
                     throw;
                 }
-                catch (Exception e) when (!cancellationToken.IsCancellationRequested && e is not OutOfMemoryException)
+                catch (Exception e) when (
+                    !cancellationToken.IsCancellationRequested
+                    && e is not OutOfMemoryException
+                    && e is not PersistentUsenetCorruptionException)
                 {
-                    // A corrupt rescue response is swallowed here and the original non-corrupt
+                    // A non-corrupt rescue failure is swallowed here and the original
                     // batch failure is surfaced as TransientSegmentExhaustionException.
-                    // Corruption evidence for this read is dropped; the next read hits the
-                    // proper corrupt path.
                     Log.Debug(e, "Individual rescue of segment {SegmentId} failed (attempt {Attempt}).",
                         segmentId, attempt);
                 }

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -1009,6 +1009,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     {
         var failure = initialFailure;
         var lease = existingLease;
+        var persistent = new PersistentCorruptionTracker();
+        persistent.NoteOrThrow(initialFailure);
         try
         {
             for (var attempt = 1; attempt <= GetCorruptionRetryLimit(segmentId); attempt++)
@@ -1045,6 +1047,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 }
                 catch (UsenetCorruptArticleException exception)
                 {
+                    persistent.NoteOrThrow(exception);
                     failure = exception;
                 }
             }

--- a/backend/Streams/PersistentCorruptionTracker.cs
+++ b/backend/Streams/PersistentCorruptionTracker.cs
@@ -1,0 +1,33 @@
+using NzbWebDAV.Exceptions;
+
+namespace NzbWebDAV.Streams;
+
+/// <summary>
+/// Collects yEnc CRC failures across providers. When two or more providers
+/// report the same (actual, expected) pair, the article is persistently
+/// corrupt and further retries cannot recover it.
+/// </summary>
+internal sealed class PersistentCorruptionTracker
+{
+    private readonly Dictionary<string, (uint Actual, uint Expected)> _pairs =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public void NoteOrThrow(UsenetCorruptArticleException exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        if (!exception.TryGetCrcPair(out var actual, out var expected))
+            return;
+
+        _pairs[exception.ProviderKey] = (actual, expected);
+
+        var matching = 0;
+        foreach (var observed in _pairs.Values)
+        {
+            if (observed.Actual == actual && observed.Expected == expected)
+                matching++;
+        }
+
+        if (matching >= 2)
+            throw new PersistentUsenetCorruptionException(exception.SegmentId, actual, expected, exception);
+    }
+}

--- a/backend/Streams/PersistentCorruptionTracker.cs
+++ b/backend/Streams/PersistentCorruptionTracker.cs
@@ -20,14 +20,7 @@ internal sealed class PersistentCorruptionTracker
 
         _pairs[exception.ProviderKey] = (actual, expected);
 
-        var matching = 0;
-        foreach (var observed in _pairs.Values)
-        {
-            if (observed.Actual == actual && observed.Expected == expected)
-                matching++;
-        }
-
-        if (matching >= 2)
+        if (_pairs.Values.Count(observed => observed.Actual == actual && observed.Expected == expected) >= 2)
             throw new PersistentUsenetCorruptionException(exception.SegmentId, actual, expected, exception);
     }
 }

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -484,6 +484,8 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         await DisposeOpenBodyAsync().ConfigureAwait(false);
         _hasProbedByte = false;
 
+        var persistent = new PersistentCorruptionTracker();
+        persistent.NoteOrThrow(corrupt);
         try
         {
             var body = await FetchBodyAsync(segmentId, cancellationToken)
@@ -505,6 +507,10 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         {
             throw;
         }
+        catch (PersistentUsenetCorruptionException)
+        {
+            throw;
+        }
         catch (OperationCanceledException)
         {
             throw;
@@ -513,13 +519,14 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         {
             throw;
         }
-        catch (UsenetCorruptArticleException)
+        catch (UsenetCorruptArticleException confirmation)
         {
+            persistent.NoteOrThrow(confirmation);
             Par2RepairTriggerSink.ReportCorruption(_fileName, segmentId);
             ExceptionDispatchInfo.Capture(corrupt).Throw();
             throw;
         }
-        catch (Exception e) when (e is not OutOfMemoryException)
+        catch (Exception e) when (e is not OutOfMemoryException && e is not PersistentUsenetCorruptionException)
         {
             Log.Debug(
                 e,

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -405,6 +405,8 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
         _hasProbedByte = false;
 
         var failure = initialFailure;
+        var persistent = new PersistentCorruptionTracker();
+        persistent.NoteOrThrow(initialFailure);
         for (var attempt = 1; attempt <= GetCorruptionRetryLimit(segmentId); attempt++)
         {
             Log.Debug(
@@ -432,6 +434,7 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
             catch (UsenetCorruptArticleException e)
             {
                 await DisposeBodyStreamAsync(retryStream).ConfigureAwait(false);
+                persistent.NoteOrThrow(e);
                 failure = e;
             }
         }

--- a/tests/NzbWebDAV.Tests/Clients/RadarrSonarr/ArrInstanceBackoffTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RadarrSonarr/ArrInstanceBackoffTests.cs
@@ -1,0 +1,90 @@
+using System.Net;
+using System.Net.Sockets;
+using NzbWebDAV.Clients.RadarrSonarr;
+
+namespace NzbWebDAV.Tests.Clients.RadarrSonarr;
+
+public sealed class ArrInstanceBackoffTests
+{
+    private static HttpRequestException Refused() =>
+        new("Connection refused", new SocketException((int)SocketError.ConnectionRefused));
+
+    private static HttpRequestException Http500() =>
+        new("server error", null, HttpStatusCode.InternalServerError);
+
+    [Fact]
+    public void SingleFailure_DoesNotBackOff()
+    {
+        var backoff = new ArrInstanceBackoff();
+        backoff.RecordFailure("http://sonarr:8989", Refused());
+
+        Assert.False(backoff.IsInBackoff("http://sonarr:8989"));
+    }
+
+    [Fact]
+    public void TwoConsecutiveReachabilityFailures_EnterBackoff()
+    {
+        var backoff = new ArrInstanceBackoff();
+        backoff.RecordFailure("http://sonarr:8989", Refused());
+        backoff.RecordFailure("http://sonarr:8989", Refused());
+
+        Assert.True(backoff.IsInBackoff("http://sonarr:8989"));
+        Assert.True(backoff.GetRemainingBackoff("http://sonarr:8989") > TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void Success_ResetsBackoff()
+    {
+        var backoff = new ArrInstanceBackoff();
+        backoff.RecordFailure("http://sonarr:8989", Refused());
+        backoff.RecordFailure("http://sonarr:8989", Refused());
+        Assert.True(backoff.IsInBackoff("http://sonarr:8989"));
+
+        backoff.RecordSuccess("http://sonarr:8989");
+
+        Assert.False(backoff.IsInBackoff("http://sonarr:8989"));
+    }
+
+    [Fact]
+    public void HttpErrorStatus_DoesNotCountAsReachabilityFailure()
+    {
+        var backoff = new ArrInstanceBackoff();
+        // A live host answering with 500 is not "down"; it must not back off.
+        backoff.RecordFailure("http://sonarr:8989", Http500());
+        backoff.RecordFailure("http://sonarr:8989", Http500());
+        backoff.RecordFailure("http://sonarr:8989", Http500());
+
+        Assert.False(backoff.IsInBackoff("http://sonarr:8989"));
+    }
+
+    [Fact]
+    public void Timeout_CountsAsReachabilityFailure()
+    {
+        var backoff = new ArrInstanceBackoff();
+        backoff.RecordFailure("http://sonarr:8989", new TaskCanceledException("timed out"));
+        backoff.RecordFailure("http://sonarr:8989", new TaskCanceledException("timed out"));
+
+        Assert.True(backoff.IsInBackoff("http://sonarr:8989"));
+    }
+
+    [Fact]
+    public void HostsAreIndependent()
+    {
+        var backoff = new ArrInstanceBackoff();
+        backoff.RecordFailure("http://sonarr:8989", Refused());
+        backoff.RecordFailure("http://sonarr:8989", Refused());
+
+        Assert.True(backoff.IsInBackoff("http://sonarr:8989"));
+        Assert.False(backoff.IsInBackoff("http://radarr:7878"));
+    }
+
+    [Fact]
+    public void HostKey_IgnoresCaseAndTrailingSlash()
+    {
+        var backoff = new ArrInstanceBackoff();
+        backoff.RecordFailure("http://Sonarr:8989/", Refused());
+        backoff.RecordFailure("http://sonarr:8989", Refused());
+
+        Assert.True(backoff.IsInBackoff("HTTP://SONARR:8989/"));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -1012,6 +1012,44 @@ public class MultiProviderNntpClientTests
     }
 
     [Fact]
+    public async Task ArticleMissCache_ThrownArticleNotFound_SecondFetch_SkipsKnownMissingProvider()
+    {
+        var config = new ConfigManager();
+        var cache = new ArticleMissNegativeCache(config);
+        var missing = new ScriptedNntpClient
+        {
+            BatchResponseCode = 430,
+            SingularResponseCode = 430,
+            SingularException = id => new UsenetArticleNotFoundException(id),
+        };
+        var backup = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(missing, host: "a.example"),
+            CreateProvider(backup, host: "b.example"),
+        ], articleMissCache: cache);
+
+        Assert.Equal(
+            UsenetResponseType.ArticleRetrievedBodyFollows,
+            (await client.DecodedBodyAsync("segment", CancellationToken.None)).ResponseType);
+        Assert.Equal(1, missing.SingularRequests);
+        Assert.Equal(1, backup.SingularRequests);
+        Assert.Equal(1, cache.Entries);
+
+        Assert.Equal(
+            UsenetResponseType.ArticleRetrievedBodyFollows,
+            (await client.DecodedBodyAsync("segment", CancellationToken.None)).ResponseType);
+        Assert.Equal(1, missing.SingularRequests);
+        Assert.Equal(2, backup.SingularRequests);
+        Assert.True(cache.Hits >= 1);
+        Assert.True(cache.Skips >= 1);
+    }
+
+    [Fact]
     public async Task ArticleMissCache_Batch_FirstPrimary430_StillReprobesOnce()
     {
         var config = new ConfigManager();

--- a/tests/NzbWebDAV.Tests/Config/MediaReadinessConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/MediaReadinessConfigTests.cs
@@ -1,0 +1,69 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+public sealed class MediaReadinessConfigTests
+{
+    private static ConfigManager CreateConfig(params ConfigItem[] items)
+    {
+        var config = new ConfigManager();
+        if (items.Length > 0)
+            config.UpdateValues(items.ToList());
+        return config;
+    }
+
+    [Fact]
+    public void MediaReadiness_EmptyCategoriesAndVideoDisabled_IsEmpty()
+    {
+        var config = CreateConfig(
+            new ConfigItem { ConfigName = ConfigKeys.ApiEnsureImportableVideo, ConfigValue = "false" });
+
+        Assert.Empty(config.GetMediaReadinessCategories());
+    }
+
+    [Fact]
+    public void MediaReadiness_VideoEnabled_IncludesDefaultMediaCategories()
+    {
+        var config = CreateConfig(
+            new ConfigItem { ConfigName = ConfigKeys.ApiEnsureImportableVideo, ConfigValue = "true" });
+
+        var categories = config.GetMediaReadinessCategories();
+        Assert.Contains("tv", categories);
+        Assert.Contains("movies", categories);
+    }
+
+    [Fact]
+    public void MediaReadiness_VideoDefault_IsEnabled()
+    {
+        // ensure-importable-video defaults to true, so media categories are ready by default.
+        var config = CreateConfig();
+
+        Assert.Contains("tv", config.GetMediaReadinessCategories());
+    }
+
+    [Fact]
+    public void MediaReadiness_ExplicitCategories_AlwaysIncluded()
+    {
+        var config = CreateConfig(
+            new ConfigItem { ConfigName = ConfigKeys.ApiEnsureImportableVideo, ConfigValue = "false" },
+            new ConfigItem { ConfigName = ConfigKeys.ApiEnsureArticleExistenceCategories, ConfigValue = "anime, docs" });
+
+        var categories = config.GetMediaReadinessCategories();
+        Assert.Contains("anime", categories);
+        Assert.Contains("docs", categories);
+        Assert.DoesNotContain("tv", categories);
+    }
+
+    [Fact]
+    public void MediaReadiness_VideoEnabled_MergesExplicitAndDefault()
+    {
+        var config = CreateConfig(
+            new ConfigItem { ConfigName = ConfigKeys.ApiEnsureImportableVideo, ConfigValue = "true" },
+            new ConfigItem { ConfigName = ConfigKeys.ApiEnsureArticleExistenceCategories, ConfigValue = "anime" });
+
+        var categories = config.GetMediaReadinessCategories();
+        Assert.Contains("anime", categories);
+        Assert.Contains("tv", categories);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Config/MediaReadinessConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/MediaReadinessConfigTests.cs
@@ -31,6 +31,7 @@ public sealed class MediaReadinessConfigTests
         var categories = config.GetMediaReadinessCategories();
         Assert.Contains("tv", categories);
         Assert.Contains("movies", categories);
+        Assert.Contains("audio", categories);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Database/RemoveHistoryItemsIdempotencyTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/RemoveHistoryItemsIdempotencyTests.cs
@@ -82,10 +82,11 @@ public sealed class RemoveHistoryItemsIdempotencyTests : IDisposable
     }
 
     [Fact]
-    public async Task RemoveHistoryItems_TwoContextsStagedBeforeEitherSaves_SecondDoesNotThrow()
+    public async Task RemoveHistoryItems_TwoContextsStagedBeforeEitherSaves_FourIdsDoNotExhaustRetries()
     {
-        var historyItemId = Guid.NewGuid();
-        _context.HistoryItems.Add(CompletedHistory(historyItemId));
+        var ids = Enumerable.Range(0, 4).Select(_ => Guid.NewGuid()).ToList();
+        foreach (var id in ids)
+            _context.HistoryItems.Add(CompletedHistory(id));
         await _context.SaveChangesAsync();
         _context.ChangeTracker.Clear();
 
@@ -93,14 +94,14 @@ public sealed class RemoveHistoryItemsIdempotencyTests : IDisposable
         var client1 = new DavDatabaseClient(_context);
         var client2 = new DavDatabaseClient(context2);
 
-        await client1.RemoveHistoryItemsAsync([historyItemId], deleteFiles: false);
-        await client2.RemoveHistoryItemsAsync([historyItemId], deleteFiles: false);
+        await client1.RemoveHistoryItemsAsync(ids, deleteFiles: false);
+        await client2.RemoveHistoryItemsAsync(ids, deleteFiles: false);
 
         await client1.SaveHistoryRemovalAsync();
         await client2.SaveHistoryRemovalAsync();
 
-        Assert.False(await _context.HistoryItems.AnyAsync(x => x.Id == historyItemId));
-        Assert.Equal(1, await _context.HistoryCleanupItems.CountAsync(x => x.Id == historyItemId));
+        Assert.False(await _context.HistoryItems.AnyAsync(x => ids.Contains(x.Id)));
+        Assert.Equal(ids.Count, await _context.HistoryCleanupItems.CountAsync(x => ids.Contains(x.Id)));
     }
 
     private static HistoryItem CompletedHistory(Guid id) => new()

--- a/tests/NzbWebDAV.Tests/Database/RemoveHistoryItemsIdempotencyTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/RemoveHistoryItemsIdempotencyTests.cs
@@ -1,0 +1,78 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Database;
+
+public sealed class RemoveHistoryItemsIdempotencyTests : IDisposable
+{
+    private readonly string _databasePath =
+        Path.Join(Path.GetTempPath(), $"nzbdav-remove-history-{Guid.NewGuid():N}.sqlite");
+    private readonly DavDatabaseContext _context;
+
+    public RemoveHistoryItemsIdempotencyTests()
+    {
+        _context = new DavDatabaseContext(new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_databasePath}")
+            .Options);
+        _context.Database.EnsureCreated();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        try { File.Delete(_databasePath); } catch (IOException) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task RemoveHistoryItems_WhenCleanupRowAlreadyPending_DoesNotThrowOrDuplicate()
+    {
+        var historyItemId = Guid.NewGuid();
+        _context.HistoryItems.Add(new HistoryItem
+        {
+            Id = historyItemId,
+            CreatedAt = DateTime.UtcNow,
+            FileName = "file.mkv",
+            JobName = "job",
+            Category = "tv",
+            DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+        });
+        // A pending cleanup row from a prior delete that has not been processed yet.
+        _context.HistoryCleanupItems.Add(new HistoryCleanupItem
+        {
+            Id = historyItemId,
+            DeleteMountedFiles = false,
+        });
+        await _context.SaveChangesAsync();
+
+        var client = new DavDatabaseClient(_context);
+        await client.RemoveHistoryItemsAsync([historyItemId], deleteFiles: false);
+        await _context.SaveChangesAsync();
+
+        Assert.False(await _context.HistoryItems.AnyAsync(x => x.Id == historyItemId));
+        Assert.Equal(1, await _context.HistoryCleanupItems.CountAsync(x => x.Id == historyItemId));
+    }
+
+    [Fact]
+    public async Task RemoveHistoryItems_WhenNoCleanupRowPending_AddsExactlyOne()
+    {
+        var historyItemId = Guid.NewGuid();
+        _context.HistoryItems.Add(new HistoryItem
+        {
+            Id = historyItemId,
+            CreatedAt = DateTime.UtcNow,
+            FileName = "file.mkv",
+            JobName = "job",
+            Category = "tv",
+            DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+        });
+        await _context.SaveChangesAsync();
+
+        var client = new DavDatabaseClient(_context);
+        await client.RemoveHistoryItemsAsync([historyItemId], deleteFiles: false);
+        await _context.SaveChangesAsync();
+
+        Assert.False(await _context.HistoryItems.AnyAsync(x => x.Id == historyItemId));
+        Assert.Equal(1, await _context.HistoryCleanupItems.CountAsync(x => x.Id == historyItemId));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Database/RemoveHistoryItemsIdempotencyTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/RemoveHistoryItemsIdempotencyTests.cs
@@ -104,7 +104,41 @@ public sealed class RemoveHistoryItemsIdempotencyTests : IDisposable
         Assert.Equal(ids.Count, await _context.HistoryCleanupItems.CountAsync(x => ids.Contains(x.Id)));
     }
 
-    private static HistoryItem CompletedHistory(Guid id) => new()
+    [Fact]
+    public async Task RemoveHistoryItems_TwoContextsDeleteFiles_ConcurrentDavItemDeleteDoesNotThrow()
+    {
+        var historyItemId = Guid.NewGuid();
+        var dirId = Guid.NewGuid();
+        _context.Items.Add(new DavItem
+        {
+            Id = dirId,
+            IdPrefix = dirId.ToString("N")[..DavItem.IdPrefixLength],
+            CreatedAt = DateTime.UtcNow,
+            Name = "job",
+            Type = DavItem.ItemType.Directory,
+            SubType = DavItem.ItemSubType.Directory,
+            Path = "/job",
+        });
+        _context.HistoryItems.Add(CompletedHistory(historyItemId, dirId));
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        await using var context2 = CreateContext();
+        var client1 = new DavDatabaseClient(_context);
+        var client2 = new DavDatabaseClient(context2);
+
+        await client1.RemoveHistoryItemsAsync([historyItemId], deleteFiles: true);
+        await client2.RemoveHistoryItemsAsync([historyItemId], deleteFiles: true);
+
+        await client1.SaveHistoryRemovalAsync();
+        await client2.SaveHistoryRemovalAsync();
+
+        Assert.False(await _context.HistoryItems.AnyAsync(x => x.Id == historyItemId));
+        Assert.False(await _context.Items.AnyAsync(x => x.Id == dirId));
+        Assert.Equal(1, await _context.HistoryCleanupItems.CountAsync(x => x.Id == historyItemId));
+    }
+
+    private static HistoryItem CompletedHistory(Guid id, Guid? downloadDirId = null) => new()
     {
         Id = id,
         CreatedAt = DateTime.UtcNow,
@@ -112,5 +146,6 @@ public sealed class RemoveHistoryItemsIdempotencyTests : IDisposable
         JobName = "job",
         Category = "tv",
         DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+        DownloadDirId = downloadDirId,
     };
 }

--- a/tests/NzbWebDAV.Tests/Database/RemoveHistoryItemsIdempotencyTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/RemoveHistoryItemsIdempotencyTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
 using NzbWebDAV.Database.Models;
 
 namespace NzbWebDAV.Tests.Database;
@@ -12,11 +13,15 @@ public sealed class RemoveHistoryItemsIdempotencyTests : IDisposable
 
     public RemoveHistoryItemsIdempotencyTests()
     {
-        _context = new DavDatabaseContext(new DbContextOptionsBuilder<DavDatabaseContext>()
-            .UseSqlite($"Data Source={_databasePath}")
-            .Options);
+        _context = CreateContext();
         _context.Database.EnsureCreated();
     }
+
+    private DavDatabaseContext CreateContext() =>
+        new(new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_databasePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .Options);
 
     public void Dispose()
     {
@@ -75,4 +80,36 @@ public sealed class RemoveHistoryItemsIdempotencyTests : IDisposable
         Assert.False(await _context.HistoryItems.AnyAsync(x => x.Id == historyItemId));
         Assert.Equal(1, await _context.HistoryCleanupItems.CountAsync(x => x.Id == historyItemId));
     }
+
+    [Fact]
+    public async Task RemoveHistoryItems_TwoContextsStagedBeforeEitherSaves_SecondDoesNotThrow()
+    {
+        var historyItemId = Guid.NewGuid();
+        _context.HistoryItems.Add(CompletedHistory(historyItemId));
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        await using var context2 = CreateContext();
+        var client1 = new DavDatabaseClient(_context);
+        var client2 = new DavDatabaseClient(context2);
+
+        await client1.RemoveHistoryItemsAsync([historyItemId], deleteFiles: false);
+        await client2.RemoveHistoryItemsAsync([historyItemId], deleteFiles: false);
+
+        await client1.SaveHistoryRemovalAsync();
+        await client2.SaveHistoryRemovalAsync();
+
+        Assert.False(await _context.HistoryItems.AnyAsync(x => x.Id == historyItemId));
+        Assert.Equal(1, await _context.HistoryCleanupItems.CountAsync(x => x.Id == historyItemId));
+    }
+
+    private static HistoryItem CompletedHistory(Guid id) => new()
+    {
+        Id = id,
+        CreatedAt = DateTime.UtcNow,
+        FileName = "file.mkv",
+        JobName = "job",
+        Category = "tv",
+        DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+    };
 }

--- a/tests/NzbWebDAV.Tests/Extensions/ExceptionExtensionsTests.cs
+++ b/tests/NzbWebDAV.Tests/Extensions/ExceptionExtensionsTests.cs
@@ -196,6 +196,30 @@ public class ExceptionExtensionsTests
         Assert.Contains("locked", reason, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Theory]
+    [InlineData(5)]
+    [InlineData(6)]
+    public void IsTransientDatabaseException_RecognizesBusyAndLocked(int errorCode)
+    {
+        var ex = new SqliteException("sqlite contention", errorCode);
+
+        Assert.True(ex.IsTransientDatabaseException());
+        Assert.False(ex.IsKnownSqliteDiskException());
+    }
+
+    [Theory]
+    [InlineData(8, "SQLite Error 8: 'attempt to write a readonly database'.")]
+    [InlineData(13, "SQLite Error 13: 'database or disk is full'.")]
+    public void SqliteReadonlyAndFull_AreKnownButNotTransient(int errorCode, string message)
+    {
+        var ex = new SqliteException(message, errorCode);
+
+        Assert.False(ex.IsTransientDatabaseException());
+        Assert.True(ex.IsKnownSqliteDiskException());
+        Assert.True(ex.TryGetKnownErrorMessage(out var reason));
+        Assert.Equal(message, reason);
+    }
+
     [Fact]
     public void IsTransientTransportException_RejectsAlreadyRetryable()
     {

--- a/tests/NzbWebDAV.Tests/Extensions/ExceptionExtensionsTests.cs
+++ b/tests/NzbWebDAV.Tests/Extensions/ExceptionExtensionsTests.cs
@@ -188,13 +188,12 @@ public class ExceptionExtensionsTests
     }
 
     [Fact]
-    public void TryGetKnownErrorMessage_OtherSqliteErrors_StayUnknown()
+    public void TryGetKnownErrorMessage_RecognizesSqliteBusy()
     {
-        // Busy/locked and friends stay unclassified: they are transient and
-        // handled by their own retry paths, not by corruption guidance.
         var ex = new SqliteException("SQLite Error 5: 'database is locked'.", 5);
 
-        Assert.False(ex.TryGetKnownErrorMessage(out _));
+        Assert.True(ex.TryGetKnownErrorMessage(out var reason));
+        Assert.Contains("locked", reason, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Services/ArrHealthServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrHealthServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Net.Sockets;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
@@ -282,6 +283,28 @@ public sealed class ArrHealthServiceTests
     }
 
     [Fact]
+    public async Task Poll_ArrSuccessThenLocalDbFailure_ClearsReachabilityBackoff()
+    {
+        var host = "http://sonarr:8989";
+        var backoff = new ArrInstanceBackoff();
+        backoff.RecordFailure(host, new SocketException());
+        Assert.False(backoff.IsInBackoff(host));
+
+        await using var harness = await DualDbHarness.CreateAsync();
+        var client = new ScriptedArrClient(host);
+        using var service = harness.CreateService(client, host, backoff);
+        service.DavContextFactory = () => throw new InvalidOperationException("local db blew up");
+
+        Assert.True(await service.TryRunCycleAsync(CancellationToken.None));
+
+        // A later Arr reachability failure must start a fresh streak. Without
+        // RecordSuccess after the HTTP calls, the prior failure would still count
+        // and this second socket error would enter backoff.
+        backoff.RecordFailure(host, new SocketException());
+        Assert.False(backoff.IsInBackoff(host));
+    }
+
+    [Fact]
     public async Task UniqueConstraint_OnDuplicateArrRecordId_IsTolerated()
     {
         await using var harness = await DualDbHarness.CreateAsync();
@@ -396,16 +419,19 @@ public sealed class ArrHealthServiceTests
             return new DualDbHarness(dir, metricsPath, davPath, metrics, dav);
         }
 
-        public ArrHealthService CreateService(ScriptedArrClient client, string host)
+        public ArrHealthService CreateService(ScriptedArrClient client, string host, ArrInstanceBackoff? backoff = null)
         {
             var config = new ConfigManager();
             SetInstances(config, ("sonarr", host, true));
-            return CreateService(config, new Dictionary<string, ArrClient> { [host] = client });
+            return CreateService(config, new Dictionary<string, ArrClient> { [host] = client }, backoff);
         }
 
-        public ArrHealthService CreateService(ConfigManager config, IReadOnlyDictionary<string, ArrClient> clients)
+        public ArrHealthService CreateService(
+            ConfigManager config,
+            IReadOnlyDictionary<string, ArrClient> clients,
+            ArrInstanceBackoff? backoff = null)
         {
-            return new ArrHealthService(config)
+            return new ArrHealthService(config, backoff: backoff)
             {
                 ClientFactory = (_, details) => clients[details.Host],
                 MetricsContextFactory = CloneMetrics,

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
@@ -785,7 +785,7 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
         public Task WriteBlob(Guid id, Stream stream, CancellationToken cancellationToken = default) =>
             Task.FromException(new NotSupportedException());
 
-        public Task WriteBlob<T>(Guid id, T blob) =>
+        public Task WriteBlob<T>(Guid id, T blob, CancellationToken cancellationToken = default) =>
             Task.FromException(new NotSupportedException());
 
         public Stream? ReadBlob(Guid id) => null;

--- a/tests/NzbWebDAV.Tests/Streams/CorruptionDetectionTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/CorruptionDetectionTests.cs
@@ -153,6 +153,53 @@ public class CorruptionDetectionTests
     }
 
     [Fact]
+    public async Task BufferedStream_SameCrcFromTwoProviders_ThrowsPersistent()
+    {
+        using var client = new ScriptedNntpClient((id, n) =>
+            ImmediateCrcCorruptStream(id, n == 1 ? "provider-a" : "provider-b"));
+        await using var stream = MultiSegmentStream.Create(
+            new[] { "segment@example" }.AsMemory(),
+            client,
+            articleBufferSize: 1,
+            estimatedSegmentSize: 8,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: false,
+            CancellationToken.None);
+        using var output = new MemoryStream();
+
+        var exception = await Assert.ThrowsAsync<PersistentUsenetCorruptionException>(
+            () => stream.CopyToAsync(output));
+
+        Assert.Equal("segment@example", exception.SegmentId);
+        Assert.Equal(0xafccdc56u, exception.ActualCrc);
+        Assert.Equal(0xa8e2a630u, exception.ExpectedCrc);
+        Assert.Equal(2, client.BodyRequestCount);
+    }
+
+    [Fact]
+    public async Task UnbufferedStream_PostEmissionSameCrcFromTwoProviders_ThrowsPersistent()
+    {
+        var payload = "hello"u8.ToArray();
+        var segmentId = $"segment-{Guid.NewGuid():N}@example";
+        using var client = new ScriptedNntpClient((id, n) =>
+            new PayloadThenCorruptYencStream(
+                payload,
+                id,
+                n == 1 ? "provider-a" : "provider-b",
+                CrcMismatch()));
+        await using var stream = CreateUnbuffered(
+            client, [segmentId], exactSizes: [payload.Length]);
+        using var output = new MemoryStream();
+
+        var exception = await Assert.ThrowsAsync<PersistentUsenetCorruptionException>(
+            () => stream.CopyToAsync(output));
+
+        Assert.Equal(segmentId, exception.SegmentId);
+        Assert.Equal(payload, output.ToArray());
+        Assert.Equal(2, client.BodyRequestCount);
+    }
+
+    [Fact]
     public async Task UnbufferedStream_FailFastOnFirstSegment_RethrowsPersistentCorruption()
     {
         using var client = new ScriptedNntpClient((id, _) => ImmediateCorruptStream(id));
@@ -244,12 +291,23 @@ public class CorruptionDetectionTests
             segmentFallbacks: fallbacks,
             exactSegmentSizes: exactSizes);
 
+    private static InvalidDataException CrcMismatch(uint actual = 0xafccdc56, uint expected = 0xa8e2a630) =>
+        new($"The decoded yEnc CRC32 was {actual:x8}, but the trailer expected {expected:x8}.");
+
     private static YencStream ImmediateCorruptStream(string segmentId) =>
         new ThrowingYencStream(
             new UsenetCorruptArticleException(segmentId, "provider-a",
                 new InvalidDataException("CRC mismatch")));
 
-    private sealed class PayloadThenCorruptYencStream(byte[] bytes, string segmentId) : YencStream(Null)
+    private static YencStream ImmediateCrcCorruptStream(string segmentId, string provider) =>
+        new ThrowingYencStream(
+            new UsenetCorruptArticleException(segmentId, provider, CrcMismatch()));
+
+    private sealed class PayloadThenCorruptYencStream(
+        byte[] bytes,
+        string segmentId,
+        string provider = "provider-a",
+        Exception? trailer = null) : YencStream(Null)
     {
         private int _position;
 
@@ -267,8 +325,8 @@ public class CorruptionDetectionTests
             }
 
             return ValueTask.FromException<int>(
-                new UsenetCorruptArticleException(segmentId, "provider-a",
-                    new InvalidDataException("CRC mismatch")));
+                new UsenetCorruptArticleException(segmentId, provider,
+                    trailer ?? new InvalidDataException("CRC mismatch")));
         }
     }
 

--- a/tests/NzbWebDAV.Tests/Streams/PersistentCorruptionTrackerTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/PersistentCorruptionTrackerTests.cs
@@ -1,0 +1,55 @@
+using System.IO;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Streams;
+
+namespace NzbWebDAV.Tests.Streams;
+
+public class PersistentCorruptionTrackerTests
+{
+    [Fact]
+    public void NoteOrThrow_SameCrcFromTwoProviders_ThrowsPersistent()
+    {
+        var tracker = new PersistentCorruptionTracker();
+        tracker.NoteOrThrow(Corrupt("a.example", 0xafccdc56, 0xa8e2a630));
+
+        var persistent = Assert.Throws<PersistentUsenetCorruptionException>(
+            () => tracker.NoteOrThrow(Corrupt("b.example", 0xafccdc56, 0xa8e2a630)));
+
+        Assert.Equal("seg@example", persistent.SegmentId);
+        Assert.Equal(0xafccdc56u, persistent.ActualCrc);
+        Assert.Equal(0xa8e2a630u, persistent.ExpectedCrc);
+        Assert.True(persistent is NonRetryableDownloadException);
+    }
+
+    [Fact]
+    public void NoteOrThrow_SameCrcFromOneProvider_StaysRetryable()
+    {
+        var tracker = new PersistentCorruptionTracker();
+        tracker.NoteOrThrow(Corrupt("a.example", 0xafccdc56, 0xa8e2a630));
+        tracker.NoteOrThrow(Corrupt("a.example", 0xafccdc56, 0xa8e2a630));
+    }
+
+    [Fact]
+    public void NoteOrThrow_DifferentCrcPairs_StayRetryable()
+    {
+        var tracker = new PersistentCorruptionTracker();
+        tracker.NoteOrThrow(Corrupt("a.example", 0xafccdc56, 0xa8e2a630));
+        tracker.NoteOrThrow(Corrupt("b.example", 0x11111111, 0xa8e2a630));
+    }
+
+    [Fact]
+    public void TryGetCrcPair_ParsesDecoderMessage()
+    {
+        var exception = Corrupt("a.example", 0xafccdc56, 0xa8e2a630);
+        Assert.True(exception.TryGetCrcPair(out var actual, out var expected));
+        Assert.Equal(0xafccdc56u, actual);
+        Assert.Equal(0xa8e2a630u, expected);
+    }
+
+    private static UsenetCorruptArticleException Corrupt(string provider, uint actual, uint expected) =>
+        new(
+            "seg@example",
+            provider,
+            new InvalidDataException(
+                $"The decoded yEnc CRC32 was {actual:x8}, but the trailer expected {expected:x8}."));
+}


### PR DESCRIPTION
## Summary

- Dead or corrupt Usenet articles no longer pin workers for tens of minutes: the article-miss cache now records thrown 430s, PAR2 discovery stops once the missing-slice cap is exceeded, and the same yEnc CRC on two providers fails the item immediately instead of retrying 20 times.
- Metrics retention no longer locks `metrics.sqlite` with a monolithic DELETE; history cleanup treats a duplicate cleanup row as success; Arr health/queue polls back off when an instance is unreachable.
- Import BODY readiness now runs for media categories by default so short or unseekable files fail into history before rclone/Arr see them. Support packs report each in-progress import's current wait stage.

## Test plan

- [ ] Confirm a BODY 430 thrown by `BaseNntpClient` populates the article-miss cache and the next fetch skips that provider (`CachedSkips >= 1`)
- [ ] Confirm a PAR2 job whose initial missing slices already exceed `maxMissingSlices` does not start discovery, and a job that crosses the cap mid-scan aborts and persists `bytesRead`
- [ ] Confirm the same CRC pair from two providers fails the queue item once (`PersistentUsenetCorruptionException`); a single-provider CRC or disagreeing CRCs stay retryable
- [ ] Restart with a multi-GB metrics database and confirm MetricsWriter/ArrHealth no longer log `database is locked` stacks at startup + hourly
- [ ] Concurrent Arr `RemoveFromHistory` calls no longer 500 on `HistoryCleanupItems.Id`
- [ ] Import a short-decoded media file in `tv`/`movies` and confirm it fails into history before rclone/Arr
- [ ] Stop Sonarr and confirm health/queue polls back off instead of retrying every ~65s
- [ ] Collect a support pack during a multi-worker import and confirm `environment.json → queue.inProgress` shows `currentStage`, `stageAgeMs`, and `semaphoreWaitMs`

Deferred audit findings filed for later: #1180 #1181 #1182 #1183 #1184 #1185 #1186 #1187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Temporarily pauses polling of unreachable Radarr/Sonarr instances and resumes automatically after recovery.
  - Improves provider fallback by remembering missing articles and detecting persistent corruption across providers.
  - Prevents duplicate cleanup records when deleting history.
  - Improves SQLite error classification and metrics flush reliability.

- **Improvements**
  - Adds clearer queue progress, stage age, wait times, and support-pack diagnostics.
  - Expands media-readiness validation for configured media categories.
  - Improves cancellation responsiveness for file operations.
  - Reduces maintenance impact during metrics cleanup and PAR2 repair.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->