### PR TITLE
fix(webdav): play multipart RARs with unrelated trailing volumes

### DIFF
--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1189,10 +1189,10 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
     public string GetRepairPatchStorePath()
         => Path.Join(DavDatabaseContext.ConfigPath, "repair-segments");
 
-    // When true, RAR archives are mounted instantly by parsing only the first
-    // volume at import; trailing volumes are resolved on first read. Falls
-    // back to eager parsing for archives that don't fit the supported shape
-    // (multi-file, solid, encrypted, or compressed).
+    // When true, RAR archives are mounted quickly by parsing the first volume
+    // and validating cached continuation headers at import; trailing ranges
+    // are resolved on first read. Falls back to eager parsing for archives
+    // that don't fit the supported shape (multi-file, solid, or compressed).
     public bool IsLazyRarParsingEnabled()
     {
         var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.ApiLazyRarParsing));

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -151,19 +151,31 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
 
     public async Task<DavMultipartFile?> GetDavMultipartFileAsync(DavItem davItem, CancellationToken ct = default)
     {
+        DavMultipartFile? multipartFile = null;
+
         // attempt to read from blob-store
         var blobId = davItem.FileBlobId;
         if (blobId.HasValue)
         {
-            var blob = await BlobStore.ReadBlob<DavMultipartFile>(blobId.Value).ConfigureAwait(false);
-            if (blob is not null) return blob;
+            multipartFile = await BlobStore.ReadBlob<DavMultipartFile>(blobId.Value).ConfigureAwait(false);
         }
 
         // read from database
-        return await ctx.MultipartFiles
+        multipartFile ??= await ctx.MultipartFiles
             .AsNoTracking()
             .FirstOrDefaultAsync(x => x.Id == davItem.Id, ct)
             .ConfigureAwait(false);
+
+        if (multipartFile?.Metadata.IsLazy == true
+            && multipartFile.Metadata.ExpectedFileSize is null
+            && davItem.FileSize is { } expectedFileSize
+            && expectedFileSize >= 0
+            && expectedFileSize < long.MaxValue)
+        {
+            multipartFile.Metadata.ExpectedFileSize = expectedFileSize;
+        }
+
+        return multipartFile;
     }
 
     // queue

--- a/backend/Database/Models/DavMultipartFile.cs
+++ b/backend/Database/Models/DavMultipartFile.cs
@@ -40,6 +40,11 @@ public partial class DavMultipartFile
 
         [MemoryPackOrder(5)]
         public PendingPart[] PendingParts { get; set; } = [];
+
+        // Stable logical member size captured from the first RAR header.
+        // Null only for blobs written before continuation-chain validation.
+        [MemoryPackOrder(6)]
+        public long? ExpectedFileSize { get; set; }
     }
 
     [MemoryPackable(GenerateType.VersionTolerant)]
@@ -63,6 +68,11 @@ public partial class DavMultipartFile
 
         [MemoryPackOrder(4)]
         public string[][]? SegmentFallbackIds { get; set; }
+
+        // Whether this RAR member continues into the next physical volume.
+        // Null for non-RAR parts and blobs written before split-aware resolution.
+        [MemoryPackOrder(5)]
+        public bool? IsSplitAfter { get; set; }
     }
 
     // A RAR part whose internal byte range hasn't been parsed yet.

--- a/backend/Queue/DeobfuscationSteps/3.GetFileInfos/GetFileInfosStep.cs
+++ b/backend/Queue/DeobfuscationSteps/3.GetFileInfos/GetFileInfosStep.cs
@@ -87,6 +87,7 @@ public static class GetFileInfosStep
             FileSize = (long?)fileDesc?.FileLength,
             IsRar = isRar,
             SniffedVideoExtension = sniffedVideoExtension,
+            First16KB = file.First16KB,
         };
     }
 
@@ -168,5 +169,6 @@ public static class GetFileInfosStep
         public long? FileSize { get; init; }
         public bool IsRar { get; init; }
         public string? SniffedVideoExtension { get; init; }
+        public byte[]? First16KB { get; init; }
     }
 }

--- a/backend/Queue/FileAggregators/RarAggregator.cs
+++ b/backend/Queue/FileAggregators/RarAggregator.cs
@@ -49,6 +49,7 @@ public class RarAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, b
                 PathInArchive = pathInArchive,
                 ArchivePassword = result.Password,
                 PendingParts = result.PendingParts,
+                ExpectedFileSize = result.TotalFileSize,
             }
         };
 

--- a/backend/Queue/FileProcessors/LazyRarProcessor.cs
+++ b/backend/Queue/FileProcessors/LazyRarProcessor.cs
@@ -11,11 +11,11 @@ using SharpCompress.Common.Rar.Headers;
 
 namespace NzbWebDAV.Queue.FileProcessors;
 
-// Altmount-style lazy RAR processor: parses only the first volume at import
-// to learn the inner file name + size, and defers parsing of trailing
-// volumes to first read (see LazyRarResolver). Returns null whenever the
-// archive doesn't match the supported shape — caller falls back to the
-// per-part eager RarProcessor in that case.
+// Altmount-style lazy RAR processor: parses the first volume to learn the
+// inner file name + size, validates cached first-header prefixes across the
+// continuation chain, and defers full trailing-volume resolution to first
+// read (see LazyRarResolver). Returns null whenever the archive doesn't
+// match the supported shape, so the caller falls back to eager parsing.
 public class LazyRarProcessor(
     List<GetFileInfosStep.FileInfo> fileInfos,
     INntpClient usenetClient,
@@ -137,6 +137,14 @@ public class LazyRarProcessor(
         }
 
         var aesParams = fileHeader.GetAesParams(password);
+        if (fileHeader.IsEncrypted && aesParams is null)
+        {
+            Log.Information(
+                "LazyRarProcessor: {File} is encrypted but no usable password was supplied, falling back to eager",
+                firstInfo.FileName);
+            return null;
+        }
+
         var totalFileSize = aesParams?.DecodedSize ?? fileHeader.UncompressedSize;
         if (totalFileSize <= 0)
         {
@@ -181,6 +189,7 @@ public class LazyRarProcessor(
             FilePartByteRange = firstPartByteRange,
             SegmentByteRanges = firstInfo.NzbFile.GetSegmentByteRanges(),
             SegmentFallbackIds = firstInfo.NzbFile.GetSegmentFallbackIds(),
+            IsSplitAfter = fileHeader.IsSplitAfter,
         };
 
         var trailingInfos = sorted.Skip(1).ToList();
@@ -242,6 +251,17 @@ public class LazyRarProcessor(
             last.EstimatedDataSize = adjusted;
         }
 
+        if (!await ValidateContinuationChainAsync(
+                fileHeader,
+                trailingInfos,
+                pathInArchive,
+                totalFileSize,
+                fileHeader.IsEncrypted)
+                .ConfigureAwait(false))
+        {
+            return null;
+        }
+
         return new Result
         {
             PathInArchive = pathInArchive,
@@ -254,6 +274,192 @@ public class LazyRarProcessor(
             ArchiveName = GetArchiveName(firstInfo.FileName),
             SniffedVideoExtension = sniffedVideoExtension,
         };
+    }
+
+    private async Task<bool> ValidateContinuationChainAsync(
+        IRarFileHeader firstHeader,
+        IReadOnlyList<GetFileInfosStep.FileInfo> trailingInfos,
+        string pathInArchive,
+        long expectedFileSize,
+        bool isEncrypted)
+    {
+        if (firstHeader.IsSplitBefore)
+        {
+            Log.Information(
+                "LazyRarProcessor: first header for {Inner} continues from an earlier volume, falling back to eager",
+                pathInArchive);
+            return false;
+        }
+
+        if (trailingInfos.Count == 0)
+        {
+            if (!firstHeader.IsSplitAfter)
+            {
+                return ValidateResolvedSize(
+                    firstHeader.AdditionalDataSize,
+                    expectedFileSize,
+                    isEncrypted,
+                    pathInArchive);
+            }
+
+            Log.Information(
+                "LazyRarProcessor: {Inner} continues past the final RAR volume, falling back to eager",
+                pathInArchive);
+            return false;
+        }
+
+        if (!firstHeader.IsSplitAfter)
+        {
+            Log.Information(
+                "LazyRarProcessor: {Inner} ends before {Count} trailing RAR volume(s), falling back to eager",
+                pathInArchive, trailingInfos.Count);
+            return false;
+        }
+
+        var resolvedSize = firstHeader.AdditionalDataSize;
+        for (var i = 0; i < trailingInfos.Count; i++)
+        {
+            var info = trailingInfos[i];
+            IRarFileHeader? continuation;
+            try
+            {
+                continuation = await ReadFirstFileHeaderAsync(info).ConfigureAwait(false);
+            }
+            catch (RetryableDownloadException)
+            {
+                throw;
+            }
+            catch (Exception e) when (
+                !ct.IsCancellationRequested &&
+                e.IsTransientTransportException() &&
+                e is not OutOfMemoryException)
+            {
+                throw new RetryableDownloadException(
+                    $"Transient provider failure while validating RAR continuation headers for {info.FileName}.",
+                    e);
+            }
+            catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
+            {
+                Log.Information(
+                    "LazyRarProcessor: could not validate continuation volume {Volume} for {Inner}; " +
+                    "falling back to eager. Reason: {Reason}",
+                    i + 2, pathInArchive, e.Message);
+                return false;
+            }
+
+            if (continuation is null)
+            {
+                Log.Information(
+                    "LazyRarProcessor: no file header in continuation volume {Volume} for {Inner}, " +
+                    "falling back to eager",
+                    i + 2, pathInArchive);
+                return false;
+            }
+
+            if (!string.Equals(continuation.FileName, pathInArchive, StringComparison.Ordinal)
+                || !continuation.IsSplitBefore
+                || continuation.IsSolid
+                || continuation.IsEncrypted != isEncrypted)
+            {
+                Log.Information(
+                    "LazyRarProcessor: continuation volume {Volume} for {Inner} contains {Found} " +
+                    "(split-before: {SplitBefore}, solid: {Solid}, encrypted: {Encrypted}); " +
+                    "falling back to eager",
+                    i + 2,
+                    pathInArchive,
+                    continuation.FileName,
+                    continuation.IsSplitBefore,
+                    continuation.IsSolid,
+                    continuation.IsEncrypted);
+                return false;
+            }
+
+            try
+            {
+                resolvedSize = checked(resolvedSize + continuation.AdditionalDataSize);
+            }
+            catch (OverflowException)
+            {
+                Log.Information(
+                    "LazyRarProcessor: continuation sizes overflow for {Inner}, falling back to eager",
+                    pathInArchive);
+                return false;
+            }
+
+            var shouldContinue = i < trailingInfos.Count - 1;
+            if (continuation.IsSplitAfter == shouldContinue) continue;
+
+            if (continuation.IsSplitAfter)
+            {
+                Log.Information(
+                    "LazyRarProcessor: {Inner} continues past final RAR volume {Volume}, falling back to eager",
+                    pathInArchive,
+                    i + 2);
+            }
+            else
+            {
+                Log.Information(
+                    "LazyRarProcessor: {Inner} ends at RAR volume {Volume} with trailing volumes remaining; " +
+                    "falling back to eager",
+                    pathInArchive,
+                    i + 2);
+            }
+            return false;
+        }
+
+        return ValidateResolvedSize(resolvedSize, expectedFileSize, isEncrypted, pathInArchive);
+    }
+
+    private static bool ValidateResolvedSize(
+        long resolvedSize,
+        long expectedFileSize,
+        bool isEncrypted,
+        string pathInArchive)
+    {
+        long expectedStoredSize;
+        try
+        {
+            expectedStoredSize = isEncrypted
+                ? checked((expectedFileSize + 15) / 16 * 16)
+                : expectedFileSize;
+        }
+        catch (OverflowException)
+        {
+            Log.Information(
+                "LazyRarProcessor: expected stored size overflows for {Inner}, falling back to eager",
+                pathInArchive);
+            return false;
+        }
+
+        const long tolerance = 16; // matches RarAggregator.ValidateVolumes
+        if (Math.Abs((decimal)resolvedSize - expectedStoredSize) <= tolerance) return true;
+
+        Log.Information(
+            "LazyRarProcessor: resolved continuation size {Resolved} does not match expected {Expected} " +
+            "for {Inner}; falling back to eager",
+            resolvedSize,
+            expectedStoredSize,
+            pathInArchive);
+        return false;
+    }
+
+    private async Task<IRarFileHeader?> ReadFirstFileHeaderAsync(GetFileInfosStep.FileInfo info)
+    {
+        if (info.First16KB is { Length: > 0 } prefix)
+        {
+            await using var prefixStream = new MemoryStream(prefix, writable: false);
+            var prefixHeaders = await RarUtil
+                .ReadHeadersUntilFirstFileAsync(prefixStream, password, ct)
+                .ConfigureAwait(false);
+            return prefixHeaders.OfType<IRarFileHeader>().LastOrDefault(h => !h.IsDirectory);
+        }
+
+        var streamLength = info.FileSize ?? info.NzbFile.GetTotalYencodedSize();
+        await using var stream = usenetClient.GetFileStream(
+            info.NzbFile, streamLength, articleBufferSize: 0);
+        var headers = await RarUtil.ReadHeadersUntilFirstFileAsync(stream, password, ct)
+            .ConfigureAwait(false);
+        return headers.OfType<IRarFileHeader>().LastOrDefault(h => !h.IsDirectory);
     }
 
     private static string GetArchiveName(string firstFileName)

--- a/backend/Queue/FileProcessors/LazyRarProcessor.cs
+++ b/backend/Queue/FileProcessors/LazyRarProcessor.cs
@@ -278,7 +278,7 @@ public class LazyRarProcessor(
 
     private async Task<bool> ValidateContinuationChainAsync(
         IRarFileHeader firstHeader,
-        IReadOnlyList<GetFileInfosStep.FileInfo> trailingInfos,
+        List<GetFileInfosStep.FileInfo> trailingInfos,
         string pathInArchive,
         long expectedFileSize,
         bool isEncrypted)

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -455,10 +455,10 @@ public class QueueItemProcessor(
         }
 
         // step 2a -- try altmount-style lazy RAR mounting for the rar group
-        // when enabled. On success, the entire rar group is handled here
-        // (only the first volume gets parsed) and skipped in step 2b. On
-        // ineligibility — multi-file, compressed, solid, or first-volume
-        // parse failure — fall through to the per-part eager pipeline.
+        // when enabled. On success, the first volume is parsed and cached
+        // continuation-header prefixes are validated before the rar group is
+        // skipped in step 2b. On ineligibility — multi-file, compressed,
+        // solid, or header-parse failure — fall through to the eager pipeline.
         LazyRarProcessor.Result? lazyRarResult = null;
         var rarFiles = fileInfos.Where(x => GetGroupName(x) == "rar").ToList();
         if (configManager.IsLazyRarParsingEnabled() && rarFiles.Count > 0)

--- a/backend/Services/LazyRarResolver.cs
+++ b/backend/Services/LazyRarResolver.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Runtime.ExceptionServices;
 using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
@@ -23,7 +24,7 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
     // Keyed by the volume's first segment ID so two readers asking for the
     // same trailing part share one parse, even if they hit different
     // FileParts.Length snapshots (which the old (Guid,int) key broke).
-    private readonly ConcurrentDictionary<(Guid, string), Task<DavMultipartFile.FilePart>> _inFlight = new();
+    private readonly ConcurrentDictionary<(Guid, string), Task<Resolution>> _inFlight = new();
 
     private readonly ConcurrentDictionary<Guid, Persistor> _persistors = new();
 
@@ -44,6 +45,18 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
         public readonly SemaphoreSlim Sem = new(1, 1);
         public long LatestStamp;
     }
+
+    private sealed class Resolution
+    {
+        public required DavMultipartFile.PendingPart Pending { get; init; }
+        public DavMultipartFile.FilePart? Part { get; init; }
+        public string? FoundPath { get; init; }
+        public bool IsSplitBefore { get; init; }
+        public bool IsSplitAfter { get; init; }
+        public bool IsSolid { get; init; }
+        public bool IsEncrypted { get; init; }
+        public Exception? Error { get; init; }
+    }
 #pragma warning restore CA1001
 
     // Resolve enough trailing volumes to cover targetByteOffset and return
@@ -56,7 +69,7 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
         long targetByteOffset,
         CancellationToken ct)
     {
-        var meta = mpf.Metadata;
+        var meta = await EnsureLastResolvedSplitStateAsync(mpf, ct).ConfigureAwait(false);
         if (!meta.IsLazy) return meta;
 
         // Old MemoryPack blobs may deserialize PendingParts as null despite
@@ -82,27 +95,215 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
         var partsToResolve = new DavMultipartFile.PendingPart[count];
         Array.Copy(pending, partsToResolve, count);
 
-        // Run resolutions in parallel, bounded by the provider plan limit.
-        // Use the same cap that governs the rest of the queue processor so
-        // we never burst past what the user's provider plan allows.
+        // Start a bounded parallel window, but consume it in physical order.
+        // This preserves tail-seek throughput while letting a terminal member
+        // part return without waiting for unrelated trailing probes.
         var maxConcurrency = Math.Max(1, configManager.GetMaxDownloadConnections());
-        using var semaphore = new SemaphoreSlim(maxConcurrency);
+        var resolveds = await ResolveOrderedPrefixAsync(
+                mpf, partsToResolve, maxConcurrency, ct)
+            .ConfigureAwait(false);
+        return CommitResolvedBatch(mpf, resolveds);
+    }
 
-        var resolveTasks = partsToResolve.Select(async part =>
+    private async Task<DavMultipartFile.Meta> EnsureLastResolvedSplitStateAsync(
+        DavMultipartFile mpf,
+        CancellationToken ct)
+    {
+        var meta = mpf.Metadata;
+        var pending = meta.PendingParts ?? [];
+        var fileParts = meta.FileParts ?? [];
+        if (!meta.IsLazy || pending.Length == 0 || fileParts.Length == 0) return meta;
+
+        var lastPart = fileParts[^1];
+        if (lastPart.IsSplitAfter is null)
         {
-            await semaphore.WaitAsync(ct).ConfigureAwait(false);
+            var splitAfter = await ReadResolvedPartSplitStateAsync(
+                    meta, lastPart, fileParts.Length - 1, ct)
+                .ConfigureAwait(false);
+
+            lock (mpf)
+            {
+                meta = mpf.Metadata;
+                fileParts = meta.FileParts ?? [];
+                if (fileParts.Length > 0
+                    && fileParts[^1].SegmentIds.SequenceEqual(lastPart.SegmentIds)
+                    && fileParts[^1].IsSplitAfter is null)
+                {
+                    fileParts[^1].IsSplitAfter = splitAfter;
+                    _ = SchedulePersistAsync(mpf, reconcileFileSize: false);
+                }
+            }
+        }
+
+        meta = mpf.Metadata;
+        fileParts = meta.FileParts ?? [];
+        if (fileParts.Length == 0 || fileParts[^1].IsSplitAfter is not false) return meta;
+        return CompleteAtResolvedTerminal(mpf);
+    }
+
+    private async Task<bool> ReadResolvedPartSplitStateAsync(
+        DavMultipartFile.Meta meta,
+        DavMultipartFile.FilePart part,
+        int partIndex,
+        CancellationToken ct)
+    {
+        var pathInArchive = meta.PathInArchive
+            ?? throw new InvalidOperationException("Lazy RAR meta missing PathInArchive.");
+        var fileSize = Math.Max(
+            part.SegmentIdByteRange.Count,
+            part.FilePartByteRange.EndExclusive);
+        await using var stream = OpenVolumeStream(
+            part.SegmentIds,
+            fileSize,
+            part.SegmentFallbackIds,
+            part.SegmentByteRanges);
+        var headers = await RarUtil.ReadHeadersUntilFirstFileAsync(
+                stream, meta.ArchivePassword, ct)
+            .ConfigureAwait(false);
+        var header = headers.OfType<IRarFileHeader>().LastOrDefault(h => !h.IsDirectory);
+        var expectedSplitBefore = partIndex > 0;
+        if (header is null
+            || !string.Equals(header.FileName, pathInArchive, StringComparison.Ordinal)
+            || header.IsSplitBefore != expectedSplitBefore
+            || header.IsSolid
+            || header.IsEncrypted != (meta.AesParams is not null))
+        {
+            var found = header is null
+                ? "no file header"
+                : $"'{header.FileName}' (split-before: {header.IsSplitBefore}, " +
+                  $"split-after: {header.IsSplitAfter}, solid: {header.IsSolid}, " +
+                  $"encrypted: {header.IsEncrypted})";
+            throw new CorruptRarException(
+                $"Lazy RAR resolution: could not recover split state for resolved volume " +
+                $"{partIndex + 1}; expected '{pathInArchive}', found {found}.");
+        }
+
+        return header.IsSplitAfter;
+    }
+
+    private DavMultipartFile.Meta CompleteAtResolvedTerminal(DavMultipartFile mpf)
+    {
+        lock (mpf)
+        {
+            var meta = mpf.Metadata;
+            var fileParts = meta.FileParts ?? [];
+            var pendingParts = meta.PendingParts ?? [];
+            if (!meta.IsLazy
+                || pendingParts.Length == 0
+                || fileParts.Length == 0
+                || fileParts[^1].IsSplitAfter is not false)
+            {
+                return meta;
+            }
+
+            ValidateTerminalSize(meta, fileParts, [], pendingParts.Length);
+            var newMeta = new DavMultipartFile.Meta
+            {
+                AesParams = meta.AesParams,
+                FileParts = fileParts,
+                IsLazy = false,
+                PathInArchive = meta.PathInArchive,
+                ArchivePassword = meta.ArchivePassword,
+                PendingParts = [],
+                ExpectedFileSize = meta.ExpectedFileSize,
+            };
+
+            Log.Information(
+                "Lazy RAR member {Path} was already complete; discarding {IgnoredCount} unrelated " +
+                "trailing volume(s) from multipart {Id}",
+                meta.PathInArchive,
+                pendingParts.Length,
+                mpf.Id);
+            mpf.Metadata = newMeta;
+            _ = SchedulePersistAsync(mpf, reconcileFileSize: true);
+            return newMeta;
+        }
+    }
+
+    private async Task<Resolution[]> ResolveOrderedPrefixAsync(
+        DavMultipartFile mpf,
+        DavMultipartFile.PendingPart[] parts,
+        int maxConcurrency,
+        CancellationToken ct)
+    {
+        var tasks = new Task<Resolution>?[parts.Length];
+        var started = Math.Min(maxConcurrency, parts.Length);
+        for (var i = 0; i < started; i++)
+            tasks[i] = GetOrStartResolutionAsync(mpf, parts[i], ct);
+
+        var results = new List<Resolution>(parts.Length);
+        try
+        {
+            for (var i = 0; i < parts.Length; i++)
+            {
+                var outcome = await tasks[i]!.ConfigureAwait(false);
+                results.Add(outcome);
+
+                if (outcome.Error is not null
+                    || outcome.Part is null
+                    || outcome.IsEncrypted != (mpf.Metadata.AesParams is not null)
+                    || !outcome.IsSplitAfter)
+                {
+                    _ = ObserveResolutionTasksAsync(
+                        tasks.Skip(i + 1).Take(started - i - 1),
+                        mpf.Metadata.PathInArchive);
+                    break;
+                }
+
+                if (started < parts.Length)
+                {
+                    tasks[started] = GetOrStartResolutionAsync(mpf, parts[started], ct);
+                    started++;
+                }
+            }
+        }
+        catch
+        {
+            _ = ObserveResolutionTasksAsync(
+                tasks.Take(started).Where(task => task is not null)!,
+                mpf.Metadata.PathInArchive);
+            throw;
+        }
+
+        return results.ToArray();
+    }
+
+    private static async Task ObserveResolutionTasksAsync(
+        IEnumerable<Task<Resolution>?> tasks,
+        string? pathInArchive)
+    {
+        foreach (var task in tasks)
+        {
+            if (task is null) continue;
             try
             {
-                return await GetOrStartResolutionAsync(mpf, part, ct).ConfigureAwait(false);
+                var outcome = await task.ConfigureAwait(false);
+                if (outcome.Error is not null)
+                {
+                    Log.Debug(
+                        outcome.Error,
+                        "Ignored failure from a RAR probe after ordered resolution stopped for {Path}",
+                        pathInArchive);
+                }
             }
-            finally
+            catch (OutOfMemoryException e)
             {
-                semaphore.Release();
+                Log.Fatal(
+                    e,
+                    "Fatal out-of-memory failure in detached RAR probe for {Path}",
+                    pathInArchive);
+                Environment.FailFast(
+                    $"Fatal out-of-memory failure in detached RAR probe for {pathInArchive}.",
+                    e);
             }
-        }).ToArray();
-
-        var resolveds = await Task.WhenAll(resolveTasks).ConfigureAwait(false);
-        return CommitResolvedBatch(mpf, resolveds);
+            catch (Exception e) when (e is not OutOfMemoryException)
+            {
+                Log.Debug(
+                    e,
+                    "Ignored RAR probe task failure after ordered resolution stopped for {Path}",
+                    pathInArchive);
+            }
+        }
     }
 
     // Convenience for the sequential read path (DavMultipartFileStream
@@ -112,7 +313,7 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
         DavMultipartFile mpf,
         CancellationToken ct)
     {
-        var meta = mpf.Metadata;
+        var meta = await EnsureLastResolvedSplitStateAsync(mpf, ct).ConfigureAwait(false);
         var pending = meta.PendingParts ?? [];
         if (!meta.IsLazy || pending.Length == 0) return meta;
 
@@ -123,7 +324,7 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
     // Coalesce by the part's first segment ID. Two concurrent readers
     // asking for the same volume share one resolution regardless of where
     // it currently sits in PendingParts.
-    private Task<DavMultipartFile.FilePart> GetOrStartResolutionAsync(
+    private Task<Resolution> GetOrStartResolutionAsync(
         DavMultipartFile mpf,
         DavMultipartFile.PendingPart pending,
         CancellationToken callerCt)
@@ -135,7 +336,7 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
         // out doesn't kill resolution for others waiting on it.
         var shared = _inFlight.GetOrAdd(key, k =>
         {
-            var task = DoResolveAsync(mpf, pending, CancellationToken.None);
+            var task = CaptureResolutionAsync(mpf, pending, CancellationToken.None);
             // Drop the entry once done so the dictionary doesn't grow
             // unbounded; the result lives in FileParts after commit.
             _ = task.ContinueWith(t => _inFlight.TryRemove(k, out _),
@@ -148,7 +349,30 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
         return shared.WaitAsync(callerCt);
     }
 
-    private async Task<DavMultipartFile.FilePart> DoResolveAsync(
+    private async Task<Resolution> CaptureResolutionAsync(
+        DavMultipartFile mpf,
+        DavMultipartFile.PendingPart pending,
+        CancellationToken ct)
+    {
+        try
+        {
+            return await DoResolveAsync(mpf, pending, ct).ConfigureAwait(false);
+        }
+        catch (Exception e) when (e is not OutOfMemoryException)
+        {
+            // Full pre-warm resolves volumes concurrently. Preserve failures as
+            // ordered outcomes so a terminal member part can make failures in
+            // unrelated trailing volumes irrelevant; failures before the
+            // terminal part are rethrown by CommitResolvedBatch.
+            return new Resolution
+            {
+                Pending = pending,
+                Error = e,
+            };
+        }
+    }
+
+    private async Task<Resolution> DoResolveAsync(
         DavMultipartFile mpf,
         DavMultipartFile.PendingPart pending,
         CancellationToken ct)
@@ -184,7 +408,7 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
         }
     }
 
-    private async Task<DavMultipartFile.FilePart> ParseVolumeHeaderAsync(
+    private async Task<Resolution> ParseVolumeHeaderAsync(
         DavMultipartFile.PendingPart pending,
         string pathInArchive,
         string? password,
@@ -192,34 +416,65 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
         CancellationToken ct)
     {
         await using var stream = OpenVolumeStream(
-            pending.SegmentIds, fileSize, pending.SegmentFallbackIds);
+            pending.SegmentIds,
+            fileSize,
+            pending.SegmentFallbackIds);
 
-        // Find-and-stop after the matching header. With in-tree SharpCompress
-        // deferred data-skip, this no longer seeks past packed payload on
-        // NzbFileStream (which previously triggered InterpolationSearch).
-        // Measure-and-retry for understated Length remains as defense in depth.
-        var match = await RarUtil.FindFirstFileHeaderAsync(
-            stream,
-            password,
-            h => h.FileName == pathInArchive,
-            ct).ConfigureAwait(false)
-            ?? throw new CorruptRarException(
-                $"Lazy RAR resolution: continuation header for '{pathInArchive}' not found in trailing volume.");
+        // A continuation must be the first real file header in the next
+        // physical volume. Reading only that header avoids scanning unrelated
+        // payload and lets split flags, rather than filename alone, define the
+        // member's volume span.
+        var headers = await RarUtil.ReadHeadersUntilFirstFileAsync(stream, password, ct)
+            .ConfigureAwait(false);
+        var match = headers.OfType<IRarFileHeader>().LastOrDefault(h => !h.IsDirectory);
+        if (match is null
+            || !string.Equals(match.FileName, pathInArchive, StringComparison.Ordinal)
+            || !match.IsSplitBefore
+            || match.IsSolid)
+        {
+            return new Resolution
+            {
+                Pending = pending,
+                FoundPath = match?.FileName,
+                IsSplitBefore = match?.IsSplitBefore ?? false,
+                IsSplitAfter = match?.IsSplitAfter ?? false,
+                IsSolid = match?.IsSolid ?? false,
+                IsEncrypted = match?.IsEncrypted ?? false,
+            };
+        }
 
         var dataStart = match.DataStartPosition;
         var dataSize = match.AdditionalDataSize;
-        return new DavMultipartFile.FilePart
+        return new Resolution
         {
-            SegmentIds = pending.SegmentIds,
-            SegmentIdByteRange = LongRange.FromStartAndSize(0, Math.Max(fileSize, dataStart + dataSize)),
-            FilePartByteRange = LongRange.FromStartAndSize(dataStart, dataSize),
-            SegmentFallbackIds = pending.SegmentFallbackIds,
+            Pending = pending,
+            Part = new DavMultipartFile.FilePart
+            {
+                SegmentIds = pending.SegmentIds,
+                SegmentIdByteRange = LongRange.FromStartAndSize(0, Math.Max(fileSize, dataStart + dataSize)),
+                FilePartByteRange = LongRange.FromStartAndSize(dataStart, dataSize),
+                SegmentFallbackIds = pending.SegmentFallbackIds,
+                IsSplitAfter = match.IsSplitAfter,
+            },
+            FoundPath = match.FileName,
+            IsSplitBefore = match.IsSplitBefore,
+            IsSplitAfter = match.IsSplitAfter,
+            IsSolid = match.IsSolid,
+            IsEncrypted = match.IsEncrypted,
         };
     }
 
-    private Stream OpenVolumeStream(string[] segmentIds, long fileSize, string[][]? segmentFallbacks = null) =>
+    private Stream OpenVolumeStream(
+        string[] segmentIds,
+        long fileSize,
+        string[][]? segmentFallbacks = null,
+        LongRange[]? segmentByteRanges = null) =>
         VolumeStreamFactory?.Invoke(segmentIds, fileSize)
-        ?? usenetClient.GetFileStream(segmentIds, fileSize, articleBufferSize: 0,
+        ?? usenetClient.GetFileStream(
+            segmentIds,
+            fileSize,
+            articleBufferSize: 0,
+            segmentByteRanges: segmentByteRanges,
             segmentFallbacks: segmentFallbacks);
 
     private async Task<long> MeasureVolumeSizeAsync(string[] segmentIds, CancellationToken ct)
@@ -235,7 +490,7 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
     // already moved some/all of our resolveds across, in which case we
     // skip them silently. Persists fire-and-forget — a failed write only
     // costs us a re-resolve after restart.
-    private DavMultipartFile.Meta CommitResolvedBatch(DavMultipartFile mpf, DavMultipartFile.FilePart[] resolveds)
+    private DavMultipartFile.Meta CommitResolvedBatch(DavMultipartFile mpf, Resolution[] resolveds)
     {
         if (resolveds.Length == 0) return mpf.Metadata;
 
@@ -253,32 +508,106 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
             while (startIdx < resolveds.Length)
             {
                 if (pendingParts.Length > 0
-                    && pendingParts[0].SegmentIds.SequenceEqual(resolveds[startIdx].SegmentIds))
+                    && pendingParts[0].SegmentIds.SequenceEqual(resolveds[startIdx].Pending.SegmentIds))
                 {
                     break;
                 }
                 startIdx++;
             }
 
-            // Match consecutive resolveds against consecutive pending head.
+            // Match consecutive outcomes against the pending head and stop at
+            // the member's terminal split part. Outcomes after that point
+            // belong to later archive members and are intentionally ignored.
+            var accepted = new List<DavMultipartFile.FilePart>();
             var matchedCount = 0;
             while (startIdx + matchedCount < resolveds.Length
                    && matchedCount < pendingParts.Length
                    && pendingParts[matchedCount].SegmentIds
-                       .SequenceEqual(resolveds[startIdx + matchedCount].SegmentIds))
+                       .SequenceEqual(resolveds[startIdx + matchedCount].Pending.SegmentIds))
             {
+                var volume = resolveds[startIdx + matchedCount];
+                if (volume.Error is not null)
+                    ExceptionDispatchInfo.Capture(volume.Error).Throw();
+
+                if (volume.Part is null)
+                {
+                    var volumeNumber = fileParts.Length + matchedCount + 1;
+                    var totalVolumes = fileParts.Length + pendingParts.Length;
+                    var found = volume.FoundPath is null
+                        ? "no file header"
+                        : $"'{volume.FoundPath}' (split-before: {volume.IsSplitBefore}, " +
+                          $"split-after: {volume.IsSplitAfter}, solid: {volume.IsSolid}, " +
+                          $"encrypted: {volume.IsEncrypted})";
+                    throw new CorruptRarException(
+                        $"Lazy RAR resolution: expected continuation header for '{meta.PathInArchive}' " +
+                        $"in volume {volumeNumber} of {totalVolumes}; found {found}.");
+                }
+
+                if (volume.IsEncrypted != (meta.AesParams is not null))
+                {
+                    throw new CorruptRarException(
+                        $"Lazy RAR resolution: continuation volume " +
+                        $"{fileParts.Length + matchedCount + 1} for '{meta.PathInArchive}' changed " +
+                        $"encryption state (expected encrypted: {meta.AesParams is not null}, " +
+                        $"found: {volume.IsEncrypted}).");
+                }
+
+                accepted.Add(volume.Part);
                 matchedCount++;
+                if (!volume.IsSplitAfter) break;
             }
 
             if (matchedCount == 0) return meta;
 
-            var newParts = new DavMultipartFile.FilePart[fileParts.Length + matchedCount];
-            Array.Copy(fileParts, newParts, fileParts.Length);
-            for (var i = 0; i < matchedCount; i++)
-                newParts[fileParts.Length + i] = resolveds[startIdx + i];
+            var terminalReached = !resolveds[startIdx + matchedCount - 1].IsSplitAfter;
+            if (!terminalReached && matchedCount == pendingParts.Length)
+            {
+                throw new CorruptRarException(
+                    $"Lazy RAR resolution: '{meta.PathInArchive}' continues beyond the final " +
+                    $"available volume {fileParts.Length + matchedCount}.");
+            }
 
-            var newPending = new DavMultipartFile.PendingPart[pendingParts.Length - matchedCount];
-            Array.Copy(pendingParts, matchedCount, newPending, 0, newPending.Length);
+            var ignoredTailCount = terminalReached
+                ? pendingParts.Length - matchedCount
+                : 0;
+            if (terminalReached)
+                ValidateTerminalSize(meta, fileParts, accepted, ignoredTailCount);
+
+            var newParts = new DavMultipartFile.FilePart[fileParts.Length + accepted.Count];
+            Array.Copy(fileParts, newParts, fileParts.Length);
+            for (var i = 0; i < accepted.Count; i++)
+                newParts[fileParts.Length + i] = accepted[i];
+
+            DavMultipartFile.PendingPart[] newPending;
+            if (terminalReached)
+            {
+                newPending = [];
+                if (ignoredTailCount > 0)
+                {
+                    Log.Information(
+                        "Lazy RAR member {Path} ended before {IgnoredCount} unrelated trailing volume(s); " +
+                        "discarding them from multipart {Id}",
+                        meta.PathInArchive,
+                        ignoredTailCount,
+                        mpf.Id);
+                }
+
+                foreach (var ignoredOutcome in resolveds.Skip(startIdx + matchedCount))
+                {
+                    if (ignoredOutcome.Error is not null)
+                    {
+                        Log.Debug(
+                            ignoredOutcome.Error,
+                            "Ignored failure while probing a RAR volume after terminal member {Path}",
+                            meta.PathInArchive);
+                    }
+                }
+            }
+            else
+            {
+                newPending = new DavMultipartFile.PendingPart[pendingParts.Length - matchedCount];
+                Array.Copy(pendingParts, matchedCount, newPending, 0, newPending.Length);
+            }
 
             var newMeta = new DavMultipartFile.Meta
             {
@@ -288,6 +617,7 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
                 PathInArchive = meta.PathInArchive,
                 ArchivePassword = meta.ArchivePassword,
                 PendingParts = newPending,
+                ExpectedFileSize = meta.ExpectedFileSize,
             };
 
             var becameComplete = meta.IsLazy && newPending.Length == 0;
@@ -296,6 +626,49 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
             _ = SchedulePersistAsync(mpf, becameComplete);
             return newMeta;
         }
+    }
+
+    private static void ValidateTerminalSize(
+        DavMultipartFile.Meta meta,
+        IReadOnlyList<DavMultipartFile.FilePart> existingParts,
+        IReadOnlyList<DavMultipartFile.FilePart> newParts,
+        int ignoredTailCount)
+    {
+        if (meta.ExpectedFileSize is not { } expectedFileSize)
+        {
+            if (ignoredTailCount == 0) return;
+            throw new CorruptRarException(
+                $"Lazy RAR resolution: '{meta.PathInArchive}' ended before {ignoredTailCount} " +
+                "trailing volume(s), but its original file size is unavailable for safe recovery.");
+        }
+
+        long resolvedSize;
+        long expectedStoredSize;
+        try
+        {
+            resolvedSize = 0;
+            foreach (var part in existingParts)
+                resolvedSize = checked(resolvedSize + part.FilePartByteRange.Count);
+            foreach (var part in newParts)
+                resolvedSize = checked(resolvedSize + part.FilePartByteRange.Count);
+
+            expectedStoredSize = meta.AesParams is null
+                ? expectedFileSize
+                : checked((expectedFileSize + 15) / 16 * 16);
+        }
+        catch (OverflowException)
+        {
+            throw new CorruptRarException(
+                $"Lazy RAR resolution: size validation overflowed for '{meta.PathInArchive}'.");
+        }
+
+        const long tolerance = 16; // matches RarAggregator.ValidateVolumes
+        if (Math.Abs((decimal)resolvedSize - expectedStoredSize) <= tolerance) return;
+
+        throw new CorruptRarException(
+            $"Lazy RAR resolution: terminal continuation for '{meta.PathInArchive}' resolves " +
+            $"{resolvedSize} stored bytes, expected {expectedStoredSize}; refusing to complete " +
+            $"the chain with {ignoredTailCount} trailing volume(s) ignored.");
     }
 
     private static long SumResolvedBytes(DavMultipartFile.Meta meta) =>

--- a/backend/Services/LazyRarResolver.cs
+++ b/backend/Services/LazyRarResolver.cs
@@ -69,6 +69,10 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
         long targetByteOffset,
         CancellationToken ct)
     {
+        var current = mpf.Metadata;
+        if (!current.IsLazy) return current;
+        if (SumResolvedBytes(current) > targetByteOffset) return current;
+
         var meta = await EnsureLastResolvedSplitStateAsync(mpf, ct).ConfigureAwait(false);
         if (!meta.IsLazy) return meta;
 
@@ -272,12 +276,11 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
         IEnumerable<Task<Resolution>?> tasks,
         string? pathInArchive)
     {
-        foreach (var task in tasks)
+        foreach (var task in tasks.Where(task => task is not null))
         {
-            if (task is null) continue;
             try
             {
-                var outcome = await task.ConfigureAwait(false);
+                var outcome = await task!.ConfigureAwait(false);
                 if (outcome.Error is not null)
                 {
                     Log.Debug(
@@ -592,15 +595,14 @@ public class LazyRarResolver(INntpClient usenetClient, ConfigManager configManag
                         mpf.Id);
                 }
 
-                foreach (var ignoredOutcome in resolveds.Skip(startIdx + matchedCount))
+                foreach (var ignoredOutcome in resolveds
+                             .Skip(startIdx + matchedCount)
+                             .Where(outcome => outcome.Error is not null))
                 {
-                    if (ignoredOutcome.Error is not null)
-                    {
-                        Log.Debug(
-                            ignoredOutcome.Error,
-                            "Ignored failure while probing a RAR volume after terminal member {Path}",
-                            meta.PathInArchive);
-                    }
+                    Log.Debug(
+                        ignoredOutcome.Error!,
+                        "Ignored failure while probing a RAR volume after terminal member {Path}",
+                        meta.PathInArchive);
                 }
             }
             else

--- a/backend/Streams/DavMultipartFileStream.cs
+++ b/backend/Streams/DavMultipartFileStream.cs
@@ -49,7 +49,10 @@ public class DavMultipartFileStream : FastReadOnlyStream
         _fileName = fileName;
         _inFlightArticleBudget = inFlightArticleBudget;
         _streamingBodyBatchWidth = streamingBodyBatchWidth;
-        _length = ComputeLength(mpf.Metadata);
+        _length = mpf.Metadata.AesParams is null
+                  && mpf.Metadata.ExpectedFileSize is >= 0 and < long.MaxValue
+            ? mpf.Metadata.ExpectedFileSize.Value
+            : ComputeLength(mpf.Metadata);
 
         if (_resolver != null
             && _mpf.Metadata.IsLazy
@@ -171,10 +174,10 @@ public class DavMultipartFileStream : FastReadOnlyStream
         set => Seek(value, SeekOrigin.Begin);
     }
 
-    // Walks resolved FileParts + pending estimates so HEAD/Length-aware
-    // clients see the stable inner-file size from the moment of mount. The
-    // estimates are adjusted at import time so this matches the real
-    // uncompressed size byte-exact.
+    // Fallback for legacy/non-RAR metadata without ExpectedFileSize. Walks
+    // resolved FileParts + pending estimates so HEAD/Length-aware clients see
+    // a stable inner-file size from the moment of mount. The estimates are
+    // adjusted at import time to match the real uncompressed size byte-exact.
     // Old MemoryPack blobs predate the lazy fields, so PendingParts can be
     // null after deserialization despite the property initializer. Guard
     // every iteration with ?? [] to stay safe.

--- a/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
@@ -77,6 +77,59 @@ public sealed class DavDatabaseClientTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task GetDavMultipartFileAsync_BackfillsExpectedSizeForLegacyLazyMetadata()
+    {
+        var id = Guid.NewGuid();
+        var item = DavItem.New(
+            id,
+            DavItem.Root,
+            "movie.mkv",
+            1_234,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.MultipartFile,
+            null,
+            null,
+            null,
+            null);
+        var multipart = new DavMultipartFile
+        {
+            Id = id,
+            Metadata = new DavMultipartFile.Meta
+            {
+                IsLazy = true,
+                PathInArchive = "movie.mkv",
+                FileParts =
+                [
+                    new DavMultipartFile.FilePart
+                    {
+                        SegmentIds = ["vol1"],
+                        SegmentIdByteRange = new NzbWebDAV.Models.LongRange(0, 1_000),
+                        FilePartByteRange = new NzbWebDAV.Models.LongRange(60, 1_000),
+                    }
+                ],
+                PendingParts =
+                [
+                    new DavMultipartFile.PendingPart
+                    {
+                        SegmentIds = ["vol2"],
+                        SegmentIdByteRange = new NzbWebDAV.Models.LongRange(0, 300),
+                        EstimatedDataSize = 294,
+                    }
+                ],
+            },
+        };
+        _context.Items.Add(item);
+        _context.MultipartFiles.Add(multipart);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var loaded = await _client.GetDavMultipartFileAsync(item);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(1_234, loaded!.Metadata.ExpectedFileSize);
+    }
+
+    [Fact]
     public async Task MoveQueueItemsToTopAsync_BumpsPriorityAndCreatedAt()
     {
         var first = CreateQueueItem("first.nzb", DateTime.UtcNow.AddMinutes(-30), QueueItem.PriorityOption.Normal);

--- a/tests/NzbWebDAV.Tests/Fakes/Rar4TestArchiveBuilder.cs
+++ b/tests/NzbWebDAV.Tests/Fakes/Rar4TestArchiveBuilder.cs
@@ -1,0 +1,125 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace NzbWebDAV.Tests.Fakes;
+
+internal static class Rar4TestArchiveBuilder
+{
+    internal static byte[] BuildRar4SplitFirstVolume(
+        string fileName,
+        int packedSize,
+        int uncompressedSize,
+        ReadOnlySpan<byte> payloadPrefix = default) =>
+        BuildRar4Volume(
+            fileName,
+            packedSize,
+            uncompressedSize,
+            firstVolume: true,
+            splitBefore: false,
+            splitAfter: true,
+            payloadPrefix: payloadPrefix);
+
+    internal static byte[] BuildRar4ContinuationVolume(
+        string fileName,
+        int packedSize,
+        int trailingBytes = 0,
+        bool splitAfter = false,
+        bool encrypted = false,
+        int? uncompressedSize = null) =>
+        BuildRar4Volume(
+            fileName,
+            packedSize,
+            uncompressedSize ?? packedSize,
+            firstVolume: false,
+            splitBefore: true,
+            splitAfter: splitAfter,
+            trailingBytes: trailingBytes,
+            encrypted: encrypted);
+
+    internal static byte[] BuildRar4Volume(
+        string fileName,
+        int packedSize,
+        int? uncompressedSize = null,
+        bool firstVolume = false,
+        bool splitBefore = false,
+        bool splitAfter = false,
+        int trailingBytes = 0,
+        ReadOnlySpan<byte> payloadPrefix = default,
+        bool encrypted = false)
+    {
+        using var stream = new MemoryStream();
+        stream.Write([0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x00]);
+
+        Span<byte> archiveBody = stackalloc byte[11];
+        archiveBody[0] = 0x73;
+        var archiveFlags = firstVolume ? (ushort)0x0101 : (ushort)0x0001;
+        BinaryPrimitives.WriteUInt16LittleEndian(archiveBody[1..], archiveFlags);
+        BinaryPrimitives.WriteUInt16LittleEndian(archiveBody[3..], 13);
+        BinaryPrimitives.WriteUInt16LittleEndian(archiveBody[5..], 0);
+        BinaryPrimitives.WriteUInt32LittleEndian(archiveBody[7..], 0);
+        WriteHeader(stream, archiveBody);
+
+        var nameBytes = Encoding.ASCII.GetBytes(fileName);
+        var headSize = (ushort)(32 + nameBytes.Length);
+        var fileBody = new byte[headSize - 2];
+        var offset = 0;
+        fileBody[offset++] = 0x74;
+        var fileFlags = (ushort)(0x8000
+                                 | (splitBefore ? 0x0001 : 0)
+                                 | (splitAfter ? 0x0002 : 0)
+                                 | (encrypted ? 0x0004 : 0));
+        BinaryPrimitives.WriteUInt16LittleEndian(fileBody.AsSpan(offset), fileFlags);
+        offset += 2;
+        BinaryPrimitives.WriteUInt16LittleEndian(fileBody.AsSpan(offset), headSize);
+        offset += 2;
+        BinaryPrimitives.WriteUInt32LittleEndian(fileBody.AsSpan(offset), (uint)packedSize);
+        offset += 4;
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            fileBody.AsSpan(offset),
+            (uint)(uncompressedSize ?? packedSize));
+        offset += 4;
+        fileBody[offset++] = 2; // HostOS Unix
+        BinaryPrimitives.WriteUInt32LittleEndian(fileBody.AsSpan(offset), 0);
+        offset += 4;
+        BinaryPrimitives.WriteUInt32LittleEndian(fileBody.AsSpan(offset), 0);
+        offset += 4;
+        fileBody[offset++] = 20; // UnpVer
+        fileBody[offset++] = 0x30; // store
+        BinaryPrimitives.WriteUInt16LittleEndian(
+            fileBody.AsSpan(offset),
+            (ushort)nameBytes.Length);
+        offset += 2;
+        BinaryPrimitives.WriteUInt32LittleEndian(fileBody.AsSpan(offset), 0);
+        offset += 4;
+        nameBytes.CopyTo(fileBody.AsSpan(offset));
+        WriteHeader(stream, fileBody);
+
+        var payload = new byte[packedSize];
+        payloadPrefix.CopyTo(payload);
+        stream.Write(payload);
+        stream.Write(new byte[trailingBytes]);
+        return stream.ToArray();
+    }
+
+    private static void WriteHeader(Stream stream, ReadOnlySpan<byte> bodyWithoutCrc)
+    {
+        var crc = RarCrc16(bodyWithoutCrc);
+        Span<byte> header = stackalloc byte[bodyWithoutCrc.Length + 2];
+        BinaryPrimitives.WriteUInt16LittleEndian(header, crc);
+        bodyWithoutCrc.CopyTo(header[2..]);
+        stream.Write(header);
+    }
+
+    private static ushort RarCrc16(ReadOnlySpan<byte> data)
+    {
+        uint crc = 0xFFFFFFFF;
+        foreach (var value in data)
+        {
+            crc ^= value;
+            for (var i = 0; i < 8; i++)
+                crc = (crc & 1) != 0 ? (crc >> 1) ^ 0xEDB88320u : crc >> 1;
+        }
+
+        return (ushort)(~crc);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Queue/GetFileInfosStepTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/GetFileInfosStepTests.cs
@@ -85,6 +85,7 @@ public class GetFileInfosStepTests
         Assert.Equal(releaseDate, result.ReleaseDate);
         Assert.True(result.IsRar);
         Assert.Null(result.FileSize);
+        Assert.Same(rarHeader, result.First16KB);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Queue/LazyRarProcessorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/LazyRarProcessorTests.cs
@@ -1,5 +1,3 @@
-using System.Buffers.Binary;
-using System.Text;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Models;
@@ -10,6 +8,7 @@ using NzbWebDAV.Streams;
 using NzbWebDAV.Utils;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
+using static NzbWebDAV.Tests.Fakes.Rar4TestArchiveBuilder;
 
 namespace NzbWebDAV.Tests.Queue;
 
@@ -268,11 +267,11 @@ public class LazyRarProcessorTests
             ["part1@example.com"] = firstBytes,
         });
 
-        var result = await new LazyRarProcessor(infos, client, password: null, CancellationToken.None)
-            .ProcessAsync() as LazyRarProcessor.Result;
+        var result = Assert.IsType<LazyRarProcessor.Result>(
+            await new LazyRarProcessor(infos, client, password: null, CancellationToken.None)
+                .ProcessAsync());
 
-        Assert.NotNull(result);
-        Assert.Equal(member, result!.PathInArchive);
+        Assert.Equal(member, result.PathInArchive);
         Assert.Equal(2, result.PendingParts.Length);
         Assert.Equal(true, result.FirstPart.IsSplitAfter);
     }
@@ -460,115 +459,6 @@ public class LazyRarProcessorTests
             IsRar = true,
             First16KB = first16KB,
         };
-    }
-
-    // Minimal RAR4 multi-volume first part: mark + archive(VOLUME|FIRSTVOLUME) +
-    // stored file header (HAS_DATA|SPLIT_AFTER) with full UNP_SIZE + packed payload.
-    private static byte[] BuildRar4SplitFirstVolume(
-        string fileName, int packedSize, int uncompressedSize, ReadOnlySpan<byte> payloadPrefix = default)
-        => BuildRar4Volume(
-            fileName,
-            packedSize,
-            uncompressedSize,
-            firstVolume: true,
-            splitBefore: false,
-            splitAfter: true,
-            payloadPrefix: payloadPrefix);
-
-    private static byte[] BuildRar4ContinuationVolume(
-        string fileName, int packedSize, bool splitAfter = false)
-        => BuildRar4Volume(
-            fileName,
-            packedSize,
-            packedSize,
-            firstVolume: false,
-            splitBefore: true,
-            splitAfter: splitAfter);
-
-    private static byte[] BuildRar4Volume(
-        string fileName,
-        int packedSize,
-        int uncompressedSize,
-        bool firstVolume,
-        bool splitBefore,
-        bool splitAfter,
-        ReadOnlySpan<byte> payloadPrefix = default,
-        bool encrypted = false)
-    {
-        using var ms = new MemoryStream();
-        ms.Write([0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x00]);
-
-        // Archive header (HEAD_SIZE=13 including CRC).
-        {
-            Span<byte> body = stackalloc byte[11];
-            body[0] = 0x73;
-            var archiveFlags = firstVolume ? (ushort)0x0101 : (ushort)0x0001;
-            BinaryPrimitives.WriteUInt16LittleEndian(body[1..], archiveFlags);
-            BinaryPrimitives.WriteUInt16LittleEndian(body[3..], 13);
-            BinaryPrimitives.WriteUInt16LittleEndian(body[5..], 0);
-            BinaryPrimitives.WriteUInt32LittleEndian(body[7..], 0);
-            WriteHeader(ms, body);
-        }
-
-        var nameBytes = Encoding.ASCII.GetBytes(fileName);
-        var headSize = (ushort)(32 + nameBytes.Length);
-        {
-            var body = new byte[headSize - 2];
-            var o = 0;
-            body[o++] = 0x74;
-            var fileFlags = (ushort)(0x8000
-                                     | (splitBefore ? 0x0001 : 0)
-                                     | (splitAfter ? 0x0002 : 0)
-                                     | (encrypted ? 0x0004 : 0));
-            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), fileFlags);
-            o += 2;
-            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), headSize);
-            o += 2;
-            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), (uint)packedSize); // ADD_SIZE
-            o += 4;
-            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), (uint)uncompressedSize); // UNP_SIZE
-            o += 4;
-            body[o++] = 2; // HostOS Unix
-            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), 0); // FileCRC
-            o += 4;
-            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), 0); // FileTime
-            o += 4;
-            body[o++] = 20; // UnpVer
-            body[o++] = 0x30; // store
-            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), (ushort)nameBytes.Length);
-            o += 2;
-            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), 0); // Attr
-            o += 4;
-            nameBytes.CopyTo(body.AsSpan(o));
-            WriteHeader(ms, body);
-        }
-
-        var payload = new byte[packedSize];
-        payloadPrefix.CopyTo(payload);
-        ms.Write(payload);
-        return ms.ToArray();
-    }
-
-    private static void WriteHeader(Stream stream, ReadOnlySpan<byte> bodyWithoutCrc)
-    {
-        var crc = RarCrc16(bodyWithoutCrc);
-        Span<byte> hdr = stackalloc byte[bodyWithoutCrc.Length + 2];
-        BinaryPrimitives.WriteUInt16LittleEndian(hdr, crc);
-        bodyWithoutCrc.CopyTo(hdr[2..]);
-        stream.Write(hdr);
-    }
-
-    private static ushort RarCrc16(ReadOnlySpan<byte> data)
-    {
-        uint crc = 0xFFFFFFFF;
-        foreach (var b in data)
-        {
-            crc ^= b;
-            for (var i = 0; i < 8; i++)
-                crc = (crc & 1) != 0 ? (crc >> 1) ^ 0xEDB88320u : crc >> 1;
-        }
-
-        return (ushort)(~crc);
     }
 
     /// <summary>

--- a/tests/NzbWebDAV.Tests/Queue/LazyRarProcessorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/LazyRarProcessorTests.cs
@@ -81,11 +81,17 @@ public class LazyRarProcessorTests
         const int packed = 1_000;
         const int uncompressed = 3_000;
         var volumeBytes = BuildRar4SplitFirstVolume("movie.mkv", packed, uncompressed);
+        var continuationBytes = BuildRar4ContinuationVolume("movie.mkv", 2_000);
         var first = FileInfoFor("vol.rar", "first@example.com", volumeBytes.Length, volumeBytes.Length);
         // Encoded trailing size must cover remaining uncompressed bytes, but the
         // 0.95*encoded estimate (minus header guess) must not overshoot remaining
         // or LazyRar falls back before the coverage bound matters.
-        var trailing = FileInfoFor("vol.r00", "r00@example.com", encodedBytes: 2_100, fileSize: null);
+        var trailing = FileInfoFor(
+            "vol.r00",
+            "r00@example.com",
+            encodedBytes: 2_100,
+            fileSize: null,
+            first16KB: continuationBytes);
 
         using var client = new MemoryServingNntpClient(new Dictionary<string, byte[]>
         {
@@ -107,13 +113,19 @@ public class LazyRarProcessorTests
         const int packed = 1_000;
         const int uncompressed = 3_000;
         var volumeBytes = BuildRar4SplitFirstVolume("movie.mkv", packed, uncompressed);
+        var continuationBytes = BuildRar4ContinuationVolume("movie.mkv", 2_000);
         var underestimatedSize = volumeBytes.Length - 100;
         var first = FileInfoFor(
             "vol.rar",
             "first@example.com",
             volumeBytes.Length,
             underestimatedSize);
-        var trailing = FileInfoFor("vol.r00", "r00@example.com", encodedBytes: 2_100, fileSize: null);
+        var trailing = FileInfoFor(
+            "vol.r00",
+            "r00@example.com",
+            encodedBytes: 2_100,
+            fileSize: null,
+            first16KB: continuationBytes);
 
         using var client = new MemoryServingNntpClient(new Dictionary<string, byte[]>
         {
@@ -137,8 +149,15 @@ public class LazyRarProcessorTests
         const int uncompressed = 3_000;
         var volumeBytes = BuildRar4SplitFirstVolume(
             "b082fa0beaa644d3aa01045d5b8d0b36.xyz", packed, uncompressed, payload);
+        var continuationBytes = BuildRar4ContinuationVolume(
+            "b082fa0beaa644d3aa01045d5b8d0b36.xyz", 2_000);
         var first = FileInfoFor("vol.rar", "first@example.com", volumeBytes.Length, volumeBytes.Length);
-        var trailing = FileInfoFor("vol.r00", "r00@example.com", encodedBytes: 2_100, fileSize: null);
+        var trailing = FileInfoFor(
+            "vol.r00",
+            "r00@example.com",
+            encodedBytes: 2_100,
+            fileSize: null,
+            first16KB: continuationBytes);
 
         using var client = new MemoryServingNntpClient(new Dictionary<string, byte[]>
         {
@@ -158,8 +177,14 @@ public class LazyRarProcessorTests
         const int packed = 1_000;
         const int uncompressed = 3_000;
         var volumeBytes = BuildRar4SplitFirstVolume("movie.mkv", packed, uncompressed);
+        var continuationBytes = BuildRar4ContinuationVolume("movie.mkv", 2_000);
         var first = FileInfoFor("vol.rar", "first@example.com", volumeBytes.Length, volumeBytes.Length);
-        var trailing = FileInfoFor("vol.r00", "r00@example.com", encodedBytes: 2_100, fileSize: null);
+        var trailing = FileInfoFor(
+            "vol.r00",
+            "r00@example.com",
+            encodedBytes: 2_100,
+            fileSize: null,
+            first16KB: continuationBytes);
 
         using var client = new MemoryServingNntpClient(new Dictionary<string, byte[]>
         {
@@ -171,6 +196,230 @@ public class LazyRarProcessorTests
 
         Assert.NotNull(result);
         Assert.Null(result!.SniffedVideoExtension);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_MemberEndsBeforeLastVolume_ReturnsNull()
+    {
+        const string member = "movie.mkv";
+        var firstBytes = BuildRar4SplitFirstVolume(member, packedSize: 1_000, uncompressedSize: 1_800);
+        var finalMemberBytes = BuildRar4ContinuationVolume(member, packedSize: 800);
+        var extraBytes = BuildRar4Volume(
+            "extra.srt",
+            packedSize: 100,
+            uncompressedSize: 100,
+            firstVolume: false,
+            splitBefore: false,
+            splitAfter: false);
+        var infos = new List<GetFileInfosStep.FileInfo>
+        {
+            FileInfoFor("opaque.part01.rar", "part1@example.com", firstBytes.Length, firstBytes.Length),
+            FileInfoFor(
+                "opaque.part02.rar",
+                "part2@example.com",
+                finalMemberBytes.Length,
+                finalMemberBytes.Length,
+                finalMemberBytes),
+            FileInfoFor(
+                "opaque.part03.rar",
+                "part3@example.com",
+                extraBytes.Length,
+                extraBytes.Length,
+                extraBytes),
+        };
+
+        using var client = new MemoryServingNntpClient(new Dictionary<string, byte[]>
+        {
+            ["part1@example.com"] = firstBytes,
+        });
+
+        var result = await new LazyRarProcessor(infos, client, password: null, CancellationToken.None)
+            .ProcessAsync();
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_MemberSpansEveryVolume_MountsLazily()
+    {
+        const string member = "movie.mkv";
+        var firstBytes = BuildRar4SplitFirstVolume(member, packedSize: 600, uncompressedSize: 1_800);
+        var middleBytes = BuildRar4ContinuationVolume(member, packedSize: 600, splitAfter: true);
+        var finalBytes = BuildRar4ContinuationVolume(member, packedSize: 600);
+        var infos = new List<GetFileInfosStep.FileInfo>
+        {
+            FileInfoFor("opaque.part01.rar", "part1@example.com", firstBytes.Length, firstBytes.Length),
+            FileInfoFor(
+                "opaque.part02.rar",
+                "part2@example.com",
+                middleBytes.Length,
+                middleBytes.Length,
+                middleBytes),
+            FileInfoFor(
+                "opaque.part03.rar",
+                "part3@example.com",
+                finalBytes.Length,
+                finalBytes.Length,
+                finalBytes),
+        };
+
+        using var client = new MemoryServingNntpClient(new Dictionary<string, byte[]>
+        {
+            ["part1@example.com"] = firstBytes,
+        });
+
+        var result = await new LazyRarProcessor(infos, client, password: null, CancellationToken.None)
+            .ProcessAsync() as LazyRarProcessor.Result;
+
+        Assert.NotNull(result);
+        Assert.Equal(member, result!.PathInArchive);
+        Assert.Equal(2, result.PendingParts.Length);
+        Assert.Equal(true, result.FirstPart.IsSplitAfter);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ContinuationWithoutSplitBefore_ReturnsNull()
+    {
+        const string member = "movie.mkv";
+        var firstBytes = BuildRar4SplitFirstVolume(member, packedSize: 600, uncompressedSize: 1_200);
+        var invalidContinuation = BuildRar4Volume(
+            member,
+            packedSize: 600,
+            uncompressedSize: 600,
+            firstVolume: false,
+            splitBefore: false,
+            splitAfter: false);
+        var first = FileInfoFor(
+            "opaque.part01.rar", "part1@example.com", firstBytes.Length, firstBytes.Length);
+        var trailing = FileInfoFor(
+            "opaque.part02.rar",
+            "part2@example.com",
+            invalidContinuation.Length,
+            invalidContinuation.Length,
+            invalidContinuation);
+
+        using var client = new MemoryServingNntpClient(new Dictionary<string, byte[]>
+        {
+            ["part1@example.com"] = firstBytes,
+        });
+
+        var result = await new LazyRarProcessor(
+                [first, trailing], client, password: null, CancellationToken.None)
+            .ProcessAsync();
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ContinuationWithDifferentMember_ReturnsNull()
+    {
+        const string member = "movie.mkv";
+        var firstBytes = BuildRar4SplitFirstVolume(member, packedSize: 600, uncompressedSize: 1_200);
+        var wrongMember = BuildRar4ContinuationVolume("different.mkv", packedSize: 600);
+        var first = FileInfoFor(
+            "opaque.part01.rar", "part1@example.com", firstBytes.Length, firstBytes.Length);
+        var trailing = FileInfoFor(
+            "opaque.part02.rar",
+            "part2@example.com",
+            wrongMember.Length,
+            wrongMember.Length,
+            wrongMember);
+
+        using var client = new MemoryServingNntpClient(new Dictionary<string, byte[]>
+        {
+            ["part1@example.com"] = firstBytes,
+        });
+
+        var result = await new LazyRarProcessor(
+                [first, trailing], client, password: null, CancellationToken.None)
+            .ProcessAsync();
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ContinuationSizeMismatch_ReturnsNull()
+    {
+        const string member = "movie.mkv";
+        var firstBytes = BuildRar4SplitFirstVolume(member, packedSize: 600, uncompressedSize: 1_300);
+        var finalBytes = BuildRar4ContinuationVolume(member, packedSize: 600);
+        var first = FileInfoFor(
+            "opaque.part01.rar", "part1@example.com", firstBytes.Length, firstBytes.Length);
+        var trailing = FileInfoFor(
+            "opaque.part02.rar",
+            "part2@example.com",
+            finalBytes.Length,
+            finalBytes.Length,
+            finalBytes);
+
+        using var client = new MemoryServingNntpClient(new Dictionary<string, byte[]>
+        {
+            ["part1@example.com"] = firstBytes,
+        });
+
+        var result = await new LazyRarProcessor(
+                [first, trailing], client, password: null, CancellationToken.None)
+            .ProcessAsync();
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_EncryptedMemberWithoutPassword_ReturnsNull()
+    {
+        var volumeBytes = BuildRar4Volume(
+            "movie.mkv",
+            packedSize: 100,
+            uncompressedSize: 100,
+            firstVolume: true,
+            splitBefore: false,
+            splitAfter: false,
+            encrypted: true);
+        var first = FileInfoFor(
+            "opaque.rar", "part1@example.com", volumeBytes.Length, volumeBytes.Length);
+        using var client = new MemoryServingNntpClient(new Dictionary<string, byte[]>
+        {
+            ["part1@example.com"] = volumeBytes,
+        });
+
+        var result = await new LazyRarProcessor(
+                [first], client, password: null, CancellationToken.None)
+            .ProcessAsync();
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ContinuationEncryptionStateChanges_ReturnsNull()
+    {
+        const string member = "movie.mkv";
+        var firstBytes = BuildRar4SplitFirstVolume(member, packedSize: 600, uncompressedSize: 1_200);
+        var encryptedContinuation = BuildRar4Volume(
+            member,
+            packedSize: 600,
+            uncompressedSize: 600,
+            firstVolume: false,
+            splitBefore: true,
+            splitAfter: false,
+            encrypted: true);
+        var first = FileInfoFor(
+            "opaque.part01.rar", "part1@example.com", firstBytes.Length, firstBytes.Length);
+        var trailing = FileInfoFor(
+            "opaque.part02.rar",
+            "part2@example.com",
+            encryptedContinuation.Length,
+            encryptedContinuation.Length,
+            encryptedContinuation);
+        using var client = new MemoryServingNntpClient(new Dictionary<string, byte[]>
+        {
+            ["part1@example.com"] = firstBytes,
+        });
+
+        var result = await new LazyRarProcessor(
+                [first, trailing], client, password: null, CancellationToken.None)
+            .ProcessAsync();
+
+        Assert.Null(result);
     }
 
     [Fact]
@@ -189,7 +438,11 @@ public class LazyRarProcessorTests
     }
 
     private static GetFileInfosStep.FileInfo FileInfoFor(
-        string fileName, string messageId, long encodedBytes, long? fileSize)
+        string fileName,
+        string messageId,
+        long encodedBytes,
+        long? fileSize,
+        byte[]? first16KB = null)
     {
         return new GetFileInfosStep.FileInfo
         {
@@ -205,6 +458,7 @@ public class LazyRarProcessorTests
             ReleaseDate = DateTimeOffset.UnixEpoch,
             FileSize = fileSize,
             IsRar = true,
+            First16KB = first16KB,
         };
     }
 
@@ -212,6 +466,34 @@ public class LazyRarProcessorTests
     // stored file header (HAS_DATA|SPLIT_AFTER) with full UNP_SIZE + packed payload.
     private static byte[] BuildRar4SplitFirstVolume(
         string fileName, int packedSize, int uncompressedSize, ReadOnlySpan<byte> payloadPrefix = default)
+        => BuildRar4Volume(
+            fileName,
+            packedSize,
+            uncompressedSize,
+            firstVolume: true,
+            splitBefore: false,
+            splitAfter: true,
+            payloadPrefix: payloadPrefix);
+
+    private static byte[] BuildRar4ContinuationVolume(
+        string fileName, int packedSize, bool splitAfter = false)
+        => BuildRar4Volume(
+            fileName,
+            packedSize,
+            packedSize,
+            firstVolume: false,
+            splitBefore: true,
+            splitAfter: splitAfter);
+
+    private static byte[] BuildRar4Volume(
+        string fileName,
+        int packedSize,
+        int uncompressedSize,
+        bool firstVolume,
+        bool splitBefore,
+        bool splitAfter,
+        ReadOnlySpan<byte> payloadPrefix = default,
+        bool encrypted = false)
     {
         using var ms = new MemoryStream();
         ms.Write([0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x00]);
@@ -220,8 +502,8 @@ public class LazyRarProcessorTests
         {
             Span<byte> body = stackalloc byte[11];
             body[0] = 0x73;
-            // MHD_VOLUME (0x0001) | MHD_FIRSTVOLUME (0x0100)
-            BinaryPrimitives.WriteUInt16LittleEndian(body[1..], 0x0101);
+            var archiveFlags = firstVolume ? (ushort)0x0101 : (ushort)0x0001;
+            BinaryPrimitives.WriteUInt16LittleEndian(body[1..], archiveFlags);
             BinaryPrimitives.WriteUInt16LittleEndian(body[3..], 13);
             BinaryPrimitives.WriteUInt16LittleEndian(body[5..], 0);
             BinaryPrimitives.WriteUInt32LittleEndian(body[7..], 0);
@@ -234,8 +516,11 @@ public class LazyRarProcessorTests
             var body = new byte[headSize - 2];
             var o = 0;
             body[o++] = 0x74;
-            // LHD_HAS_DATA (0x8000) | LHD_SPLIT_AFTER (0x0002)
-            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), 0x8002);
+            var fileFlags = (ushort)(0x8000
+                                     | (splitBefore ? 0x0001 : 0)
+                                     | (splitAfter ? 0x0002 : 0)
+                                     | (encrypted ? 0x0004 : 0));
+            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), fileFlags);
             o += 2;
             BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), headSize);
             o += 2;

--- a/tests/NzbWebDAV.Tests/Services/LazyRarResolverTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/LazyRarResolverTests.cs
@@ -1,5 +1,3 @@
-using System.Buffers.Binary;
-using System.Text;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Config;
@@ -10,6 +8,7 @@ using NzbWebDAV.Services;
 using NzbWebDAV.Tests.Database;
 using NzbWebDAV.Utils;
 using UsenetSharp.Models;
+using static NzbWebDAV.Tests.Fakes.Rar4TestArchiveBuilder;
 
 namespace NzbWebDAV.Tests.Services;
 
@@ -207,6 +206,28 @@ public class LazyRarResolverTests
     }
 
     [Fact]
+    public async Task EnsureResolvedThroughAsync_CoveredRangeSkipsLegacySplitRecovery()
+    {
+        using var client = new MeasuringNntpClient("unused", 0);
+        var resolver = new LazyRarResolver(client, new ConfigManager())
+        {
+            VolumeStreamFactory = (_, _) => throw new InvalidOperationException(
+                "Covered reads must not open a RAR volume."),
+        };
+        var mpf = MultipartFile(
+            "movie.mkv",
+            Pending("vol2-seg0", volumeLength: 800, estimatedDataSize: 800));
+        mpf.Metadata.FileParts[0].IsSplitAfter = null;
+
+        var meta = await resolver.EnsureResolvedThroughAsync(
+            mpf, targetByteOffset: 0, ct: CancellationToken.None);
+
+        Assert.Same(mpf.Metadata, meta);
+        Assert.True(meta.IsLazy);
+        Assert.Null(meta.FileParts[0].IsSplitAfter);
+    }
+
+    [Fact]
     public async Task EnsureResolvedThroughAsync_LegacyResolvedTerminalDropsPendingTail()
     {
         const string pathInArchive = "movie.mkv";
@@ -365,100 +386,6 @@ public class LazyRarResolverTests
             SegmentIdByteRange = LongRange.FromStartAndSize(0, volumeLength),
             EstimatedDataSize = estimatedDataSize,
         };
-
-    // Minimal RAR4 multi-volume continuation: mark + archive(VOLUME) +
-    // stored file header (HAS_DATA|SPLIT_BEFORE) + packed payload.
-    private static byte[] BuildRar4ContinuationVolume(
-        string fileName,
-        int packedSize,
-        int trailingBytes = 0,
-        bool splitAfter = false)
-        => BuildRar4Volume(
-            fileName,
-            packedSize,
-            splitBefore: true,
-            splitAfter: splitAfter,
-            trailingBytes: trailingBytes);
-
-    private static byte[] BuildRar4Volume(
-        string fileName,
-        int packedSize,
-        bool splitBefore,
-        bool splitAfter,
-        int trailingBytes = 0)
-    {
-        using var ms = new MemoryStream();
-        ms.Write([0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x00]);
-
-        // Archive header (HEAD_SIZE=13 including CRC).
-        {
-            Span<byte> body = stackalloc byte[11];
-            body[0] = 0x73;
-            BinaryPrimitives.WriteUInt16LittleEndian(body[1..], 0x0001); // MHD_VOLUME
-            BinaryPrimitives.WriteUInt16LittleEndian(body[3..], 13);
-            BinaryPrimitives.WriteUInt16LittleEndian(body[5..], 0);
-            BinaryPrimitives.WriteUInt32LittleEndian(body[7..], 0);
-            WriteHeader(ms, body);
-        }
-
-        var nameBytes = Encoding.ASCII.GetBytes(fileName);
-        var headSize = (ushort)(32 + nameBytes.Length);
-        {
-            var body = new byte[headSize - 2];
-            var o = 0;
-            body[o++] = 0x74;
-            var fileFlags = (ushort)(0x8000
-                                     | (splitBefore ? 0x0001 : 0)
-                                     | (splitAfter ? 0x0002 : 0));
-            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), fileFlags);
-            o += 2;
-            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), headSize);
-            o += 2;
-            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), (uint)packedSize); // ADD_SIZE
-            o += 4;
-            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), (uint)packedSize); // UNP_SIZE
-            o += 4;
-            body[o++] = 2; // HostOS Unix
-            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), 0); // FileCRC
-            o += 4;
-            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), 0); // FileTime
-            o += 4;
-            body[o++] = 20; // UnpVer
-            body[o++] = 0x30; // store
-            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), (ushort)nameBytes.Length);
-            o += 2;
-            BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(o), 0); // Attr
-            o += 4;
-            nameBytes.CopyTo(body.AsSpan(o));
-            WriteHeader(ms, body);
-        }
-
-        ms.Write(new byte[packedSize]);
-        ms.Write(new byte[trailingBytes]);
-        return ms.ToArray();
-    }
-
-    private static void WriteHeader(Stream stream, ReadOnlySpan<byte> bodyWithoutCrc)
-    {
-        var crc = RarCrc16(bodyWithoutCrc);
-        Span<byte> hdr = stackalloc byte[bodyWithoutCrc.Length + 2];
-        BinaryPrimitives.WriteUInt16LittleEndian(hdr, crc);
-        bodyWithoutCrc.CopyTo(hdr[2..]);
-        stream.Write(hdr);
-    }
-
-    private static ushort RarCrc16(ReadOnlySpan<byte> data)
-    {
-        uint crc = 0xFFFFFFFF;
-        foreach (var b in data)
-        {
-            crc ^= b;
-            for (var i = 0; i < 8; i++)
-                crc = (crc & 1) != 0 ? (crc >> 1) ^ 0xEDB88320u : crc >> 1;
-        }
-
-        return (ushort)(~crc);
-    }
 
     // Only GetYencHeadersAsync is used by the measured-size retry path.
     private sealed class MeasuringNntpClient(string segmentId, long measuredSize) : NntpClient

--- a/tests/NzbWebDAV.Tests/Services/LazyRarResolverTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/LazyRarResolverTests.cs
@@ -64,6 +64,7 @@ public class LazyRarResolverTests
                         SegmentIds = ["vol1-seg0"],
                         SegmentIdByteRange = LongRange.FromStartAndSize(0, 100),
                         FilePartByteRange = LongRange.FromStartAndSize(10, 90),
+                        IsSplitAfter = true,
                     }
                 ],
                 PendingParts =
@@ -75,6 +76,7 @@ public class LazyRarResolverTests
                         EstimatedDataSize = underestimatedSize - 80,
                     }
                 ],
+                ExpectedFileSize = 90 + packedSize,
             }
         };
 
@@ -123,6 +125,7 @@ public class LazyRarResolverTests
                             SegmentIds = ["vol1-seg0"],
                             SegmentIdByteRange = LongRange.FromStartAndSize(0, 100),
                             FilePartByteRange = LongRange.FromStartAndSize(10, 90),
+                            IsSplitAfter = true,
                         }
                     ],
                     PendingParts =
@@ -134,6 +137,7 @@ public class LazyRarResolverTests
                             EstimatedDataSize = packedSize,
                         }
                     ],
+                    ExpectedFileSize = 90 + packedSize,
                 }
             };
 
@@ -168,9 +172,220 @@ public class LazyRarResolverTests
         }
     }
 
+    [Fact]
+    public async Task EnsureResolvedThroughAsync_TerminalPartDropsUnrelatedTrailingVolumes()
+    {
+        const string pathInArchive = "movie.mkv";
+        var finalMemberBytes = BuildRar4ContinuationVolume(pathInArchive, packedSize: 800);
+        var extraBytes = BuildRar4Volume(
+            "extra.srt",
+            packedSize: 100,
+            splitBefore: false,
+            splitAfter: false);
+        var volumes = new Dictionary<string, byte[]>
+        {
+            ["vol2-seg0"] = finalMemberBytes,
+            ["vol3-seg0"] = extraBytes,
+        };
+        using var client = new MeasuringNntpClient("unused", 0);
+        var resolver = new LazyRarResolver(client, new ConfigManager())
+        {
+            VolumeStreamFactory = (ids, size) => new BoundedLengthStream(volumes[ids[0]], size),
+        };
+        var mpf = MultipartFile(
+            pathInArchive,
+            Pending("vol2-seg0", finalMemberBytes.Length, 780),
+            Pending("vol3-seg0", extraBytes.Length, 20));
+
+        var meta = await resolver.EnsureResolvedThroughAsync(
+            mpf, long.MaxValue, CancellationToken.None);
+
+        Assert.False(meta.IsLazy);
+        Assert.Empty(meta.PendingParts);
+        Assert.Equal(2, meta.FileParts.Length);
+        Assert.Equal(800, meta.FileParts[1].FilePartByteRange.Count);
+    }
+
+    [Fact]
+    public async Task EnsureResolvedThroughAsync_LegacyResolvedTerminalDropsPendingTail()
+    {
+        const string pathInArchive = "movie.mkv";
+        var finalMemberBytes = BuildRar4ContinuationVolume(pathInArchive, packedSize: 800);
+        var volumes = new Dictionary<string, byte[]>
+        {
+            ["vol2-seg0"] = finalMemberBytes,
+        };
+        using var client = new MeasuringNntpClient("unused", 0);
+        var resolver = new LazyRarResolver(client, new ConfigManager())
+        {
+            VolumeStreamFactory = (ids, size) => new BoundedLengthStream(volumes[ids[0]], size),
+        };
+        var mpf = MultipartFile(
+            pathInArchive,
+            Pending("vol3-seg0", volumeLength: 200, estimatedDataSize: 20));
+        mpf.Metadata.FileParts =
+        [
+            mpf.Metadata.FileParts[0],
+            new DavMultipartFile.FilePart
+            {
+                SegmentIds = ["vol2-seg0"],
+                SegmentIdByteRange = LongRange.FromStartAndSize(0, finalMemberBytes.Length),
+                FilePartByteRange = LongRange.FromStartAndSize(
+                    finalMemberBytes.Length - 800,
+                    800),
+                IsSplitAfter = null,
+            }
+        ];
+        mpf.Metadata.ExpectedFileSize = 1_740;
+
+        var meta = await resolver.EnsureResolvedThroughAsync(
+            mpf, long.MaxValue, CancellationToken.None);
+
+        Assert.False(meta.IsLazy);
+        Assert.Empty(meta.PendingParts);
+        Assert.Equal(2, meta.FileParts.Length);
+        Assert.Equal(false, meta.FileParts[1].IsSplitAfter);
+    }
+
+    [Fact]
+    public async Task EnsureResolvedThroughAsync_TerminalSizeMismatchDoesNotDropTail()
+    {
+        const string pathInArchive = "movie.mkv";
+        var finalMemberBytes = BuildRar4ContinuationVolume(pathInArchive, packedSize: 800);
+        var extraBytes = BuildRar4Volume(
+            "extra.srt",
+            packedSize: 100,
+            splitBefore: false,
+            splitAfter: false);
+        var volumes = new Dictionary<string, byte[]>
+        {
+            ["vol2-seg0"] = finalMemberBytes,
+            ["vol3-seg0"] = extraBytes,
+        };
+        using var client = new MeasuringNntpClient("unused", 0);
+        var resolver = new LazyRarResolver(client, new ConfigManager())
+        {
+            VolumeStreamFactory = (ids, size) => new BoundedLengthStream(volumes[ids[0]], size),
+        };
+        var mpf = MultipartFile(
+            pathInArchive,
+            Pending("vol2-seg0", finalMemberBytes.Length, 780),
+            Pending("vol3-seg0", extraBytes.Length, 20));
+        mpf.Metadata.ExpectedFileSize = 2_000;
+
+        var failure = await Assert.ThrowsAsync<NzbWebDAV.Exceptions.CorruptRarException>(
+            () => resolver.EnsureResolvedThroughAsync(
+                mpf, long.MaxValue, CancellationToken.None));
+
+        Assert.Contains("resolves 1740 stored bytes, expected 2000", failure.Message);
+        Assert.True(mpf.Metadata.IsLazy);
+        Assert.Equal(2, mpf.Metadata.PendingParts.Length);
+    }
+
+    [Fact]
+    public async Task EnsureResolvedThroughAsync_ChainContinuesPastLastVolume_Throws()
+    {
+        const string pathInArchive = "movie.mkv";
+        var continuationBytes = BuildRar4ContinuationVolume(
+            pathInArchive, packedSize: 800, splitAfter: true);
+        using var client = new MeasuringNntpClient("unused", 0);
+        var resolver = new LazyRarResolver(client, new ConfigManager())
+        {
+            VolumeStreamFactory = (_, size) => new BoundedLengthStream(continuationBytes, size),
+        };
+        var mpf = MultipartFile(
+            pathInArchive,
+            Pending("vol2-seg0", continuationBytes.Length, 800));
+
+        var failure = await Assert.ThrowsAsync<NzbWebDAV.Exceptions.CorruptRarException>(
+            () => resolver.EnsureResolvedThroughAsync(
+                mpf, long.MaxValue, CancellationToken.None));
+
+        Assert.Contains("continues beyond the final available volume", failure.Message);
+        Assert.True(mpf.Metadata.IsLazy);
+        Assert.Single(mpf.Metadata.PendingParts);
+    }
+
+    [Fact]
+    public async Task EnsureResolvedThroughAsync_MismatchedContinuationReportsVolumeAndHeader()
+    {
+        var wrongMemberBytes = BuildRar4Volume(
+            "extra.srt",
+            packedSize: 100,
+            splitBefore: true,
+            splitAfter: false);
+        using var client = new MeasuringNntpClient("unused", 0);
+        var resolver = new LazyRarResolver(client, new ConfigManager())
+        {
+            VolumeStreamFactory = (_, size) => new BoundedLengthStream(wrongMemberBytes, size),
+        };
+        var mpf = MultipartFile(
+            "movie.mkv",
+            Pending("vol2-seg0", wrongMemberBytes.Length, 100));
+
+        var failure = await Assert.ThrowsAsync<NzbWebDAV.Exceptions.CorruptRarException>(
+            () => resolver.EnsureResolvedThroughAsync(
+                mpf, long.MaxValue, CancellationToken.None));
+
+        Assert.Contains("volume 2 of 2", failure.Message);
+        Assert.Contains("'extra.srt'", failure.Message);
+        Assert.Contains("split-before: True", failure.Message);
+    }
+
+    private static DavMultipartFile MultipartFile(
+        string pathInArchive,
+        params DavMultipartFile.PendingPart[] pending) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Metadata = new DavMultipartFile.Meta
+            {
+                IsLazy = true,
+                PathInArchive = pathInArchive,
+                FileParts =
+                [
+                    new DavMultipartFile.FilePart
+                    {
+                        SegmentIds = ["vol1-seg0"],
+                        SegmentIdByteRange = LongRange.FromStartAndSize(0, 1_000),
+                        FilePartByteRange = LongRange.FromStartAndSize(60, 940),
+                        IsSplitAfter = true,
+                    }
+                ],
+                PendingParts = pending,
+                ExpectedFileSize = 940 + pending.Sum(part => part.EstimatedDataSize),
+            }
+        };
+
+    private static DavMultipartFile.PendingPart Pending(
+        string segmentId, long volumeLength, long estimatedDataSize) =>
+        new()
+        {
+            SegmentIds = [segmentId],
+            SegmentIdByteRange = LongRange.FromStartAndSize(0, volumeLength),
+            EstimatedDataSize = estimatedDataSize,
+        };
+
     // Minimal RAR4 multi-volume continuation: mark + archive(VOLUME) +
     // stored file header (HAS_DATA|SPLIT_BEFORE) + packed payload.
-    private static byte[] BuildRar4ContinuationVolume(string fileName, int packedSize, int trailingBytes = 0)
+    private static byte[] BuildRar4ContinuationVolume(
+        string fileName,
+        int packedSize,
+        int trailingBytes = 0,
+        bool splitAfter = false)
+        => BuildRar4Volume(
+            fileName,
+            packedSize,
+            splitBefore: true,
+            splitAfter: splitAfter,
+            trailingBytes: trailingBytes);
+
+    private static byte[] BuildRar4Volume(
+        string fileName,
+        int packedSize,
+        bool splitBefore,
+        bool splitAfter,
+        int trailingBytes = 0)
     {
         using var ms = new MemoryStream();
         ms.Write([0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x00]);
@@ -192,7 +407,10 @@ public class LazyRarResolverTests
             var body = new byte[headSize - 2];
             var o = 0;
             body[o++] = 0x74;
-            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), 0x8001); // HAS_DATA|SPLIT_BEFORE
+            var fileFlags = (ushort)(0x8000
+                                     | (splitBefore ? 0x0001 : 0)
+                                     | (splitAfter ? 0x0002 : 0));
+            BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), fileFlags);
             o += 2;
             BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(o), headSize);
             o += 2;

--- a/tests/NzbWebDAV.Tests/Streams/DavMultipartFileStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/DavMultipartFileStreamTests.cs
@@ -279,6 +279,41 @@ public class DavMultipartFileStreamTests
     }
 
     [Fact]
+    public async Task ReadAsync_ExpectedFileSizeKeepsRecoveredLegacyLengthStable()
+    {
+        using var client = new FakeNntpClient(new Dictionary<string, byte[]>
+        {
+            ["segment"] = Enumerable.Range(0, 8).Select(x => (byte)x).ToArray(),
+        }, useCachedYencStreams: true);
+        var multipart = MultipartFile(
+            segmentRange: LongRange.FromStartAndSize(0, 8),
+            fileRange: LongRange.FromStartAndSize(0, 8));
+        multipart.Metadata.IsLazy = true;
+        multipart.Metadata.ExpectedFileSize = 8;
+        multipart.Metadata.PendingParts =
+        [
+            new DavMultipartFile.PendingPart
+            {
+                SegmentIds = ["unrelated-tail"],
+                SegmentIdByteRange = LongRange.FromStartAndSize(0, 8),
+                EstimatedDataSize = 8,
+            }
+        ];
+        await using var stream = new DavMultipartFileStream(
+            multipart,
+            client,
+            articleBufferSize: 0,
+            resolver: null,
+            usePipelinedBodyRequests: false,
+            fileName: "movie.mkv");
+
+        var buffer = new byte[8];
+        Assert.Equal(8, await stream.ReadAsync(buffer));
+        Assert.Equal(0, await stream.ReadAsync(new byte[1]));
+        Assert.Equal(8, stream.Length);
+    }
+
+    [Fact]
     public async Task ReadAsync_UnresolvableTrailingVolume_DoesNotLookLikeEndOfFile()
     {
         using var client = new FakeNntpClient(new Dictionary<string, byte[]>


### PR DESCRIPTION
## Summary
- validate lazy RAR members with continuation names, split flags, encryption state, and exact stored size before mounting
- fall back to eager parsing when a media member does not span the full physical volume set
- recover existing lazy metadata by detecting terminal members, trimming unrelated tails, and preserving the advertised stream length

Fixes #1209

## Test plan
- [x] Add synthetic RAR4 regressions for terminal media followed by unrelated volumes
- [x] Add coverage for valid continuation chains, mismatched names/flags/sizes/encryption, and legacy metadata recovery
- [x] Add stable-length and legacy expected-size backfill coverage
- [ ] Confirm the full automated gate in PR CI (repository policy skips CI-covered suites locally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lazy multi-volume RAR handling and validation.
  * Detects mismatched, incomplete, encrypted, or incorrectly ordered volumes and safely falls back when needed.
  * Correctly handles archives whose content ends before trailing volumes.
  * Restores expected file sizes for legacy lazy files, improving stream length and end-of-file behavior.
  * Preserves initial file data needed for reliable archive detection.
* **Tests**
  * Added coverage for multi-volume RAR validation, size mismatches, encryption changes, missing volumes, trailing volumes, and legacy metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->