### PR TITLE
fix(queue): cancelled imports no longer keep parsing huge NZB files

### DIFF
--- a/backend/Models/Nzb/NzbDocument.cs
+++ b/backend/Models/Nzb/NzbDocument.cs
@@ -30,10 +30,10 @@ public class NzbDocument
                 switch (reader.Name)
                 {
                     case "head":
-                        await ReadHeadAsync(reader, document.Metadata).ConfigureAwait(false);
+                        await ReadHeadAsync(reader, document.Metadata, ct).ConfigureAwait(false);
                         break;
                     case "file":
-                        var file = await ReadFileAsync(reader).ConfigureAwait(false);
+                        var file = await ReadFileAsync(reader, ct).ConfigureAwait(false);
                         document.Files.Add(file);
                         break;
                 }
@@ -41,19 +41,29 @@ public class NzbDocument
 
             return document;
         }
+        catch (OperationCanceledException)
+        {
+            // Cancellation must stay cancellation; only malformed XML maps to
+            // InvalidDataException (which finalizes as failed history).
+            throw;
+        }
         catch (XmlException e)
         {
             throw new InvalidDataException("Could not parse the nzb document (malformed nzb)", e);
         }
     }
 
-    private static async Task ReadHeadAsync(XmlReader reader, Dictionary<string, string> metadata)
+    private static async Task ReadHeadAsync(
+        XmlReader reader,
+        Dictionary<string, string> metadata,
+        CancellationToken ct)
     {
         if (reader.IsEmptyElement)
             return;
 
         while (true)
         {
+            ct.ThrowIfCancellationRequested();
             if (reader is { NodeType: XmlNodeType.EndElement, Name: "head" })
                 break;
 
@@ -73,7 +83,7 @@ public class NzbDocument
         }
     }
 
-    private static async Task<NzbFile> ReadFileAsync(XmlReader reader)
+    private static async Task<NzbFile> ReadFileAsync(XmlReader reader, CancellationToken ct)
     {
         var file = new NzbFile
         {
@@ -85,12 +95,13 @@ public class NzbDocument
 
         while (await reader.ReadAsync().ConfigureAwait(false))
         {
+            ct.ThrowIfCancellationRequested();
             if (reader is { NodeType: XmlNodeType.EndElement, Name: "file" })
                 break;
 
             if (reader is { NodeType: XmlNodeType.Element, Name: "segments" })
             {
-                await ReadSegmentsAsync(reader, file).ConfigureAwait(false);
+                await ReadSegmentsAsync(reader, file, ct).ConfigureAwait(false);
             }
         }
 
@@ -98,7 +109,7 @@ public class NzbDocument
         return file;
     }
 
-    private static async Task ReadSegmentsAsync(XmlReader reader, NzbFile file)
+    private static async Task ReadSegmentsAsync(XmlReader reader, NzbFile file, CancellationToken ct)
     {
         if (reader.IsEmptyElement)
             return;
@@ -110,6 +121,7 @@ public class NzbDocument
 
             if (reader is { NodeType: XmlNodeType.Element, Name: "segment" })
             {
+                ct.ThrowIfCancellationRequested();
                 var bytesAttr = reader.GetAttribute("bytes");
                 var numberAttr = reader.GetAttribute("number");
                 var segment = new NzbSegment

--- a/backend/Models/Nzb/NzbInputValidator.cs
+++ b/backend/Models/Nzb/NzbInputValidator.cs
@@ -17,9 +17,13 @@ public static class NzbInputValidator
     /// <summary>
     /// Walks NZB XML incrementally, enforces <paramref name="limits"/>, and
     /// returns the sum of valid segment byte counts. Does not echo message IDs
-    /// or raw XML in error text.
+    /// or raw XML in error text. Cancellation is observed per file and per
+    /// segment so a cancelled submission stops promptly on huge documents.
     /// </summary>
-    public static long ValidateAndSumSegmentBytes(Stream stream, NzbInputLimits limits)
+    public static long ValidateAndSumSegmentBytes(
+        Stream stream,
+        NzbInputLimits limits,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(stream);
         ArgumentNullException.ThrowIfNull(limits);
@@ -53,6 +57,7 @@ public static class NzbInputValidator
 
                 if (reader.LocalName == "file")
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     fileCount++;
                     if (fileCount > limits.MaxFiles)
                     {
@@ -72,7 +77,7 @@ public static class NzbInputValidator
 
                     totalBytes = AddSegmentBytesOrThrow(
                         totalBytes,
-                        ReadFileSegments(reader, limits, errors, ref totalSegments),
+                        ReadFileSegments(reader, limits, errors, ref totalSegments, cancellationToken),
                         errors);
                 }
             }
@@ -91,7 +96,8 @@ public static class NzbInputValidator
         XmlReader reader,
         NzbInputLimits limits,
         ValidationErrors errors,
-        ref int totalSegments)
+        ref int totalSegments,
+        CancellationToken cancellationToken)
     {
         long fileBytes = 0;
         var seenNumbers = new HashSet<int>();
@@ -105,6 +111,7 @@ public static class NzbInputValidator
 
             if (reader is { NodeType: XmlNodeType.Element, LocalName: "segment" })
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 totalSegments++;
                 if (totalSegments > limits.MaxTotalSegments)
                 {

--- a/backend/Models/Nzb/NzbInputValidator.cs
+++ b/backend/Models/Nzb/NzbInputValidator.cs
@@ -106,12 +106,12 @@ public static class NzbInputValidator
 
         while (true)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (reader is { NodeType: XmlNodeType.EndElement, LocalName: "file" })
                 break;
 
             if (reader is { NodeType: XmlNodeType.Element, LocalName: "segment" })
             {
-                cancellationToken.ThrowIfCancellationRequested();
                 totalSegments++;
                 if (totalSegments > limits.MaxTotalSegments)
                 {

--- a/backend/Queue/NzbSubmissionService.cs
+++ b/backend/Queue/NzbSubmissionService.cs
@@ -119,7 +119,7 @@ public class NzbSubmissionService(
             // compute the total segment bytes
             await using var nzbFileStream = BlobStore.ReadBlob(id)!;
             var totalSegmentBytes = NzbInputValidator.ValidateAndSumSegmentBytes(
-                nzbFileStream, NzbInputLimits.Default);
+                nzbFileStream, NzbInputLimits.Default, request.CancellationToken);
 
             // Keep enqueues after any manually moved item in their priority band.
             // CreatedAt remains the immutable enqueue timestamp; SortOrder owns

--- a/tests/NzbWebDAV.Tests/Api/NzbInputValidatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/NzbInputValidatorTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Tests.TestUtils;
 
 namespace NzbWebDAV.Tests.Api;
 
@@ -148,6 +149,33 @@ public class NzbInputValidatorTests
 
         Assert.Contains("subject", ex.Errors["nzb"][0], StringComparison.OrdinalIgnoreCase);
         Assert.Contains("1024", ex.Errors["nzb"][0], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PreCancelledToken_ThrowsOperationCanceled()
+    {
+        var xml = BuildNzb(fileCount: 1, segmentsPerFile: 2);
+        using var stream = Bytes(xml);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.Throws<OperationCanceledException>(
+            () => NzbInputValidator.ValidateAndSumSegmentBytes(
+                stream, NzbInputLimits.Default, cts.Token));
+    }
+
+    [Fact]
+    public void CancelMidDocument_ThrowsOperationCanceledBeforeLastSegment()
+    {
+        // ~3 MB single-file document; cancelling after 64 KiB of reads must
+        // surface as OCE (not ApiValidationException) while segments remain.
+        var xml = BuildNzb(fileCount: 1, segmentsPerFile: 50_000);
+        using var cts = new CancellationTokenSource();
+        using var stream = TestStreams.CancelAfterBytes(Bytes(xml), cancelAfterBytes: 64 * 1024, cts);
+
+        Assert.Throws<OperationCanceledException>(
+            () => NzbInputValidator.ValidateAndSumSegmentBytes(
+                stream, NzbInputLimits.Default, cts.Token));
     }
 
     private static string BuildNzb(int fileCount, int segmentsPerFile, long segmentBytes = 15)

--- a/tests/NzbWebDAV.Tests/Api/NzbInputValidatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/NzbInputValidatorTests.cs
@@ -178,6 +178,22 @@ public class NzbInputValidatorTests
                 stream, NzbInputLimits.Default, cts.Token));
     }
 
+    [Fact]
+    public void CancelWhileReadingFinalSegment_ThrowsOperationCanceled()
+    {
+        // Delivery stops one byte into the final segment's content and the token
+        // is cancelled when the reader pulls the remainder, so cancellation lands
+        // after the per-segment check but before the closing </file> is seen.
+        var xml = BuildNzb(fileCount: 1, segmentsPerFile: 1);
+        var segmentContentStart = xml.IndexOf('>', xml.IndexOf("<segment ", StringComparison.Ordinal)) + 1;
+        using var cts = new CancellationTokenSource();
+        using var stream = TestStreams.CancelOnReadBeyond(Bytes(xml), byteLimit: segmentContentStart + 1, cts);
+
+        Assert.Throws<OperationCanceledException>(
+            () => NzbInputValidator.ValidateAndSumSegmentBytes(
+                stream, NzbInputLimits.Default, cts.Token));
+    }
+
     private static string BuildNzb(int fileCount, int segmentsPerFile, long segmentBytes = 15)
     {
         var builder = new StringBuilder("<nzb>");

--- a/tests/NzbWebDAV.Tests/Models/NzbDocumentTests.cs
+++ b/tests/NzbWebDAV.Tests/Models/NzbDocumentTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using NzbWebDAV.Models;
 using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Tests.TestUtils;
 
 namespace NzbWebDAV.Tests.Models;
 
@@ -92,6 +93,43 @@ public class NzbDocumentTests
 
         Assert.Equal("Could not parse the nzb document (malformed nzb)", exception.Message);
         Assert.IsType<System.Xml.XmlException>(exception.InnerException);
+    }
+
+    [Fact]
+    public async Task LoadAsync_PreCancelledToken_ThrowsOperationCanceled()
+    {
+        const string xml = """
+            <nzb><file subject="file"><segments>
+              <segment bytes="10" number="1">a@example</segment>
+            </segments></file></nzb>
+            """;
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => NzbDocument.LoadAsync(stream, cts.Token));
+    }
+
+    [Fact]
+    public async Task LoadAsync_CancelMidSegments_ThrowsOperationCanceledUnwrapped()
+    {
+        // ~3 MB single-file document; cancelling after 64 KiB of reads must
+        // propagate as OCE, not as InvalidDataException("malformed nzb").
+        var builder = new StringBuilder("<nzb><file subject=\"huge\"><segments>");
+        for (var i = 1; i <= 50_000; i++)
+            builder.Append($"<segment bytes=\"15\" number=\"{i}\">id-{i}@example</segment>");
+        builder.Append("</segments></file></nzb>");
+        using var cts = new CancellationTokenSource();
+        await using var stream = TestStreams.CancelAfterBytes(
+            new MemoryStream(Encoding.UTF8.GetBytes(builder.ToString())),
+            cancelAfterBytes: 64 * 1024,
+            cts);
+
+        // ThrowsAsync requires the exact type: an OCE wrapped as
+        // InvalidDataException("malformed nzb") would fail this assertion.
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => NzbDocument.LoadAsync(stream, cts.Token));
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/TestUtils/TestStreams.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/TestStreams.cs
@@ -6,4 +6,57 @@ namespace NzbWebDAV.Tests.TestUtils;
 internal static class TestStreams
 {
     public static Stream Create(byte[] payload) => new MemoryStream(payload, writable: false);
+
+    /// <summary>
+    /// Wraps <paramref name="inner"/> and cancels <paramref name="cts"/> once more than
+    /// <paramref name="cancelAfterBytes"/> bytes have been read, so parsers observe
+    /// cancellation deterministically mid-stream.
+    /// </summary>
+    public static Stream CancelAfterBytes(Stream inner, long cancelAfterBytes, CancellationTokenSource cts) =>
+        new CancelAfterBytesStream(inner, cancelAfterBytes, cts);
+
+    private sealed class CancelAfterBytesStream(Stream inner, long cancelAfterBytes, CancellationTokenSource cts)
+        : Stream
+    {
+        private long _bytesRead;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => _bytesRead;
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = inner.Read(buffer, offset, count);
+            Add(read);
+            return read;
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            var read = await inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            Add(read);
+            return read;
+        }
+
+        private void Add(int read)
+        {
+            if (read <= 0) return;
+            _bytesRead += read;
+            if (_bytesRead > cancelAfterBytes)
+                cts.Cancel();
+        }
+
+        public override void Flush() => inner.Flush();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
 }

--- a/tests/NzbWebDAV.Tests/TestUtils/TestStreams.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/TestStreams.cs
@@ -15,6 +15,68 @@ internal static class TestStreams
     public static Stream CancelAfterBytes(Stream inner, long cancelAfterBytes, CancellationTokenSource cts) =>
         new CancelAfterBytesStream(inner, cancelAfterBytes, cts);
 
+    /// <summary>
+    /// Wraps <paramref name="inner"/> and delivers at most <paramref name="byteLimit"/> bytes,
+    /// cancelling <paramref name="cts"/> on the first read beyond the limit (that read still
+    /// returns the remaining data). Unlike <see cref="CancelAfterBytes"/>, delivery is capped so
+    /// buffered readers cannot race ahead of the cancellation point.
+    /// </summary>
+    public static Stream CancelOnReadBeyond(Stream inner, long byteLimit, CancellationTokenSource cts) =>
+        new CancelOnReadBeyondStream(inner, byteLimit, cts);
+
+    private sealed class CancelOnReadBeyondStream(Stream inner, long byteLimit, CancellationTokenSource cts)
+        : Stream
+    {
+        private long _bytesRead;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => _bytesRead;
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (_bytesRead >= byteLimit)
+            {
+                cts.Cancel();
+                var read = inner.Read(buffer, offset, count);
+                _bytesRead += read;
+                return read;
+            }
+
+            var capped = inner.Read(buffer, offset, (int)Math.Min(count, byteLimit - _bytesRead));
+            _bytesRead += capped;
+            return capped;
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            if (_bytesRead >= byteLimit)
+            {
+                cts.Cancel();
+                return await inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            }
+
+            var read = await inner
+                .ReadAsync(buffer[..(int)Math.Min(buffer.Length, byteLimit - _bytesRead)], cancellationToken)
+                .ConfigureAwait(false);
+            _bytesRead += read;
+            return read;
+        }
+
+        public override void Flush() => inner.Flush();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
     private sealed class CancelAfterBytesStream(Stream inner, long cancelAfterBytes, CancellationTokenSource cts)
         : Stream
     {


### PR DESCRIPTION
## Summary

- Thread `CancellationToken` through `NzbInputValidator.ValidateAndSumSegmentBytes` and `NzbDocument.LoadAsync`'s nested file/segment readers so a cancelled submission or queue worker stops within one element instead of parsing a 500k-segment document to completion.
- Cancellation stays `OperationCanceledException` (never mapped to validation errors or `InvalidDataException`), so cancelled items are not recorded as failed history.
- No change to validation limits, error messages, or success-path behavior.

Fixes #1184

## Test plan

- [x] `NzbInputValidatorTests`: pre-cancelled token and mid-document cancel both throw `OperationCanceledException`; all existing validation-message tests unchanged and green.
- [x] `NzbDocumentTests`: pre-cancelled token throws OCE; mid-segments cancel propagates as OCE, not wrapped as "malformed nzb".
- [x] `AddFileRequestTests` (submission path) green.
- [ ] CI: full backend + frontend gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * NZB parsing and validation now respond promptly when an operation is canceled.
  * Cancellation errors are preserved correctly instead of being reported as invalid NZB data.
  * Large or slow NZB submissions can be stopped during file and segment processing.

* **Tests**
  * Added coverage for cancellation before processing begins and during document reading, file validation, and segment processing.
  * Verified cancellation behavior remains consistent for streamed and partially read NZB content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
