### PR TITLE
fix(queue): deleting or pausing a stuck download no longer hangs forever

### DIFF
--- a/backend/Api/SabControllers/AddUrl/AddUrlController.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlController.cs
@@ -20,13 +20,26 @@ public class AddUrlController(
 {
     public async Task<AddUrlResponse> AddUrlAsync(AddUrlRequest request)
     {
+        // Owns the shared fetch/ingest deadline created in AddUrlRequest.New.
+        using var fetchDeadline = request.FetchDeadlineSource;
         var controller = new AddFileController(Context, dbClient, queueManager, Config, websocketManager);
-        var response = await controller.AddFileAsync(request).ConfigureAwait(false);
-        return new AddUrlResponse()
+        try
         {
-            Status = response.Status,
-            NzoIds = response.NzoIds,
-        };
+            var response = await controller.AddFileAsync(request).ConfigureAwait(false);
+            return new AddUrlResponse()
+            {
+                Status = response.Status,
+                NzoIds = response.NzoIds,
+            };
+        }
+        catch (OperationCanceledException ex) when (
+            fetchDeadline?.IsCancellationRequested == true && !Context.RequestAborted.IsCancellationRequested)
+        {
+            // The deadline fired while SubmitAsync was copying the response body;
+            // surface a fetch failure to the SAB client instead of an aborted request.
+            throw new BadHttpRequestException(
+                "Failed to fetch the nzb file: the download timed out.", ex);
+        }
     }
 
     protected override async Task<IActionResult> Handle()

--- a/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
@@ -21,7 +21,19 @@ public class AddUrlRequest() : AddFileRequest
     private static readonly HttpClient PermissiveDirectHttpClient = InitializeHttpClient(skipTlsVerification: true);
     private static readonly HttpRequestOptionsKey<TrustedHostsMatcher> TrustedHostsOptionKey = new("TrustedHosts");
 
-    public static async Task<AddUrlRequest> New(HttpContext context, ConfigManager configManager, IndexerHitTracker hitTracker)
+    /// <summary>
+    /// Shared fetch/ingest deadline created by <see cref="New"/>. Its token is
+    /// this request's <see cref="AddFileRequest.CancellationToken"/>, so the
+    /// header wait and the body copy inside SubmitAsync share one budget.
+    /// Owned (and disposed) by AddUrlController.AddUrlAsync.
+    /// </summary>
+    internal CancellationTokenSource? FetchDeadlineSource { get; init; }
+
+    public static async Task<AddUrlRequest> New(
+        HttpContext context,
+        ConfigManager configManager,
+        IndexerHitTracker hitTracker,
+        TimeSpan? fetchTimeout = null)
     {
         var errors = new ValidationErrors();
         var nzbUrl = context.GetRequestParam("name");
@@ -61,14 +73,30 @@ public class AddUrlRequest() : AddFileRequest
             }
         }
 
-        var nzbFile = await GetNzbFile(
-            nzbUrl,
-            nzbName,
-            userAgent,
-            proxyUrl,
-            skipTlsVerification,
-            trustedHosts,
-            context.RequestAborted).ConfigureAwait(false);
+        // One deadline covers the header wait in GetNzbFile and the body copy
+        // inside SubmitAsync; with ResponseHeadersRead neither HttpClient.Timeout
+        // nor a per-call CTS bounds the body. Linked so client abort still cancels.
+        var fetchDeadline = CancellationTokenSource.CreateLinkedTokenSource(context.RequestAborted);
+        fetchDeadline.CancelAfter(fetchTimeout ?? FetchTimeout);
+        NzbFileResponse nzbFile;
+        try
+        {
+            nzbFile = await GetNzbFile(
+                nzbUrl,
+                nzbName,
+                userAgent,
+                proxyUrl,
+                skipTlsVerification,
+                trustedHosts,
+                fetchDeadline.Token,
+                context.RequestAborted).ConfigureAwait(false);
+        }
+        catch
+        {
+            fetchDeadline.Dispose();
+            throw;
+        }
+
         if (matchedIndexer is not null)
             _ = hitTracker.RecordAsync(matchedIndexer.Name, IndexerApiHit.HitType.Download, CancellationToken.None);
         return new AddUrlRequest()
@@ -80,7 +108,8 @@ public class AddUrlRequest() : AddFileRequest
                        ?? configManager.GetManualUploadCategory(),
             Priority = MapPriorityOption(context.GetRequestParam("priority")),
             PostProcessing = MapPostProcessingOption(context.GetRequestParam("pp")),
-            CancellationToken = context.RequestAborted
+            CancellationToken = fetchDeadline.Token,
+            FetchDeadlineSource = fetchDeadline,
         };
     }
 
@@ -108,7 +137,8 @@ public class AddUrlRequest() : AddFileRequest
         string? proxyUrl,
         bool skipTlsVerification,
         TrustedHostsMatcher trustedHosts,
-        CancellationToken cancellationToken)
+        CancellationToken fetchToken,
+        CancellationToken requestAborted)
     {
         try
         {
@@ -116,7 +146,7 @@ public class AddUrlRequest() : AddFileRequest
                 throw new InvalidOperationException($"The url is invalid.");
 
             var response = await GetAsync(
-                url, userAgent, proxyUrl, skipTlsVerification, trustedHosts, cancellationToken).ConfigureAwait(false);
+                url, userAgent, proxyUrl, skipTlsVerification, trustedHosts, fetchToken).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 response.Dispose();
@@ -131,7 +161,7 @@ public class AddUrlRequest() : AddFileRequest
                                    ?? throw new InvalidOperationException("Nzb filename could not be determined.");
             var fileName = NzbStreamUtil.NormalizeFileName(resolvedFileName);
 
-            var fileStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            var fileStream = await response.Content.ReadAsStreamAsync(fetchToken).ConfigureAwait(false);
 
             return new NzbFileResponse
             {
@@ -140,9 +170,14 @@ public class AddUrlRequest() : AddFileRequest
                 FileStream = fileStream
             };
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (requestAborted.IsCancellationRequested)
         {
             throw;
+        }
+        catch (OperationCanceledException ex) when (fetchToken.IsCancellationRequested)
+        {
+            throw new BadHttpRequestException(
+                $"Failed to fetch nzb-file url `{url}`: the download timed out.", ex);
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or InvalidOperationException or IOException)
         {
@@ -164,9 +199,9 @@ public class AddUrlRequest() : AddFileRequest
         CancellationToken cancellationToken
     )
     {
-        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        timeoutCts.CancelAfter(FetchTimeout);
-        var ct = timeoutCts.Token;
+        // The caller owns the fetch deadline and keeps it alive through the body
+        // copy in SubmitAsync; do not scope a timeout CTS here.
+        var ct = cancellationToken;
         var currentUri = ValidateHttpUri(url);
         var httpClient = string.IsNullOrWhiteSpace(proxyUrl)
             ? (skipTlsVerification ? PermissiveDirectHttpClient : StrictDirectHttpClient)

--- a/backend/Api/SabControllers/RemoveFromQueue/RemoveFromQueueController.cs
+++ b/backend/Api/SabControllers/RemoveFromQueue/RemoveFromQueueController.cs
@@ -23,7 +23,17 @@ public class RemoveFromQueueController(
             ? await GetQueueItemIdsToRemoveAsync(request).ConfigureAwait(false)
             : request.NzoIds;
         var service = new QueueRemovalService(dbClient, queueManager, websocketManager);
-        await service.RemoveAsync(ids, request.CancellationToken).ConfigureAwait(false);
+        var stillRunning = await service.RemoveAsync(ids, request.CancellationToken).ConfigureAwait(false);
+        if (stillRunning.Count > 0)
+        {
+            return new RemoveFromQueueResponse()
+            {
+                Status = false,
+                Error = $"{stillRunning.Count} item(s) are still stopping and could not be removed; " +
+                        "try again shortly.",
+            };
+        }
+
         return new RemoveFromQueueResponse() { Status = true };
     }
 

--- a/backend/Models/Nzb/NzbDocument.cs
+++ b/backend/Models/Nzb/NzbDocument.cs
@@ -30,10 +30,10 @@ public class NzbDocument
                 switch (reader.Name)
                 {
                     case "head":
-                        await ReadHeadAsync(reader, document.Metadata).ConfigureAwait(false);
+                        await ReadHeadAsync(reader, document.Metadata, ct).ConfigureAwait(false);
                         break;
                     case "file":
-                        var file = await ReadFileAsync(reader).ConfigureAwait(false);
+                        var file = await ReadFileAsync(reader, ct).ConfigureAwait(false);
                         document.Files.Add(file);
                         break;
                 }
@@ -41,19 +41,29 @@ public class NzbDocument
 
             return document;
         }
+        catch (OperationCanceledException)
+        {
+            // Cancellation must stay cancellation; only malformed XML maps to
+            // InvalidDataException (which finalizes as failed history).
+            throw;
+        }
         catch (XmlException e)
         {
             throw new InvalidDataException("Could not parse the nzb document (malformed nzb)", e);
         }
     }
 
-    private static async Task ReadHeadAsync(XmlReader reader, Dictionary<string, string> metadata)
+    private static async Task ReadHeadAsync(
+        XmlReader reader,
+        Dictionary<string, string> metadata,
+        CancellationToken ct)
     {
         if (reader.IsEmptyElement)
             return;
 
         while (true)
         {
+            ct.ThrowIfCancellationRequested();
             if (reader is { NodeType: XmlNodeType.EndElement, Name: "head" })
                 break;
 
@@ -73,7 +83,7 @@ public class NzbDocument
         }
     }
 
-    private static async Task<NzbFile> ReadFileAsync(XmlReader reader)
+    private static async Task<NzbFile> ReadFileAsync(XmlReader reader, CancellationToken ct)
     {
         var file = new NzbFile
         {
@@ -85,12 +95,13 @@ public class NzbDocument
 
         while (await reader.ReadAsync().ConfigureAwait(false))
         {
+            ct.ThrowIfCancellationRequested();
             if (reader is { NodeType: XmlNodeType.EndElement, Name: "file" })
                 break;
 
             if (reader is { NodeType: XmlNodeType.Element, Name: "segments" })
             {
-                await ReadSegmentsAsync(reader, file).ConfigureAwait(false);
+                await ReadSegmentsAsync(reader, file, ct).ConfigureAwait(false);
             }
         }
 
@@ -98,7 +109,7 @@ public class NzbDocument
         return file;
     }
 
-    private static async Task ReadSegmentsAsync(XmlReader reader, NzbFile file)
+    private static async Task ReadSegmentsAsync(XmlReader reader, NzbFile file, CancellationToken ct)
     {
         if (reader.IsEmptyElement)
             return;
@@ -110,6 +121,7 @@ public class NzbDocument
 
             if (reader is { NodeType: XmlNodeType.Element, Name: "segment" })
             {
+                ct.ThrowIfCancellationRequested();
                 var bytesAttr = reader.GetAttribute("bytes");
                 var numberAttr = reader.GetAttribute("number");
                 var segment = new NzbSegment

--- a/backend/Models/Nzb/NzbInputValidator.cs
+++ b/backend/Models/Nzb/NzbInputValidator.cs
@@ -17,9 +17,13 @@ public static class NzbInputValidator
     /// <summary>
     /// Walks NZB XML incrementally, enforces <paramref name="limits"/>, and
     /// returns the sum of valid segment byte counts. Does not echo message IDs
-    /// or raw XML in error text.
+    /// or raw XML in error text. Cancellation is observed per file and per
+    /// segment so a cancelled submission stops promptly on huge documents.
     /// </summary>
-    public static long ValidateAndSumSegmentBytes(Stream stream, NzbInputLimits limits)
+    public static long ValidateAndSumSegmentBytes(
+        Stream stream,
+        NzbInputLimits limits,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(stream);
         ArgumentNullException.ThrowIfNull(limits);
@@ -53,6 +57,7 @@ public static class NzbInputValidator
 
                 if (reader.LocalName == "file")
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     fileCount++;
                     if (fileCount > limits.MaxFiles)
                     {
@@ -72,7 +77,7 @@ public static class NzbInputValidator
 
                     totalBytes = AddSegmentBytesOrThrow(
                         totalBytes,
-                        ReadFileSegments(reader, limits, errors, ref totalSegments),
+                        ReadFileSegments(reader, limits, errors, ref totalSegments, cancellationToken),
                         errors);
                 }
             }
@@ -91,7 +96,8 @@ public static class NzbInputValidator
         XmlReader reader,
         NzbInputLimits limits,
         ValidationErrors errors,
-        ref int totalSegments)
+        ref int totalSegments,
+        CancellationToken cancellationToken)
     {
         long fileBytes = 0;
         var seenNumbers = new HashSet<int>();
@@ -105,6 +111,7 @@ public static class NzbInputValidator
 
             if (reader is { NodeType: XmlNodeType.Element, LocalName: "segment" })
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 totalSegments++;
                 if (totalSegments > limits.MaxTotalSegments)
                 {

--- a/backend/Models/Nzb/NzbInputValidator.cs
+++ b/backend/Models/Nzb/NzbInputValidator.cs
@@ -106,12 +106,12 @@ public static class NzbInputValidator
 
         while (true)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (reader is { NodeType: XmlNodeType.EndElement, LocalName: "file" })
                 break;
 
             if (reader is { NodeType: XmlNodeType.Element, LocalName: "segment" })
             {
-                cancellationToken.ThrowIfCancellationRequested();
                 totalSegments++;
                 if (totalSegments > limits.MaxTotalSegments)
                 {

--- a/backend/Models/Nzb/NzbInputValidator.cs
+++ b/backend/Models/Nzb/NzbInputValidator.cs
@@ -168,6 +168,19 @@ public static class NzbInputValidator
         }
     }
 
+    /// <summary>
+    /// The size-limit error thrown both while streaming the decompressed
+    /// document to disk (via a bounded read stream) and while validating the
+    /// committed blob, so SAB clients always get the same 4xx sentence.
+    /// </summary>
+    internal static ApiValidationException CreateSizeLimitException() =>
+        new(
+            new Dictionary<string, string[]>
+            {
+                ["nzb"] = ["The NZB document exceeds the maximum allowed size."],
+            },
+            "The NZB document exceeds the maximum allowed size.");
+
     private static void Throw(string field, string message)
     {
         var errors = new ValidationErrors();

--- a/backend/Queue/IQueueCoordinator.cs
+++ b/backend/Queue/IQueueCoordinator.cs
@@ -14,7 +14,11 @@ public interface IQueueCoordinator
     QueueManager.InProgressQueueItemSnapshot? FindInProgressQueueItem(Guid queueItemId);
     IDisposable? TryReserveQueueSlot(int persistedCount, int maxItems, int resumeThreshold);
     void AwakenQueue(DateTime? dateTime = null);
-    Task RemoveQueueItemsAsync(List<Guid> queueItemIds, DavDatabaseClient dbClient, CancellationToken ct = default);
+    /// <summary>
+    /// Removes the requested items; ids whose in-progress workers ignored
+    /// cancellation are returned and remain queued instead of being deleted.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> RemoveQueueItemsAsync(List<Guid> queueItemIds, DavDatabaseClient dbClient, CancellationToken ct = default);
     Task PauseQueueItemsAsync(List<Guid> queueItemIds, DavDatabaseClient dbClient, CancellationToken ct = default);
     Task ResumeQueueItemsAsync(List<Guid> queueItemIds, DavDatabaseClient dbClient, CancellationToken ct = default);
     Task SetQueueItemsPriorityAsync(

--- a/backend/Queue/NzbSubmissionService.cs
+++ b/backend/Queue/NzbSubmissionService.cs
@@ -119,7 +119,7 @@ public class NzbSubmissionService(
             // compute the total segment bytes
             await using var nzbFileStream = BlobStore.ReadBlob(id)!;
             var totalSegmentBytes = NzbInputValidator.ValidateAndSumSegmentBytes(
-                nzbFileStream, NzbInputLimits.Default);
+                nzbFileStream, NzbInputLimits.Default, request.CancellationToken);
 
             // Keep enqueues after any manually moved item in their priority band.
             // CreatedAt remains the immutable enqueue timestamp; SortOrder owns

--- a/backend/Queue/NzbSubmissionService.cs
+++ b/backend/Queue/NzbSubmissionService.cs
@@ -246,7 +246,19 @@ public class NzbSubmissionService(
             category,
             wasInProgress ? "; cancelling in-progress download" : "");
 
-        await queueManager.RemoveQueueItemsAsync([existingId.Value], dbClient, ct).ConfigureAwait(false);
+        var stillRunning = await queueManager
+            .RemoveQueueItemsAsync([existingId.Value], dbClient, ct)
+            .ConfigureAwait(false);
+        if (stillRunning.Count > 0)
+        {
+            // Inserting over a quarantined worker would hit the queue unique
+            // constraint and re-attempt removal — a remove/insert loop against a
+            // hung task. Fail the submission visibly instead.
+            throw new BadHttpRequestException(
+                $"The existing queue item '{fileName}' is still stopping and cannot be replaced yet; " +
+                "try again shortly.");
+        }
+
         _ = websocketManager.SendMessage(WebsocketTopic.QueueItemRemoved, existingId.Value.ToString());
         _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"], ct);
     }
@@ -273,7 +285,16 @@ public class NzbSubmissionService(
             category,
             wasInProgress ? "; cancelling in-progress download" : "");
 
-        await queueManager.RemoveQueueItemsAsync([conflictingId.Value], freshClient, ct).ConfigureAwait(false);
+        var stillRunning = await queueManager
+            .RemoveQueueItemsAsync([conflictingId.Value], freshClient, ct)
+            .ConfigureAwait(false);
+        if (stillRunning.Count > 0)
+        {
+            throw new BadHttpRequestException(
+                $"The existing queue item '{fileName}' is still stopping and cannot be replaced yet; " +
+                "try again shortly.");
+        }
+
         _ = websocketManager.SendMessage(WebsocketTopic.QueueItemRemoved, conflictingId.Value.ToString());
         _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"], ct);
     }

--- a/backend/Queue/NzbSubmissionService.cs
+++ b/backend/Queue/NzbSubmissionService.cs
@@ -88,6 +88,7 @@ public class NzbSubmissionService(
             await AfterDuplicatePreCheckHook().ConfigureAwait(false);
 
         QueueItem? queueItem;
+        string? backupPath = null;
         try
         {
             var prepared = await NzbStreamUtil.OpenMaybeCompressedAsync(
@@ -97,8 +98,14 @@ public class NzbSubmissionService(
             try
             {
                 // Store normalized XML so every downstream parser remains
-                // compression-agnostic.
-                await BlobStore.WriteBlob(id, nzbInputStream, request.CancellationToken)
+                // compression-agnostic. The bounded stream enforces the
+                // decompressed size limit during the copy, so an oversize
+                // document (or gzip bomb) fails before filling the disk.
+                await using var bounded = new LimitedReadStream(
+                    nzbInputStream,
+                    NzbInputLimits.Default.MaxXmlBytes,
+                    NzbInputValidator.CreateSizeLimitException);
+                await BlobStore.WriteBlob(id, bounded, request.CancellationToken)
                     .ConfigureAwait(false);
             }
             catch (InvalidDataException exception) when (prepared.IsGzip)
@@ -106,20 +113,23 @@ public class NzbSubmissionService(
                 throw new BadHttpRequestException("The uploaded gzip NZB is invalid.", exception);
             }
 
+            // compute the total segment bytes before any backup, so a rejected
+            // document never leaves a backup file behind
+            await using var nzbFileStream = BlobStore.ReadBlob(id)!;
+            var totalSegmentBytes = NzbInputValidator.ValidateAndSumSegmentBytes(
+                nzbFileStream, NzbInputLimits.Default, request.CancellationToken);
+
             // backup the nzb file if enabled
             if (configManager.IsNzbBackupEnabled())
             {
                 var backupLocation = configManager.GetNzbBackupLocation();
                 if (backupLocation != null)
                 {
-                    await BackupNzbAsync(id, request.FileName, category, backupLocation).ConfigureAwait(false);
+                    backupPath = await BackupNzbAsync(
+                            id, request.FileName, category, backupLocation, request.CancellationToken)
+                        .ConfigureAwait(false);
                 }
             }
-
-            // compute the total segment bytes
-            await using var nzbFileStream = BlobStore.ReadBlob(id)!;
-            var totalSegmentBytes = NzbInputValidator.ValidateAndSumSegmentBytes(
-                nzbFileStream, NzbInputLimits.Default, request.CancellationToken);
 
             // Keep enqueues after any manually moved item in their priority band.
             // CreatedAt remains the immutable enqueue timestamp; SortOrder owns
@@ -189,8 +199,10 @@ public class NzbSubmissionService(
         }
         catch
         {
-            // Delete partial or unreferenced blobs after ingest/database failures.
+            // Delete partial or unreferenced blobs after ingest/database failures,
+            // plus any backup sidecar written before the failure.
             BlobStore.Delete(id);
+            TryDeleteBackupFile(backupPath);
             throw;
         }
 
@@ -287,8 +299,15 @@ public class NzbSubmissionService(
         return false;
     }
 
-    private static async Task BackupNzbAsync(Guid id, string fileName, string category, string backupLocation)
+    /// <summary>
+    /// Copies the committed blob into the configured backup directory and
+    /// returns the written path so a later submission failure can remove it.
+    /// A failed or cancelled copy deletes its own partial file.
+    /// </summary>
+    private static async Task<string> BackupNzbAsync(
+        Guid id, string fileName, string category, string backupLocation, CancellationToken ct)
     {
+        string? destPath = null;
         try
         {
             ValidateBackupCategory(category);
@@ -310,7 +329,7 @@ public class NzbSubmissionService(
                 ? destDir
                 : destDir + Path.DirectorySeparatorChar;
             var safeFileName = GetSafeBackupFileName(id, fileName);
-            var destPath = CombineUnderDirectory(destDirPrefix, safeFileName);
+            destPath = CombineUnderDirectory(destDirPrefix, safeFileName);
             var counter = 2;
             while (System.IO.File.Exists(destPath))
             {
@@ -324,11 +343,32 @@ public class NzbSubmissionService(
 
             await using var src = BlobStore.ReadBlob(id);
             await using var dst = System.IO.File.Create(destPath);
-            await src!.CopyToAsync(dst).ConfigureAwait(false);
+            await src!.CopyToAsync(dst, ct).ConfigureAwait(false);
+            return destPath;
         }
-        catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
+        catch (Exception e) when (!e.IsCancellationException(ct) && e is not OutOfMemoryException)
         {
+            TryDeleteBackupFile(destPath);
             throw new InvalidOperationException($"Could not save nzb to `{backupLocation}`", e);
+        }
+        catch
+        {
+            TryDeleteBackupFile(destPath);
+            throw;
+        }
+    }
+
+    private static void TryDeleteBackupFile(string? backupPath)
+    {
+        if (backupPath is null) return;
+        try
+        {
+            if (System.IO.File.Exists(backupPath))
+                System.IO.File.Delete(backupPath);
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            Log.Warning(e, "Could not delete NZB backup file {BackupPath} after a submission failure", backupPath);
         }
     }
 

--- a/backend/Queue/PostProcessors/CreateStrmFilesPostProcessor.cs
+++ b/backend/Queue/PostProcessors/CreateStrmFilesPostProcessor.cs
@@ -5,6 +5,7 @@ using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Utils;
 using NzbWebDAV.WebDav;
+using Serilog;
 
 namespace NzbWebDAV.Queue.PostProcessors;
 
@@ -16,23 +17,53 @@ public class CreateStrmFilesPostProcessor(
     private static readonly string ContentRootPrefix =
         DavItem.ContentFolder.Path.TrimEnd('/') + "/";
 
-    public async Task CreateStrmFilesAsync()
+    /// <summary>
+    /// Outcome of a written STRM sidecar. <see cref="PreviousContent"/> is null for a
+    /// newly created file and holds the pre-write content for a rewritten one, so a
+    /// failed publish can restore rewrites instead of deleting pre-existing files.
+    /// </summary>
+    internal sealed record StrmWrite(string Path, string? PreviousContent);
+
+    public async Task CreateStrmFilesAsync(CancellationToken cancellationToken = default)
     {
         var candidates = CollectVideoItems();
         var created = new List<DavItem>();
+        var rewritten = new List<StrmWrite>();
         try
         {
             foreach (var videoItem in candidates)
             {
-                if (await CreateStrmFileAsync(videoItem).ConfigureAwait(false))
+                var write = await CreateStrmFileAsync(videoItem, cancellationToken).ConfigureAwait(false);
+                if (write is null)
+                    continue;
+                if (write.PreviousContent is null)
                     created.Add(videoItem);
+                else
+                    rewritten.Add(write);
             }
         }
         catch
         {
             foreach (var createdItem in created)
                 DeleteStrmFile(createdItem);
+            foreach (var rewrite in rewritten)
+                TryRestorePreviousContent(rewrite);
             throw;
+        }
+    }
+
+    private static void TryRestorePreviousContent(StrmWrite write)
+    {
+        try
+        {
+            File.WriteAllText(write.Path, write.PreviousContent);
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            Log.Warning(
+                e,
+                "Could not restore previous STRM file {StrmPath} after a publish failure",
+                write.Path);
         }
     }
 
@@ -66,16 +97,17 @@ public class CreateStrmFilesPostProcessor(
 
     /// <summary>
     /// Writes (or updates) the STRM sidecar for a DavItem. Shared by queue post-processing
-    /// and the Recreate STRM maintenance task.
+    /// and the Recreate STRM maintenance task. Returns null when no write was needed;
+    /// otherwise the written path plus the pre-write content (null when newly created).
     /// </summary>
-    internal static async Task<bool> WriteStrmFileAsync(
+    internal static async Task<StrmWrite?> WriteStrmFileAsync(
         ConfigManager configManager,
         DavItem davItem,
         bool forceRewrite,
         CancellationToken cancellationToken = default)
     {
         if (!IsStrmCandidate(davItem))
-            return false;
+            return null;
 
         var strmFilePath = Path.GetFullPath(GetStrmFilePath(configManager, davItem));
         var completedDownloadsRoot = Path.GetFullPath(configManager.GetStrmCompletedDownloadDir());
@@ -91,23 +123,24 @@ public class CreateStrmFilesPostProcessor(
             throw new IOException($"Generated STRM path '{strmFilePath}' is beneath a symbolic-link directory.");
 
         var targetUrl = GetStrmTargetUrl(configManager, davItem);
-        if (!forceRewrite && File.Exists(strmFilePath))
+        string? previousContent = null;
+        if (File.Exists(strmFilePath))
         {
-            var existing = await File.ReadAllTextAsync(strmFilePath, cancellationToken).ConfigureAwait(false);
-            if (existing == targetUrl)
-                return false;
+            previousContent = await File.ReadAllTextAsync(strmFilePath, cancellationToken).ConfigureAwait(false);
+            if (!forceRewrite && previousContent == targetUrl)
+                return null;
         }
 
-        var wasCreated = !File.Exists(strmFilePath);
         await File.WriteAllTextAsync(strmFilePath, targetUrl, cancellationToken).ConfigureAwait(false);
         davItem.GeneratedStrmOutputRoot = completedDownloadsRoot;
         davItem.GeneratedStrmPath = strmFilePath;
         davItem.GeneratedStrmTarget = targetUrl;
-        return wasCreated;
+        return new StrmWrite(strmFilePath, previousContent);
     }
 
-    private async Task<bool> CreateStrmFileAsync(DavItem davItem) =>
-        await WriteStrmFileAsync(configManager, davItem, forceRewrite: false).ConfigureAwait(false);
+    private async Task<StrmWrite?> CreateStrmFileAsync(DavItem davItem, CancellationToken cancellationToken) =>
+        await WriteStrmFileAsync(configManager, davItem, forceRewrite: false, cancellationToken)
+            .ConfigureAwait(false);
 
     internal static string GetStrmFilePath(ConfigManager configManager, DavItem davItem)
     {

--- a/backend/Queue/PostProcessors/CreateStrmFilesPostProcessor.cs
+++ b/backend/Queue/PostProcessors/CreateStrmFilesPostProcessor.cs
@@ -45,10 +45,25 @@ public class CreateStrmFilesPostProcessor(
         catch
         {
             foreach (var createdItem in created)
-                DeleteStrmFile(createdItem);
+                TryDeleteStrmFile(createdItem);
             foreach (var rewrite in rewritten)
                 TryRestorePreviousContent(rewrite);
             throw;
+        }
+    }
+
+    private static void TryDeleteStrmFile(DavItem davItem)
+    {
+        try
+        {
+            DeleteStrmFile(davItem);
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            Log.Warning(
+                e,
+                "Could not remove new STRM file for {ItemPath} after a publish failure",
+                davItem.Path);
         }
     }
 

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -529,11 +529,9 @@ public class QueueItemProcessor(
             if (configManager.IsEnsureImportableMediaEnabled())
                 new EnsureImportableMediaValidator(dbClient).ThrowIfValidationFails();
 
-            // create strm files, if necessary
-            if (configManager.GetImportStrategy() == "strm")
-                await new CreateStrmFilesPostProcessor(configManager, dbClient, queueItem.Id)
-                    .CreateStrmFilesAsync()
-                    .ConfigureAwait(false);
+            // STRM sidecars are published after the commit below (see
+            // MarkQueueItemCompleted), never inside these staged operations:
+            // a failed SaveChanges must not leave sidecars for an uncommitted import.
 
             await SiblingDonorAttacher.BackfillCompletedSiblingsAsync(
                 dbClient, queueItem, nzb, configManager, ct).ConfigureAwait(false);
@@ -855,6 +853,35 @@ public class QueueItemProcessor(
 
         try
         {
+            // STRM sidecars publish only after the mount tree and history row have
+            // committed, and outside the finalize lock: sidecar filesystem I/O needs
+            // no global serialization, and a hung write (e.g. a stalled network mount)
+            // must not block other imports whose history is already committed. The
+            // files land before the Arr refresh below, preserving scan order.
+            if (error is null && configManager.GetImportStrategy() == "strm")
+            {
+                try
+                {
+                    await new CreateStrmFilesPostProcessor(configManager, dbClient, queueItem.Id)
+                        .CreateStrmFilesAsync(finalizeCt)
+                        .ConfigureAwait(false);
+                    if (dbClient.Ctx.ChangeTracker.HasChanges())
+                        await dbClient.Ctx.SaveChangesAsync(finalizeCt).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception strmError)
+                {
+                    // The import is already committed; a sidecar failure must not
+                    // re-finalize it as failed. Operators can run Recreate STRM Files.
+                    strmError.LogWarningKnownOrStack(
+                        "STRM publish failed for {JobName} after the import committed",
+                        queueItem.JobName);
+                }
+            }
+
             _ = websocketManager.SendMessage(WebsocketTopic.QueueItemRemoved, queueItem.Id.ToString());
             _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemAdded, historyJson!);
             _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"], ct);

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -72,6 +72,9 @@ public class QueueItemProcessor(
     }
 
     private const int MaxProviderRetryAttempts = 20;
+    private const int MaxFinalizeCommitRetries = 3;
+    private static readonly TimeSpan TransientDatabaseBackoff = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan DiskOrCorruptionBackoff = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan StageWarningInterval = TimeSpan.FromMinutes(2);
 
     /// <summary>
@@ -223,6 +226,27 @@ public class QueueItemProcessor(
         // it to the history as a failed job.
         catch (Exception e) when (e is not OutOfMemoryException)
         {
+            // A persistence-layer failure is not a content failure. Keep the item
+            // queued with a backoff instead of writing a misleading failed-history
+            // row for healthy content; the next claim retries the finalize.
+            if (e.IsTransientDatabaseException())
+            {
+                e.LogWarningKnownOrStack(
+                    "Queue finalize deferred for {JobName}; the import stays queued and is not failed",
+                    queueItem.JobName);
+                await PauseQueueItemAfterDatabaseErrorAsync(TransientDatabaseBackoff).ConfigureAwait(false);
+                return;
+            }
+
+            if (e.IsKnownSqliteDiskException() || e.IsDatabaseCorruptionException())
+            {
+                e.LogWarningKnownOrStack(
+                    "Queue finalize blocked for {JobName}; the import stays queued and is not failed",
+                    queueItem.JobName);
+                await PauseQueueItemAfterDatabaseErrorAsync(DiskOrCorruptionBackoff).ConfigureAwait(false);
+                return;
+            }
+
             // Remember definitively missing articles so retries of this item and re-grabs
             // of the same release fail in milliseconds at the step-0 precheck instead of
             // re-verifying every article across all providers (issue #732).
@@ -243,7 +267,39 @@ public class QueueItemProcessor(
                     "Failed to mark queue item {JobName} as failed after processing error: {ProcessingError}",
                     queueItem.JobName,
                     e.Message);
+                if (ex.IsTransientDatabaseException())
+                {
+                    // Without a backoff the row is immediately reclaimable and the
+                    // failing finalize hot-loops; leave it queued with a pause instead.
+                    await PauseQueueItemAfterDatabaseErrorAsync(TransientDatabaseBackoff)
+                        .ConfigureAwait(false);
+                }
             }
+        }
+    }
+
+    /// <summary>
+    /// Leaves the item queued with a PauseUntil backoff after a database
+    /// infrastructure failure. The backoff write is itself best-effort: if the
+    /// database is still contended, the row is simply reclaimable one cycle early.
+    /// </summary>
+    private async Task PauseQueueItemAfterDatabaseErrorAsync(TimeSpan backoff)
+    {
+        try
+        {
+            dbClient.Ctx.ClearChangeTracker();
+            queueItem.PauseUntil = DateTime.Now + backoff;
+            dbClient.Ctx.QueueItems.Attach(queueItem);
+            dbClient.Ctx.Entry(queueItem).Property(x => x.PauseUntil).IsModified = true;
+            await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+            _ = websocketManager.SendMessage(WebsocketTopic.QueueItemStatus, $"{queueItem.Id}|Queued");
+        }
+        catch (Exception ex) when (ex is DbUpdateException or InvalidOperationException)
+        {
+            Log.Warning(
+                "Could not persist the database-error backoff for {JobName}: {Reason}",
+                queueItem.JobName,
+                ex.GetBaseException().Message);
         }
     }
 
@@ -843,7 +899,7 @@ public class QueueItemProcessor(
             try
             {
                 _stageReporter("finalize-commit");
-                await dbClient.Ctx.SaveChangesAsync(finalizeCt).ConfigureAwait(false);
+                await SaveFinalizeWithTransientRetryAsync(finalizeCt).ConfigureAwait(false);
             }
             finally
             {
@@ -909,6 +965,38 @@ public class QueueItemProcessor(
             // post-finalize logging or watchdog recording throws.
             retryAttempts.TryRemove(queueItem.Id, out _);
             OnTerminal?.Invoke();
+        }
+    }
+
+    /// <summary>
+    /// Retries the finalize commit in place on SQLITE_BUSY/LOCKED contention only.
+    /// The ChangeTracker is left intact so each attempt re-runs the same commit;
+    /// blob writes are idempotent (same ids, temp-file + move). Disk-full,
+    /// read-only, and corruption errors are never retried here.
+    /// </summary>
+    private async Task SaveFinalizeWithTransientRetryAsync(CancellationToken finalizeCt)
+    {
+        for (var attempt = 0; ; attempt++)
+        {
+            try
+            {
+                await dbClient.Ctx.SaveChangesAsync(finalizeCt).ConfigureAwait(false);
+                return;
+            }
+            catch (Exception ex) when (
+                attempt < MaxFinalizeCommitRetries
+                && ex.IsTransientDatabaseException()
+                && !finalizeCt.IsCancellationRequested)
+            {
+                Log.Warning(
+                    "Queue finalize commit deferred for {JobName} (attempt {Attempt}/{MaxAttempts}). Reason: {Reason}",
+                    queueItem.JobName,
+                    attempt + 1,
+                    MaxFinalizeCommitRetries + 1,
+                    ex.GetBaseException().Message);
+                await Task.Delay(TimeSpan.FromMilliseconds(250 * (attempt + 1)), finalizeCt)
+                    .ConfigureAwait(false);
+            }
         }
     }
 

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -868,10 +868,6 @@ public class QueueItemProcessor(
                     if (dbClient.Ctx.ChangeTracker.HasChanges())
                         await dbClient.Ctx.SaveChangesAsync(finalizeCt).ConfigureAwait(false);
                 }
-                catch (OperationCanceledException)
-                {
-                    throw;
-                }
                 catch (Exception strmError)
                 {
                     // The import is already committed; a sidecar failure must not

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -255,11 +255,17 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
                 .ToList();
         }, ct).ConfigureAwait(false);
 
+        // Cancel every worker first, then wait on one shared grace budget:
+        // per-item waits would multiply the worst case to N × grace period.
+        foreach (var item in toCancel)
+            await item.CancellationTokenSource.CancelAsync().ConfigureAwait(false);
+
         List<Guid> stillRunning = [];
+        using var grace = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        grace.CancelAfter(StuckCancelGracePeriod);
         foreach (var item in toCancel)
         {
-            await item.CancellationTokenSource.CancelAsync().ConfigureAwait(false);
-            if (await TryAwaitWorkerAsync(item, StuckCancelGracePeriod, ct).ConfigureAwait(false))
+            if (await TryAwaitWorkerAsync(item, grace.Token).ConfigureAwait(false))
             {
                 await ObserveStoppedWorkerAsync(item).ConfigureAwait(false);
             }
@@ -297,16 +303,16 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
     }
 
     /// <summary>
-    /// Waits up to <paramref name="wait"/> for a cancelled worker to stop.
-    /// Returns false when the worker is still running after the grace period.
+    /// Waits for a cancelled worker to stop until <paramref name="graceExpired"/>
+    /// fires. Returns false when the worker is still running at that point.
     /// </summary>
     private static async Task<bool> TryAwaitWorkerAsync(
         InProgressQueueItem item,
-        TimeSpan wait,
-        CancellationToken ct = default)
+        CancellationToken graceExpired)
     {
         // WhenAny does not observe ProcessingTask exceptions — the reaper does.
-        var finished = await Task.WhenAny(item.ProcessingTask, Task.Delay(wait, ct))
+        var finished = await Task.WhenAny(
+                item.ProcessingTask, Task.Delay(Timeout.InfiniteTimeSpan, graceExpired))
             .ConfigureAwait(false);
         return finished == item.ProcessingTask || item.ProcessingTask.IsCompleted;
     }
@@ -491,10 +497,16 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
                 .ToList();
         }, ct).ConfigureAwait(false);
 
+        // Cancel every worker first, then wait on one shared grace budget:
+        // per-item waits would multiply the worst case to N × grace period.
+        foreach (var item in toCancel)
+            await item.CancellationTokenSource.CancelAsync().ConfigureAwait(false);
+
+        using var grace = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        grace.CancelAfter(StuckCancelGracePeriod);
         foreach (var item in toCancel)
         {
-            await item.CancellationTokenSource.CancelAsync().ConfigureAwait(false);
-            if (await TryAwaitWorkerAsync(item, StuckCancelGracePeriod, ct).ConfigureAwait(false))
+            if (await TryAwaitWorkerAsync(item, grace.Token).ConfigureAwait(false))
             {
                 await ObserveStoppedWorkerAsync(item).ConfigureAwait(false);
             }
@@ -596,7 +608,9 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
                 catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
 #pragma warning restore CA2016
                 {
-                    Log.Debug(e, "Queue workers finished with errors during shutdown");
+                    // The filter excludes cancellations, so only unexpected worker
+                    // faults land here; those keep their stack at Error.
+                    Log.Error(e, "Queue workers finished with errors during shutdown");
                 }
             }
             else

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -232,7 +232,15 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
         }
     }
 
-    public async Task RemoveQueueItemsAsync
+    /// <summary>
+    /// Cancels in-progress workers and deletes the requested rows. A worker that
+    /// ignores cancellation past <see cref="StuckCancelGracePeriod"/> is
+    /// quarantined: its row, counters, and <see cref="_inProgress"/> entry are
+    /// kept (so no second worker starts for the same id or mount key) and its id
+    /// is returned so callers can surface a failure instead of hanging.
+    /// </summary>
+    /// <returns>Ids whose workers are still running and were not removed.</returns>
+    public async Task<IReadOnlyList<Guid>> RemoveQueueItemsAsync
     (
         List<Guid> queueItemIds,
         DavDatabaseClient dbClient,
@@ -247,31 +255,74 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
                 .ToList();
         }, ct).ConfigureAwait(false);
 
+        List<Guid> stillRunning = [];
         foreach (var item in toCancel)
         {
-            try
+            await item.CancellationTokenSource.CancelAsync().ConfigureAwait(false);
+            if (await TryAwaitWorkerAsync(item, StuckCancelGracePeriod, ct).ConfigureAwait(false))
             {
-                await item.CancellationTokenSource.CancelAsync().ConfigureAwait(false);
-                await item.ProcessingTask.ConfigureAwait(false);
+                await ObserveStoppedWorkerAsync(item).ConfigureAwait(false);
             }
-#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
-            catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
-#pragma warning restore CA2016
+            else
             {
-                Log.Debug(e, "Queue item {QueueItemId} exited with error after cancel", item.QueueItem.Id);
+                stillRunning.Add(item.QueueItem.Id);
+                _ = WatchForIgnoredCancelAsync(item);
             }
         }
 
-        await LockAsync(async () =>
+        var removableIds = queueItemIds.Where(id => !stillRunning.Contains(id)).ToList();
+        if (removableIds.Count > 0)
         {
-            await dbClient.RemoveQueueItemsAsync(queueItemIds, ct).ConfigureAwait(false);
-            await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
-            foreach (var id in queueItemIds)
+            await LockAsync(async () =>
             {
-                _retryAttempts.TryRemove(id, out _);
-                _stallAttempts.TryRemove(id, out _);
-            }
-        }, ct).ConfigureAwait(false);
+                await dbClient.RemoveQueueItemsAsync(removableIds, ct).ConfigureAwait(false);
+                await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+                foreach (var id in removableIds)
+                {
+                    _retryAttempts.TryRemove(id, out _);
+                    _stallAttempts.TryRemove(id, out _);
+                }
+            }, ct).ConfigureAwait(false);
+        }
+
+        if (stillRunning.Count > 0)
+        {
+            Log.Warning(
+                "Queue items {QueueItemIds} ignored cancellation and were not removed; " +
+                "their rows stay queued until the workers stop (restart the container to reclaim).",
+                string.Join(", ", stillRunning));
+        }
+
+        return stillRunning;
+    }
+
+    /// <summary>
+    /// Waits up to <paramref name="wait"/> for a cancelled worker to stop.
+    /// Returns false when the worker is still running after the grace period.
+    /// </summary>
+    private static async Task<bool> TryAwaitWorkerAsync(
+        InProgressQueueItem item,
+        TimeSpan wait,
+        CancellationToken ct = default)
+    {
+        // WhenAny does not observe ProcessingTask exceptions — the reaper does.
+        var finished = await Task.WhenAny(item.ProcessingTask, Task.Delay(wait, ct))
+            .ConfigureAwait(false);
+        return finished == item.ProcessingTask || item.ProcessingTask.IsCompleted;
+    }
+
+    private static async Task ObserveStoppedWorkerAsync(InProgressQueueItem item)
+    {
+        try
+        {
+            await item.ProcessingTask.ConfigureAwait(false);
+        }
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+        catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
+#pragma warning restore CA2016
+        {
+            Log.Debug(e, "Queue item {QueueItemId} exited with error after cancel", item.QueueItem.Id);
+        }
     }
 
 
@@ -442,16 +493,16 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
 
         foreach (var item in toCancel)
         {
-            try
+            await item.CancellationTokenSource.CancelAsync().ConfigureAwait(false);
+            if (await TryAwaitWorkerAsync(item, StuckCancelGracePeriod, ct).ConfigureAwait(false))
             {
-                await item.CancellationTokenSource.CancelAsync().ConfigureAwait(false);
-                await item.ProcessingTask.ConfigureAwait(false);
+                await ObserveStoppedWorkerAsync(item).ConfigureAwait(false);
             }
-#pragma warning disable CA2016
-            catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
-#pragma warning restore CA2016
+            else
             {
-                Log.Debug(e, "Queue item {QueueItemId} exited with error after cancel", item.QueueItem.Id);
+                // The row is already paused in the database; the worker keeps its
+                // slot until it stops, and the observer logs if it never does.
+                _ = WatchForIgnoredCancelAsync(item);
             }
         }
     }
@@ -513,31 +564,59 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
             }
         }
 
-        // Shutdown: cancel remaining workers and observe their tasks.
+        // Shutdown: cancel remaining workers and observe their tasks, bounded by
+        // the stuck-cancel grace period so a worker that ignores cancellation
+        // cannot pin the process forever.
         foreach (var item in _inProgress.Values)
             await item.CancellationTokenSource.CancelAsync().ConfigureAwait(false);
 
         var remaining = _inProgress.Values.Select(x => x.ProcessingTask).ToArray();
         if (remaining.Length > 0)
         {
-            try { await Task.WhenAll(remaining).ConfigureAwait(false); }
-            catch (OperationCanceledException)
-            {
-                // Workers are cancelled deliberately during shutdown.
-            }
-            catch (AggregateException e) when (
-                e.Flatten().InnerExceptions.All(exception => exception.IsCancellationException()))
-            {
-                // Task.WhenAll may retain multiple expected worker cancellations.
-            }
-#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
-            catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
+            var allWorkers = Task.WhenAll(remaining);
+            // ct is already cancelled (that is why we are here); the grace delay
+            // must not inherit it or the wait would end instantly.
+#pragma warning disable CA2016 // deliberate: ct is already cancelled on the shutdown path
+            var finished = await Task.WhenAny(allWorkers, Task.Delay(StuckCancelGracePeriod))
+                .ConfigureAwait(false);
 #pragma warning restore CA2016
+            if (finished == allWorkers || allWorkers.IsCompleted)
             {
-                Log.Debug(e, "Queue workers finished with errors during shutdown");
+                try { await allWorkers.ConfigureAwait(false); }
+                catch (OperationCanceledException)
+                {
+                    // Workers are cancelled deliberately during shutdown.
+                }
+                catch (AggregateException e) when (
+                    e.Flatten().InnerExceptions.All(exception => exception.IsCancellationException()))
+                {
+                    // Task.WhenAll may retain multiple expected worker cancellations.
+                }
+#pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
+                catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
+#pragma warning restore CA2016
+                {
+                    Log.Debug(e, "Queue workers finished with errors during shutdown");
+                }
+            }
+            else
+            {
+                var hung = _inProgress.Values
+                    .Where(x => !x.ProcessingTask.IsCompleted)
+                    .ToList();
+                Log.Error(
+                    "Queue shutdown: {Count} worker(s) ignored cancellation and are still running after " +
+                    "{GraceSeconds:0}s: {QueueItemIds}. Their slots stay occupied until the tasks " +
+                    "complete; restart the container to reclaim them.",
+                    hung.Count,
+                    StuckCancelGracePeriod.TotalSeconds,
+                    string.Join(", ", hung.Select(x => x.QueueItem.Id)));
             }
         }
 
+        // Reaps only completed workers; quarantined (still-running) workers keep
+        // their resources — disposing a live worker's DB context or stream would
+        // fault it later on a thread nobody observes.
         await ReapCompletedWorkersAsync(CancellationToken.None).ConfigureAwait(false);
     }
 
@@ -1249,8 +1328,21 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
         }
 
         _cancellationTokenSource?.Dispose();
-        _stateLock.Dispose();
-        _finalizeLock.Dispose();
+        if (_inProgress.IsEmpty)
+        {
+            _stateLock.Dispose();
+            _finalizeLock.Dispose();
+        }
+        else
+        {
+            // Quarantined workers may still enter MarkQueueItemCompleted and take
+            // these locks; disposing them now would fault live tasks.
+            Log.Warning(
+                "QueueManager disposed with {Count} quarantined worker(s) still running; " +
+                "shared locks are intentionally left undisposed.",
+                _inProgress.Count);
+        }
+
         _sleepingQueueToken.Dispose();
     }
 

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -265,7 +265,7 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
         grace.CancelAfter(StuckCancelGracePeriod);
         foreach (var item in toCancel)
         {
-            if (await TryAwaitWorkerAsync(item, grace.Token).ConfigureAwait(false))
+            if (await TryAwaitWorkerAsync(item, grace.Token, ct).ConfigureAwait(false))
             {
                 await ObserveStoppedWorkerAsync(item).ConfigureAwait(false);
             }
@@ -305,15 +305,19 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
     /// <summary>
     /// Waits for a cancelled worker to stop until <paramref name="graceExpired"/>
     /// fires. Returns false when the worker is still running at that point.
+    /// Caller cancellation (<paramref name="callerCt"/>) aborts the wait instead of
+    /// reading as a stuck worker.
     /// </summary>
     private static async Task<bool> TryAwaitWorkerAsync(
         InProgressQueueItem item,
-        CancellationToken graceExpired)
+        CancellationToken graceExpired,
+        CancellationToken callerCt)
     {
         // WhenAny does not observe ProcessingTask exceptions — the reaper does.
         var finished = await Task.WhenAny(
                 item.ProcessingTask, Task.Delay(Timeout.InfiniteTimeSpan, graceExpired))
             .ConfigureAwait(false);
+        callerCt.ThrowIfCancellationRequested();
         return finished == item.ProcessingTask || item.ProcessingTask.IsCompleted;
     }
 
@@ -506,7 +510,7 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
         grace.CancelAfter(StuckCancelGracePeriod);
         foreach (var item in toCancel)
         {
-            if (await TryAwaitWorkerAsync(item, grace.Token).ConfigureAwait(false))
+            if (await TryAwaitWorkerAsync(item, grace.Token, ct).ConfigureAwait(false))
             {
                 await ObserveStoppedWorkerAsync(item).ConfigureAwait(false);
             }

--- a/backend/Queue/QueueRemovalService.cs
+++ b/backend/Queue/QueueRemovalService.cs
@@ -11,15 +11,27 @@ public sealed class QueueRemovalService(
     QueueManager queueManager,
     WebsocketManager websocketManager)
 {
-    public async Task RemoveAsync(List<Guid> ids, CancellationToken cancellationToken)
+    /// <summary>
+    /// Removes the requested items and returns the ids whose workers ignored
+    /// cancellation (still running, still queued). Only actually-removed ids are
+    /// announced to the frontend.
+    /// </summary>
+    public async Task<IReadOnlyList<Guid>> RemoveAsync(List<Guid> ids, CancellationToken cancellationToken)
     {
+        IReadOnlyList<Guid> stillRunning = [];
         if (ids.Count > 0)
         {
-            await queueManager.RemoveQueueItemsAsync(ids, dbClient, cancellationToken)
+            stillRunning = await queueManager.RemoveQueueItemsAsync(ids, dbClient, cancellationToken)
                 .ConfigureAwait(false);
         }
 
-        _ = websocketManager.SendMessage(WebsocketTopic.QueueItemRemoved, string.Join(",", ids));
-        _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"], cancellationToken);
+        var removedIds = ids.Where(id => !stillRunning.Contains(id)).ToList();
+        if (removedIds.Count > 0)
+        {
+            _ = websocketManager.SendMessage(WebsocketTopic.QueueItemRemoved, string.Join(",", removedIds));
+            _ = DavDatabaseContext.RcloneVfsForget(["/nzbs"], cancellationToken);
+        }
+
+        return stillRunning;
     }
 }

--- a/backend/Services/WardenBackupService.cs
+++ b/backend/Services/WardenBackupService.cs
@@ -155,7 +155,7 @@ public partial class WardenBackupService : BackgroundService
             await using var raw = await resp.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
             using var buffer = await BufferAsync(raw, ct).ConfigureAwait(false);
             using Stream body = LooksGzip(buffer) ? new GZipStream(buffer, CompressionMode.Decompress) : buffer;
-            using var limitedBody = new LimitedReadStream(body, WardenInputLimits.MaxDecompressedBytes);
+            using var limitedBody = WardenInputLimits.CreateLimitedStream(body);
             var count = await _store.ReplaceSourceAsync(WardenStore.LocalSourceId, limitedBody, ct).ConfigureAwait(false);
             Log.Information("Warden backup: restored {Count} fingerprints from {Repo}", count, s.Repo);
             return $"Restored {count:N0} fingerprints into your list.";

--- a/backend/Services/WardenInputLimits.cs
+++ b/backend/Services/WardenInputLimits.cs
@@ -1,3 +1,5 @@
+using NzbWebDAV.Utils;
+
 namespace NzbWebDAV.Services;
 
 internal static class WardenInputLimits
@@ -5,32 +7,8 @@ internal static class WardenInputLimits
     internal const long MaxDecompressedBytes = 512L * 1024 * 1024;
     internal const int MaxRecordCharacters = 64 * 1024;
     internal const int MaxRecords = 4_000_000;
-}
 
-internal sealed class LimitedReadStream(Stream inner, long maximumBytes) : Stream
-{
-    private long _read;
-
-    public override bool CanRead => inner.CanRead;
-    public override bool CanSeek => false;
-    public override bool CanWrite => false;
-    public override long Length => throw new NotSupportedException();
-    public override long Position { get => _read; set => throw new NotSupportedException(); }
-    public override void Flush() => throw new NotSupportedException();
-    public override int Read(byte[] buffer, int offset, int count) => Count(inner.Read(buffer, offset, count));
-    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default) => ReadAndCountAsync(buffer, ct);
-    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
-    public override void SetLength(long value) => throw new NotSupportedException();
-    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
-
-    private int Count(int read)
-    {
-        if (read > 0 && _read > maximumBytes - read)
-            throw new InvalidOperationException($"Warden source exceeds the {maximumBytes:N0}-byte decompressed limit.");
-        _read += read;
-        return read;
-    }
-
-    private async ValueTask<int> ReadAndCountAsync(Memory<byte> buffer, CancellationToken ct) =>
-        Count(await inner.ReadAsync(buffer, ct).ConfigureAwait(false));
+    internal static LimitedReadStream CreateLimitedStream(Stream body) =>
+        new(body, MaxDecompressedBytes, static () => new InvalidOperationException(
+            $"Warden source exceeds the {MaxDecompressedBytes:N0}-byte decompressed limit."));
 }

--- a/backend/Services/WardenRemoteSourceService.cs
+++ b/backend/Services/WardenRemoteSourceService.cs
@@ -78,7 +78,7 @@ public class WardenRemoteSourceService : BackgroundService
 
             using Stream body = LooksGzip(buffer) ? new GZipStream(buffer, CompressionMode.Decompress) : buffer;
 
-            using var limitedBody = new LimitedReadStream(body, WardenInputLimits.MaxDecompressedBytes);
+            using var limitedBody = WardenInputLimits.CreateLimitedStream(body);
             var count = await _store.ReplaceSourceAsync(source.Id, limitedBody, ct).ConfigureAwait(false);
             _store.SetSourceStatus(source.Id, newEtag, now, now, $"ok ({count})");
             Log.Information("Warden: refreshed remote list {Name} ({Count} fingerprints)", source.Name, count);

--- a/backend/Utils/LimitedReadStream.cs
+++ b/backend/Utils/LimitedReadStream.cs
@@ -1,0 +1,38 @@
+namespace NzbWebDAV.Utils;
+
+/// <summary>
+/// Bounds the total bytes read from an inner stream. The first read that would
+/// exceed <paramref name="maximumBytes"/> throws the exception produced by
+/// <paramref name="createLimitException"/>, so callers control whether a limit
+/// trip surfaces as a user-facing validation error or an internal failure.
+/// </summary>
+internal sealed class LimitedReadStream(
+    Stream inner,
+    long maximumBytes,
+    Func<Exception> createLimitException) : Stream
+{
+    private long _read;
+
+    public override bool CanRead => inner.CanRead;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+    public override long Position { get => _read; set => throw new NotSupportedException(); }
+    public override void Flush() => throw new NotSupportedException();
+    public override int Read(byte[] buffer, int offset, int count) => Count(inner.Read(buffer, offset, count));
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default) => ReadAndCountAsync(buffer, ct);
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    private int Count(int read)
+    {
+        if (read > 0 && _read > maximumBytes - read)
+            throw createLimitException();
+        _read += read;
+        return read;
+    }
+
+    private async ValueTask<int> ReadAndCountAsync(Memory<byte> buffer, CancellationToken ct) =>
+        Count(await inner.ReadAsync(buffer, ct).ConfigureAwait(false));
+}

--- a/tests/NzbWebDAV.Tests/Api/AddUrlDeadlineTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AddUrlDeadlineTests.cs
@@ -1,0 +1,182 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Api.SabControllers.AddUrl;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
+using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.Api;
+
+/// <summary>
+/// The addurl fetch deadline is shared by the header wait and the response-body
+/// copy inside SubmitAsync, so a server that answers headers and then stalls
+/// cannot ingest unbounded data past the deadline.
+/// </summary>
+[Collection(nameof(ConfigPathCollection))]
+public sealed class AddUrlDeadlineTests : IAsyncLifetime
+{
+    private readonly string _configRoot =
+        Path.Join(Path.GetTempPath(), $"nzbdav-addurl-cfg-{Guid.NewGuid():N}");
+    private string? _previousConfigPath;
+    private DavDatabaseContext _context = null!;
+    private DavDatabaseClient _dbClient = null!;
+    private QueueManager _queueManager = null!;
+    private ConfigManager _configManager = null!;
+    private WebsocketManager _websocketManager = null!;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.MigrateAsync();
+        _dbClient = new DavDatabaseClient(_context);
+
+        _configManager = new ConfigManager();
+        _configManager.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig()),
+            },
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.ApiAddUrlTrustedHosts,
+                ConfigValue = "127.0.0.1",
+            },
+        ]);
+
+        _websocketManager = new WebsocketManager();
+        var usenet = new UsenetStreamingClient(
+            _configManager,
+            _websocketManager,
+            new ProviderUsageTracker(),
+            new MetricsWriter(),
+            new ProviderBytesTracker(),
+            new StreamTraceBuffer(100),
+            new ActiveReadRegistry());
+        _queueManager = new QueueManager(
+            usenet,
+            _configManager,
+            _websocketManager,
+            new ProviderUsageTracker(),
+            new WatchdogLog(),
+            new QueueItemSourceTracker(),
+            new BenchmarkGate(),
+            startLoop: false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _queueManager.Dispose();
+        await _context.DisposeAsync();
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        try { Directory.Delete(_configRoot, recursive: true); } catch (IOException) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task AddUrl_SlowDripBody_HitsSharedFetchDeadline()
+    {
+        using var server = new SlowDripServer();
+        var url = $"http://127.0.0.1:{server.Port}/slow.nzb";
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.QueryString =
+            new QueryString($"?name={Uri.EscapeDataString(url)}&nzbname=slow.nzb");
+        var controller = new AddUrlController(
+            httpContext, _dbClient, _queueManager, _configManager, _websocketManager,
+            new IndexerHitTracker());
+
+        var request = await AddUrlRequest.New(
+            httpContext, _configManager, new IndexerHitTracker(),
+            fetchTimeout: TimeSpan.FromMilliseconds(500));
+
+        var stopwatch = Stopwatch.StartNew();
+        var ex = await Assert.ThrowsAsync<BadHttpRequestException>(
+            () => controller.AddUrlAsync(request));
+        stopwatch.Stop();
+
+        Assert.Contains("timed out", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(30),
+            $"deadline did not bound the fetch (elapsed {stopwatch.Elapsed})");
+        Assert.False(await _context.QueueItems.AsNoTracking().AnyAsync());
+        Assert.Empty(Directory.GetFiles(_configRoot, "*.tmp", SearchOption.AllDirectories));
+    }
+
+    /// <summary>
+    /// Answers with valid NZB headers and a first body chunk, then stalls until
+    /// disposed — the body never completes within the fetch deadline.
+    /// </summary>
+    private sealed class SlowDripServer : IDisposable
+    {
+        private readonly TcpListener _listener = new(IPAddress.Loopback, 0);
+        private readonly CancellationTokenSource _shutdown = new();
+        private readonly Task _loop;
+
+        public SlowDripServer()
+        {
+            _listener.Start();
+            Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+            _loop = Task.Run(ServeAsync);
+        }
+
+        public int Port { get; }
+
+        private async Task ServeAsync()
+        {
+            try
+            {
+                using var client = await _listener.AcceptTcpClientAsync(_shutdown.Token);
+                await using var stream = client.GetStream();
+                var headers = Encoding.ASCII.GetBytes(
+                    "HTTP/1.1 200 OK\r\n" +
+                    "Content-Type: application/x-nzb\r\n" +
+                    "Content-Disposition: attachment; filename=\"slow.nzb\"\r\n" +
+                    "Connection: close\r\n\r\n");
+                await stream.WriteAsync(headers, _shutdown.Token);
+                await stream.WriteAsync(
+                    Encoding.ASCII.GetBytes("<nzb><file subject=\"slow\">"), _shutdown.Token);
+                await stream.FlushAsync(_shutdown.Token);
+                await Task.Delay(Timeout.Infinite, _shutdown.Token);
+            }
+            catch (Exception) when (_shutdown.IsCancellationRequested)
+            {
+                // test teardown
+            }
+        }
+
+        public void Dispose()
+        {
+            _shutdown.Cancel();
+            _listener.Stop();
+            try { _loop.Wait(TimeSpan.FromSeconds(5)); }
+            catch (AggregateException) { /* teardown */ }
+            _shutdown.Dispose();
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Api/NzbInputValidatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/NzbInputValidatorTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using NzbWebDAV.Api.Errors;
 using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Tests.TestUtils;
 
 namespace NzbWebDAV.Tests.Api;
 
@@ -148,6 +149,33 @@ public class NzbInputValidatorTests
 
         Assert.Contains("subject", ex.Errors["nzb"][0], StringComparison.OrdinalIgnoreCase);
         Assert.Contains("1024", ex.Errors["nzb"][0], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PreCancelledToken_ThrowsOperationCanceled()
+    {
+        var xml = BuildNzb(fileCount: 1, segmentsPerFile: 2);
+        using var stream = Bytes(xml);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.Throws<OperationCanceledException>(
+            () => NzbInputValidator.ValidateAndSumSegmentBytes(
+                stream, NzbInputLimits.Default, cts.Token));
+    }
+
+    [Fact]
+    public void CancelMidDocument_ThrowsOperationCanceledBeforeLastSegment()
+    {
+        // ~3 MB single-file document; cancelling after 64 KiB of reads must
+        // surface as OCE (not ApiValidationException) while segments remain.
+        var xml = BuildNzb(fileCount: 1, segmentsPerFile: 50_000);
+        using var cts = new CancellationTokenSource();
+        using var stream = TestStreams.CancelAfterBytes(Bytes(xml), cancelAfterBytes: 64 * 1024, cts);
+
+        Assert.Throws<OperationCanceledException>(
+            () => NzbInputValidator.ValidateAndSumSegmentBytes(
+                stream, NzbInputLimits.Default, cts.Token));
     }
 
     private static string BuildNzb(int fileCount, int segmentsPerFile, long segmentBytes = 15)

--- a/tests/NzbWebDAV.Tests/Api/NzbInputValidatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/NzbInputValidatorTests.cs
@@ -178,6 +178,22 @@ public class NzbInputValidatorTests
                 stream, NzbInputLimits.Default, cts.Token));
     }
 
+    [Fact]
+    public void CancelWhileReadingFinalSegment_ThrowsOperationCanceled()
+    {
+        // Delivery stops one byte into the final segment's content and the token
+        // is cancelled when the reader pulls the remainder, so cancellation lands
+        // after the per-segment check but before the closing </file> is seen.
+        var xml = BuildNzb(fileCount: 1, segmentsPerFile: 1);
+        var segmentContentStart = xml.IndexOf('>', xml.IndexOf("<segment ", StringComparison.Ordinal)) + 1;
+        using var cts = new CancellationTokenSource();
+        using var stream = TestStreams.CancelOnReadBeyond(Bytes(xml), byteLimit: segmentContentStart + 1, cts);
+
+        Assert.Throws<OperationCanceledException>(
+            () => NzbInputValidator.ValidateAndSumSegmentBytes(
+                stream, NzbInputLimits.Default, cts.Token));
+    }
+
     private static string BuildNzb(int fileCount, int segmentsPerFile, long segmentBytes = 15)
     {
         var builder = new StringBuilder("<nzb>");

--- a/tests/NzbWebDAV.Tests/Api/NzbSubmissionIngestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/NzbSubmissionIngestTests.cs
@@ -1,0 +1,235 @@
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Api.Errors;
+using NzbWebDAV.Api.SabControllers.AddFile;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Services.StreamTrace;
+using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Tests.Utils;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.Api;
+
+/// <summary>
+/// Submission-ingest bounds: the decompressed 256 MiB limit is enforced while
+/// the blob is copied (not after), validation runs before any NZB backup, and
+/// rejected submissions leave neither blobs nor backup files.
+/// </summary>
+[Collection(nameof(ConfigPathCollection))]
+public sealed class NzbSubmissionIngestTests : IAsyncLifetime
+{
+    private readonly string _configRoot =
+        Path.Join(Path.GetTempPath(), $"nzbdav-ingest-cfg-{Guid.NewGuid():N}");
+    private string? _previousConfigPath;
+    private DavDatabaseContext _context = null!;
+    private DavDatabaseClient _dbClient = null!;
+    private QueueManager _queueManager = null!;
+    private ConfigManager _configManager = null!;
+    private WebsocketManager _websocketManager = null!;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.MigrateAsync();
+        _dbClient = new DavDatabaseClient(_context);
+
+        _configManager = new ConfigManager();
+        _configManager.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig()),
+            },
+        ]);
+
+        _websocketManager = new WebsocketManager();
+        var usenet = new UsenetStreamingClient(
+            _configManager,
+            _websocketManager,
+            new ProviderUsageTracker(),
+            new MetricsWriter(),
+            new ProviderBytesTracker(),
+            new StreamTraceBuffer(100),
+            new ActiveReadRegistry());
+        _queueManager = new QueueManager(
+            usenet,
+            _configManager,
+            _websocketManager,
+            new ProviderUsageTracker(),
+            new WatchdogLog(),
+            new QueueItemSourceTracker(),
+            new BenchmarkGate(),
+            startLoop: false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _queueManager.Dispose();
+        await _context.DisposeAsync();
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        try { Directory.Delete(_configRoot, recursive: true); } catch (IOException) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task SubmitAsync_OversizeDecompressedXml_FailsDuringCopyAndLeavesNothing()
+    {
+        var assignedId = Guid.NewGuid();
+        var oversize = (long)NzbInputLimits.Default.MaxXmlBytes + 1;
+        var controller = CreateController();
+
+        var ex = await Assert.ThrowsAsync<ApiValidationException>(() =>
+            controller.AddFileAsync(CreateRequest(
+                "oversize.nzb", assignedId, new LimitedReadStreamTests.RepeatingByteStream(oversize))));
+
+        Assert.Contains("maximum allowed size", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Null(BlobStore.ReadBlob(assignedId));
+        Assert.False(await _context.QueueItems.AsNoTracking().AnyAsync(q => q.Id == assignedId));
+        Assert.Empty(Directory.GetFiles(_configRoot, "*.tmp", SearchOption.AllDirectories));
+    }
+
+    [Fact]
+    public async Task SubmitAsync_GzipBomb_EnforcesDecompressedLimit()
+    {
+        var assignedId = Guid.NewGuid();
+        // A tiny compressed payload that decompresses past the 256 MiB limit.
+        var bomb = new MemoryStream();
+        await using (var compressor = new GZipStream(bomb, CompressionMode.Compress, leaveOpen: true))
+        {
+            var chunk = new byte[1024 * 1024];
+            for (var remaining = (long)NzbInputLimits.Default.MaxXmlBytes + 1;
+                 remaining > 0;
+                 remaining -= chunk.Length)
+            {
+                await compressor.WriteAsync(chunk);
+            }
+        }
+
+        bomb.Position = 0;
+        Assert.True(bomb.Length < 8 * 1024 * 1024, "the bomb payload should compress well");
+        var controller = CreateController();
+
+        var ex = await Assert.ThrowsAsync<ApiValidationException>(() =>
+            controller.AddFileAsync(CreateRequest("bomb.nzb", assignedId, bomb)));
+
+        Assert.Contains("maximum allowed size", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Null(BlobStore.ReadBlob(assignedId));
+        Assert.False(await _context.QueueItems.AsNoTracking().AnyAsync(q => q.Id == assignedId));
+    }
+
+    [Fact]
+    public async Task SubmitAsync_BackupEnabled_ValidationFailureLeavesNoBackupFile()
+    {
+        var backupRoot = Path.Join(_configRoot, "nzb-backups");
+        EnableBackup(backupRoot);
+        var assignedId = Guid.NewGuid();
+        const string invalidNzb = """
+            <nzb><file subject="bad"><segments>
+              <segment bytes="nope" number="1">id-one@example</segment>
+            </segments></file></nzb>
+            """;
+        var controller = CreateController();
+
+        await Assert.ThrowsAsync<ApiValidationException>(() =>
+            controller.AddFileAsync(CreateRequest(
+                "invalid.nzb", assignedId,
+                new MemoryStream(Encoding.UTF8.GetBytes(invalidNzb)))));
+
+        Assert.Null(BlobStore.ReadBlob(assignedId));
+        Assert.False(Directory.Exists(backupRoot)
+            && Directory.EnumerateFiles(backupRoot, "*.nzb", SearchOption.AllDirectories).Any());
+    }
+
+    [Fact]
+    public async Task SubmitAsync_BackupEnabled_ValidNzbStillBackedUp()
+    {
+        var backupRoot = Path.Join(_configRoot, "nzb-backups");
+        EnableBackup(backupRoot);
+        var assignedId = Guid.NewGuid();
+        var controller = CreateController();
+
+        var response = await controller.AddFileAsync(CreateRequest(
+            "good.nzb", assignedId,
+            new MemoryStream(Encoding.UTF8.GetBytes(ValidNzb))));
+
+        Assert.True(response.Status);
+        var backupFile = Assert.Single(
+            Directory.EnumerateFiles(backupRoot, "*.nzb", SearchOption.AllDirectories));
+        Assert.Equal(ValidNzb, await File.ReadAllTextAsync(backupFile));
+    }
+
+    private const string ValidNzb = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
+          <file subject="test">
+            <groups><group>alt.binaries.test</group></groups>
+            <segments>
+              <segment bytes="100" number="1">seg@example.com</segment>
+            </segments>
+          </file>
+        </nzb>
+        """;
+
+    private void EnableBackup(string backupRoot)
+    {
+        _configManager.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.ApiNzbBackupEnabled,
+                ConfigValue = "true",
+            },
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.ApiNzbBackupLocation,
+                ConfigValue = backupRoot,
+            },
+        ]);
+    }
+
+    private AddFileController CreateController() =>
+        new(
+            new DefaultHttpContext(),
+            _dbClient,
+            _queueManager,
+            _configManager,
+            _websocketManager);
+
+    private static AddFileRequest CreateRequest(string fileName, Guid nzoId, Stream nzbStream) =>
+        new()
+        {
+            NzoId = nzoId,
+            ReplaceExistingQueueItem = true,
+            FileName = fileName,
+            ContentType = "application/x-nzb",
+            NzbFileStream = nzbStream,
+            Category = "tv",
+            Priority = QueueItem.PriorityOption.Normal,
+            PostProcessing = QueueItem.PostProcessingOption.None,
+            CancellationToken = CancellationToken.None,
+        };
+}

--- a/tests/NzbWebDAV.Tests/Fakes/ScriptedVideoNntpClient.cs
+++ b/tests/NzbWebDAV.Tests/Fakes/ScriptedVideoNntpClient.cs
@@ -1,0 +1,144 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Streams;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Tests.Fakes;
+
+/// <summary>
+/// Serves a single-segment video file from memory with a correct yEnc header
+/// filename, so the import pipeline deobfuscates to the given file name.
+/// </summary>
+internal sealed class ScriptedVideoNntpClient(
+    string fileName,
+    string segmentId,
+    byte[] payload) : NntpClient
+{
+    public override Task ConnectAsync(
+        string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+        Task.CompletedTask;
+
+    public override Task<UsenetResponse> AuthenticateAsync(
+        string user, string pass, CancellationToken cancellationToken) =>
+        throw new NotSupportedException();
+
+    public override Task<UsenetStatResponse> StatAsync(
+        SegmentId id, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var exists = id.ToString() == segmentId;
+        return Task.FromResult(new UsenetStatResponse
+        {
+            ResponseCode = exists
+                ? (int)UsenetResponseType.ArticleExists
+                : (int)UsenetResponseType.NoArticleWithThatMessageId,
+            ResponseMessage = exists ? "223 exists" : "430 missing",
+            ArticleExists = exists,
+        });
+    }
+
+    public override Task<UsenetHeadResponse> HeadAsync(
+        SegmentId id, CancellationToken cancellationToken) =>
+        throw new NotSupportedException();
+
+    public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+        SegmentId id, CancellationToken cancellationToken) =>
+        DecodedBodyAsync(id, null, cancellationToken);
+
+    public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+        SegmentId id,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (id.ToString() != segmentId)
+            return Task.FromException<UsenetDecodedBodyResponse>(
+                new UsenetArticleNotFoundException(id.ToString(), "430 missing"));
+        onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+        return Task.FromResult(new UsenetDecodedBodyResponse
+        {
+            SegmentId = id.ToString(),
+            ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+            ResponseMessage = "222 body",
+            Stream = CreateStream(),
+        });
+    }
+
+    public override Task<UsenetDecodedBodyResponse?> TryGetLocalDecodedBodyAsync(
+        SegmentId id, CancellationToken cancellationToken) =>
+        Task.FromResult<UsenetDecodedBodyResponse?>(null);
+
+    public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+        IReadOnlyList<SegmentId> segmentIds,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
+        CancellationToken cancellationToken)
+    {
+        var responses = segmentIds
+            .Select(id => DecodedBodyAsync(id, cancellationToken))
+            .ToArray();
+        return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
+    }
+
+    public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+        SegmentId id, CancellationToken cancellationToken) =>
+        DecodedArticleAsync(id, null, cancellationToken);
+
+    public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+        SegmentId id,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (id.ToString() != segmentId)
+            throw new UsenetArticleNotFoundException(id.ToString(), "430 missing");
+        onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+        return Task.FromResult(new UsenetDecodedArticleResponse
+        {
+            SegmentId = id.ToString(),
+            ResponseCode = (int)UsenetResponseType.ArticleRetrievedHeadAndBodyFollow,
+            ResponseMessage = "220 article",
+            Stream = CreateStream(),
+            ArticleHeaders = new UsenetArticleHeader
+            {
+                Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Date"] = DateTimeOffset.UtcNow.ToString("R"),
+                },
+            },
+        });
+    }
+
+    public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+        throw new NotSupportedException();
+
+    public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+        string id, CancellationToken cancellationToken) =>
+        Task.FromResult(new UsenetExclusiveConnection(null));
+
+    public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+        IReadOnlyList<SegmentId> ids, CancellationToken cancellationToken) =>
+        Task.FromResult(new UsenetExclusiveConnection(null));
+
+    public override Task<long> GetFileSizeAsync(NzbWebDAV.Models.Nzb.NzbFile file, CancellationToken ct) =>
+        Task.FromResult((long)payload.Length);
+
+    public override void Dispose()
+    {
+    }
+
+    private CachedYencStream CreateStream() =>
+        new(
+            new UsenetYencHeader
+            {
+                FileName = fileName,
+                FileSize = payload.Length,
+                LineLength = 128,
+                PartNumber = 1,
+                TotalParts = 1,
+                PartOffset = 0,
+                PartSize = payload.Length,
+            },
+            new MemoryStream(payload, writable: false));
+}

--- a/tests/NzbWebDAV.Tests/Models/NzbDocumentTests.cs
+++ b/tests/NzbWebDAV.Tests/Models/NzbDocumentTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using NzbWebDAV.Models;
 using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Tests.TestUtils;
 
 namespace NzbWebDAV.Tests.Models;
 
@@ -92,6 +93,43 @@ public class NzbDocumentTests
 
         Assert.Equal("Could not parse the nzb document (malformed nzb)", exception.Message);
         Assert.IsType<System.Xml.XmlException>(exception.InnerException);
+    }
+
+    [Fact]
+    public async Task LoadAsync_PreCancelledToken_ThrowsOperationCanceled()
+    {
+        const string xml = """
+            <nzb><file subject="file"><segments>
+              <segment bytes="10" number="1">a@example</segment>
+            </segments></file></nzb>
+            """;
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => NzbDocument.LoadAsync(stream, cts.Token));
+    }
+
+    [Fact]
+    public async Task LoadAsync_CancelMidSegments_ThrowsOperationCanceledUnwrapped()
+    {
+        // ~3 MB single-file document; cancelling after 64 KiB of reads must
+        // propagate as OCE, not as InvalidDataException("malformed nzb").
+        var builder = new StringBuilder("<nzb><file subject=\"huge\"><segments>");
+        for (var i = 1; i <= 50_000; i++)
+            builder.Append($"<segment bytes=\"15\" number=\"{i}\">id-{i}@example</segment>");
+        builder.Append("</segments></file></nzb>");
+        using var cts = new CancellationTokenSource();
+        await using var stream = TestStreams.CancelAfterBytes(
+            new MemoryStream(Encoding.UTF8.GetBytes(builder.ToString())),
+            cancelAfterBytes: 64 * 1024,
+            cts);
+
+        // ThrowsAsync requires the exact type: an OCE wrapped as
+        // InvalidDataException("malformed nzb") would fail this assertion.
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => NzbDocument.LoadAsync(stream, cts.Token));
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Queue/CreateStrmFilesPostProcessorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/CreateStrmFilesPostProcessorTests.cs
@@ -134,6 +134,51 @@ public class CreateStrmFilesPostProcessorTests : IDisposable
     }
 
     [Fact]
+    public async Task CreateStrmFilesAsync_RestoresRewrittenFilesWhenLaterWriteFails()
+    {
+        var category = SeedDirectory(DavItem.ContentFolder, "tv");
+        var job = SeedDirectory(category, "Show", _historyItemId);
+        var second = SeedVideo(job, "second.mkv", _historyItemId);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+        // Added items are processed before persisted rows, so this write runs
+        // first. A stale sidecar from a previous import makes it a rewrite that
+        // must be restored — not deleted — when the later write fails.
+        var first = SeedVideo(job, "first.mkv", _historyItemId);
+        var firstPath = CreateStrmFilesPostProcessor.GetStrmFilePath(_config, first);
+        Directory.CreateDirectory(Path.GetDirectoryName(firstPath)!);
+        await File.WriteAllTextAsync(firstPath, "stale-url-from-previous-import");
+
+        var secondPath = CreateStrmFilesPostProcessor.GetStrmFilePath(_config, second);
+        Directory.CreateDirectory(secondPath);
+
+        var processor = new CreateStrmFilesPostProcessor(_config, _dbClient, _historyItemId);
+        await Assert.ThrowsAnyAsync<Exception>(() => processor.CreateStrmFilesAsync());
+
+        Assert.Equal("stale-url-from-previous-import", await File.ReadAllTextAsync(firstPath));
+        Assert.True(Directory.Exists(secondPath));
+    }
+
+    [Fact]
+    public async Task CreateStrmFilesAsync_CancelledToken_ThrowsAndWritesNothing()
+    {
+        var category = SeedDirectory(DavItem.ContentFolder, "tv");
+        var job = SeedDirectory(category, "Show", _historyItemId);
+        SeedVideo(job, "episode.mkv", _historyItemId);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        var processor = new CreateStrmFilesPostProcessor(_config, _dbClient, _historyItemId);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => processor.CreateStrmFilesAsync(cts.Token));
+
+        Assert.Empty(Directory.GetFiles(_strmDir, "*.strm", SearchOption.AllDirectories));
+    }
+
+    [Fact]
     public async Task DeleteStrmFile_UsesPersistedPathAfterCompletedDirectoryChanges()
     {
         var davItem = new DavItem

--- a/tests/NzbWebDAV.Tests/Queue/FinalizeDatabaseErrorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/FinalizeDatabaseErrorTests.cs
@@ -1,0 +1,224 @@
+using System.Text;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Tests.Fakes;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.Queue;
+
+/// <summary>
+/// Database infrastructure failures at the finalize boundary are not content
+/// failures: SQLITE_BUSY/LOCKED retries the commit in place, and persistent
+/// contention or disk/corruption errors leave the item queued with a backoff
+/// instead of writing a misleading failed-history row.
+/// </summary>
+[Collection(nameof(ConfigPathCollection))]
+public sealed class FinalizeDatabaseErrorTests : IAsyncLifetime
+{
+    private const string Category = "other";
+    private const string JobName = "finalize-db-job";
+    private const string VideoFileName = "movie.mkv";
+
+    private readonly string _configRoot =
+        Path.Join(Path.GetTempPath(), $"nzbdav-finalize-cfg-{Guid.NewGuid():N}");
+    private readonly string _segmentId = $"finalize-seg-{Guid.NewGuid():N}@example.com";
+    private readonly byte[] _payload = Enumerable.Range(0, 4096).Select(i => (byte)(i % 251)).ToArray();
+    private string? _previousConfigPath;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+
+        await using var context = CreateContext();
+        await context.Database.MigrateAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        await Task.CompletedTask;
+        try { Directory.Delete(_configRoot, recursive: true); } catch (IOException) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task FinalizeCommit_TransientBusyOnce_RetriesAndCompletesImport()
+    {
+        var interceptor = new SqliteFaultOnFinalizeInterceptor(errorCode: 5, maxThrows: 1);
+        await using var context = CreateContext(interceptor);
+        var queueItem = await SeedQueueItemAsync(context, _segmentId);
+
+        await ProcessAsync(context, queueItem, _segmentId);
+
+        // One faulted attempt plus one successful in-place retry.
+        Assert.Equal(2, interceptor.FinalizeAttempts);
+        context.ChangeTracker.Clear();
+        Assert.Empty(await context.QueueItems.AsNoTracking().ToListAsync());
+        var historyItem = Assert.Single(await context.HistoryItems.AsNoTracking().ToListAsync());
+        Assert.Null(historyItem.FailMessage);
+        Assert.Equal(HistoryItem.DownloadStatusOption.Completed, historyItem.DownloadStatus);
+        Assert.True(await context.Items.AsNoTracking().AnyAsync(x => x.Name == VideoFileName));
+    }
+
+    [Fact]
+    public async Task FinalizeCommit_PersistentBusy_LeavesItemQueuedWithBackoff()
+    {
+        var interceptor = new SqliteFaultOnFinalizeInterceptor(errorCode: 5, maxThrows: int.MaxValue);
+        await using var context = CreateContext(interceptor);
+        var queueItem = await SeedQueueItemAsync(context, _segmentId);
+
+        await ProcessAsync(context, queueItem, _segmentId);
+
+        context.ChangeTracker.Clear();
+        Assert.Empty(await context.HistoryItems.AsNoTracking().ToListAsync());
+        var remaining = await context.QueueItems.AsNoTracking().SingleAsync();
+        Assert.Equal(queueItem.Id, remaining.Id);
+        Assert.NotNull(remaining.PauseUntil);
+        Assert.True(remaining.PauseUntil > DateTime.Now.AddSeconds(30),
+            $"expected a real backoff, got {remaining.PauseUntil}");
+        Assert.True(remaining.PauseUntil < DateTime.Now.AddMinutes(2),
+            $"transient contention should back off for ~60s, got {remaining.PauseUntil}");
+    }
+
+    [Theory]
+    [InlineData(8)]
+    [InlineData(13)]
+    [InlineData(11)]
+    public async Task FinalizeCommit_DiskOrCorruption_LeavesItemQueuedWithLongBackoff(int errorCode)
+    {
+        var interceptor = new SqliteFaultOnFinalizeInterceptor(errorCode, maxThrows: int.MaxValue);
+        await using var context = CreateContext(interceptor);
+        var queueItem = await SeedQueueItemAsync(context, _segmentId);
+
+        await ProcessAsync(context, queueItem, _segmentId);
+
+        // Disk/corruption codes are not retried in place...
+        Assert.Equal(1, interceptor.FinalizeAttempts);
+        context.ChangeTracker.Clear();
+        Assert.Empty(await context.HistoryItems.AsNoTracking().ToListAsync());
+        var remaining = await context.QueueItems.AsNoTracking().SingleAsync();
+        Assert.Equal(queueItem.Id, remaining.Id);
+        Assert.NotNull(remaining.PauseUntil);
+        Assert.True(remaining.PauseUntil > DateTime.Now.AddMinutes(3),
+            $"disk/corruption should back off for minutes, got {remaining.PauseUntil}");
+    }
+
+    [Fact]
+    public async Task FailedFinalize_PersistentBusy_PausesInsteadOfHotLooping()
+    {
+        // Content failure (missing article) whose failed-history finalize then
+        // hits persistent SQLITE_BUSY: the item must stay queued with a backoff
+        // rather than becoming immediately reclaimable.
+        var missingSegmentId = $"missing-{Guid.NewGuid():N}@example.com";
+        var interceptor = new SqliteFaultOnFinalizeInterceptor(errorCode: 5, maxThrows: int.MaxValue);
+        await using var context = CreateContext(interceptor);
+        var queueItem = await SeedQueueItemAsync(context, missingSegmentId);
+
+        await ProcessAsync(context, queueItem, missingSegmentId);
+
+        context.ChangeTracker.Clear();
+        Assert.Empty(await context.HistoryItems.AsNoTracking().ToListAsync());
+        var remaining = await context.QueueItems.AsNoTracking().SingleAsync();
+        Assert.Equal(queueItem.Id, remaining.Id);
+        Assert.NotNull(remaining.PauseUntil);
+        Assert.True(remaining.PauseUntil > DateTime.Now.AddSeconds(30),
+            $"expected a real backoff, got {remaining.PauseUntil}");
+    }
+
+    private DavDatabaseContext CreateContext(params IInterceptor[] extraInterceptors) =>
+        new(new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .AddInterceptors(extraInterceptors)
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options);
+
+    private async Task<QueueItem> SeedQueueItemAsync(DavDatabaseContext context, string segmentId)
+    {
+        var nzbBytes = CreateNzbBytes(segmentId);
+        var queueItem = new QueueItem
+        {
+            Id = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            FileName = $"{JobName}.nzb",
+            JobName = JobName,
+            NzbFileSize = nzbBytes.Length,
+            TotalSegmentBytes = _payload.Length,
+            Category = Category,
+            Priority = QueueItem.PriorityOption.Normal,
+            PostProcessing = QueueItem.PostProcessingOption.None,
+        };
+        context.QueueItems.Add(queueItem);
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+        return await context.QueueItems.SingleAsync(q => q.Id == queueItem.Id);
+    }
+
+    private async Task ProcessAsync(DavDatabaseContext context, QueueItem queueItem, string segmentId)
+    {
+        await using var nzbStream = new MemoryStream(CreateNzbBytes(segmentId));
+        var processor = new QueueItemProcessor(
+            queueItem,
+            nzbStream,
+            new DavDatabaseClient(context),
+            new ScriptedVideoNntpClient(VideoFileName, _segmentId, _payload),
+            new ConfigManager(),
+            new WebsocketManager(),
+            new Progress<int>(),
+            CancellationToken.None);
+        await processor.ProcessAsync();
+    }
+
+    private byte[] CreateNzbBytes(string segmentId) => Encoding.UTF8.GetBytes(
+        $"""
+        <?xml version="1.0" encoding="utf-8"?>
+        <nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
+          <file subject="&quot;{VideoFileName}&quot; yEnc (1/1)">
+            <groups><group>alt.binaries.test</group></groups>
+            <segments>
+              <segment bytes="{_payload.Length}" number="1">{segmentId}</segment>
+            </segments>
+          </file>
+        </nzb>
+        """);
+
+    /// <summary>
+    /// Faults any save that deletes a queue item (success or failed-history
+    /// finalize) with the given SQLite primary result code, up to maxThrows times.
+    /// </summary>
+    private sealed class SqliteFaultOnFinalizeInterceptor(int errorCode, int maxThrows)
+        : SaveChangesInterceptor
+    {
+        private int _finalizeAttempts;
+        public int FinalizeAttempts => Volatile.Read(ref _finalizeAttempts);
+
+        public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+            DbContextEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            var isFinalize = eventData.Context!.ChangeTracker.Entries<QueueItem>()
+                .Any(e => e.State == EntityState.Deleted);
+            if (isFinalize && Interlocked.Increment(ref _finalizeAttempts) <= maxThrows)
+            {
+                throw new DbUpdateException(
+                    "simulated sqlite fault",
+                    new SqliteException($"SQLite Error {errorCode}.", errorCode));
+            }
+
+            return base.SavingChangesAsync(eventData, result, cancellationToken);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
@@ -687,6 +687,226 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
         }
     }
 
+    [Fact]
+    public async Task RemoveQueueItemsAsync_HungWorker_QuarantinesAndReturnsWithinGrace()
+    {
+        // A worker ignoring cancellation must not hang a SAB delete: the call
+        // returns after the grace period with the id flagged still-running, the
+        // row stays queued, and the slot stays occupied until the task stops.
+        _queueManager.StuckItemThreshold = TimeSpan.FromHours(1);
+        var hung = new HungStream();
+        var item = CreateQueueItem("hung-remove.nzb", "movies", "HungRemoveJob");
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            ctx.QueueItems.Add(item);
+            await ctx.SaveChangesAsync();
+        }
+
+        _queueManager.GetTopQueueItemOverride = async (exclude, ct) =>
+        {
+            await using var ctx = new DavDatabaseContext(_options);
+            var client = new DavDatabaseClient(ctx);
+            var (claimed, _) = await client.GetTopQueueItem(exclude, ct);
+            if (claimed is null) return (null, null);
+            ctx.ChangeTracker.Clear();
+            return (claimed, hung);
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var loop = _queueManager.ProcessQueueAsync(cts.Token);
+        try
+        {
+            object? inProgress = await WaitForInProgress(item.Id, TimeSpan.FromSeconds(5));
+            Assert.NotNull(inProgress);
+
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            IReadOnlyList<Guid> stillRunning;
+            await using (var ctx = new DavDatabaseContext(_options))
+            {
+                stillRunning = await _queueManager.RemoveQueueItemsAsync(
+                    [item.Id], new DavDatabaseClient(ctx), CancellationToken.None);
+            }
+
+            stopwatch.Stop();
+
+            Assert.Equal([item.Id], stillRunning.ToArray());
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10),
+                $"remove hung for {stopwatch.Elapsed}; expected a bounded grace wait");
+
+            // Quarantined: row kept, slot still occupied, no counters cleared.
+            Assert.NotNull(FindInProgressItem(item.Id));
+            Assert.False(GetProcessingTask(inProgress!).IsCompleted);
+            await using (var ctx = new DavDatabaseContext(_options))
+            {
+                Assert.Equal(1, await ctx.QueueItems.CountAsync());
+                Assert.Equal(0, await ctx.HistoryItems.CountAsync());
+            }
+
+            // Releasing the hung I/O lets the cancelled worker stop and the
+            // coordinator reap it; the row remains queued for a later claim.
+            hung.Release();
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+            while (DateTime.UtcNow < deadline && FindInProgressItem(item.Id) is not null)
+                await Task.Delay(20);
+
+            Assert.Null(FindInProgressItem(item.Id));
+            await using (var ctx = new DavDatabaseContext(_options))
+            {
+                Assert.Equal(1, await ctx.QueueItems.CountAsync());
+                Assert.Equal(0, await ctx.HistoryItems.CountAsync());
+            }
+        }
+        finally
+        {
+            hung.Release();
+            await cts.CancelAsync();
+            await loop.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [Fact]
+    public async Task Shutdown_HungWorker_LogsErrorAndReturnsWithinGrace()
+    {
+        _queueManager.StuckItemThreshold = TimeSpan.FromHours(1);
+        var hung = new HungStream();
+        var item = CreateQueueItem("hung-shutdown.nzb", "movies", "HungShutdownJob");
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            ctx.QueueItems.Add(item);
+            await ctx.SaveChangesAsync();
+        }
+
+        _queueManager.GetTopQueueItemOverride = async (exclude, ct) =>
+        {
+            await using var ctx = new DavDatabaseContext(_options);
+            var client = new DavDatabaseClient(ctx);
+            var (claimed, _) = await client.GetTopQueueItem(exclude, ct);
+            if (claimed is null) return (null, null);
+            ctx.ChangeTracker.Clear();
+            return (claimed, hung);
+        };
+
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Error()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var loop = _queueManager.ProcessQueueAsync(cts.Token);
+        try
+        {
+            object? inProgress = await WaitForInProgress(item.Id, TimeSpan.FromSeconds(5));
+            Assert.NotNull(inProgress);
+
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            await cts.CancelAsync();
+            await loop.WaitAsync(TimeSpan.FromSeconds(10));
+            stopwatch.Stop();
+
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10),
+                $"shutdown hung for {stopwatch.Elapsed}; expected a bounded grace wait");
+            Assert.Contains(sink.Events, e =>
+                e.Level == LogEventLevel.Error
+                && e.RenderMessage().Contains("ignored cancellation", StringComparison.OrdinalIgnoreCase));
+
+            // Quarantined workers keep their slot and are not reaped.
+            Assert.NotNull(FindInProgressItem(item.Id));
+        }
+        finally
+        {
+            hung.Release();
+            Log.Logger = previous;
+        }
+    }
+
+    [Fact]
+    public async Task ReplaceExistingQueueItem_HungWorker_FailsSubmissionInsteadOfInserting()
+    {
+        _queueManager.StuckItemThreshold = TimeSpan.FromHours(1);
+        var hung = new HungStream();
+        var item = CreateQueueItem("replace-hung.nzb", "movies", "ReplaceHungJob");
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            ctx.QueueItems.Add(item);
+            await ctx.SaveChangesAsync();
+        }
+
+        _queueManager.GetTopQueueItemOverride = async (exclude, ct) =>
+        {
+            await using var ctx = new DavDatabaseContext(_options);
+            var client = new DavDatabaseClient(ctx);
+            var (claimed, _) = await client.GetTopQueueItem(exclude, ct);
+            if (claimed is null) return (null, null);
+            ctx.ChangeTracker.Clear();
+            return (claimed, hung);
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var loop = _queueManager.ProcessQueueAsync(cts.Token);
+        try
+        {
+            object? inProgress = await WaitForInProgress(item.Id, TimeSpan.FromSeconds(5));
+            Assert.NotNull(inProgress);
+
+            var controller = new global::NzbWebDAV.Api.SabControllers.AddFile.AddFileController(
+                new Microsoft.AspNetCore.Http.DefaultHttpContext(),
+                new DavDatabaseClient(new DavDatabaseContext(_options)),
+                _queueManager,
+                _configManager,
+                new WebsocketManager());
+
+            var nzb = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
+                  <file subject="test">
+                    <groups><group>alt.binaries.test</group></groups>
+                    <segments>
+                      <segment bytes="100" number="1">seg@example.com</segment>
+                    </segments>
+                  </file>
+                </nzb>
+                """;
+
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            var error = await Assert.ThrowsAsync<Microsoft.AspNetCore.Http.BadHttpRequestException>(() =>
+                controller.AddFileAsync(new global::NzbWebDAV.Api.SabControllers.AddFile.AddFileRequest
+                {
+                    ReplaceExistingQueueItem = true,
+                    FileName = "replace-hung.nzb",
+                    ContentType = "application/x-nzb",
+                    NzbFileStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(nzb)),
+                    Category = "movies",
+                    Priority = QueueItem.PriorityOption.Normal,
+                    PostProcessing = QueueItem.PostProcessingOption.None,
+                    CancellationToken = CancellationToken.None,
+                }));
+            stopwatch.Stop();
+
+            Assert.Contains("still stopping", error.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10),
+                $"replace hung for {stopwatch.Elapsed}; expected a bounded grace wait");
+
+            // The quarantined row survives and no replacement row was inserted.
+            await using (var ctx = new DavDatabaseContext(_options))
+            {
+                var rows = await ctx.QueueItems.AsNoTracking().ToListAsync();
+                Assert.Single(rows);
+                Assert.Equal(item.Id, rows[0].Id);
+            }
+        }
+        finally
+        {
+            hung.Release();
+            await cts.CancelAsync();
+            await loop.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
     private async Task<object?> WaitForInProgress(Guid queueItemId, TimeSpan timeout, QueueManager? manager = null)
     {
         var deadline = DateTime.UtcNow + timeout;

--- a/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
@@ -1012,6 +1012,71 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
         }
     }
 
+    [Fact]
+    public async Task RemoveQueueItemsAsync_CallerCancelDuringGrace_PropagatesCancellation()
+    {
+        // A caller abort during the grace wait must surface as cancellation, not
+        // as a "worker ignored the cancel" quarantine result.
+        _queueManager.StuckItemThreshold = TimeSpan.FromHours(1);
+        _queueManager.StuckCancelGracePeriod = TimeSpan.FromSeconds(30);
+        var hung = new HungStream();
+        var item = CreateQueueItem("hung-abort.nzb", "movies", "HungAbortJob");
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            ctx.QueueItems.Add(item);
+            await ctx.SaveChangesAsync();
+        }
+
+        _queueManager.GetTopQueueItemOverride = async (exclude, ct) =>
+        {
+            await using var ctx = new DavDatabaseContext(_options);
+            var client = new DavDatabaseClient(ctx);
+            var (claimed, _) = await client.GetTopQueueItem(exclude, ct);
+            if (claimed is null) return (null, null);
+            ctx.ChangeTracker.Clear();
+            return (claimed, hung);
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var loop = _queueManager.ProcessQueueAsync(cts.Token);
+        try
+        {
+            Assert.NotNull(await WaitForInProgress(item.Id, TimeSpan.FromSeconds(5)));
+
+            using var requestCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+            await using (var ctx = new DavDatabaseContext(_options))
+            {
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                    _queueManager.RemoveQueueItemsAsync(
+                        [item.Id], new DavDatabaseClient(ctx), requestCts.Token));
+            }
+
+            // The row and the quarantined slot survive the aborted request.
+            Assert.NotNull(FindInProgressItem(item.Id));
+            await using (var ctx = new DavDatabaseContext(_options))
+            {
+                Assert.Equal(1, await ctx.QueueItems.CountAsync());
+                Assert.Equal(0, await ctx.HistoryItems.CountAsync());
+            }
+        }
+        finally
+        {
+            _queueManager.GetTopQueueItemOverride = (_, _) =>
+                Task.FromResult<(QueueItem? queueItem, Stream? queueNzbStream)>((null, null));
+            hung.Release();
+            await cts.CancelAsync();
+            try
+            {
+                await loop.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            catch (OperationCanceledException) when (cts.IsCancellationRequested)
+            {
+                // Expected when shutdown cancels an in-flight claim.
+            }
+        }
+    }
+
     private async Task<object?> WaitForInProgress(Guid queueItemId, TimeSpan timeout, QueueManager? manager = null)
     {
         var deadline = DateTime.UtcNow + timeout;

--- a/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
@@ -743,12 +743,24 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
                 Assert.Equal(0, await ctx.HistoryItems.CountAsync());
             }
 
-            // Releasing the hung I/O lets the cancelled worker stop and the
-            // coordinator reap it; the row remains queued for a later claim.
+            // Stop re-claims before releasing: the row stays queued and claimable,
+            // and a released HungStream reads as EOF, which would fail a re-claimed
+            // worker into history and break the assertions below.
+            _queueManager.GetTopQueueItemOverride = (_, _) =>
+                Task.FromResult<(QueueItem? queueItem, Stream? queueNzbStream)>((null, null));
+
+            // Releasing the hung I/O lets the cancelled worker stop; the shutdown
+            // path then reaps it. The row remains queued for a later claim.
             hung.Release();
-            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
-            while (DateTime.UtcNow < deadline && FindInProgressItem(item.Id) is not null)
-                await Task.Delay(20);
+            await cts.CancelAsync();
+            try
+            {
+                await loop.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            catch (OperationCanceledException) when (cts.IsCancellationRequested)
+            {
+                // Expected when shutdown cancels an in-flight claim.
+            }
 
             Assert.Null(FindInProgressItem(item.Id));
             await using (var ctx = new DavDatabaseContext(_options))
@@ -761,7 +773,14 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
         {
             hung.Release();
             await cts.CancelAsync();
-            await loop.WaitAsync(TimeSpan.FromSeconds(5));
+            try
+            {
+                await loop.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            catch (OperationCanceledException) when (cts.IsCancellationRequested)
+            {
+                // Expected when shutdown cancels an in-flight claim.
+            }
         }
     }
 
@@ -901,9 +920,95 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
         }
         finally
         {
+            // Block re-claims before releasing the hung stream so teardown cannot
+            // start a fresh worker that reads EOF off the released stream.
+            _queueManager.GetTopQueueItemOverride = (_, _) =>
+                Task.FromResult<(QueueItem? queueItem, Stream? queueNzbStream)>((null, null));
             hung.Release();
             await cts.CancelAsync();
-            await loop.WaitAsync(TimeSpan.FromSeconds(5));
+            try
+            {
+                await loop.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            catch (OperationCanceledException) when (cts.IsCancellationRequested)
+            {
+                // Expected when shutdown cancels an in-flight claim.
+            }
+        }
+    }
+
+    [Fact]
+    public async Task RemoveQueueItemsAsync_TwoHungWorkers_ShareOneGraceBudget()
+    {
+        // Two hung workers must be bounded by one shared grace period, not
+        // N × grace: cancel all first, then wait on a single deadline.
+        _queueManager.StuckItemThreshold = TimeSpan.FromHours(1);
+        _queueManager.StuckCancelGracePeriod = TimeSpan.FromSeconds(2);
+        _configManager.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.QueueWorkerCount, ConfigValue = "2" },
+        ]);
+
+        var hung1 = new HungStream();
+        var hung2 = new HungStream();
+        var item1 = CreateQueueItem("hung-a.nzb", "movies", "HungJobA");
+        var item2 = CreateQueueItem("hung-b.nzb", "movies", "HungJobB");
+        item2.CreatedAt = item1.CreatedAt.AddMinutes(1);
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            ctx.QueueItems.AddRange(item1, item2);
+            await ctx.SaveChangesAsync();
+        }
+
+        var claims = new Queue<HungStream>([hung1, hung2]);
+        _queueManager.GetTopQueueItemOverride = async (exclude, ct) =>
+        {
+            await using var ctx = new DavDatabaseContext(_options);
+            var client = new DavDatabaseClient(ctx);
+            var (claimed, _) = await client.GetTopQueueItem(exclude, ct);
+            if (claimed is null) return (null, null);
+            ctx.ChangeTracker.Clear();
+            return (claimed, claims.Count > 0 ? claims.Dequeue() : new HungStream());
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        var loop = _queueManager.ProcessQueueAsync(cts.Token);
+        try
+        {
+            Assert.NotNull(await WaitForInProgress(item1.Id, TimeSpan.FromSeconds(5)));
+            Assert.NotNull(await WaitForInProgress(item2.Id, TimeSpan.FromSeconds(5)));
+
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            IReadOnlyList<Guid> stillRunning;
+            await using (var ctx = new DavDatabaseContext(_options))
+            {
+                stillRunning = await _queueManager.RemoveQueueItemsAsync(
+                    [item1.Id, item2.Id], new DavDatabaseClient(ctx), CancellationToken.None);
+            }
+
+            stopwatch.Stop();
+
+            Assert.Equal(2, stillRunning.Count);
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromMilliseconds(3500),
+                $"two hung workers took {stopwatch.Elapsed}; one shared 2s grace budget " +
+                "should bound the wait, per-worker budgets would take ~4s");
+        }
+        finally
+        {
+            _queueManager.GetTopQueueItemOverride = (_, _) =>
+                Task.FromResult<(QueueItem? queueItem, Stream? queueNzbStream)>((null, null));
+            hung1.Release();
+            hung2.Release();
+            await cts.CancelAsync();
+            try
+            {
+                await loop.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            catch (OperationCanceledException) when (cts.IsCancellationRequested)
+            {
+                // Expected when shutdown cancels an in-flight claim.
+            }
         }
     }
 

--- a/tests/NzbWebDAV.Tests/Queue/StrmPublishAfterCommitTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/StrmPublishAfterCommitTests.cs
@@ -2,20 +2,15 @@ using System.Text;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Migrations;
-using NzbWebDAV.Clients.Usenet;
-using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Interceptors;
 using NzbWebDAV.Database.MigrationHelpers;
 using NzbWebDAV.Database.Models;
-using NzbWebDAV.Exceptions;
 using NzbWebDAV.Queue;
-using NzbWebDAV.Streams;
 using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Tests.Fakes;
 using NzbWebDAV.Websocket;
-using UsenetSharp.Models;
-using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Tests.Queue;
 
@@ -238,141 +233,5 @@ public sealed class StrmPublishAfterCommitTests : IAsyncLifetime
                 throw new DbUpdateException("simulated finalize commit failure");
             return base.SavingChangesAsync(eventData, result, cancellationToken);
         }
-    }
-
-    /// <summary>
-    /// Serves a single-segment video file from memory with a correct yEnc header
-    /// filename, so the import pipeline deobfuscates to <see cref="VideoFileName"/>.
-    /// </summary>
-    private sealed class ScriptedVideoNntpClient(
-        string fileName,
-        string segmentId,
-        byte[] payload) : NntpClient
-    {
-        public override Task ConnectAsync(
-            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
-            Task.CompletedTask;
-
-        public override Task<UsenetResponse> AuthenticateAsync(
-            string user, string pass, CancellationToken cancellationToken) =>
-            throw new NotSupportedException();
-
-        public override Task<UsenetStatResponse> StatAsync(
-            SegmentId id, CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            var exists = id.ToString() == segmentId;
-            return Task.FromResult(new UsenetStatResponse
-            {
-                ResponseCode = exists
-                    ? (int)UsenetResponseType.ArticleExists
-                    : (int)UsenetResponseType.NoArticleWithThatMessageId,
-                ResponseMessage = exists ? "223 exists" : "430 missing",
-                ArticleExists = exists,
-            });
-        }
-
-        public override Task<UsenetHeadResponse> HeadAsync(
-            SegmentId id, CancellationToken cancellationToken) =>
-            throw new NotSupportedException();
-
-        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
-            SegmentId id, CancellationToken cancellationToken) =>
-            DecodedBodyAsync(id, null, cancellationToken);
-
-        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
-            SegmentId id,
-            ArticleBodyCompletionHandler? onConnectionReadyAgain,
-            CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (id.ToString() != segmentId)
-                return Task.FromException<UsenetDecodedBodyResponse>(
-                    new UsenetArticleNotFoundException(id.ToString(), "430 missing"));
-            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
-            return Task.FromResult(new UsenetDecodedBodyResponse
-            {
-                SegmentId = id.ToString(),
-                ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
-                ResponseMessage = "222 body",
-                Stream = CreateStream(),
-            });
-        }
-
-        public override Task<UsenetDecodedBodyResponse?> TryGetLocalDecodedBodyAsync(
-            SegmentId id, CancellationToken cancellationToken) =>
-            Task.FromResult<UsenetDecodedBodyResponse?>(null);
-
-        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
-            IReadOnlyList<SegmentId> segmentIds,
-            ArticleBodyCompletionHandler? onConnectionReadyAgain,
-            CancellationToken cancellationToken)
-        {
-            var responses = segmentIds
-                .Select(id => DecodedBodyAsync(id, cancellationToken))
-                .ToArray();
-            return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
-        }
-
-        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
-            SegmentId id, CancellationToken cancellationToken) =>
-            DecodedArticleAsync(id, null, cancellationToken);
-
-        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
-            SegmentId id,
-            ArticleBodyCompletionHandler? onConnectionReadyAgain,
-            CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (id.ToString() != segmentId)
-                throw new UsenetArticleNotFoundException(id.ToString(), "430 missing");
-            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
-            return Task.FromResult(new UsenetDecodedArticleResponse
-            {
-                SegmentId = id.ToString(),
-                ResponseCode = (int)UsenetResponseType.ArticleRetrievedHeadAndBodyFollow,
-                ResponseMessage = "220 article",
-                Stream = CreateStream(),
-                ArticleHeaders = new UsenetArticleHeader
-                {
-                    Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                    {
-                        ["Date"] = DateTimeOffset.UtcNow.ToString("R"),
-                    },
-                },
-            });
-        }
-
-        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
-            throw new NotSupportedException();
-
-        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
-            string id, CancellationToken cancellationToken) =>
-            Task.FromResult(new UsenetExclusiveConnection(null));
-
-        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
-            IReadOnlyList<SegmentId> ids, CancellationToken cancellationToken) =>
-            Task.FromResult(new UsenetExclusiveConnection(null));
-
-        public override Task<long> GetFileSizeAsync(NzbWebDAV.Models.Nzb.NzbFile file, CancellationToken ct) =>
-            Task.FromResult((long)payload.Length);
-
-        public override void Dispose()
-        {
-        }
-
-        private CachedYencStream CreateStream() =>
-            new(
-                new UsenetYencHeader
-                {
-                    FileName = fileName,
-                    FileSize = payload.Length,
-                    LineLength = 128,
-                    PartNumber = 1,
-                    TotalParts = 1,
-                    PartOffset = 0,
-                    PartSize = payload.Length,
-                },
-                new MemoryStream(payload, writable: false));
     }
 }

--- a/tests/NzbWebDAV.Tests/Queue/StrmPublishAfterCommitTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/StrmPublishAfterCommitTests.cs
@@ -1,0 +1,378 @@
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Websocket;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Tests.Queue;
+
+/// <summary>
+/// STRM sidecars publish only after the finalize commit succeeds: a failed
+/// SaveChanges leaves no sidecars, a post-commit sidecar failure never
+/// re-finalizes the import, and duplicate mark-failed imports publish nothing.
+/// </summary>
+[Collection(nameof(ConfigPathCollection))]
+public sealed class StrmPublishAfterCommitTests : IAsyncLifetime
+{
+    private const string Category = "other";
+    private const string JobName = "movie-job";
+    private const string VideoFileName = "movie.mkv";
+
+    private readonly string _configRoot =
+        Path.Join(Path.GetTempPath(), $"nzbdav-strm-cfg-{Guid.NewGuid():N}");
+    private readonly string _strmDir =
+        Path.Join(Path.GetTempPath(), $"nzbdav-strm-out-{Guid.NewGuid():N}");
+    private readonly string _segmentId = $"strm-seg-{Guid.NewGuid():N}@example.com";
+    private readonly byte[] _payload = Enumerable.Range(0, 4096).Select(i => (byte)(i % 251)).ToArray();
+    private string? _previousConfigPath;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Directory.CreateDirectory(_strmDir);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+
+        await using var context = CreateContext();
+        await context.Database.MigrateAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        await Task.CompletedTask;
+        try { Directory.Delete(_configRoot, recursive: true); } catch (IOException) { /* best effort */ }
+        try { Directory.Delete(_strmDir, recursive: true); } catch (IOException) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task SuccessfulImport_PublishesStrmAfterCommit()
+    {
+        await using var context = CreateContext();
+        var queueItem = await SeedQueueItemAsync(context);
+
+        await ProcessAsync(context, CreateConfig(), queueItem);
+
+        context.ChangeTracker.Clear();
+        Assert.Empty(await context.QueueItems.AsNoTracking().ToListAsync());
+        var historyItem = Assert.Single(await context.HistoryItems.AsNoTracking().ToListAsync());
+        Assert.Null(historyItem.FailMessage);
+        Assert.Equal(HistoryItem.DownloadStatusOption.Completed, historyItem.DownloadStatus);
+
+        var strmPath = Path.Join(_strmDir, Category, JobName, VideoFileName + ".strm");
+        Assert.True(File.Exists(strmPath), $"expected sidecar at {strmPath}");
+        Assert.Contains("/view/", await File.ReadAllTextAsync(strmPath));
+
+        var videoItem = await context.Items.AsNoTracking()
+            .SingleAsync(x => x.Name == VideoFileName);
+        Assert.Equal(strmPath, videoItem.GeneratedStrmPath);
+    }
+
+    [Fact]
+    public async Task FinalizeSaveFailure_LeavesNoStrmFiles()
+    {
+        await using var context = CreateContext(new ThrowOnQueueDeleteSaveInterceptor());
+        var queueItem = await SeedQueueItemAsync(context);
+
+        await ProcessAsync(context, CreateConfig(), queueItem);
+
+        // Both the success finalize and the failed-history finalize fail at the
+        // simulated commit boundary; the pre-fix code wrote sidecars inside the
+        // staged operations, before that boundary.
+        Assert.Empty(Directory.GetFiles(_strmDir, "*.strm", SearchOption.AllDirectories));
+        context.ChangeTracker.Clear();
+        Assert.Empty(await context.HistoryItems.AsNoTracking().ToListAsync());
+        Assert.True(await context.QueueItems.AsNoTracking().AnyAsync(q => q.Id == queueItem.Id));
+    }
+
+    [Fact]
+    public async Task StrmFailureAfterCommit_KeepsCompletedHistory()
+    {
+        // Force the sidecar write to fail: a regular file blocks the per-job
+        // directory the writer needs to create.
+        await File.WriteAllTextAsync(Path.Join(_strmDir, Category), "blocked");
+
+        await using var context = CreateContext();
+        var queueItem = await SeedQueueItemAsync(context);
+
+        // Must not throw: a sidecar failure is logged, not re-finalized.
+        await ProcessAsync(context, CreateConfig(), queueItem);
+
+        context.ChangeTracker.Clear();
+        Assert.Empty(await context.QueueItems.AsNoTracking().ToListAsync());
+        var historyItem = Assert.Single(await context.HistoryItems.AsNoTracking().ToListAsync());
+        Assert.Null(historyItem.FailMessage);
+        Assert.Equal(HistoryItem.DownloadStatusOption.Completed, historyItem.DownloadStatus);
+        Assert.Empty(Directory.GetFiles(_strmDir, "*.strm", SearchOption.AllDirectories));
+    }
+
+    [Fact]
+    public async Task DuplicateMarkFailed_PublishesNoStrmFiles()
+    {
+        await using var context = CreateContext();
+        var categoryFolder = DavItem.New(
+            Guid.NewGuid(), DavItem.ContentFolder, Category, null,
+            DavItem.ItemType.Directory, DavItem.ItemSubType.Directory,
+            null, null, null, null);
+        var mountFolder = DavItem.New(
+            Guid.NewGuid(), categoryFolder, JobName, null,
+            DavItem.ItemType.Directory, DavItem.ItemSubType.Directory,
+            null, null, Guid.NewGuid(), null);
+        context.Items.Add(categoryFolder);
+        context.Items.Add(mountFolder);
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+        var queueItem = await SeedQueueItemAsync(context);
+
+        var config = CreateConfig();
+        config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.ApiDuplicateNzbBehavior, ConfigValue = "mark-failed" },
+        ]);
+        await ProcessAsync(context, config, queueItem);
+
+        context.ChangeTracker.Clear();
+        var historyItem = Assert.Single(await context.HistoryItems.AsNoTracking().ToListAsync());
+        Assert.Equal(HistoryItem.DownloadStatusOption.Failed, historyItem.DownloadStatus);
+        Assert.Contains("Duplicate nzb", historyItem.FailMessage);
+        Assert.Empty(Directory.GetFiles(_strmDir, "*.strm", SearchOption.AllDirectories));
+    }
+
+    private ConfigManager CreateConfig()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.ApiImportStrategy, ConfigValue = "strm" },
+            new ConfigItem { ConfigName = ConfigKeys.ApiCompletedDownloadsDir, ConfigValue = _strmDir },
+            new ConfigItem { ConfigName = ConfigKeys.GeneralBaseUrl, ConfigValue = "http://localhost:3000" },
+            new ConfigItem { ConfigName = ConfigKeys.ApiStrmKey, ConfigValue = "test-strm-key" },
+        ]);
+        return config;
+    }
+
+    private DavDatabaseContext CreateContext(params IInterceptor[] extraInterceptors) =>
+        new(new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .AddInterceptors(extraInterceptors)
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options);
+
+    private async Task<QueueItem> SeedQueueItemAsync(DavDatabaseContext context)
+    {
+        var queueItem = new QueueItem
+        {
+            Id = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            FileName = $"{JobName}.nzb",
+            JobName = JobName,
+            NzbFileSize = CreateNzbBytes().Length,
+            TotalSegmentBytes = _payload.Length,
+            Category = Category,
+            Priority = QueueItem.PriorityOption.Normal,
+            PostProcessing = QueueItem.PostProcessingOption.None,
+        };
+        context.QueueItems.Add(queueItem);
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+        return await context.QueueItems.SingleAsync(q => q.Id == queueItem.Id);
+    }
+
+    private async Task ProcessAsync(DavDatabaseContext context, ConfigManager config, QueueItem queueItem)
+    {
+        await using var nzbStream = new MemoryStream(CreateNzbBytes());
+        var processor = new QueueItemProcessor(
+            queueItem,
+            nzbStream,
+            new DavDatabaseClient(context),
+            new ScriptedVideoNntpClient(VideoFileName, _segmentId, _payload),
+            config,
+            new WebsocketManager(),
+            new Progress<int>(),
+            CancellationToken.None);
+        await processor.ProcessAsync();
+    }
+
+    private byte[] CreateNzbBytes() => Encoding.UTF8.GetBytes(
+        $"""
+        <?xml version="1.0" encoding="utf-8"?>
+        <nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
+          <file subject="&quot;{VideoFileName}&quot; yEnc (1/1)">
+            <groups><group>alt.binaries.test</group></groups>
+            <segments>
+              <segment bytes="{_payload.Length}" number="1">{_segmentId}</segment>
+            </segments>
+          </file>
+        </nzb>
+        """);
+
+    /// <summary>
+    /// Simulates a finalize-commit failure: any save that deletes a queue item
+    /// (success or failed-history finalize) faults with a DbUpdateException.
+    /// </summary>
+    private sealed class ThrowOnQueueDeleteSaveInterceptor : SaveChangesInterceptor
+    {
+        public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+            DbContextEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            if (eventData.Context!.ChangeTracker.Entries<QueueItem>()
+                    .Any(e => e.State == EntityState.Deleted))
+                throw new DbUpdateException("simulated finalize commit failure");
+            return base.SavingChangesAsync(eventData, result, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Serves a single-segment video file from memory with a correct yEnc header
+    /// filename, so the import pipeline deobfuscates to <see cref="VideoFileName"/>.
+    /// </summary>
+    private sealed class ScriptedVideoNntpClient(
+        string fileName,
+        string segmentId,
+        byte[] payload) : NntpClient
+    {
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId id, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var exists = id.ToString() == segmentId;
+            return Task.FromResult(new UsenetStatResponse
+            {
+                ResponseCode = exists
+                    ? (int)UsenetResponseType.ArticleExists
+                    : (int)UsenetResponseType.NoArticleWithThatMessageId,
+                ResponseMessage = exists ? "223 exists" : "430 missing",
+                ArticleExists = exists,
+            });
+        }
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId id, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId id, CancellationToken cancellationToken) =>
+            DecodedBodyAsync(id, null, cancellationToken);
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId id,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (id.ToString() != segmentId)
+                return Task.FromException<UsenetDecodedBodyResponse>(
+                    new UsenetArticleNotFoundException(id.ToString(), "430 missing"));
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedBodyResponse
+            {
+                SegmentId = id.ToString(),
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                ResponseMessage = "222 body",
+                Stream = CreateStream(),
+            });
+        }
+
+        public override Task<UsenetDecodedBodyResponse?> TryGetLocalDecodedBodyAsync(
+            SegmentId id, CancellationToken cancellationToken) =>
+            Task.FromResult<UsenetDecodedBodyResponse?>(null);
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            var responses = segmentIds
+                .Select(id => DecodedBodyAsync(id, cancellationToken))
+                .ToArray();
+            return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
+        }
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId id, CancellationToken cancellationToken) =>
+            DecodedArticleAsync(id, null, cancellationToken);
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId id,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (id.ToString() != segmentId)
+                throw new UsenetArticleNotFoundException(id.ToString(), "430 missing");
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedArticleResponse
+            {
+                SegmentId = id.ToString(),
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedHeadAndBodyFollow,
+                ResponseMessage = "220 article",
+                Stream = CreateStream(),
+                ArticleHeaders = new UsenetArticleHeader
+                {
+                    Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["Date"] = DateTimeOffset.UtcNow.ToString("R"),
+                    },
+                },
+            });
+        }
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+            string id, CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetExclusiveConnection(null));
+
+        public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+            IReadOnlyList<SegmentId> ids, CancellationToken cancellationToken) =>
+            Task.FromResult(new UsenetExclusiveConnection(null));
+
+        public override Task<long> GetFileSizeAsync(NzbWebDAV.Models.Nzb.NzbFile file, CancellationToken ct) =>
+            Task.FromResult((long)payload.Length);
+
+        public override void Dispose()
+        {
+        }
+
+        private CachedYencStream CreateStream() =>
+            new(
+                new UsenetYencHeader
+                {
+                    FileName = fileName,
+                    FileSize = payload.Length,
+                    LineLength = 128,
+                    PartNumber = 1,
+                    TotalParts = 1,
+                    PartOffset = 0,
+                    PartSize = payload.Length,
+                },
+                new MemoryStream(payload, writable: false));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckWorkerAdmissionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckWorkerAdmissionTests.cs
@@ -122,7 +122,7 @@ public sealed class HealthCheckWorkerAdmissionTests
         public QueueManager.InProgressQueueItemSnapshot? FindInProgressQueueItem(Guid queueItemId) => null;
         public IDisposable? TryReserveQueueSlot(int persistedCount, int maxItems, int resumeThreshold) => null;
         public void AwakenQueue(DateTime? dateTime = null) { }
-        public Task RemoveQueueItemsAsync(List<Guid> queueItemIds, DavDatabaseClient dbClient, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<IReadOnlyList<Guid>> RemoveQueueItemsAsync(List<Guid> queueItemIds, DavDatabaseClient dbClient, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<Guid>>([]);
         public Task PauseQueueItemsAsync(List<Guid> queueItemIds, DavDatabaseClient dbClient, CancellationToken ct = default) => Task.CompletedTask;
         public Task ResumeQueueItemsAsync(List<Guid> queueItemIds, DavDatabaseClient dbClient, CancellationToken ct = default) => Task.CompletedTask;
         public Task SetQueueItemsPriorityAsync(List<Guid> queueItemIds, QueueItem.PriorityOption priority, DavDatabaseClient dbClient, CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/NzbWebDAV.Tests/TestUtils/TestStreams.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/TestStreams.cs
@@ -6,4 +6,57 @@ namespace NzbWebDAV.Tests.TestUtils;
 internal static class TestStreams
 {
     public static Stream Create(byte[] payload) => new MemoryStream(payload, writable: false);
+
+    /// <summary>
+    /// Wraps <paramref name="inner"/> and cancels <paramref name="cts"/> once more than
+    /// <paramref name="cancelAfterBytes"/> bytes have been read, so parsers observe
+    /// cancellation deterministically mid-stream.
+    /// </summary>
+    public static Stream CancelAfterBytes(Stream inner, long cancelAfterBytes, CancellationTokenSource cts) =>
+        new CancelAfterBytesStream(inner, cancelAfterBytes, cts);
+
+    private sealed class CancelAfterBytesStream(Stream inner, long cancelAfterBytes, CancellationTokenSource cts)
+        : Stream
+    {
+        private long _bytesRead;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => _bytesRead;
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = inner.Read(buffer, offset, count);
+            Add(read);
+            return read;
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            var read = await inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            Add(read);
+            return read;
+        }
+
+        private void Add(int read)
+        {
+            if (read <= 0) return;
+            _bytesRead += read;
+            if (_bytesRead > cancelAfterBytes)
+                cts.Cancel();
+        }
+
+        public override void Flush() => inner.Flush();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
 }

--- a/tests/NzbWebDAV.Tests/TestUtils/TestStreams.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/TestStreams.cs
@@ -15,6 +15,68 @@ internal static class TestStreams
     public static Stream CancelAfterBytes(Stream inner, long cancelAfterBytes, CancellationTokenSource cts) =>
         new CancelAfterBytesStream(inner, cancelAfterBytes, cts);
 
+    /// <summary>
+    /// Wraps <paramref name="inner"/> and delivers at most <paramref name="byteLimit"/> bytes,
+    /// cancelling <paramref name="cts"/> on the first read beyond the limit (that read still
+    /// returns the remaining data). Unlike <see cref="CancelAfterBytes"/>, delivery is capped so
+    /// buffered readers cannot race ahead of the cancellation point.
+    /// </summary>
+    public static Stream CancelOnReadBeyond(Stream inner, long byteLimit, CancellationTokenSource cts) =>
+        new CancelOnReadBeyondStream(inner, byteLimit, cts);
+
+    private sealed class CancelOnReadBeyondStream(Stream inner, long byteLimit, CancellationTokenSource cts)
+        : Stream
+    {
+        private long _bytesRead;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => _bytesRead;
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (_bytesRead >= byteLimit)
+            {
+                cts.Cancel();
+                var read = inner.Read(buffer, offset, count);
+                _bytesRead += read;
+                return read;
+            }
+
+            var capped = inner.Read(buffer, offset, (int)Math.Min(count, byteLimit - _bytesRead));
+            _bytesRead += capped;
+            return capped;
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            if (_bytesRead >= byteLimit)
+            {
+                cts.Cancel();
+                return await inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            }
+
+            var read = await inner
+                .ReadAsync(buffer[..(int)Math.Min(buffer.Length, byteLimit - _bytesRead)], cancellationToken)
+                .ConfigureAwait(false);
+            _bytesRead += read;
+            return read;
+        }
+
+        public override void Flush() => inner.Flush();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
     private sealed class CancelAfterBytesStream(Stream inner, long cancelAfterBytes, CancellationTokenSource cts)
         : Stream
     {

--- a/tests/NzbWebDAV.Tests/Utils/LimitedReadStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/LimitedReadStreamTests.cs
@@ -1,0 +1,89 @@
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public class LimitedReadStreamTests
+{
+    [Fact]
+    public async Task Copy_ExactlyMaxBytes_Succeeds()
+    {
+        var payload = new byte[1024];
+        new Random(42).NextBytes(payload);
+        await using var inner = new MemoryStream(payload);
+        await using var limited = new LimitedReadStream(
+            inner, payload.Length, () => new InvalidOperationException("limit"));
+
+        var copied = new MemoryStream();
+        await limited.CopyToAsync(copied);
+
+        Assert.Equal(payload, copied.ToArray());
+    }
+
+    [Fact]
+    public async Task Copy_OneBytePastLimit_ThrowsFactoryException()
+    {
+        await using var inner = new MemoryStream(new byte[1025]);
+        await using var limited = new LimitedReadStream(
+            inner, 1024, () => new InvalidOperationException("limit tripped"));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => limited.CopyToAsync(new MemoryStream()));
+
+        Assert.Equal("limit tripped", ex.Message);
+    }
+
+    [Fact]
+    public async Task Copy_Cancelled_ThrowsOperationCanceledNotLimit()
+    {
+        // A repeating inner stream never ends; the read token must win over the
+        // limit accounting so cancellation stays cancellation.
+        await using var inner = new RepeatingByteStream(long.MaxValue);
+        await using var limited = new LimitedReadStream(
+            inner, long.MaxValue, () => new InvalidOperationException("limit"));
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => limited.CopyToAsync(new MemoryStream(), cts.Token));
+    }
+
+    /// <summary>
+    /// Yields <paramref name="length"/> zero bytes without allocating them.
+    /// </summary>
+    internal sealed class RepeatingByteStream(long length) : Stream
+    {
+        private readonly long _length = length;
+        private long _remaining = length;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => _length - _remaining;
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var take = (int)Math.Min(count, _remaining);
+            Array.Clear(buffer, offset, take);
+            _remaining -= take;
+            return take;
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            var take = (int)Math.Min(buffer.Length, _remaining);
+            buffer.Span[..take].Clear();
+            _remaining -= take;
+            return ValueTask.FromResult(take);
+        }
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/tests/NzbWebDAV.Tests/Utils/LimitedReadStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/LimitedReadStreamTests.cs
@@ -1,3 +1,4 @@
+using NzbWebDAV.Tests.TestUtils;
 using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Tests.Utils;
@@ -35,14 +36,18 @@ public class LimitedReadStreamTests
     [Fact]
     public async Task Copy_Cancelled_ThrowsOperationCanceledNotLimit()
     {
-        // A repeating inner stream never ends; the read token must win over the
-        // limit accounting so cancellation stays cancellation.
-        await using var inner = new RepeatingByteStream(long.MaxValue);
+        // Deterministic cancellation after 64 KiB of reads (a timer races the
+        // MemoryStream's own size limit on fast machines). The stream limit sits
+        // far above the cancel point, so the copy must end via cancellation.
+        using var cts = new CancellationTokenSource();
+        await using var inner = TestStreams.CancelAfterBytes(
+            new RepeatingByteStream(long.MaxValue), cancelAfterBytes: 64 * 1024, cts);
         await using var limited = new LimitedReadStream(
             inner, long.MaxValue, () => new InvalidOperationException("limit"));
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
 
-        await Assert.ThrowsAsync<OperationCanceledException>(
+        // ThrowsAny: an OCE crossing async method boundaries resurfaces as
+        // TaskCanceledException; either proves cancellation beat the limit.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => limited.CopyToAsync(new MemoryStream(), cts.Token));
     }
 


### PR DESCRIPTION
## Summary

Stacked on #1197 (diffs show only this change once it merges).

- SAB delete, pause, duplicate-replace, and shutdown previously awaited a cancelled worker's task with **no deadline**, so one worker stuck in uninterruptible I/O hung every control path. All now wait only up to the existing 2-minute stuck-cancel grace period.
- A worker that overruns is **quarantined**, not abandoned: it keeps its queue row, retry/stall counters, and `_inProgress` slot (so no second worker can start for the same id or mount key), and the ignored-cancel observer logs the same Error as the stuck watchdog. Nothing disposes a live worker's DB context, stream, or the shared locks while it can still run.
- SAB delete now returns `status: false` with a clear message when an item is still stopping; duplicate-replace fails the submission visibly instead of hitting the queue unique constraint and looping on remove/insert against the hung task.
- Shutdown logs the hung worker ids and returns after the grace period instead of blocking the process; `Dispose` skips disposing the shared semaphores while quarantined workers exist.

Fixes #1181

## Test plan

- [x] New `QueueStuckWatchdogTests` cases with `HungStream`: `RemoveQueueItemsAsync` returns within grace with the id flagged still-running (row kept, slot occupied, counters intact; later release reaps cleanly and the row stays queued); shutdown logs the Error and returns within grace; duplicate-replace over a hung worker fails the submission with "still stopping" and inserts nothing.
- [x] Existing watchdog/manager suites green (26 passed), plus Api/WebDav/migration/profile suites (3771 passed).
- [ ] CI: full backend + frontend gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Queue removal now reports items that remain in a stopping state and provides a retry message.
  * Prevented replacement submissions while the existing queue item is still stopping.
  * Removal notifications and related cleanup now occur only for items successfully removed.
  * Shutdown and cancellation return within a bounded period when workers do not respond.
  * Preserved queue items and their status when cancellation is ignored.

* **Tests**
  * Added coverage for hung-worker removal, shutdown, and replacement scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
