### PR TITLE
feat(health): re-run health checks across the whole library from Settings → Maintenance

### DIFF
--- a/backend/Api/Controllers/GetHealthCheckQueue/GetHealthCheckQueueController.cs
+++ b/backend/Api/Controllers/GetHealthCheckQueue/GetHealthCheckQueueController.cs
@@ -29,10 +29,11 @@ public class GetHealthCheckQueueController(DavDatabaseClient dbClient) : BaseApi
 
         // Match HealthCheckService.ExecuteAsync: only media/archive candidates are ever
         // processed, so non-media files (nfo/srt/jpg/…) must not inflate this count or
-        // the Health UI "initial scan pending" banner never clears.
+        // the Health UI "initial scan pending" banner never clears. Operator-forced rechecks
+        // (ForcedRecheckSentinel) count as pending alongside never-checked files.
         var uncheckedCount = 0;
         await foreach (var name in HealthCheckService.GetHealthCheckQueueItemsQuery(dbClient)
-            .Where(x => x.NextHealthCheck == null)
+            .Where(x => x.NextHealthCheck == null || x.NextHealthCheck == HealthCheckService.ForcedRecheckSentinel)
             .Select(x => x.Name)
             .AsAsyncEnumerable()
             .ConfigureAwait(false))

--- a/backend/Api/Controllers/ResetHealthCheckQueue/ResetHealthCheckQueueController.cs
+++ b/backend/Api/Controllers/ResetHealthCheckQueue/ResetHealthCheckQueueController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services;
 
 namespace NzbWebDAV.Api.Controllers.ResetHealthCheckQueue;
 
@@ -19,11 +20,15 @@ public class ResetHealthCheckQueueController(DavDatabaseClient dbClient) : BaseA
                 new BaseApiResponse { Status = false, Error = "POST required" });
         }
 
+        // Mark every non-urgent usenet file with the forced-recheck sentinel. Unlike a plain
+        // null reset, the sentinel overrides the history-linked exclusion in the health-check
+        // queue query, so files still present in SAB history are re-checked too — without
+        // deleting any history rows. Urgent repairs (UnixEpoch) are left untouched.
         var resetCount = await dbClient.Ctx.Items
             .Where(x => x.Type == DavItem.ItemType.UsenetFile)
-            .Where(x => x.NextHealthCheck != null && x.NextHealthCheck != DateTimeOffset.UnixEpoch)
+            .Where(x => x.NextHealthCheck != DateTimeOffset.UnixEpoch)
             .ExecuteUpdateAsync(
-                x => x.SetProperty(item => item.NextHealthCheck, (DateTimeOffset?)null),
+                x => x.SetProperty(item => item.NextHealthCheck, HealthCheckService.ForcedRecheckSentinel),
                 HttpContext.RequestAborted)
             .ConfigureAwait(false);
 

--- a/backend/Api/Controllers/ResetHealthCheckQueue/ResetHealthCheckQueueController.cs
+++ b/backend/Api/Controllers/ResetHealthCheckQueue/ResetHealthCheckQueueController.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Services;
+using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Api.Controllers.ResetHealthCheckQueue;
 
@@ -24,13 +25,29 @@ public class ResetHealthCheckQueueController(DavDatabaseClient dbClient) : BaseA
         // null reset, the sentinel overrides the history-linked exclusion in the health-check
         // queue query, so files still present in SAB history are re-checked too — without
         // deleting any history rows. Urgent repairs (UnixEpoch) are left untouched.
-        var resetCount = await dbClient.Ctx.Items
+        await dbClient.Ctx.Items
             .Where(x => x.Type == DavItem.ItemType.UsenetFile)
             .Where(x => x.NextHealthCheck != DateTimeOffset.UnixEpoch)
             .ExecuteUpdateAsync(
                 x => x.SetProperty(item => item.NextHealthCheck, HealthCheckService.ForcedRecheckSentinel),
                 HttpContext.RequestAborted)
             .ConfigureAwait(false);
+
+        // Report only the files the checker will actually process (media/archive candidates),
+        // matching the Health page pending count. Marked non-media sidecar files are skipped
+        // by the candidate filter and swept at startup. The candidate check is not
+        // SQL-translatable, so stream names like GetHealthCheckQueueController does.
+        var resetCount = 0;
+        await foreach (var name in dbClient.Ctx.Items
+            .Where(x => x.Type == DavItem.ItemType.UsenetFile)
+            .Where(x => x.NextHealthCheck == HealthCheckService.ForcedRecheckSentinel)
+            .Select(x => x.Name)
+            .AsAsyncEnumerable()
+            .WithCancellation(HttpContext.RequestAborted)
+            .ConfigureAwait(false))
+        {
+            if (FilenameUtil.IsHealthCheckCandidate(name)) resetCount++;
+        }
 
         return Ok(new ResetHealthCheckQueueResponse
         {

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -82,6 +82,14 @@ public class HealthCheckService : BackgroundService
     public const int SampleFloor = 8000;
 
     /// <summary>
+    /// Operator-forced full recheck sentinel for <see cref="DavItem.NextHealthCheck"/>, written by
+    /// the reset-health-check-queue endpoint. Like the UnixEpoch urgent sentinel it overrides the
+    /// history-linked exclusion, but it is processed as a normal STAT check (not an urgent repair)
+    /// and is overwritten by regular scheduling once the check completes.
+    /// </summary>
+    public static readonly DateTimeOffset ForcedRecheckSentinel = DateTimeOffset.UnixEpoch.AddSeconds(1);
+
+    /// <summary>
     /// One-time boot delay before the first background sweep. Queue resume, first streams,
     /// and pool warm-up hit cold connection pools simultaneously at startup; giving them a
     /// short grace window keeps health-check STATs out of the connection storm (#881).
@@ -257,11 +265,13 @@ public class HealthCheckService : BackgroundService
     public static IOrderedQueryable<DavItem> GetHealthCheckQueueItems(DavDatabaseClient dbClient)
     {
         // Playback-triggered urgent repairs stay first. Never-checked files come next so
-        // routine rechecks cannot starve the initial scan.
+        // routine rechecks cannot starve the initial scan, then operator-forced rechecks
+        // (newest release first), then routine scheduled rechecks.
         return GetHealthCheckQueueItemsQuery(dbClient)
             .OrderBy(x =>
                 x.NextHealthCheck == DateTimeOffset.UnixEpoch ? 0 :
-                x.NextHealthCheck == null ? 1 : 2)
+                x.NextHealthCheck == null ? 1 :
+                x.NextHealthCheck == ForcedRecheckSentinel ? 2 : 3)
             .ThenBy(x => x.NextHealthCheck)
             .ThenByDescending(x => x.ReleaseDate)
             .ThenBy(x => x.Id);
@@ -271,12 +281,15 @@ public class HealthCheckService : BackgroundService
     {
         // History-linked files are skipped for routine STAT checks so they do not race SAB
         // post-processing. UnixEpoch is the playback-triggered urgent sentinel from
-        // ExceptionMiddleware and intentionally overrides only that exclusion.
+        // ExceptionMiddleware; ForcedRecheckSentinel is the operator-triggered full-library
+        // recheck from the reset-health-check-queue endpoint. Both intentionally override
+        // only that exclusion.
         return dbClient.Ctx.Items
             .Where(x => x.Type == DavItem.ItemType.UsenetFile)
             .Where(x =>
                 x.HistoryItemId == null ||
-                x.NextHealthCheck == DateTimeOffset.UnixEpoch);
+                x.NextHealthCheck == DateTimeOffset.UnixEpoch ||
+                x.NextHealthCheck == ForcedRecheckSentinel);
     }
 
     private DavDatabaseContext CreateContext() =>

--- a/docs/configuration/maintenance.md
+++ b/docs/configuration/maintenance.md
@@ -30,6 +30,7 @@ Database housekeeping, scheduled orphan cleanup, and one-off tools.
 | Convert STRM → Symlinks | Strategy migration | Needs library dir + rclone mount |
 | Recreate STRM Files | Refresh sidecars | Needs STRM strategy + completed dir + base URL |
 | Migrate blobs to blobstore | Background optimization | Usually automatic |
+| Re-run Library Health Checks [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since } | Fresh health-check pass over every library file, including items still in SAB history | Heavy Usenet STAT traffic on large libraries; runs in the background |
 | Reset Health-Check Statistics | Clear HC history | Cannot undo |
 | Reset Overview Statistics [since 0.8.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.8.0){ .nzbdav-since } | Clear overview metrics | Cannot undo |
 

--- a/docs/configuration/maintenance.md
+++ b/docs/configuration/maintenance.md
@@ -30,7 +30,7 @@ Database housekeeping, scheduled orphan cleanup, and one-off tools.
 | Convert STRM → Symlinks | Strategy migration | Needs library dir + rclone mount |
 | Recreate STRM Files | Refresh sidecars | Needs STRM strategy + completed dir + base URL |
 | Migrate blobs to blobstore | Background optimization | Usually automatic |
-| Re-run Library Health Checks [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since } | Fresh health-check pass over every library file, including items still in SAB history | Heavy Usenet STAT traffic on large libraries; runs in the background |
+| Re-run Library Health Checks [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since } | Fresh health-check pass over every video, audio, and archive file, including items still in SAB history | Heavy Usenet STAT traffic on large libraries; runs in the background |
 | Reset Health-Check Statistics | Clear HC history | Cannot undo |
 | Reset Overview Statistics [since 0.8.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.8.0){ .nzbdav-since } | Clear overview metrics | Cannot undo |
 

--- a/docs/operations/health-repairs.md
+++ b/docs/operations/health-repairs.md
@@ -39,3 +39,11 @@ through the API does not add a repair-history row.
 ## Manual checks
 
 Use the Health UI / repairs flows in the app to inspect failures. Known transport issues should appear as clear warnings in logs rather than opaque crashes — see [Logs](logs-crash-dumps.md).
+
+## Re-running health checks [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since }
+
+**Settings → Maintenance → Re-run Library Health Checks** queues a fresh background health-check
+pass over every library file, including files still present in SAB history — no history rows are
+deleted, and existing health-check results are kept. Checks run a few files at a time, pause while
+the download queue is processing, and can generate significant Usenet (STAT) traffic on large
+libraries. Track progress on the **Health** page.

--- a/docs/operations/health-repairs.md
+++ b/docs/operations/health-repairs.md
@@ -43,7 +43,7 @@ Use the Health UI / repairs flows in the app to inspect failures. Known transpor
 ## Re-running health checks [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since }
 
 **Settings → Maintenance → Re-run Library Health Checks** queues a fresh background health-check
-pass over every library file, including files still present in SAB history — no history rows are
-deleted, and existing health-check results are kept. Checks run a few files at a time, pause while
-the download queue is processing, and can generate significant Usenet (STAT) traffic on large
-libraries. Track progress on the **Health** page.
+pass over every video, audio, and archive file in the library, including files still present in
+SAB history — no history rows are deleted, and existing health-check results are kept. Checks run
+a few files at a time, pause while the download queue is processing, and can generate significant
+Usenet (STAT) traffic on large libraries. Track progress on the **Health** page.

--- a/frontend/app/routes/settings/maintenance/maintenance.tsx
+++ b/frontend/app/routes/settings/maintenance/maintenance.tsx
@@ -9,6 +9,7 @@ import { ConvertStrmToSymlinks } from "./strm-to-symlinks/strm-to-symlinks";
 import { RecreateStrmFiles } from "./recreate-strm-files/recreate-strm-files";
 import { MigrateDatabaseFilesToBlobstore } from "./migrate-database-files-to-blobstore/migrate-database-files-to-blobstore";
 import { ResetHealthCheckStats } from "./reset-health-check-stats/reset-health-check-stats";
+import { ResetHealthCheckQueue } from "./reset-health-check-queue/reset-health-check-queue";
 import { ResetOverviewStats } from "./reset-overview-stats/reset-overview-stats";
 
 type MaintenanceProps = {
@@ -309,7 +310,7 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
               Run repair, migration, and destructive cleanup tools on demand.
             </p>
           </div>
-          <span className="badge badge-ghost badge-sm shrink-0">8 tools</span>
+          <span className="badge badge-ghost badge-sm shrink-0">9 tools</span>
         </div>
         <div className="space-y-3">
           <MaintenanceTaskDetails title="Remove Orphaned Files">
@@ -329,6 +330,9 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
           </MaintenanceTaskDetails>
           <MaintenanceTaskDetails title="Migrate Large Database Blobs to Blobstore">
             <MigrateDatabaseFilesToBlobstore savedConfig={savedConfig} />
+          </MaintenanceTaskDetails>
+          <MaintenanceTaskDetails title="Re-run Library Health Checks">
+            <ResetHealthCheckQueue />
           </MaintenanceTaskDetails>
           <MaintenanceTaskDetails title="Reset Health-Check Statistics">
             <ResetHealthCheckStats />

--- a/frontend/app/routes/settings/maintenance/reset-health-check-queue/reset-health-check-queue.tsx
+++ b/frontend/app/routes/settings/maintenance/reset-health-check-queue/reset-health-check-queue.tsx
@@ -12,7 +12,7 @@ export function ResetHealthCheckQueue() {
   const onQueue = useCallback(async () => {
     if (
       !window.confirm(
-        "Queue a fresh health-check pass over every library file? " +
+        "Queue a fresh health-check pass over every video, audio, and archive file in the library? " +
           "This generates significant Usenet (STAT) traffic on large libraries.",
       )
     ) {
@@ -46,7 +46,7 @@ export function ResetHealthCheckQueue() {
       <Alert className="alert-soft items-start py-3 text-sm" variant="info">
         <Icon name="info" className="!text-[20px]" />
         <div>
-          <p className="font-semibold">Covers the whole library</p>
+          <p className="font-semibold">Covers your whole media library</p>
           <p className="mt-0.5 text-xs opacity-80">
             Includes files still present in SAB history — no history is deleted. Existing
             health-check results and statistics are kept.
@@ -55,9 +55,9 @@ export function ResetHealthCheckQueue() {
       </Alert>
 
       <p className="text-sm leading-relaxed text-base-content/70">
-        Queue a fresh background health-check pass over every library file. Checks run a few files
-        at a time, pause while downloads are processing, and can generate significant Usenet (STAT)
-        traffic on large libraries.
+        Queue a fresh background health-check pass over every video, audio, and archive file in
+        the library. Checks run a few files at a time, pause while downloads are processing, and
+        can generate significant Usenet (STAT) traffic on large libraries.
       </p>
 
       <div className="rounded-lg border border-base-content/10 bg-base-200/40 p-3">

--- a/frontend/app/routes/settings/maintenance/reset-health-check-queue/reset-health-check-queue.tsx
+++ b/frontend/app/routes/settings/maintenance/reset-health-check-queue/reset-health-check-queue.tsx
@@ -55,9 +55,9 @@ export function ResetHealthCheckQueue() {
       </Alert>
 
       <p className="text-sm leading-relaxed text-base-content/70">
-        Queue a fresh background health-check pass over every video, audio, and archive file in
-        the library. Checks run a few files at a time, pause while downloads are processing, and
-        can generate significant Usenet (STAT) traffic on large libraries.
+        Queue a fresh background health-check pass over every video, audio, and archive file in the
+        library. Checks run a few files at a time, pause while downloads are processing, and can
+        generate significant Usenet (STAT) traffic on large libraries.
       </p>
 
       <div className="rounded-lg border border-base-content/10 bg-base-200/40 p-3">

--- a/frontend/app/routes/settings/maintenance/reset-health-check-queue/reset-health-check-queue.tsx
+++ b/frontend/app/routes/settings/maintenance/reset-health-check-queue/reset-health-check-queue.tsx
@@ -1,0 +1,101 @@
+import { useCallback, useState } from "react";
+import { Button } from "~/components/ui/button";
+import { Alert } from "~/components/ui/feedback";
+import { Icon } from "~/components/ui/icon";
+import { withUrlBase } from "~/utils/url-base";
+
+export function ResetHealthCheckQueue() {
+  const [isRunning, setIsRunning] = useState(false);
+  const [queuedCount, setQueuedCount] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const onQueue = useCallback(async () => {
+    if (
+      !window.confirm(
+        "Queue a fresh health-check pass over every library file? " +
+          "This generates significant Usenet (STAT) traffic on large libraries.",
+      )
+    ) {
+      return;
+    }
+
+    setIsRunning(true);
+    setQueuedCount(null);
+    setError(null);
+    try {
+      const response = await fetch(withUrlBase("/api/reset-health-check-queue"), {
+        method: "POST",
+      });
+      if (!response.ok) {
+        // Error body from POST /api/reset-health-check-queue (BaseApiResponse).
+        const body = (await response.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error || `Request failed (${response.status})`);
+      }
+      // Success body from POST /api/reset-health-check-queue (ResetHealthCheckQueueResponse).
+      const data = (await response.json()) as { resetCount?: number };
+      setQueuedCount(data.resetCount ?? 0);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to queue library health checks.");
+    } finally {
+      setIsRunning(false);
+    }
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <Alert className="alert-soft items-start py-3 text-sm" variant="info">
+        <Icon name="info" className="!text-[20px]" />
+        <div>
+          <p className="font-semibold">Covers the whole library</p>
+          <p className="mt-0.5 text-xs opacity-80">
+            Includes files still present in SAB history — no history is deleted. Existing
+            health-check results and statistics are kept.
+          </p>
+        </div>
+      </Alert>
+
+      <p className="text-sm leading-relaxed text-base-content/70">
+        Queue a fresh background health-check pass over every library file. Checks run a few files
+        at a time, pause while downloads are processing, and can generate significant Usenet (STAT)
+        traffic on large libraries.
+      </p>
+
+      <div className="rounded-lg border border-base-content/10 bg-base-200/40 p-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <Button
+            type="button"
+            variant={isRunning ? "secondary" : "primary"}
+            disabled={isRunning}
+            className="shrink-0"
+            onClick={() => void onQueue()}
+          >
+            <Icon
+              name={isRunning ? "progress_activity" : "health_and_safety"}
+              className={`!text-[18px] ${isRunning ? "animate-spin" : ""}`}
+            />
+            {isRunning ? "Queueing..." : "Re-run Health Checks"}
+          </Button>
+          <div
+            aria-live="polite"
+            className={`min-w-0 break-words font-mono text-xs ${
+              error ? "text-error" : queuedCount !== null ? "text-success" : "text-base-content/70"
+            }`}
+          >
+            {error ??
+              (queuedCount !== null ? (
+                <>
+                  {`Queued ${queuedCount.toLocaleString()} file(s) for re-check. Track progress on the `}
+                  <a className="link font-medium" href={withUrlBase("/health")}>
+                    Health page
+                  </a>
+                  .
+                </>
+              ) : (
+                "Ready to queue."
+              ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tests/NzbWebDAV.Tests/Api/AdminContractTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AdminContractTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text.Json;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services;
 using NzbWebDAV.Tests.TestUtils;
 
 namespace NzbWebDAV.Tests.Api;
@@ -81,7 +82,12 @@ public sealed class AdminContractTests
         var resetItem = Assert.Single(
             afterJson.RootElement.GetProperty("items").EnumerateArray(),
             item => item.GetProperty("id").GetString() == scheduled.Id.ToString());
-        Assert.Equal(JsonValueKind.Null, resetItem.GetProperty("nextHealthCheck").ValueKind);
+        // The reset marks files with the forced-recheck sentinel (not null) so the re-check
+        // also covers files still linked to SAB history; the queue API surfaces that marker.
+        Assert.Equal(JsonValueKind.String, resetItem.GetProperty("nextHealthCheck").ValueKind);
+        Assert.Equal(
+            HealthCheckService.ForcedRecheckSentinel,
+            resetItem.GetProperty("nextHealthCheck").GetDateTimeOffset());
         Assert.True(afterJson.RootElement.GetProperty("uncheckedCount").GetInt32() >= 1);
     }
 

--- a/tests/NzbWebDAV.Tests/Api/ResetHealthCheckQueueControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/ResetHealthCheckQueueControllerTests.cs
@@ -43,18 +43,22 @@ public sealed class ResetHealthCheckQueueControllerTests : IAsyncLifetime
     {
         var scheduled = NewItem("scheduled.mkv", DavItem.ItemType.UsenetFile, DateTimeOffset.UtcNow.AddDays(1));
         var uncheckedFile = NewItem("unchecked.mkv", DavItem.ItemType.UsenetFile, null);
+        var sidecar = NewItem("cover.jpg", DavItem.ItemType.UsenetFile, DateTimeOffset.UtcNow.AddDays(1));
         var urgent = NewItem("urgent.mkv", DavItem.ItemType.UsenetFile, DateTimeOffset.UnixEpoch);
         var directory = NewItem("directory", DavItem.ItemType.Directory, DateTimeOffset.UtcNow.AddDays(1));
-        _context.Items.AddRange(scheduled, uncheckedFile, urgent, directory);
+        _context.Items.AddRange(scheduled, uncheckedFile, sidecar, urgent, directory);
         await _context.SaveChangesAsync();
         _context.ChangeTracker.Clear();
 
         var response = await InvokeAsync();
 
+        // Only executable health-check candidates are counted; the non-media sidecar is
+        // marked but skipped by the checker's candidate filter.
         Assert.Equal(2, response.ResetCount);
         var updated = await _context.Items.ToDictionaryAsync(x => x.Id);
         Assert.Equal(HealthCheckService.ForcedRecheckSentinel, updated[scheduled.Id].NextHealthCheck);
         Assert.Equal(HealthCheckService.ForcedRecheckSentinel, updated[uncheckedFile.Id].NextHealthCheck);
+        Assert.Equal(HealthCheckService.ForcedRecheckSentinel, updated[sidecar.Id].NextHealthCheck);
         Assert.Equal(DateTimeOffset.UnixEpoch, updated[urgent.Id].NextHealthCheck);
         Assert.NotNull(updated[directory.Id].NextHealthCheck);
         Assert.NotEqual(HealthCheckService.ForcedRecheckSentinel, updated[directory.Id].NextHealthCheck);

--- a/tests/NzbWebDAV.Tests/Api/ResetHealthCheckQueueControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/ResetHealthCheckQueueControllerTests.cs
@@ -7,6 +7,7 @@ using NzbWebDAV.Database;
 using NzbWebDAV.Database.Interceptors;
 using NzbWebDAV.Database.MigrationHelpers;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services;
 
 namespace NzbWebDAV.Tests.Api;
 
@@ -38,7 +39,7 @@ public sealed class ResetHealthCheckQueueControllerTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task ResetAsync_NullsScheduledUsenetFiles_WhilePreservingUrgentAndDirectories()
+    public async Task ResetAsync_MarksNonUrgentUsenetFilesForcedRecheck_WhilePreservingUrgentAndDirectories()
     {
         var scheduled = NewItem("scheduled.mkv", DavItem.ItemType.UsenetFile, DateTimeOffset.UtcNow.AddDays(1));
         var uncheckedFile = NewItem("unchecked.mkv", DavItem.ItemType.UsenetFile, null);
@@ -50,12 +51,13 @@ public sealed class ResetHealthCheckQueueControllerTests : IAsyncLifetime
 
         var response = await InvokeAsync();
 
-        Assert.Equal(1, response.ResetCount);
+        Assert.Equal(2, response.ResetCount);
         var updated = await _context.Items.ToDictionaryAsync(x => x.Id);
-        Assert.Null(updated[scheduled.Id].NextHealthCheck);
-        Assert.Null(updated[uncheckedFile.Id].NextHealthCheck);
+        Assert.Equal(HealthCheckService.ForcedRecheckSentinel, updated[scheduled.Id].NextHealthCheck);
+        Assert.Equal(HealthCheckService.ForcedRecheckSentinel, updated[uncheckedFile.Id].NextHealthCheck);
         Assert.Equal(DateTimeOffset.UnixEpoch, updated[urgent.Id].NextHealthCheck);
         Assert.NotNull(updated[directory.Id].NextHealthCheck);
+        Assert.NotEqual(HealthCheckService.ForcedRecheckSentinel, updated[directory.Id].NextHealthCheck);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckQueueItemsQueryTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckQueueItemsQueryTests.cs
@@ -37,19 +37,23 @@ public sealed class HealthCheckQueueItemsQueryTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Query_ExcludesHistoryLinkedNonUrgent_AndIncludesUrgentAndUnlinked()
+    public async Task Query_ExcludesHistoryLinkedNonUrgent_AndIncludesUrgentForcedAndUnlinked()
     {
         var historyId = Guid.NewGuid();
         var scheduledAt = DateTimeOffset.UtcNow.AddHours(1);
 
         var historyLinkedNonUrgent = NewUsenetFile("history-linked-non-urgent.mkv", historyId, scheduledAt);
+        var historyLinkedUnchecked = NewUsenetFile("history-linked-unchecked.mkv", historyId, null);
         var historyLinkedUrgent = NewUsenetFile("history-linked-urgent.mkv", historyId, DateTimeOffset.UnixEpoch);
+        var historyLinkedForced = NewUsenetFile("history-linked-forced.mkv", historyId, HealthCheckService.ForcedRecheckSentinel);
         var unlinkedUrgent = NewUsenetFile("unlinked-urgent.mkv", null, DateTimeOffset.UnixEpoch);
         var unlinkedScheduled = NewUsenetFile("unlinked-scheduled.mkv", null, scheduledAt);
 
         _context.Items.AddRange(
             historyLinkedNonUrgent,
+            historyLinkedUnchecked,
             historyLinkedUrgent,
+            historyLinkedForced,
             unlinkedUrgent,
             unlinkedScheduled);
         await _context.SaveChangesAsync();
@@ -60,7 +64,9 @@ public sealed class HealthCheckQueueItemsQueryTests : IAsyncLifetime
             .ToListAsync();
 
         Assert.DoesNotContain(historyLinkedNonUrgent.Id, ids);
+        Assert.DoesNotContain(historyLinkedUnchecked.Id, ids);
         Assert.Contains(historyLinkedUrgent.Id, ids);
+        Assert.Contains(historyLinkedForced.Id, ids);
         Assert.Contains(unlinkedUrgent.Id, ids);
         Assert.Contains(unlinkedScheduled.Id, ids);
     }
@@ -116,34 +122,38 @@ public sealed class HealthCheckQueueItemsQueryTests : IAsyncLifetime
         var subtitleFile = NewUsenetFile("subs.srt", null, nextHealthCheck: null);
         var nfoFile = NewUsenetFile("info.nfo", null, nextHealthCheck: null);
         var scheduledMedia = NewUsenetFile("already-checked.mkv", null, DateTimeOffset.UtcNow.AddHours(1));
+        var forcedMedia = NewUsenetFile("forced-recheck.mkv", Guid.NewGuid(), HealthCheckService.ForcedRecheckSentinel);
+        var forcedImage = NewUsenetFile("forced-cover.jpg", null, HealthCheckService.ForcedRecheckSentinel);
 
         _context.Items.AddRange(
-            videoFile, audioFile, archiveFile, imageFile, subtitleFile, nfoFile, scheduledMedia);
+            videoFile, audioFile, archiveFile, imageFile, subtitleFile, nfoFile, scheduledMedia,
+            forcedMedia, forcedImage);
         await _context.SaveChangesAsync();
         _context.ChangeTracker.Clear();
 
-        // Mirror GetHealthCheckQueueController uncheckedCount: never-checked files that
-        // HealthCheckService will actually process.
+        // Mirror GetHealthCheckQueueController uncheckedCount: never-checked and operator-forced
+        // files that HealthCheckService will actually process.
         var uncheckedCount = (await HealthCheckService.GetHealthCheckQueueItemsQuery(_dbClient)
-            .Where(x => x.NextHealthCheck == null)
+            .Where(x => x.NextHealthCheck == null || x.NextHealthCheck == HealthCheckService.ForcedRecheckSentinel)
             .Select(x => x.Name)
             .ToListAsync())
             .Count(FilenameUtil.IsHealthCheckCandidate);
 
-        Assert.Equal(3, uncheckedCount);
+        Assert.Equal(4, uncheckedCount);
     }
 
     [Fact]
-    public async Task OrderedQuery_PrioritizesUrgentThenUncheckedThenScheduledItems()
+    public async Task OrderedQuery_PrioritizesUrgentThenUncheckedThenForcedThenScheduledItems()
     {
         var historyId = Guid.NewGuid();
         var scheduledAt = DateTimeOffset.UtcNow.AddHours(-2);
 
         var historyLinkedUrgent = NewUsenetFile("urgent-first.mkv", historyId, DateTimeOffset.UnixEpoch);
         var uncheckedItem = NewUsenetFile("unchecked-second.mkv", null, nextHealthCheck: null);
-        var unlinkedScheduled = NewUsenetFile("scheduled-third.mkv", null, scheduledAt);
+        var historyLinkedForced = NewUsenetFile("forced-third.mkv", historyId, HealthCheckService.ForcedRecheckSentinel);
+        var unlinkedScheduled = NewUsenetFile("scheduled-fourth.mkv", null, scheduledAt);
 
-        _context.Items.AddRange(historyLinkedUrgent, uncheckedItem, unlinkedScheduled);
+        _context.Items.AddRange(historyLinkedUrgent, uncheckedItem, historyLinkedForced, unlinkedScheduled);
         await _context.SaveChangesAsync();
         _context.ChangeTracker.Clear();
 
@@ -152,7 +162,7 @@ public sealed class HealthCheckQueueItemsQueryTests : IAsyncLifetime
             .ToListAsync();
 
         Assert.Equal(
-            [historyLinkedUrgent.Id, uncheckedItem.Id, unlinkedScheduled.Id],
+            [historyLinkedUrgent.Id, uncheckedItem.Id, historyLinkedForced.Id, unlinkedScheduled.Id],
             orderedIds);
     }
 


### PR DESCRIPTION
## Summary

- Adds a **Re-run Library Health Checks** task to Settings → Maintenance, surfacing the previously API-only `POST /api/reset-health-check-queue` (prompted by a Discord support thread where a user had to discover the endpoint plus Prune Completed History to redo a first-run health check).
- Fixes the endpoint so a reset actually covers the full library: it now marks every non-urgent file with a forced-recheck sentinel that overrides the SAB-history-linked exclusion in the health-check queue — previously, files still present in SAB history (and never-checked files) were silently skipped, so only a fraction of the library was re-checked. History rows are no longer sacrificed for this; nothing is deleted.
- The Health page pending count includes forced re-checks, and the provider-change "Re-check library health" banner gets the same full-library coverage.

Refs #105

## Test plan

- [x] Backend: `ResetHealthCheckQueueControllerTests` + `HealthCheckQueueItemsQueryTests` updated for sentinel semantics (6/6 passing locally)
- [x] Frontend: `npm run typecheck` + eslint on touched files
- [ ] PR CI (backend build/tests, frontend lint/typecheck/build/tests)
- [ ] Manual: run the task from Settings → Maintenance and watch the Health page work through the full pending count, including history-linked files

Note: docs use a `since 1.3.0` pill assuming a minor bump from 1.2.6 — please confirm against the release-please PR before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a maintenance option to re-run health checks across the entire library.
  - Added confirmation, progress feedback, queued counts, error reporting, and a link to the Health page.
  - Forced rechecks now appear in the health-check queue with appropriate prioritization.

- **Bug Fixes**
  - Health-check counts now include operator-requested rechecks.
  - Rechecks preserve existing results and history while covering eligible library files.

- **Documentation**
  - Documented processing behavior, progress reporting, and potential STAT traffic impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
