### PR TITLE
fix(health): PAR2 no longer declares undamaged files unrepairable

### DIFF
--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -556,8 +556,11 @@ public class HealthCheckService : BackgroundService
             }
 
             // When no Arr replacement is available, PAR2 remains the only automatic recovery path.
-            if (ShouldAttemptPar2Repair()
-                && await _par2RepairService.TryPar2RepairAsync(davItem, [e.SegmentId], ct).ConfigureAwait(false))
+            var par2Outcome = ShouldAttemptPar2Repair()
+                ? await _par2RepairService.TryPar2RepairAsync(
+                    davItem, [e.SegmentId], ct).ConfigureAwait(false)
+                : Par2RepairOutcome.NotRepaired;
+            if (par2Outcome is not Par2RepairOutcome.NotRepaired)
             {
                 var utcNow = DateTimeOffset.UtcNow;
                 davItem.LastHealthCheck = utcNow;
@@ -567,8 +570,13 @@ public class HealthCheckService : BackgroundService
                 await RecordHealthResult(
                     dbClient, davItem,
                     HealthCheckResult.HealthResult.Healthy,
-                    HealthCheckResult.RepairAction.RepairedViaPar2,
-                    "Missing segment repaired from PAR2 parity.", ct).ConfigureAwait(false);
+                    par2Outcome is Par2RepairOutcome.Repaired
+                        ? HealthCheckResult.RepairAction.RepairedViaPar2
+                        : HealthCheckResult.RepairAction.None,
+                    par2Outcome is Par2RepairOutcome.Repaired
+                        ? "Missing segment repaired from PAR2 parity."
+                        : "PAR2 verified every file slice and found no damage.",
+                    ct).ConfigureAwait(false);
                 return;
             }
 
@@ -639,8 +647,11 @@ public class HealthCheckService : BackgroundService
 
         // PAR2 first, with the full hole list: reconstruct from parity before any verdict.
         // It is also the only automatic recovery path when no Arr replacement is available.
-        if (ShouldAttemptPar2Repair()
-            && await _par2RepairService.TryPar2RepairAsync(davItem, holeSegmentIds, ct).ConfigureAwait(false))
+        var par2Outcome = ShouldAttemptPar2Repair()
+            ? await _par2RepairService.TryPar2RepairAsync(
+                davItem, holeSegmentIds, ct).ConfigureAwait(false)
+            : Par2RepairOutcome.NotRepaired;
+        if (par2Outcome is not Par2RepairOutcome.NotRepaired)
         {
             var utcNow = DateTimeOffset.UtcNow;
             davItem.LastHealthCheck = utcNow;
@@ -648,14 +659,20 @@ public class HealthCheckService : BackgroundService
             _failureTracker.ClearFailure(davItem.Id);
             _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);
             // The patched segments are served locally now; any earlier hole/corrupt record is obsolete.
-            if (nzbFile.MissingSegmentIndices != null || nzbFile.CorruptSegmentIndices != null)
+            if (par2Outcome is Par2RepairOutcome.Repaired
+                && (nzbFile.MissingSegmentIndices != null || nzbFile.CorruptSegmentIndices != null))
                 await SwapNzbFileBlobAsync(davItem, nzbFile, null, null, replaceCorruptRecord: true)
                     .ConfigureAwait(false);
             await RecordHealthResult(
                 dbClient, davItem,
                 HealthCheckResult.HealthResult.Healthy,
-                HealthCheckResult.RepairAction.RepairedViaPar2,
-                "Missing segment(s) repaired from PAR2 parity.", ct).ConfigureAwait(false);
+                par2Outcome is Par2RepairOutcome.Repaired
+                    ? HealthCheckResult.RepairAction.RepairedViaPar2
+                    : HealthCheckResult.RepairAction.None,
+                par2Outcome is Par2RepairOutcome.Repaired
+                    ? "Missing segment(s) repaired from PAR2 parity."
+                    : "PAR2 verified every file slice and found no damage.",
+                ct).ConfigureAwait(false);
             return;
         }
 
@@ -1652,11 +1669,13 @@ public class HealthCheckService : BackgroundService
             return;
         }
 
-        if (ShouldAttemptPar2Repair()
-            && await _par2RepairService.TryPar2RepairAsync(
+        var par2Outcome = ShouldAttemptPar2Repair()
+            ? await _par2RepairService.TryPar2RepairAsync(
                 davItem,
                 failureSnapshot.HasTargetableSegmentIds ? failureSnapshot.SegmentIds : null,
-                ct).ConfigureAwait(false))
+                ct).ConfigureAwait(false)
+            : Par2RepairOutcome.NotRepaired;
+        if (par2Outcome is not Par2RepairOutcome.NotRepaired)
         {
             var utcNow = DateTimeOffset.UtcNow;
             davItem.LastHealthCheck = utcNow;
@@ -1666,8 +1685,13 @@ public class HealthCheckService : BackgroundService
             await RecordHealthResult(
                 dbClient, davItem,
                 HealthCheckResult.HealthResult.Healthy,
-                HealthCheckResult.RepairAction.RepairedViaPar2,
-                "Missing segment(s) repaired from PAR2 parity after streaming failure.", ct)
+                par2Outcome is Par2RepairOutcome.Repaired
+                    ? HealthCheckResult.RepairAction.RepairedViaPar2
+                    : HealthCheckResult.RepairAction.None,
+                par2Outcome is Par2RepairOutcome.Repaired
+                    ? "Missing segment(s) repaired from PAR2 parity after streaming failure."
+                    : "PAR2 verified every file slice and found no damage.",
+                ct)
                 .ConfigureAwait(false);
             return;
         }

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -24,6 +24,13 @@ using UsenetSharp.Models;
 
 namespace NzbWebDAV.Services.Repair;
 
+public enum Par2RepairOutcome
+{
+    NotRepaired = 0,
+    Repaired = 1,
+    VerifiedClean = 2,
+}
+
 public class Par2RepairService : BackgroundService
 {
     private const int MaxQueueLength = 50;
@@ -98,7 +105,7 @@ public class Par2RepairService : BackgroundService
     {
         _queuedOrRunning.TryRemove(davItemId, out _);
         if (_repairFlights.TryRemove(davItemId, out var flight))
-            flight.Completion.TrySetResult(false);
+            flight.Completion.TrySetResult(Par2RepairOutcome.NotRepaired);
     }
 
     internal Task RequeueRetainedForTestsAsync(Guid davItemId, CancellationToken ct) =>
@@ -190,16 +197,16 @@ public class Par2RepairService : BackgroundService
 
     /// <summary>
     /// Attempts PAR2 repair synchronously for health-check and urgent paths.
-    /// Returns true when reconstruction succeeded and patches were committed.
+    /// Returns the outcome of the repair or verification attempt.
     /// Virtual so health-check classification tests can script the outcome.
     /// </summary>
-    public virtual async Task<bool> TryPar2RepairAsync(
+    public virtual async Task<Par2RepairOutcome> TryPar2RepairAsync(
         DavItem davItem,
         IReadOnlyList<string>? missingSegmentIds,
         CancellationToken ct)
     {
         if (!_configManager.IsPar2RepairEnabled())
-            return false;
+            return Par2RepairOutcome.NotRepaired;
 
         var mine = new RepairFlight();
         var flight = _repairFlights.GetOrAdd(davItem.Id, mine);
@@ -215,7 +222,7 @@ public class Par2RepairService : BackgroundService
         {
             // The repair owner stopped; callers should follow their normal safe fallback
             // rather than surfacing a cancellation that they did not request.
-            return false;
+            return Par2RepairOutcome.NotRepaired;
         }
     }
 
@@ -299,13 +306,13 @@ public class Par2RepairService : BackgroundService
                 catch (Exception e) when (e is not OutOfMemoryException)
                 {
                     _queuedOrRunning.TryRemove(item.DavItemId, out _);
-                    CompleteFlight(item.DavItemId, item.Flight, false);
+                    CompleteFlight(item.DavItemId, item.Flight, Par2RepairOutcome.NotRepaired);
                     e.LogWarningKnownOrStack("PAR2 background repair worker failed for {Path}", item.Path);
                 }
                 catch (OutOfMemoryException oom)
                 {
                     _queuedOrRunning.TryRemove(item.DavItemId, out _);
-                    CompleteFlight(item.DavItemId, item.Flight, false);
+                    CompleteFlight(item.DavItemId, item.Flight, Par2RepairOutcome.NotRepaired);
                     OomDiagnostics.LogHeapStateOnOom(oom, "PAR2 background repair worker");
                     Log.Warning("PAR2 background repair worker deferred after exhausting managed memory. Path: {Path}", item.Path);
                 }
@@ -491,7 +498,7 @@ public class Par2RepairService : BackgroundService
         {
             _queuedOrRunning.TryRemove(item.DavItemId, out _);
             _retainedSegmentIds.TryRemove(item.DavItemId, out _);
-            CompleteFlight(item.DavItemId, item.Flight, false);
+            CompleteFlight(item.DavItemId, item.Flight, Par2RepairOutcome.NotRepaired);
             return;
         }
 
@@ -499,7 +506,7 @@ public class Par2RepairService : BackgroundService
             .ConfigureAwait(false);
     }
 
-    private async Task<bool> RunFlightAsync(
+    private async Task<Par2RepairOutcome> RunFlightAsync(
         RepairFlight flight,
         DavItem davItem,
         IReadOnlyList<string>? missingSegmentIds,
@@ -537,7 +544,10 @@ public class Par2RepairService : BackgroundService
         }
     }
 
-    private void CompleteFlight(Guid davItemId, RepairFlight flight, bool result)
+    private void CompleteFlight(
+        Guid davItemId,
+        RepairFlight flight,
+        Par2RepairOutcome result)
     {
         flight.Completion.TrySetResult(result);
         _repairFlights.TryRemove(new KeyValuePair<Guid, RepairFlight>(davItemId, flight));
@@ -549,7 +559,7 @@ public class Par2RepairService : BackgroundService
         _repairFlights.TryRemove(new KeyValuePair<Guid, RepairFlight>(davItemId, flight));
     }
 
-    private async Task<bool> RunRepairAsync(
+    private async Task<Par2RepairOutcome> RunRepairAsync(
         DavItem davItem,
         IReadOnlyList<string>? missingSegmentIds,
         bool queueGuard,
@@ -558,7 +568,7 @@ public class Par2RepairService : BackgroundService
         if (!_configManager.IsPar2RepairEnabled())
         {
             if (queueGuard) _queuedOrRunning.TryRemove(davItem.Id, out _);
-            return false;
+            return Par2RepairOutcome.NotRepaired;
         }
 
         Par2RepairJob? job = null;
@@ -569,7 +579,7 @@ public class Par2RepairService : BackgroundService
             if (job == null)
             {
                 if (queueGuard) _queuedOrRunning.TryRemove(davItem.Id, out _);
-                return false;
+                return Par2RepairOutcome.NotRepaired;
             }
 
             job.State = Par2RepairJob.RepairJobState.Running;
@@ -601,12 +611,21 @@ public class Par2RepairService : BackgroundService
                 Interlocked.Add(ref _totalBytesRead, result.BytesRead);
                 Interlocked.Add(ref _totalSlicesReconstructed, result.SlicesReconstructed);
                 Interlocked.Add(ref _totalSegmentsCommitted, result.SegmentsCommitted);
+                if (result.VerifiedClean)
+                {
+                    Log.Information(
+                        "PAR2 verification succeeded for {Path}: all slices matched, " +
+                        "{Bytes} bytes read in {Elapsed}",
+                        davItem.Path, result.BytesRead, stopwatch.Elapsed);
+                    return Par2RepairOutcome.VerifiedClean;
+                }
+
                 Log.Information(
                     "PAR2 repair succeeded for {Path}: {Slices} slice(s) reconstructed, "
                     + "{Segments} segment(s) committed, {Bytes} bytes read in {Elapsed}",
                     davItem.Path, result.SlicesReconstructed, result.SegmentsCommitted,
                     result.BytesRead, stopwatch.Elapsed);
-                return true;
+                return Par2RepairOutcome.Repaired;
             }
 
             job.State = result.IsInfeasible
@@ -627,7 +646,7 @@ public class Par2RepairService : BackgroundService
             Log.Warning(
                 "PAR2 repair {Outcome} for {Path}. Reason: {Reason}",
                 result.IsInfeasible ? "infeasible" : "failed", davItem.Path, result.FailureReason);
-            return false;
+            return Par2RepairOutcome.NotRepaired;
         }
         catch (OutOfMemoryException oom)
         {
@@ -638,7 +657,7 @@ public class Par2RepairService : BackgroundService
             PrometheusMetrics.Current?.ObservePar2RepairDuration(stopwatch.Elapsed);
             Interlocked.Increment(ref _totalFailed);
             Log.Warning("PAR2 repair deferred after exhausting managed memory. Path: {Path}", davItem.Path);
-            return false;
+            return Par2RepairOutcome.NotRepaired;
         }
         catch (Exception e) when (e is not OperationCanceledException)
         {
@@ -649,7 +668,7 @@ public class Par2RepairService : BackgroundService
             e.LogWarningKnownOrStack("PAR2 repair error for {Path}", davItem.Path);
             PrometheusMetrics.Current?.RecordPar2RepairJob("failed");
             PrometheusMetrics.Current?.ObservePar2RepairDuration(stopwatch.Elapsed);
-            return false;
+            return Par2RepairOutcome.NotRepaired;
         }
         finally
         {
@@ -738,13 +757,11 @@ public class Par2RepairService : BackgroundService
         unavailableSegments.UnionWith(persistedMissing);
         unavailableSegments.UnionWith(persistedCorrupt);
 
-        if (unavailableSegments.Count == 0 && job.MissingSegmentIds.Length == 0
-            && persistedMissing.Count == 0 && persistedCorrupt.Count == 0)
-        {
-            unavailableSegments.UnionWith(Enumerable.Range(0, segmentIds.Length));
-        }
+        var verifyAll = job.MissingSegmentIds.Length == 0
+                        && persistedMissing.Count == 0
+                        && persistedCorrupt.Count == 0;
 
-        if (unavailableSegments.Count == 0)
+        if (!verifyAll && unavailableSegments.Count == 0)
             return RepairExecutionResult.NotFeasible("No missing or corrupt segments to repair.");
 
         var unavailableSlices = new HashSet<int>();
@@ -761,7 +778,7 @@ public class Par2RepairService : BackgroundService
             return RepairExecutionResult.NotFeasible("Segment-to-slice mapping overflowed.");
         }
 
-        if (unavailableSlices.Count == 0)
+        if (!verifyAll && unavailableSlices.Count == 0)
             return RepairExecutionResult.NotFeasible("Missing or corrupt segments do not map to PAR2 slices.");
 
         var maxMissingSlices = _configManager.GetPar2MaxMissingSlices();
@@ -855,6 +872,9 @@ public class Par2RepairService : BackgroundService
                     $"Missing slice count {unavailableSlices.Count} exceeds cap {maxMissingSlices}.",
                     bytesRead);
             }
+
+            if (verifyAll && unavailableSlices.Count == 0)
+                return RepairExecutionResult.Verified(bytesRead);
 
             var patchTargets = SegmentsOverlappingSlices(sliceMap, unavailableSlices, segmentIds);
             var stagedPatchBytes = patchTargets.Sum(target => segmentRanges[target.Index].Count);
@@ -1813,10 +1833,10 @@ public class Par2RepairService : BackgroundService
 
     private sealed class RepairFlight
     {
-        public TaskCompletionSource<bool> Completion { get; } =
+        public TaskCompletionSource<Par2RepairOutcome> Completion { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public Task<bool> Task => Completion.Task;
+        public Task<Par2RepairOutcome> Task => Completion.Task;
     }
 
     private void RetainSegmentIds(Guid davItemId, string path, IEnumerable<string> segmentIds)
@@ -1927,6 +1947,7 @@ public class Par2RepairService : BackgroundService
 
     private sealed record RepairExecutionResult(
         bool Success,
+        bool VerifiedClean,
         bool IsInfeasible,
         string? FailureReason,
         long BytesRead,
@@ -1934,13 +1955,16 @@ public class Par2RepairService : BackgroundService
         int SegmentsCommitted)
     {
         public static RepairExecutionResult Succeeded(long bytesRead, int slices, int segmentsCommitted)
-            => new(true, false, null, bytesRead, slices, segmentsCommitted);
+            => new(true, false, false, null, bytesRead, slices, segmentsCommitted);
+
+        public static RepairExecutionResult Verified(long bytesRead)
+            => new(true, true, false, null, bytesRead, 0, 0);
 
         public static RepairExecutionResult NotFeasible(string reason, long bytesRead = 0)
-            => new(false, true, reason, bytesRead, 0, 0);
+            => new(false, false, true, reason, bytesRead, 0, 0);
 
         public static RepairExecutionResult Failed(string reason, long bytesRead = 0)
-            => new(false, false, reason, bytesRead, 0, 0);
+            => new(false, false, false, reason, bytesRead, 0, 0);
     }
 
     private sealed class SliceSegmentAccessor

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
@@ -282,6 +282,29 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Par2VerifiedClean_RecordsHealthyWithoutRepairStatus()
+    {
+        var segments = NewSegmentIds(6);
+        var sizes = new long[] { 10_000, 10_000, 50, 10_000, 10_000, 10_000 };
+        var (item, _) = await AddVideoFileAsync(
+            "movie.mkv", segments, sizes, preExistingHoles: [2]);
+        var fake = NewFakeClient(segments, missing: [2]);
+        _failureTracker.RecordFailure(item.Id);
+        var (service, par2) = await NewServiceAsync(
+            fake, Par2RepairOutcome.VerifiedClean);
+
+        await service.PerformHealthCheck(item, _dbClient, concurrency: 4, CancellationToken.None);
+
+        var row = Assert.Single(GetHealthRows(item.Id));
+        Assert.Equal(HealthCheckResult.HealthResult.Healthy, row.Result);
+        Assert.Equal(HealthCheckResult.RepairAction.None, row.RepairStatus);
+        Assert.Equal(
+            "PAR2 verified every file slice and found no damage.",
+            row.Message);
+        Assert.Equal([segments[2]], Assert.Single(par2.Requests));
+    }
+
+    [Fact]
     public async Task Par2Success_RunsWithoutEnabledArrWhenArrPreferenceIsOff()
     {
         _configManager.UpdateValues(
@@ -798,7 +821,7 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
 
     private async Task<(HealthCheckService Service, ScriptedPar2RepairService Par2)> NewServiceAsync(
         FakeNntpClient fake,
-        bool par2Outcome)
+        Par2RepairOutcome par2Outcome)
     {
         await _usenet.ReplaceUnderlyingClientForTestsAsync(fake);
         var par2 = new ScriptedPar2RepairService(_configManager, _patchStore, par2Outcome);
@@ -814,6 +837,13 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
             new ArrReplacementSearchBudget());
         return (service, par2);
     }
+
+    private Task<(HealthCheckService Service, ScriptedPar2RepairService Par2)> NewServiceAsync(
+        FakeNntpClient fake,
+        bool par2Outcome) =>
+        NewServiceAsync(
+            fake,
+            par2Outcome ? Par2RepairOutcome.Repaired : Par2RepairOutcome.NotRepaired);
 
     private async Task<(DavItem Item, Guid BlobId)> AddVideoFileAsync(
         string name,
@@ -912,11 +942,11 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
     private sealed class ScriptedPar2RepairService(
         ConfigManager configManager,
         RepairPatchStore store,
-        bool repairOutcome) : Par2RepairService(configManager, null!, store)
+        Par2RepairOutcome repairOutcome) : Par2RepairService(configManager, null!, store)
     {
         public List<string[]> Requests { get; } = [];
 
-        public override Task<bool> TryPar2RepairAsync(
+        public override Task<Par2RepairOutcome> TryPar2RepairAsync(
             DavItem davItem, IReadOnlyList<string>? missingSegmentIds, CancellationToken ct)
         {
             Requests.Add(missingSegmentIds?.ToArray() ?? []);

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceCorruptSourceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceCorruptSourceTests.cs
@@ -109,7 +109,7 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
         var ok = await release.Service.TryPar2RepairAsync(
             release.Item, [release.ContentSegmentIds[0]], CancellationToken.None);
 
-        Assert.True(ok);
+        Assert.Equal(Par2RepairOutcome.Repaired, ok);
         Assert.True(release.Store.Contains(release.ContentSegmentIds[0]));
         Assert.False(release.Fake.BodyRequestCounts.ContainsKey(release.ContentSegmentIds[0]));
         Assert.Equal(
@@ -127,7 +127,7 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
         var ok = await release.Service.TryPar2RepairAsync(
             release.Item, [release.ContentSegmentIds[0]], CancellationToken.None);
 
-        Assert.True(ok);
+        Assert.Equal(Par2RepairOutcome.Repaired, ok);
         // Discovery, Reed-Solomon reduction, and whole-file MD5 are independent
         // sequential passes. The test client has no disk segment cache, proving
         // source bytes are discarded rather than retained for the lifetime of repair.
@@ -145,7 +145,7 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
         var ok = await release.Service.TryPar2RepairAsync(
             release.Item, [release.ContentSegmentIds[0]], CancellationToken.None);
 
-        Assert.True(ok);
+        Assert.Equal(Par2RepairOutcome.Repaired, ok);
         Assert.True(release.Store.Contains(release.ContentSegmentIds[0]));
         Assert.True(release.Store.Contains(release.ContentSegmentIds[1]));
         Assert.Equal(
@@ -171,7 +171,7 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
             [release.ContentSegmentIds[0], release.ContentSegmentIds[2]],
             CancellationToken.None);
 
-        Assert.True(ok);
+        Assert.Equal(Par2RepairOutcome.Repaired, ok);
         Assert.True(release.Store.Contains(release.ContentSegmentIds[0]));
         Assert.True(release.Store.Contains(release.ContentSegmentIds[2]));
         Assert.False(release.Store.Contains(release.ContentSegmentIds[1]));
@@ -188,7 +188,7 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
         var ok = await release.Service.TryPar2RepairAsync(
             release.Item, [release.ContentSegmentIds[0]], CancellationToken.None);
 
-        Assert.True(ok);
+        Assert.Equal(Par2RepairOutcome.Repaired, ok);
         Assert.True(release.Store.Contains(release.ContentSegmentIds[0]));
         Assert.True(release.Store.Contains(release.ContentSegmentIds[1]));
         Assert.Equal(Slice(fileData, 0, sizes[0]), await ReadPatchAsync(release.Store, release.ContentSegmentIds[0]));
@@ -206,7 +206,7 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
         var ok = await release.Service.TryPar2RepairAsync(
             release.Item, [release.ContentSegmentIds[2]], CancellationToken.None);
 
-        Assert.True(ok);
+        Assert.Equal(Par2RepairOutcome.Repaired, ok);
         Assert.True(release.Store.Contains(release.ContentSegmentIds[2]));
         Assert.Equal(
             Slice(fileData, sizes[0] + sizes[1], sizes[2]),
@@ -228,7 +228,7 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
         var ok = await release.Service.TryPar2RepairAsync(
             release.Item, [release.ContentSegmentIds[0]], CancellationToken.None);
 
-        Assert.True(ok);
+        Assert.Equal(Par2RepairOutcome.Repaired, ok);
         Assert.True(release.Store.Contains(release.ContentSegmentIds[0]));
         Assert.Equal(
             target.AsSpan(0, SliceSize).ToArray(),
@@ -250,7 +250,7 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
         var ok = await release.Service.TryPar2RepairAsync(
             release.Item, [release.ContentSegmentIds[0]], CancellationToken.None);
 
-        Assert.True(ok);
+        Assert.Equal(Par2RepairOutcome.Repaired, ok);
         Assert.Equal(1, release.Fake.BodyRequestCounts[release.ContentSegmentIds[1]]);
         Assert.Equal(1, release.Fake.CompletionCallbackCounts[release.ContentSegmentIds[1]]);
         Assert.True(release.Store.Contains(release.ContentSegmentIds[1]));
@@ -314,7 +314,9 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
             Assert.False(successfulJoiner.IsCompleted);
 
             allowSourceRead.TrySetResult(true);
-            Assert.True(await successfulJoiner.WaitAsync(TimeSpan.FromSeconds(10)));
+            Assert.Equal(
+                Par2RepairOutcome.Repaired,
+                await successfulJoiner.WaitAsync(TimeSpan.FromSeconds(10)));
             Assert.True(release.Store.Contains(release.ContentSegmentIds[0]));
             Assert.Equal(1, release.Service.GetDiagnosticSnapshot().TotalSucceeded);
 
@@ -341,7 +343,7 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
             [release.ContentSegmentIds[0], release.ContentSegmentIds[1]],
             CancellationToken.None);
 
-        Assert.False(ok);
+        Assert.Equal(Par2RepairOutcome.NotRepaired, ok);
         Assert.False(release.Store.Contains(release.ContentSegmentIds[0]));
         Assert.False(release.Store.Contains(release.ContentSegmentIds[1]));
         var job = await ReadJobAsync(release.Item.Id);
@@ -361,7 +363,7 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
             [release.ContentSegmentIds[0], release.ContentSegmentIds[1]],
             CancellationToken.None);
 
-        Assert.False(ok);
+        Assert.Equal(Par2RepairOutcome.NotRepaired, ok);
         Assert.False(release.Store.Contains(release.ContentSegmentIds[0]));
         var job = await ReadJobAsync(release.Item.Id);
         Assert.Equal(Par2RepairJob.RepairJobState.Infeasible, job.State);
@@ -380,7 +382,7 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
         var ok = await release.Service.TryPar2RepairAsync(
             release.Item, [release.ContentSegmentIds[0]], CancellationToken.None);
 
-        Assert.False(ok);
+        Assert.Equal(Par2RepairOutcome.NotRepaired, ok);
         Assert.False(release.Store.Contains(release.ContentSegmentIds[0]));
         var job = await ReadJobAsync(release.Item.Id);
         Assert.Equal(Par2RepairJob.RepairJobState.Failed, job.State);
@@ -397,10 +399,63 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
         var ok = await release.Service.TryPar2RepairAsync(
             release.Item, [release.ContentSegmentIds[0]], CancellationToken.None);
 
-        Assert.True(ok);
+        Assert.Equal(Par2RepairOutcome.Repaired, ok);
         Assert.Equal(release.Fake.BodyRequestCount, release.Fake.CompletionCallbackCount);
         foreach (var (id, count) in release.Fake.BodyRequestCounts)
             Assert.Equal(count, release.Fake.CompletionCallbackCounts.GetValueOrDefault(id));
+    }
+
+    [Fact]
+    public async Task VerifyAll_CleanFileAboveCap_ReturnsVerifiedClean()
+    {
+        var fileData = PatternBytes(SliceSize * 3, 0xBC);
+        await using var release = await SeedAsync(
+            fileData, EqualSegments(3), recoveryExponents: [0u], maxMissingSlices: "1");
+
+        var outcome = await release.Service.TryPar2RepairAsync(
+            release.Item, null, CancellationToken.None);
+
+        Assert.Equal(Par2RepairOutcome.VerifiedClean, outcome);
+        var job = await ReadJobAsync(release.Item.Id);
+        Assert.Equal(Par2RepairJob.RepairJobState.Succeeded, job.State);
+        Assert.Equal(0, job.SlicesReconstructed);
+        Assert.False(release.Store.Contains(release.ContentSegmentIds[0]));
+        Assert.False(release.Store.Contains(release.ContentSegmentIds[1]));
+        Assert.False(release.Store.Contains(release.ContentSegmentIds[2]));
+    }
+
+    [Fact]
+    public async Task VerifyAll_DamageAboveCap_UsesActualDamagedSliceCount()
+    {
+        var fileData = PatternBytes(SliceSize * 3, 0xBD);
+        await using var release = await SeedAsync(
+            fileData, EqualSegments(3), recoveryExponents: [0u, 1u],
+            corruptOnRead: [0, 1], maxMissingSlices: "1");
+
+        var outcome = await release.Service.TryPar2RepairAsync(
+            release.Item, null, CancellationToken.None);
+
+        Assert.Equal(Par2RepairOutcome.NotRepaired, outcome);
+        var job = await ReadJobAsync(release.Item.Id);
+        Assert.Equal(Par2RepairJob.RepairJobState.Infeasible, job.State);
+        Assert.Equal("Missing slice count 2 exceeds cap 1.", job.FailureReason);
+    }
+
+    [Fact]
+    public async Task VerifyAll_DamageWithinCap_ReconstructsOnlyDamagedSegment()
+    {
+        var fileData = PatternBytes(SliceSize * 3, 0xBE);
+        await using var release = await SeedAsync(
+            fileData, EqualSegments(3), recoveryExponents: [0u, 1u],
+            corruptOnRead: [0], maxMissingSlices: "1");
+
+        var outcome = await release.Service.TryPar2RepairAsync(
+            release.Item, null, CancellationToken.None);
+
+        Assert.Equal(Par2RepairOutcome.Repaired, outcome);
+        Assert.True(release.Store.Contains(release.ContentSegmentIds[0]));
+        Assert.False(release.Store.Contains(release.ContentSegmentIds[1]));
+        Assert.False(release.Store.Contains(release.ContentSegmentIds[2]));
     }
 
     private async Task<SeededRelease> SeedAsync(


### PR DESCRIPTION
## Summary
- Verify every PAR2 slice when no damage is known instead of pre-classifying all slices as unavailable.
- Distinguish clean verification from reconstruction so health history remains truthful.
- Apply the missing-slice cap to the actual discovered damage and add regression coverage.

Fixes #1190

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter \"FullyQualifiedName~Par2RepairServiceCorruptSourceTests|FullyQualifiedName~HealthCheckDegradedClassificationTests\"` (47 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PAR2 verification to distinguish repaired files from files that were already healthy.
  - Health checks now report clean verification accurately without falsely indicating a repair.
  - Verification-only checks can complete successfully when all data is intact.
  - Repair handling now correctly limits reconstruction to detected damage where applicable.

- **Tests**
  - Added coverage for clean verification, repair limits, and damaged-file reconstruction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->