### PR TITLE
fix(usenet): missing-article playback no longer freezes all streams and imports

### DIFF
--- a/backend/Queue/FileAggregators/FileAggregator.cs
+++ b/backend/Queue/FileAggregators/FileAggregator.cs
@@ -1,6 +1,7 @@
 ﻿using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Models.Nzb;
 using NzbWebDAV.Queue.FileProcessors;
 using NzbWebDAV.Utils;
 
@@ -11,42 +12,74 @@ public class FileAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, 
     protected override DavDatabaseClient DBClient => dbClient;
     protected override DavItem MountDirectory => mountDirectory;
 
-    public override void UpdateDatabase(List<BaseProcessor.Result> processorResults)
+    /// <summary>
+    /// A direct (non-archive) file an import will mount, with the exact relative path
+    /// and leaf name <see cref="UpdateDatabase"/> persists. Pre-commit consumers such as
+    /// import-readiness plan from this same projection so they cannot drift from what
+    /// gets mounted.
+    /// </summary>
+    internal sealed record PlannedDirectFile(
+        string RelativePath,
+        string Name,
+        long FileSize,
+        DateTimeOffset ReleaseDate,
+        NzbFile NzbFile,
+        string? SniffedVideoExtension);
+
+    internal static List<PlannedDirectFile> PlanDirectFiles(
+        List<BaseProcessor.Result> processorResults,
+        string mountName)
     {
+        var planned = new List<PlannedDirectFile>();
         foreach (var processorResult in processorResults)
         {
             if (processorResult is not FileProcessor.Result result) continue;
             if (string.IsNullOrEmpty(result.FileName) && result.SniffedVideoExtension is null)
                 continue;
-            var parentDirectory = EnsureParentDirectory(
-                string.IsNullOrEmpty(result.FileName)
-                    ? MountDirectory.Name + result.SniffedVideoExtension
-                    : result.FileName);
+            var relativePath = string.IsNullOrEmpty(result.FileName)
+                ? mountName + result.SniffedVideoExtension
+                : result.FileName;
             var leafName = string.IsNullOrEmpty(result.FileName)
-                ? MountDirectory.Name
+                ? mountName
                 : Path.GetFileName(result.FileName);
             var name = ImportableVideoNamer.Normalize(
                 SanitizeDavName(leafName),
                 result.SniffedVideoExtension,
-                MountDirectory.Name,
+                mountName,
                 allowBaseRename: true);
+            planned.Add(new PlannedDirectFile(
+                relativePath,
+                name,
+                result.FileSize,
+                result.ReleaseDate,
+                result.NzbFile,
+                result.SniffedVideoExtension));
+        }
 
+        return planned;
+    }
+
+    public override void UpdateDatabase(List<BaseProcessor.Result> processorResults)
+    {
+        foreach (var planned in PlanDirectFiles(processorResults, MountDirectory.Name))
+        {
+            var parentDirectory = EnsureParentDirectory(planned.RelativePath);
             var davNzbFile = new DavNzbFile()
             {
                 Id = Guid.NewGuid(),
-                SegmentIds = result.NzbFile.GetSegmentIds(),
-                SegmentByteRanges = result.NzbFile.GetSegmentByteRanges(),
-                SegmentFallbackIds = result.NzbFile.GetSegmentFallbackIds(),
+                SegmentIds = planned.NzbFile.GetSegmentIds(),
+                SegmentByteRanges = planned.NzbFile.GetSegmentByteRanges(),
+                SegmentFallbackIds = planned.NzbFile.GetSegmentFallbackIds(),
             };
 
             var davItem = DavItem.New(
                 id: Guid.NewGuid(),
                 parent: parentDirectory,
-                name: name,
-                fileSize: result.FileSize,
+                name: planned.Name,
+                fileSize: planned.FileSize,
                 type: DavItem.ItemType.UsenetFile,
                 subType: DavItem.ItemSubType.NzbFile,
-                releaseDate: result.ReleaseDate,
+                releaseDate: planned.ReleaseDate,
                 lastHealthCheck: checkedFullHealth ? DateTimeOffset.UtcNow : null,
                 historyItemId: MountDirectory.HistoryItemId,
                 fileBlobId: davNzbFile.Id,

--- a/backend/Queue/FileAggregators/PlannedImportOutputs.cs
+++ b/backend/Queue/FileAggregators/PlannedImportOutputs.cs
@@ -1,0 +1,88 @@
+using NzbWebDAV.Queue.FileProcessors;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Queue.FileAggregators;
+
+/// <summary>
+/// Pure projection of the files a completed import will mount, computed from processor
+/// results before the database is touched. Mirrors each aggregator's output naming so
+/// pre-commit filtering (import-readiness target selection) applies the same sample
+/// size heuristic the blocklist post-processor applies to persisted items. Duplicate
+/// renames preserve extensions, so planned and persisted video sets always match.
+/// </summary>
+internal static class PlannedImportOutputs
+{
+    internal static long GetLargestVideoFileSize(
+        List<BaseProcessor.Result> processorResults,
+        string mountName)
+    {
+        return PlanNamesAndSizes(processorResults, mountName)
+            .Where(x => FilenameUtil.IsVideoFile(x.Name))
+            .Select(x => x.FileSize)
+            .DefaultIfEmpty(0)
+            .Max();
+    }
+
+    private static IEnumerable<(string Name, long FileSize)> PlanNamesAndSizes(
+        List<BaseProcessor.Result> processorResults,
+        string mountName)
+    {
+        foreach (var direct in FileAggregator.PlanDirectFiles(processorResults, mountName))
+            yield return (direct.Name, direct.FileSize);
+
+        var rarGroups = processorResults
+            .OfType<RarProcessor.Result>()
+            .SelectMany(x => x.StoredFileSegments)
+            .GroupBy(x => x.PathWithinArchive)
+            .ToList();
+        foreach (var group in rarGroups)
+        {
+            var parts = group.ToList();
+            var sniffedVideoExtension = parts
+                .Select(x => x.SniffedVideoExtension)
+                .FirstOrDefault(x => x is not null);
+            yield return (
+                ImportableVideoNamer.Normalize(
+                    PathSanitizer.SanitizeComponent(Path.GetFileName(group.Key)),
+                    sniffedVideoExtension,
+                    mountName,
+                    allowBaseRename: rarGroups.Count == 1),
+                RarAggregator.ResolvePublishedFileSize(parts));
+        }
+
+        foreach (var lazy in processorResults.OfType<LazyRarProcessor.Result>())
+        {
+            yield return (
+                ImportableVideoNamer.Normalize(
+                    PathSanitizer.SanitizeComponent(Path.GetFileName(lazy.PathInArchive)),
+                    lazy.SniffedVideoExtension,
+                    mountName,
+                    allowBaseRename: true),
+                lazy.TotalFileSize);
+        }
+
+        foreach (var result in processorResults.OfType<SevenZipProcessor.Result>())
+        {
+            var sevenZipFiles = result.SevenZipFiles;
+            foreach (var sevenZipFile in sevenZipFiles)
+            {
+                var meta = sevenZipFile.DavMultipartFileMeta;
+                yield return (
+                    ImportableVideoNamer.Normalize(
+                        PathSanitizer.SanitizeComponent(Path.GetFileName(sevenZipFile.PathWithinArchive)),
+                        sevenZipFile.SniffedVideoExtension,
+                        mountName,
+                        allowBaseRename: sevenZipFiles.Count == 1),
+                    meta.AesParams?.DecodedSize
+                        ?? meta.FileParts.Sum(x => x.FilePartByteRange.Count));
+            }
+        }
+
+        foreach (var multipart in processorResults.OfType<MultipartMkvProcessor.Result>())
+        {
+            yield return (
+                PathSanitizer.SanitizeComponent(multipart.Filename),
+                multipart.Parts.Sum(x => x.FilePartByteRange.Count));
+        }
+    }
+}

--- a/backend/Queue/PostProcessors/BlocklistedFilePostProcessor.cs
+++ b/backend/Queue/PostProcessors/BlocklistedFilePostProcessor.cs
@@ -47,12 +47,15 @@ public class BlocklistedFilePostProcessor(ConfigManager configManager, DavDataba
 
         foreach (var file in addedFiles)
         {
-            if (FileFilterUtil.MatchesAnyGlob(file.Name, blocklistedFilenames))
-                yield return (file, "blacklisted filename");
-
-            else if (sampleFilterEnabled
-                     && FileFilterUtil.IsSampleFile(file.Name, file.FileSize, largestVideoFileSize, file.Path))
-                yield return (file, FileFilterUtil.LooksLikeSampleName(file.Name) ? "sample file" : "sample directory");
+            var reason = FileFilterUtil.GetRemovalReason(
+                file.Name,
+                file.FileSize,
+                file.Path,
+                largestVideoFileSize,
+                blocklistedFilenames,
+                sampleFilterEnabled);
+            if (reason is not null)
+                yield return (file, reason);
         }
     }
 

--- a/backend/Queue/PostProcessors/FinalMediaReadinessValidator.cs
+++ b/backend/Queue/PostProcessors/FinalMediaReadinessValidator.cs
@@ -1,10 +1,11 @@
-using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
-using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Queue.FileAggregators;
+using NzbWebDAV.Queue.FileProcessors;
 using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Queue.PostProcessors;
@@ -16,61 +17,106 @@ namespace NzbWebDAV.Queue.PostProcessors;
 /// nor consult or seed the process-wide playback-hole tracker.
 /// </summary>
 internal sealed class FinalMediaReadinessValidator(
-    DavDatabaseClient dbClient,
     INntpClient usenetClient,
     ConfigManager configManager)
 {
     private const int ProbeBytes = VideoSignatureUtil.First16KBLength;
 
-    public async Task ValidateAsync(CancellationToken ct)
+    /// <summary>A direct media output to probe: the mounted name and its NZB source.</summary>
+    internal sealed record ProbeTarget(string Name, NzbFile NzbFile, long FileSize);
+
+    /// <summary>
+    /// Plans the same direct media files the import will mount, minus the files output
+    /// filtering will remove (blocklist globs and the sample heuristic), so probes only
+    /// ever run for files that will actually be served.
+    /// </summary>
+    internal static IReadOnlyList<ProbeTarget> PlanTargets(
+        List<BaseProcessor.Result> processorResults,
+        string category,
+        string mountName,
+        ConfigManager configManager)
     {
-        var items = dbClient.Ctx.ChangeTracker.Entries<DavItem>()
-            .Where(entry => entry.State == EntityState.Added)
-            .Select(entry => entry.Entity)
-            .Where(item => item.SubType == DavItem.ItemSubType.NzbFile && FilenameUtil.IsMediaFile(item.Name))
-            .ToList();
+        var directFiles = FileAggregator.PlanDirectFiles(processorResults, mountName);
+        var largestVideoFileSize = PlannedImportOutputs.GetLargestVideoFileSize(processorResults, mountName);
+        var blocklistedFilenames = configManager.GetBlocklistedFiles();
+        var sampleFilterEnabled = configManager.IsSampleFilterEnabled();
 
-        foreach (var item in items)
+        var targets = new List<ProbeTarget>();
+        foreach (var file in directFiles)
         {
-            var payload = item.FileBlobId is { } blobId
-                ? dbClient.Ctx.BlobNzbFiles.FirstOrDefault(file => file.Id == blobId)
-                : null;
-            if (payload is null)
-                throw new NonRetryableDownloadException(
-                    $"Import readiness check could not load media payload for {item.Name}.");
+            if (!FilenameUtil.IsMediaFile(file.Name)) continue;
+            var davPath = PlannedDavPath(category, mountName, file);
+            if (FileFilterUtil.GetRemovalReason(
+                    file.Name,
+                    file.FileSize,
+                    davPath,
+                    largestVideoFileSize,
+                    blocklistedFilenames,
+                    sampleFilterEnabled) is not null)
+                continue;
 
+            targets.Add(new ProbeTarget(file.Name, file.NzbFile, file.FileSize));
+        }
+
+        return targets;
+    }
+
+    public async Task ValidateAsync(IReadOnlyList<ProbeTarget> targets, CancellationToken ct)
+    {
+        foreach (var target in targets)
+        {
             try
             {
                 await using var stream = usenetClient.GetFileStream(
-                    payload.SegmentIds,
-                    item.FileSize ?? 0,
+                    target.NzbFile,
+                    target.FileSize,
                     articleBufferSize: 0,
-                    payload.SegmentByteRanges,
                     usePipelinedBodyRequests: false,
-                    fileName: $"import-readiness {item.Name}",
-                    segmentFallbacks: payload.SegmentFallbackIds,
+                    fileName: $"import-readiness {target.Name}",
                     useContainerAwareFill: configManager.IsContainerAwareFillEnabled(),
                     streamingBodyBatchWidth: 1);
 
-                var head = await ReadExactlyAtAsync(stream, 0, Math.Min(ProbeBytes, item.FileSize ?? 0), ct)
+                var head = await ReadExactlyAtAsync(stream, 0, Math.Min(ProbeBytes, target.FileSize), ct)
                     .ConfigureAwait(false);
-                ValidateContainerSignature(item, head);
+                ValidateContainerSignature(target.Name, head);
 
-                var tailStart = Math.Max(0, (item.FileSize ?? 0) - ProbeBytes);
-                _ = await ReadExactlyAtAsync(stream, tailStart, (item.FileSize ?? 0) - tailStart, ct)
+                var tailStart = Math.Max(0, target.FileSize - ProbeBytes);
+                _ = await ReadExactlyAtAsync(stream, tailStart, target.FileSize - tailStart, ct)
                     .ConfigureAwait(false);
             }
             catch (Exception e) when (e.IsNonRetryableDownloadException())
             {
                 throw new NonRetryableDownloadException(
-                    $"Import readiness check found unreadable media bytes for {item.Name}.", e);
+                    $"Import readiness check found unreadable media bytes for {target.Name}.", e);
             }
             catch (Exception e) when (e is not OutOfMemoryException && !e.IsCancellationException(ct))
             {
                 throw new RetryableDownloadException(
-                    $"Import readiness check could not read media bytes for {item.Name}.", e);
+                    $"Import readiness check could not read media bytes for {target.Name}.", e);
             }
         }
+    }
+
+    private static string PlannedDavPath(
+        string category,
+        string mountName,
+        FileAggregator.PlannedDirectFile file)
+    {
+        // Mirrors the mounted path shape (/content/<category>/<job>/<dirs>/<name>) so
+        // FileFilterUtil.HasSampleDirectory sees the same release subfolders. That check
+        // skips the category and job segments, so the planned (pre-increment) mount name
+        // is sufficient here.
+        var directorySegments = file.RelativePath
+            .Split(
+                [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar, '/'],
+                StringSplitOptions.RemoveEmptyEntries)
+            .SkipLast(1)
+            .Select(segment => PathSanitizer.SanitizeComponent(segment));
+        return string.Join(
+            '/',
+            new[] { DavItem.ContentFolder.Path, category, mountName }
+                .Concat(directorySegments)
+                .Append(file.Name));
     }
 
     private static async Task<byte[]> ReadExactlyAtAsync(Stream stream, long position, long length, CancellationToken ct)
@@ -93,9 +139,9 @@ internal sealed class FinalMediaReadinessValidator(
         return buffer;
     }
 
-    private static void ValidateContainerSignature(DavItem item, byte[] head)
+    private static void ValidateContainerSignature(string name, byte[] head)
     {
-        var extension = Path.GetExtension(item.Name);
+        var extension = Path.GetExtension(name);
         var expected = extension.Equals(".mkv", StringComparison.OrdinalIgnoreCase)
             || extension.Equals(".webm", StringComparison.OrdinalIgnoreCase)
             || extension.Equals(".mp4", StringComparison.OrdinalIgnoreCase)
@@ -109,7 +155,7 @@ internal sealed class FinalMediaReadinessValidator(
         if (expected && VideoSignatureUtil.GuessVideoExtension(head) is null)
         {
             throw new NonRetryableDownloadException(
-                $"Import readiness check found an invalid media container header for {item.Name}.");
+                $"Import readiness check found an invalid media container header for {name}.");
         }
     }
 }

--- a/backend/Queue/PostProcessors/FinalMediaReadinessValidator.cs
+++ b/backend/Queue/PostProcessors/FinalMediaReadinessValidator.cs
@@ -11,8 +11,9 @@ namespace NzbWebDAV.Queue.PostProcessors;
 
 /// <summary>
 /// Reads the opening and closing bytes of direct media outputs before SAB reports
-/// completion. This intentionally runs only for categories that already opted into
-/// article-health checks: it is an additional BODY-level signal, not a global delay.
+/// completion. Probes run unbuffered and unpipelined — one segment at a time — and
+/// under a non-rooted label, so they neither hold playback-scale prefetch windows
+/// nor consult or seed the process-wide playback-hole tracker.
 /// </summary>
 internal sealed class FinalMediaReadinessValidator(
     DavDatabaseClient dbClient,
@@ -43,13 +44,13 @@ internal sealed class FinalMediaReadinessValidator(
                 await using var stream = usenetClient.GetFileStream(
                     payload.SegmentIds,
                     item.FileSize ?? 0,
-                    configManager.GetArticleBufferSize(),
+                    articleBufferSize: 0,
                     payload.SegmentByteRanges,
-                    configManager.IsPipelinedBodyRequestsEnabled(),
-                    item.Path,
-                    payload.SegmentFallbackIds,
+                    usePipelinedBodyRequests: false,
+                    fileName: $"import-readiness {item.Name}",
+                    segmentFallbacks: payload.SegmentFallbackIds,
                     useContainerAwareFill: configManager.IsContainerAwareFillEnabled(),
-                    streamingBodyBatchWidth: configManager.GetStreamingBodyBatchWidth());
+                    streamingBodyBatchWidth: 1);
 
                 var head = await ReadExactlyAtAsync(stream, 0, Math.Min(ProbeBytes, item.FileSize ?? 0), ct)
                     .ConfigureAwait(false);

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -496,6 +496,20 @@ public class QueueItemProcessor(
             queueItem.Id, nzbFiles.Count, msFirstSeg, msPar2, msRar, msProcessors, msHealth,
             ct.GetContext<QueueDownloadContext>()?.SemaphoreWaitMilliseconds ?? 0);
 
+        // BODY-level readiness runs before finalization so a slow or damaged probe can
+        // never hold the process-wide finalize lock. Targets are the same direct media
+        // files that output filtering will mount.
+        if (configManager.GetMediaReadinessCategories().Contains(queueItem.Category.ToLowerInvariant()))
+        {
+            await RunStageAsync(
+                "import-readiness",
+                () => new FinalMediaReadinessValidator(usenetClient, configManager)
+                    .ValidateAsync(
+                        FinalMediaReadinessValidator.PlanTargets(
+                            fileProcessingResults, queueItem.Category, queueItem.JobName, configManager),
+                        ct)).ConfigureAwait(false);
+        }
+
         // update the database
         await MarkQueueItemCompleted(startTime, error: null, async () =>
         {
@@ -514,17 +528,6 @@ public class QueueItemProcessor(
             // validate media files found
             if (configManager.IsEnsureImportableMediaEnabled())
                 new EnsureImportableMediaValidator(dbClient).ThrowIfValidationFails();
-
-            // BODY readiness runs for the explicit health-check categories and, when
-            // ensure-importable-video is on, for the common media categories — so a
-            // short-decoded or unseekable file fails into history before Arr/rclone.
-            if (configManager.GetMediaReadinessCategories().Contains(queueItem.Category.ToLowerInvariant()))
-            {
-                await RunStageAsync(
-                    "import-readiness",
-                    () => new FinalMediaReadinessValidator(dbClient, usenetClient, configManager)
-                        .ValidateAsync(ct)).ConfigureAwait(false);
-            }
 
             // create strm files, if necessary
             if (configManager.GetImportStrategy() == "strm")

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -381,6 +381,10 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
             if (ShouldStopPrefetch(segmentsEnqueued, enqueuedBytes))
                 break;
 
+            // Fail-fast must win before the batch goes on the wire: once BODY commands
+            // are issued, every response needs an owner that drains or disposes it.
+            ThrowIfPlaybackFailFast();
+
             await WaitForPrefetchCeilingAsync(cancellationToken).ConfigureAwait(false);
 
             // Adaptive width: narrower batches → more outstanding connections at the
@@ -535,8 +539,27 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         var batch = await _usenetClient.DecodedBodiesAsync(
             liveIds, onConnectionReadyAgain: null, cancellationToken).ConfigureAwait(false);
         if (batch.Responses.Count != liveIds.Length)
+        {
+            // The client broke the batch contract after the commands went on the wire.
+            // Drain whatever arrived so the shared batch connection can complete.
+            foreach (var responseTask in batch.Responses)
+            {
+                try
+                {
+                    var response = await responseTask.ConfigureAwait(false);
+                    if (response.Stream is not null)
+                        await response.Stream.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception e) when (e is not OutOfMemoryException)
+                {
+                    Log.Debug(e, "Failed to drain BODY response after batch size mismatch for {FileName}.", _fileName);
+                }
+            }
+
             throw new InvalidOperationException(
                 $"Pipelined BODY returned {batch.Responses.Count} responses for {liveIds.Length} requests.");
+        }
+
         return batch.Responses.ToArray();
     }
 
@@ -826,8 +849,32 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         var lease = initialLease;
         try
         {
-            ThrowIfPlaybackFailFast();
+            // The producer issued this batch before the task ran, so the response must
+            // always be owned here. A fail-fast check before the await would strand an
+            // already-on-the-wire body, and UsenetSharp's pump cannot release the shared
+            // batch connection until every handed-out stream is consumed or disposed.
             var response = await responseTask.ConfigureAwait(false);
+            if (PlaybackHoleTracker.ShouldFailFast(_fileName, out var failFast))
+            {
+                if (response.Stream is not null)
+                {
+                    try
+                    {
+                        await response.Stream.DisposeAsync().ConfigureAwait(false);
+                    }
+                    catch (Exception disposeError) when (disposeError is not OutOfMemoryException)
+                    {
+                        Log.Debug(
+                            disposeError,
+                            "Failed to dispose pipelined BODY stream after playback fail-fast for {FileName}.",
+                            _fileName);
+                    }
+                }
+
+                ExceptionDispatchInfo.Capture(
+                    failFast ?? new UsenetArticleNotFoundException(segmentId)).Throw();
+            }
+
             await ThrowOnSegmentIdMismatchAsync(segmentId, response).ConfigureAwait(false);
 #pragma warning disable CA2000 // stream ownership transfers to the returned SegmentDownloadResult
             var drained = await DrainSegmentAsync(

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -847,6 +847,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     {
         var estimate = GetPlannedSegmentBytes(segmentIndex);
         var lease = initialLease;
+        Exception? playbackFailFast = null;
         try
         {
             // The producer issued this batch before the task ran, so the response must
@@ -871,8 +872,8 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                     }
                 }
 
-                ExceptionDispatchInfo.Capture(
-                    failFast ?? new UsenetArticleNotFoundException(segmentId)).Throw();
+                playbackFailFast = failFast ?? new UsenetArticleNotFoundException(segmentId);
+                ExceptionDispatchInfo.Capture(playbackFailFast).Throw();
             }
 
             await ThrowOnSegmentIdMismatchAsync(segmentId, response).ConfigureAwait(false);
@@ -883,6 +884,13 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 .ConfigureAwait(false);
             lease = null; // owned by BudgetedStream / buffer
             return ToDownloadResult(drained, estimate, segmentId);
+        }
+        catch (Exception) when (playbackFailFast is not null)
+        {
+            // A tracker-provided fail-fast bypasses the miss/corruption recovery below:
+            // those handlers can issue fallback or rescue requests on a path already
+            // declared dead, and a successful fallback would defeat the fail-fast.
+            throw;
         }
         catch (UsenetArticleNotFoundException e)
         {

--- a/backend/Utils/FileFilterUtil.cs
+++ b/backend/Utils/FileFilterUtil.cs
@@ -89,6 +89,29 @@ public static partial class FileFilterUtil
     }
 
     /// <summary>
+    /// The queue's removal decision for one output file: configured filename globs
+    /// first, then the sample heuristic against the largest video in the same release.
+    /// Shared by the blocklist post-processor (on persisted items) and import-readiness
+    /// target planning (on planned outputs) so both filter identically.
+    /// </summary>
+    public static string? GetRemovalReason(
+        string fileName,
+        long? fileSize,
+        string? davPath,
+        long largestVideoFileSize,
+        IReadOnlyCollection<string> blocklistedFilenames,
+        bool sampleFilterEnabled)
+    {
+        if (MatchesAnyGlob(fileName, blocklistedFilenames))
+            return "blacklisted filename";
+
+        if (sampleFilterEnabled && IsSampleFile(fileName, fileSize, largestVideoFileSize, davPath))
+            return LooksLikeSampleName(fileName) ? "sample file" : "sample directory";
+
+        return null;
+    }
+
+    /// <summary>
     /// True when the filename matches any of the given globs (`*` and `?`).
     /// Matching is case-insensitive and applied to the filename only.
     /// </summary>

--- a/tests/NzbWebDAV.Tests/Queue/FinalMediaReadinessValidatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/FinalMediaReadinessValidatorTests.cs
@@ -1,0 +1,603 @@
+using System.Collections.Concurrent;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Models;
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Queue.FileProcessors;
+using NzbWebDAV.Queue.PostProcessors;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Metrics;
+using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Tests.Streams;
+using NzbWebDAV.Websocket;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Queue;
+
+[Collection(nameof(PlaybackHoleTrackerCollection))]
+public sealed class FinalMediaReadinessValidatorTests : IDisposable
+{
+    private static readonly byte[] EbmlMagic = [0x1A, 0x45, 0xDF, 0xA3];
+
+    public FinalMediaReadinessValidatorTests() => PlaybackHoleTracker.ResetForTests();
+    public void Dispose() => PlaybackHoleTracker.ResetForTests();
+
+    [Fact]
+    public async Task ValidateAsync_ProbesHeadAndTailWithBoundedUnpipelinedStream()
+    {
+        var nzbFile = TwoSegmentFile("head@test", "tail@test", out var headBytes, out var tailBytes);
+        var client = new ProbeRecordingClient();
+        client.Serve("head@test", headBytes);
+        client.Serve("tail@test", tailBytes);
+
+        // A tripped playback-hole state for the mounted path must not affect the probe:
+        // validation has to read the real provider bytes.
+        var davPath = "/content/movies/Job/Movie.mkv";
+        for (var i = 0; i < GapFillLimits.MaxConsecutiveZeroFills; i++)
+            PlaybackHoleTracker.RecordHole(davPath, $"other-{i}@test", new UsenetArticleNotFoundException($"other-{i}@test"));
+
+        await new FinalMediaReadinessValidator(client, new ConfigManager())
+            .ValidateAsync([new FinalMediaReadinessValidator.ProbeTarget("Movie.mkv", nzbFile, 40_000)],
+                CancellationToken.None);
+
+        Assert.Equal(1, client.GetFileStreamCalls);
+        Assert.Equal(0, client.ArticleBufferSize);
+        Assert.Equal(false, client.UsePipelinedBodyRequests);
+        Assert.Equal(1, client.StreamingBodyBatchWidth);
+        Assert.Equal("import-readiness Movie.mkv", client.ProbeFileName);
+        Assert.False(client.ProbeFileName!.StartsWith('/'));
+        Assert.Equal(2, client.BodyRequestCount);
+        Assert.Equal(0, client.BatchRequestCount);
+        Assert.True(PlaybackHoleTracker.ShouldFailFast(davPath, out _));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_MissingHeadSegment_IsNonRetryable_AndDoesNotPoisonPlaybackTracker()
+    {
+        var nzbFile = TwoSegmentFile("gone-head@test", "gone-tail@test", out _, out _);
+        var client = new ProbeRecordingClient();
+        var davPath = "/content/movies/Job/Movie.mkv";
+
+        var exception = await Assert.ThrowsAsync<NonRetryableDownloadException>(() =>
+            new FinalMediaReadinessValidator(client, new ConfigManager())
+                .ValidateAsync([new FinalMediaReadinessValidator.ProbeTarget("Movie.mkv", nzbFile, 40_000)],
+                    CancellationToken.None));
+
+        Assert.Contains("Movie.mkv", exception.Message);
+        Assert.IsType<UsenetArticleNotFoundException>(exception.InnerException);
+        Assert.False(PlaybackHoleTracker.ShouldFailFast(davPath, out _));
+        Assert.False(PlaybackHoleTracker.IsKnownMissingSegment(davPath, "gone-head@test"));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_InvalidContainerSignature_IsNonRetryable()
+    {
+        var nzbFile = TwoSegmentFile("bad-head@test", "bad-tail@test", out _, out var tailBytes);
+        var client = new ProbeRecordingClient();
+        client.Serve("bad-head@test", new byte[20_000]);
+        client.Serve("bad-tail@test", tailBytes);
+
+        var exception = await Assert.ThrowsAsync<NonRetryableDownloadException>(() =>
+            new FinalMediaReadinessValidator(client, new ConfigManager())
+                .ValidateAsync([new FinalMediaReadinessValidator.ProbeTarget("Movie.mkv", nzbFile, 40_000)],
+                    CancellationToken.None));
+
+        Assert.Contains("unreadable media bytes", exception.Message);
+        Assert.IsType<NonRetryableDownloadException>(exception.InnerException);
+        Assert.Contains("invalid media container header", exception.InnerException.Message);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_Cancellation_StaysCancellation()
+    {
+        var nzbFile = TwoSegmentFile("cancel-head@test", "cancel-tail@test", out var headBytes, out _);
+        var client = new ProbeRecordingClient();
+        client.Serve("cancel-head@test", headBytes);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            new FinalMediaReadinessValidator(client, new ConfigManager())
+                .ValidateAsync([new FinalMediaReadinessValidator.ProbeTarget("Movie.mkv", nzbFile, 40_000)],
+                    cts.Token));
+    }
+
+    [Fact]
+    public void PlanTargets_MountsOnlyMediaThatSurvivesOutputFiltering()
+    {
+        var results = new List<BaseProcessor.Result>
+        {
+            DirectFile("Movie.mkv", 2_000_000_000),
+            DirectFile("Movie.unpack.mkv", 1_500_000_000),
+            DirectFile("Movie.sample.mkv", 50_000_000),
+            DirectFile("notes.txt", 2_000),
+            DirectFile("", 1_000_000_000, sniffed: ".mkv"),
+        };
+
+        var targets = FinalMediaReadinessValidator.PlanTargets(results, "movies", "Job", new ConfigManager());
+
+        Assert.Equal(
+            ["Job.mkv", "Movie.mkv"],
+            targets.Select(x => x.Name).OrderBy(x => x).ToArray());
+    }
+
+    [Fact]
+    public void PlanTargets_SampleHeuristicUsesLargestVideoAcrossArchiveOutputs()
+    {
+        var sample = DirectFile("tiny.sample.mkv", 50_000_000);
+        var archivedMovie = new RarProcessor.Result
+        {
+            StoredFileSegments =
+            [
+                new RarProcessor.StoredFileSegment
+                {
+                    NzbFile = new NzbFile
+                    {
+                        Subject = "\"archive.rar\" yEnc",
+                        Segments = { new NzbSegment { MessageId = "rar-seg@test", Bytes = 1000 } },
+                    },
+                    PartSize = 1000,
+                    ArchiveName = "archive.rar",
+                    PartNumber = new RarProcessor.PartNumber { PartNumberFromHeader = 0 },
+                    ReleaseDate = DateTimeOffset.UnixEpoch,
+                    PathWithinArchive = "Archived.Movie.mkv",
+                    ByteRangeWithinPart = new LongRange(0, 1000),
+                    AesParams = null,
+                    FileUncompressedSize = 5_000_000_000,
+                },
+            ],
+        };
+
+        var withArchive = FinalMediaReadinessValidator.PlanTargets(
+            [sample, archivedMovie], "movies", "Job", new ConfigManager());
+        var withoutArchive = FinalMediaReadinessValidator.PlanTargets(
+            [sample], "movies", "Job", new ConfigManager());
+
+        Assert.Empty(withArchive);
+        Assert.Single(withoutArchive);
+    }
+
+    private static FileProcessor.Result DirectFile(
+        string fileName,
+        long fileSize,
+        string? sniffed = null)
+    {
+        return new FileProcessor.Result
+        {
+            NzbFile = new NzbFile
+            {
+                Subject = $"\"{(string.IsNullOrEmpty(fileName) ? "obfuscated" : fileName)}\" yEnc",
+                Segments = { new NzbSegment { MessageId = $"seg-{Guid.NewGuid():N}@test", Bytes = fileSize } },
+            },
+            FileName = fileName,
+            FileSize = fileSize,
+            ReleaseDate = DateTimeOffset.UnixEpoch,
+            SniffedVideoExtension = sniffed,
+        };
+    }
+
+    private static NzbFile TwoSegmentFile(
+        string headId,
+        string tailId,
+        out byte[] headBytes,
+        out byte[] tailBytes)
+    {
+        headBytes = new byte[20_000];
+        EbmlMagic.CopyTo(headBytes, 0);
+        tailBytes = new byte[20_000];
+        return new NzbFile
+        {
+            Subject = "\"Movie.mkv\" yEnc (1/2)",
+            Segments =
+            {
+                new NzbSegment
+                {
+                    MessageId = headId,
+                    Bytes = 20_000,
+                    ByteRange = new LongRange(0, 20_000),
+                },
+                new NzbSegment
+                {
+                    MessageId = tailId,
+                    Bytes = 20_000,
+                    ByteRange = new LongRange(20_000, 40_000),
+                },
+            },
+        };
+    }
+
+    private sealed class ProbeRecordingClient : NntpClient
+    {
+        private readonly Dictionary<string, byte[]> _segments = new(StringComparer.Ordinal);
+
+        public int GetFileStreamCalls { get; private set; }
+        public int ArticleBufferSize { get; private set; } = -1;
+        public bool? UsePipelinedBodyRequests { get; private set; }
+        public string? ProbeFileName { get; private set; }
+        public int? StreamingBodyBatchWidth { get; private set; }
+        public int BodyRequestCount { get; private set; }
+        public int BatchRequestCount { get; private set; }
+
+        public void Serve(string segmentId, byte[] bytes) => _segments[segmentId] = bytes;
+
+        public override NzbFileStream GetFileStream(
+            NzbFile nzbFile,
+            long fileSize,
+            int articleBufferSize,
+            bool usePipelinedBodyRequests = true,
+            string? fileName = null,
+            InFlightArticleBudget? inFlightArticleBudget = null,
+            bool useContainerAwareFill = false,
+            int streamingBodyBatchWidth = 4,
+            HashSet<string>? knownCorruptSegmentIds = null,
+            IReadOnlySet<int>? knownMissingSegmentIndices = null)
+        {
+            GetFileStreamCalls++;
+            ArticleBufferSize = articleBufferSize;
+            UsePipelinedBodyRequests = usePipelinedBodyRequests;
+            ProbeFileName = fileName;
+            StreamingBodyBatchWidth = streamingBodyBatchWidth;
+            return base.GetFileStream(
+                nzbFile,
+                fileSize,
+                articleBufferSize,
+                usePipelinedBodyRequests,
+                fileName,
+                inFlightArticleBudget,
+                useContainerAwareFill,
+                streamingBodyBatchWidth,
+                knownCorruptSegmentIds,
+                knownMissingSegmentIndices);
+        }
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, null, cancellationToken);
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            BodyRequestCount++;
+            var key = segmentId.ToString();
+            if (!_segments.TryGetValue(key, out var bytes))
+            {
+                return Task.FromException<UsenetDecodedBodyResponse>(
+                    new UsenetArticleNotFoundException(key, "430 No such article"));
+            }
+
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedBodyResponse
+            {
+                SegmentId = key,
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                ResponseMessage = "222 body",
+                Stream = new CachedYencStream(
+                    new UsenetYencHeader
+                    {
+                        FileName = "probe.bin",
+                        FileSize = 40_000,
+                        LineLength = 128,
+                        PartNumber = 1,
+                        TotalParts = 2,
+                        PartOffset = 0,
+                        PartSize = bytes.Length,
+                    },
+                    new MemoryStream(bytes, writable: false)),
+            });
+        }
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            BatchRequestCount++;
+            var responses = segmentIds
+                .Select(id => DecodedBodyAsync(id, cancellationToken))
+                .ToArray();
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
+        }
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+}
+
+/// <summary>
+/// Processor-level proof that the readiness probe runs before finalization: while a
+/// probe is blocked on the provider, the process-wide finalize lock stays available
+/// for an unrelated worker.
+/// </summary>
+[Collection(nameof(ConfigPathCollection))]
+public sealed class ImportReadinessFinalizeLockTests : IAsyncLifetime
+{
+    private const string SegmentIdText = "readiness-segment@test";
+    private readonly string _configRoot =
+        Path.Join(Path.GetTempPath(), $"nzbdav-readiness-lock-{Guid.NewGuid():N}");
+    private string? _previousConfigPath;
+    private DavDatabaseContext _context = null!;
+    private DavDatabaseClient _dbClient = null!;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={Path.Join(_configRoot, "db.sqlite")}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.MigrateAsync();
+        _dbClient = new DavDatabaseClient(_context);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        try
+        {
+            if (Directory.Exists(_configRoot))
+                Directory.Delete(_configRoot, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+    }
+
+    [Fact]
+    public async Task ImportReadiness_DoesNotHoldFinalizeLock()
+    {
+        var payload = new byte[20_000];
+        new byte[] { 0x1A, 0x45, 0xDF, 0xA3 }.CopyTo(payload, 0);
+        using var client = new GatedProbeClient(payload);
+        var queueItem = await SeedQueueItemAsync();
+
+        using var finalizeLock = new SemaphoreSlim(1, 1);
+        var readinessReported = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var processor = new QueueItemProcessor(
+            queueItem,
+            CreateNzbStream(),
+            _dbClient,
+            client,
+            new ConfigManager(),
+            new WebsocketManager(),
+            new ProviderUsageTracker(),
+            new WatchdogLog(),
+            new QueueItemSourceTracker(),
+            new Progress<int>(),
+            new ConcurrentDictionary<Guid, int>(),
+            finalizeLock,
+            CancellationToken.None,
+            stageReporter: stage =>
+            {
+                if (stage == "import-readiness") readinessReported.TrySetResult();
+            });
+
+        var run = Task.Run(() => processor.ProcessAsync());
+        try
+        {
+            // Wait until the probe is blocked inside its BODY fetch. The stage is
+            // reported before the validator runs, so both markers are now behind us.
+            await readinessReported.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await client.ProbeBodyBlocked.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            // Pre-fix, the probe ran inside MarkQueueItemCompleted and held this lock
+            // for the whole NNTP read, starving every other worker's completion.
+            Assert.True(
+                await finalizeLock.WaitAsync(TimeSpan.Zero),
+                "Finalize lock was held while the import-readiness probe was blocked on Usenet.");
+            finalizeLock.Release();
+        }
+        finally
+        {
+            client.ReleaseProbe();
+        }
+
+        await run.WaitAsync(TimeSpan.FromSeconds(30));
+
+        _context.ChangeTracker.Clear();
+        Assert.Empty(await _context.QueueItems.AsNoTracking().ToListAsync());
+        var historyItem = Assert.Single(await _context.HistoryItems.AsNoTracking().ToListAsync());
+        Assert.True(
+            historyItem.DownloadStatus == HistoryItem.DownloadStatusOption.Completed,
+            $"Expected Completed; got {historyItem.DownloadStatus}: {historyItem.FailMessage}");
+    }
+
+    private async Task<QueueItem> SeedQueueItemAsync()
+    {
+        var nzbBytes = Encoding.UTF8.GetBytes(NzbXml);
+        var queueItem = new QueueItem
+        {
+            Id = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            FileName = "Movie.nzb",
+            JobName = "Movie.Release",
+            NzbFileSize = nzbBytes.Length,
+            TotalSegmentBytes = 20_000,
+            Category = "movies",
+            Priority = QueueItem.PriorityOption.Normal,
+            PostProcessing = QueueItem.PostProcessingOption.None,
+        };
+        _context.QueueItems.Add(queueItem);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+        return await _context.QueueItems.SingleAsync(x => x.Id == queueItem.Id);
+    }
+
+    private static MemoryStream CreateNzbStream() => new(Encoding.UTF8.GetBytes(NzbXml));
+
+    private const string NzbXml =
+        $"""
+        <?xml version="1.0" encoding="utf-8"?>
+        <nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
+          <file subject="&quot;Movie.mkv&quot; yEnc (1/1)">
+            <groups><group>alt.binaries.test</group></groups>
+            <segments>
+              <segment bytes="20000" number="1">{SegmentIdText}</segment>
+            </segments>
+          </file>
+        </nzb>
+        """;
+
+    /// <summary>
+    /// Serves the single-segment video normally for import stages, but holds the first
+    /// BODY response — which only the import-readiness probe issues — on a gate.
+    /// </summary>
+    private sealed class GatedProbeClient(byte[] payload) : NntpClient
+    {
+        private readonly TaskCompletionSource _probeGate =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ProbeBodyBlocked { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void ReleaseProbe() => _probeGate.TrySetResult();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedArticleAsync(segmentId, null, cancellationToken);
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedArticleResponse
+            {
+                SegmentId = segmentId.ToString(),
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedHeadAndBodyFollow,
+                ResponseMessage = "220 article",
+                Stream = CreatePayloadStream(),
+                ArticleHeaders = new UsenetArticleHeader
+                {
+                    Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["Date"] = DateTimeOffset.UtcNow.ToString("R"),
+                    },
+                },
+            });
+        }
+
+        public override Task<long> GetFileSizeAsync(NzbFile file, CancellationToken ct) =>
+            Task.FromResult((long)payload.Length);
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, null, cancellationToken);
+
+        public override async Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ProbeBodyBlocked.TrySetResult();
+            await _probeGate.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return new UsenetDecodedBodyResponse
+            {
+                SegmentId = segmentId.ToString(),
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                ResponseMessage = "222 body",
+                Stream = CreatePayloadStream(),
+            };
+        }
+
+        private CachedYencStream CreatePayloadStream() =>
+            new(
+                new UsenetYencHeader
+                {
+                    FileName = "Movie.mkv",
+                    FileSize = payload.Length,
+                    LineLength = 128,
+                    PartNumber = 1,
+                    TotalParts = 1,
+                    PartOffset = 0,
+                    PartSize = payload.Length,
+                },
+                new MemoryStream(payload, writable: false));
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Streams/KnownMissingFastPathTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/KnownMissingFastPathTests.cs
@@ -282,6 +282,7 @@ public class KnownMissingFastPathTests
                 usePipelinedBodyRequests: true,
                 CancellationToken.None,
                 fileName: path,
+                segmentFallbacks: ids.Select(id => new[] { $"fallback-{id}" }).ToArray(),
                 exactSegmentSizes: new long[] { 5, 5, 5, 5 });
 
             await Assert.ThrowsAsync<UsenetArticleNotFoundException>(
@@ -294,6 +295,10 @@ public class KnownMissingFastPathTests
             Assert.Equal(ids.Length, client.IssuedStreamCount);
             Assert.Equal(ids.Length, client.DisposedStreamCount);
             Assert.Equal(1, client.CompletionCallbackCount);
+
+            // A tracker-provided fail-fast must not trigger fallback or rescue fetches
+            // on a path already declared dead — the singular path stays untouched.
+            Assert.Equal(0, client.SingularBodyRequestCount);
 
             var followUp = await client.DecodedBodyAsync("follow-up@test", null, CancellationToken.None);
             Assert.NotNull(followUp.Stream);
@@ -336,6 +341,7 @@ public class KnownMissingFastPathTests
 
         public int BatchRequestCount { get; private set; }
         public int CompletionCallbackCount { get; private set; }
+        public int SingularBodyRequestCount { get; private set; }
         public int IssuedStreamCount => _streams.Count;
         public int DisposedStreamCount => _disposedStreams;
 
@@ -388,6 +394,7 @@ public class KnownMissingFastPathTests
             ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
+            SingularBodyRequestCount++;
             if (Volatile.Read(ref _batchOutstanding) != 0)
             {
                 return Task.FromException<UsenetDecodedBodyResponse>(
@@ -422,7 +429,7 @@ public class KnownMissingFastPathTests
 
         public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
             SegmentId segmentId, CancellationToken cancellationToken) =>
-            throw new NotSupportedException();
+            DecodedBodyAsync(segmentId, null, cancellationToken);
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
             SegmentId segmentId, CancellationToken cancellationToken) =>

--- a/tests/NzbWebDAV.Tests/Streams/KnownMissingFastPathTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/KnownMissingFastPathTests.cs
@@ -1,9 +1,12 @@
 using System.Text;
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Streams;
 using NzbWebDAV.Tests.Fakes;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Tests.Streams;
 
@@ -226,6 +229,82 @@ public class KnownMissingFastPathTests
         }
     }
 
+    [Fact]
+    public async Task PipelinedStream_AlreadyFailFast_IssuesNoBodyRequests()
+    {
+        PlaybackHoleTracker.ResetForTests();
+        var path = $"/view/fail-fast-{Guid.NewGuid():N}.mkv";
+        var ids = new[] { "miss-a@test", "miss-b@test", "miss-c@test", "miss-d@test" };
+        try
+        {
+            foreach (var id in ids.Take(GapFillLimits.MaxConsecutiveZeroFills))
+                PlaybackHoleTracker.RecordHole(path, id, new UsenetArticleNotFoundException(id));
+
+            var client = new FakeNntpClient(ids.ToDictionary(id => id, _ => new byte[5]));
+            await using var stream = MultiSegmentStream.Create(
+                ids.AsMemory(),
+                client,
+                articleBufferSize: 4,
+                estimatedSegmentSize: 5,
+                failFastOnFirstSegment: false,
+                usePipelinedBodyRequests: true,
+                CancellationToken.None,
+                fileName: path,
+                exactSegmentSizes: new long[] { 5, 5, 5, 5 });
+
+            await Assert.ThrowsAsync<UsenetArticleNotFoundException>(
+                async () => await stream.CopyToAsync(Stream.Null));
+
+            Assert.Equal(0, client.BatchRequestCount);
+            Assert.Equal(0, client.BodyRequestCount);
+        }
+        finally
+        {
+            PlaybackHoleTracker.ResetForTests();
+        }
+    }
+
+    [Fact]
+    public async Task PipelinedFailFastAfterBatchIssue_OwnsEveryIssuedResponse()
+    {
+        PlaybackHoleTracker.ResetForTests();
+        var path = $"/view/fail-fast-{Guid.NewGuid():N}.mkv";
+        var ids = new[] { "seg-a@test", "seg-b@test", "seg-c@test", "seg-d@test" };
+        try
+        {
+            var client = new TrackerTrippingBatchClient(path);
+            var stream = MultiSegmentStream.Create(
+                ids.AsMemory(),
+                client,
+                articleBufferSize: 4,
+                estimatedSegmentSize: 5,
+                failFastOnFirstSegment: false,
+                usePipelinedBodyRequests: true,
+                CancellationToken.None,
+                fileName: path,
+                exactSegmentSizes: new long[] { 5, 5, 5, 5 });
+
+            await Assert.ThrowsAsync<UsenetArticleNotFoundException>(
+                async () => await stream.CopyToAsync(Stream.Null));
+            await stream.DisposeAsync();
+
+            // Every response the batch put on the wire must be consumed or disposed,
+            // or UsenetSharp's pump stays blocked behind the unread body and the batch
+            // completion callback (which returns the pooled connection) never fires.
+            Assert.Equal(ids.Length, client.IssuedStreamCount);
+            Assert.Equal(ids.Length, client.DisposedStreamCount);
+            Assert.Equal(1, client.CompletionCallbackCount);
+
+            var followUp = await client.DecodedBodyAsync("follow-up@test", null, CancellationToken.None);
+            Assert.NotNull(followUp.Stream);
+            await followUp.Stream.DisposeAsync();
+        }
+        finally
+        {
+            PlaybackHoleTracker.ResetForTests();
+        }
+    }
+
     private static Stream CreateGapFillStream(
         string[] ids,
         INntpClient client,
@@ -242,4 +321,134 @@ public class KnownMissingFastPathTests
             CancellationToken.None,
             fileName: path,
             exactSegmentSizes: sizes);
+
+    /// <summary>
+    /// Models the batch backpressure contract: the completion callback fires only once
+    /// every handed-out body stream is disposed, and the single pooled connection cannot
+    /// serve a follow-up request until then. The tracker is tripped after the batch is
+    /// on the wire but before the segment tasks accept their responses.
+    /// </summary>
+    private sealed class TrackerTrippingBatchClient(string path) : NntpClient
+    {
+        private readonly List<TrackingYencStream> _streams = [];
+        private int _disposedStreams;
+        private int _batchOutstanding;
+
+        public int BatchRequestCount { get; private set; }
+        public int CompletionCallbackCount { get; private set; }
+        public int IssuedStreamCount => _streams.Count;
+        public int DisposedStreamCount => _disposedStreams;
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            BatchRequestCount++;
+            Interlocked.Exchange(ref _batchOutstanding, 1);
+
+            var responses = new List<Task<UsenetDecodedBodyResponse>>();
+            foreach (var segmentId in segmentIds)
+            {
+                var stream = new TrackingYencStream(OnStreamDisposed);
+                _streams.Add(stream);
+                responses.Add(Task.FromResult(new UsenetDecodedBodyResponse
+                {
+                    SegmentId = segmentId.ToString(),
+                    ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                    ResponseMessage = $"222 <{segmentId}>",
+                    Stream = stream,
+                }));
+            }
+
+            void CompleteBatch()
+            {
+                if (Interlocked.Exchange(ref _batchOutstanding, 0) != 1) return;
+                CompletionCallbackCount++;
+                onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            }
+
+            cancellationToken.Register(static state => ((Action)state!)(), (Action)CompleteBatch);
+
+            foreach (var segmentId in segmentIds.Take(GapFillLimits.MaxConsecutiveZeroFills))
+                PlaybackHoleTracker.RecordHole(
+                    path, segmentId.ToString(), new UsenetArticleNotFoundException(segmentId.ToString()));
+
+            return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
+
+            void OnStreamDisposed()
+            {
+                if (Interlocked.Increment(ref _disposedStreams) == _streams.Count)
+                    CompleteBatch();
+            }
+        }
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            if (Volatile.Read(ref _batchOutstanding) != 0)
+            {
+                return Task.FromException<UsenetDecodedBodyResponse>(
+                    new InvalidOperationException("The pooled connection is still held by the abandoned batch."));
+            }
+
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedBodyResponse
+            {
+                SegmentId = segmentId.ToString(),
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                ResponseMessage = $"222 <{segmentId}>",
+                Stream = new YencStream(new MemoryStream([1, 2, 3, 4, 5], writable: false)),
+            });
+        }
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+
+        private sealed class TrackingYencStream(Action onDisposed)
+            : YencStream(new MemoryStream([1, 2, 3, 4, 5], writable: false))
+        {
+            protected override void Dispose(bool disposing)
+            {
+                onDisposed();
+                base.Dispose(disposing);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the v1.2.5 regression where playback through Plex/rclone stopped entirely and new imports sat at 0% until the stuck-item watchdog cancelled them, two reporters confirmed.

- **Pipelined BODY responses are now always owned after issue.** The producer issues a batch before its segment tasks run; a task that hit the new cross-range playback fail-fast check (#1158) before awaiting its response stranded an on-the-wire body, so UsenetSharp's pump stayed blocked and the batch completion callback never returned the pooled connection. Repeated range retries (rclone/Plex probing a damaged release, as captured in a reporter's support pack with the pool pinned at 16/16 active and queue fetches starved) could exhaust the provider pool until restart. Segment tasks now always await and own their issued response, disposing it before propagating fail-fast; the producer checks fail-fast before a batch goes on the wire, so a tripped path sends no requests at all; and a client that violates the batch response-count contract is drained before the error surfaces.
- **Import-readiness probes are bounded.** The v1.2.5 head/tail probe opened files with full streaming defaults (buffer 40 x batch width 4, pipelined, no read budget) to read 32 KB. Probes now run unbuffered and unpipelined under a non-rooted label, so they cannot pin the article budget and never consult or seed the process-wide playback-hole tracker.
- **Readiness no longer runs inside the finalize lock.** It runs as a pre-finalize stage on exactly the files that will be mounted (sharing FileAggregator's name projection and the blocklist/sample removal decision), so a slow or damaged probe cannot block every other worker's completion.

No database migration.

Thanks to the reporters — the support pack (`queue` stage data, pool gauges) is what pinned this down. On v1.2.5, rolling back to v1.2.4 remains the reliable workaround until this ships; a restart only clears the current stall.

## Test plan

- [x] New deterministic regression tests fail pre-fix and pass post-fix:
  - `PipelinedFailFastAfterBatchIssue_OwnsEveryIssuedResponse` (response ownership, exactly-once batch completion, follow-up fetch on the returned connection)
  - `PipelinedStream_AlreadyFailFast_IssuesNoBodyRequests`
  - `FinalMediaReadinessValidatorTests` (bounded unpipelined probe, error classification, tracker isolation, output-filter parity incl. cross-archive sample sizing)
  - `ImportReadinessFinalizeLockTests.ImportReadiness_DoesNotHoldFinalizeLock` (lock free while a probe is blocked on the provider)
- [x] Existing `Streams` (366) and `Queue`/filter/aggregator (412) test suites pass locally
- [ ] PR CI (frontend + backend gate)

🤖 Generated with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media import validation for missing segments, invalid files, and playback issues.
  * Blocklisted and sample files are now consistently excluded during imports.
  * Improved handling of interrupted downloads and failed streaming requests.
  * Prevented unnecessary provider requests when playback has already failed.
  * Ensured failed streaming responses are properly cleaned up for reliable connection reuse.

* **Performance**
  * Import readiness checks now run without holding up finalization, improving queue responsiveness.
  * More efficient import planning maintains consistent filenames, sizes, and metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->