### PR TITLE
fix(health): classify persistently missing streaming payloads as orphaned

### DIFF
--- a/backend/Database/BlobStore.cs
+++ b/backend/Database/BlobStore.cs
@@ -53,6 +53,6 @@ public static class BlobStore
     public static Task<T?> ReadBlob<T>(Guid id)
         => Current.ReadBlob<T>(id);
 
-    public static void Delete(Guid id)
+    public static bool Delete(Guid id)
         => Current.Delete(id);
 }

--- a/backend/Database/FileBlobStore.cs
+++ b/backend/Database/FileBlobStore.cs
@@ -161,10 +161,22 @@ public sealed class FileBlobStore : IBlobStore, IDisposable
     {
         _metadataCache.Remove(id);
         var blobPath = GetBlobPath(id);
-        var deleted = File.Exists(blobPath);
+        var deleted = false;
 
-        if (deleted)
+        try
+        {
+            File.GetAttributes(blobPath);
             File.Delete(blobPath);
+            deleted = true;
+        }
+        catch (FileNotFoundException)
+        {
+            // The blob is already absent; the cleanup operation is idempotent.
+        }
+        catch (DirectoryNotFoundException)
+        {
+            // The blob's sharded directory is already absent.
+        }
 
         lock (_lockObj)
         {

--- a/backend/Database/FileBlobStore.cs
+++ b/backend/Database/FileBlobStore.cs
@@ -163,23 +163,23 @@ public sealed class FileBlobStore : IBlobStore, IDisposable
         var blobPath = GetBlobPath(id);
         var deleted = false;
 
-        try
-        {
-            File.GetAttributes(blobPath);
-            File.Delete(blobPath);
-            deleted = true;
-        }
-        catch (FileNotFoundException)
-        {
-            // The blob is already absent; the cleanup operation is idempotent.
-        }
-        catch (DirectoryNotFoundException)
-        {
-            // The blob's sharded directory is already absent.
-        }
-
         lock (_lockObj)
         {
+            try
+            {
+                File.GetAttributes(blobPath);
+                File.Delete(blobPath);
+                deleted = true;
+            }
+            catch (FileNotFoundException)
+            {
+                // The blob is already absent; the cleanup operation is idempotent.
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // The blob's sharded directory is already absent.
+            }
+
             var nextTwoDir = Path.GetDirectoryName(blobPath);
             var firstTwoDir = Path.GetDirectoryName(nextTwoDir);
             TryDeleteEmptyDirectory(nextTwoDir);

--- a/backend/Database/FileBlobStore.cs
+++ b/backend/Database/FileBlobStore.cs
@@ -157,12 +157,13 @@ public sealed class FileBlobStore : IBlobStore, IDisposable
         }
     }
 
-    public void Delete(Guid id)
+    public bool Delete(Guid id)
     {
         _metadataCache.Remove(id);
         var blobPath = GetBlobPath(id);
+        var deleted = File.Exists(blobPath);
 
-        if (File.Exists(blobPath))
+        if (deleted)
             File.Delete(blobPath);
 
         lock (_lockObj)
@@ -172,6 +173,8 @@ public sealed class FileBlobStore : IBlobStore, IDisposable
             TryDeleteEmptyDirectory(nextTwoDir);
             TryDeleteEmptyDirectory(firstTwoDir);
         }
+
+        return deleted;
     }
 
     public void Dispose()

--- a/backend/Database/IBlobStore.cs
+++ b/backend/Database/IBlobStore.cs
@@ -14,5 +14,5 @@ public interface IBlobStore
     Task WriteBlob<T>(Guid id, T blob, CancellationToken cancellationToken = default);
     Stream? ReadBlob(Guid id);
     Task<T?> ReadBlob<T>(Guid id);
-    void Delete(Guid id);
+    bool Delete(Guid id);
 }

--- a/backend/Services/BlobCleanupService.cs
+++ b/backend/Services/BlobCleanupService.cs
@@ -88,7 +88,19 @@ public class BlobCleanupService(IDbContextFactory<DavDatabaseContext> dbContextF
             // Delete the blob before SaveChangesAsync so a failure leaves the
             // cleanup item in the DB for a retry; BlobStore.Delete is
             // idempotent when the file is already gone.
-            BlobStore.Delete(blobId);
+            var deleted = BlobStore.Delete(blobId);
+            if (deleted)
+            {
+                Log.Information(
+                    "blob-delete source=payload-cleanup id={BlobId} reason=unreferenced",
+                    blobId);
+            }
+            else
+            {
+                Log.Debug(
+                    "Payload cleanup found blob {BlobId} already absent.",
+                    blobId);
+            }
         }
         else
         {

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -30,6 +30,10 @@ public class HealthCheckService : BackgroundService
 {
     private const int MaximumMissingSegmentIds = 100_000;
     private const int NoMatchConfirmationsRequired = 2;
+    internal const string MissingPayloadMessagePrefix = "Streaming payload missing.";
+    private const int MissingPayloadConfirmationsRequired = 3;
+    private static readonly TimeSpan MissingPayloadInitialRecheck = TimeSpan.FromDays(1);
+    private static readonly TimeSpan MissingPayloadConfirmedRecheck = TimeSpan.FromDays(7);
     private static readonly TimeSpan HealthCheckProgressTimeout = TimeSpan.FromMinutes(5);
 
     // Repeated remove-and-blocklist repairs for the same library path in a short window indicate
@@ -38,6 +42,36 @@ public class HealthCheckService : BackgroundService
     internal const int RepairRecurrenceLimit = 3;
     internal static readonly TimeSpan RepairRecurrenceWindow = TimeSpan.FromHours(6);
     private const int MaximumTrackedRepairPaths = 10_000;
+
+    internal static bool IsMissingPayloadMessage(string? message) =>
+        message?.StartsWith(
+            MissingPayloadMessagePrefix,
+            StringComparison.Ordinal) == true;
+
+    internal static async Task<int> GetMissingPayloadConfirmationAsync(
+        DavDatabaseContext context,
+        Guid davItemId,
+        CancellationToken ct)
+    {
+        var recentMessages = await context.HealthCheckResults
+            .AsNoTracking()
+            .Where(result => result.DavItemId == davItemId)
+            .OrderByDescending(result => result.CreatedAt)
+            .ThenByDescending(result => result.Id)
+            .Select(result => result.Message)
+            .Take(MissingPayloadConfirmationsRequired - 1)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        return recentMessages
+            .TakeWhile(IsMissingPayloadMessage)
+            .Count() + 1;
+    }
+
+    internal static TimeSpan GetMissingPayloadRecheckDelay(int confirmations) =>
+        confirmations >= MissingPayloadConfirmationsRequired
+            ? MissingPayloadConfirmedRecheck
+            : MissingPayloadInitialRecheck;
 
     // How many of a rejected release's segment ids to seed into the fail-fast cache.
     // Bounded so a single large release cannot evict the whole FIFO cache; the queue
@@ -524,21 +558,37 @@ public class HealthCheckService : BackgroundService
             // This says nothing about the release's health, so surface it for
             // operator action instead of deleting or blocklisting through Arr.
             CompleteHealthProgress(davItem.Id);
-            var utcNow = DateTimeOffset.UtcNow;
+            var confirmations = await GetMissingPayloadConfirmationAsync(
+                dbClient.Ctx,
+                davItem.Id,
+                ct).ConfigureAwait(false);
+            var utcNow = _timeProvider.GetUtcNow();
+            var delay = GetMissingPayloadRecheckDelay(confirmations);
             davItem.LastHealthCheck = utcNow;
-            davItem.NextHealthCheck = utcNow + TimeSpan.FromDays(1);
+            davItem.NextHealthCheck = utcNow + delay;
             Log.Warning(
-                "Health check cannot run for {Path}: {Reason}",
-                davItem.Path, e.Message);
+                "Health check cannot run for {Path}: {Reason} " +
+                "(confirmation {Count}/{Threshold}; next check in {Delay})",
+                davItem.Path,
+                e.Message,
+                confirmations,
+                MissingPayloadConfirmationsRequired,
+                delay);
             Log.Debug(e, "Missing streaming payload stack for {Path}", davItem.Path);
+            var state = confirmations >= MissingPayloadConfirmationsRequired
+                ? "The payload has been missing for at least 3 consecutive checks; " +
+                  "this DavItem is orphaned and will be rechecked weekly."
+                : "The file will be rechecked daily.";
             await RecordHealthResult(
                 dbClient, davItem,
                 HealthCheckResult.HealthResult.Unhealthy,
                 HealthCheckResult.RepairAction.ActionNeeded,
                 string.Join(" ", [
+                    MissingPayloadMessagePrefix,
                     "The file's streaming data is missing from the server",
                     "(often a database restore without the blobs/ folder).",
-                    "Remove and re-download the release, or restore from a backup that includes blobs."
+                    "Remove and re-download the release, or restore from a backup that includes blobs.",
+                    state,
                 ]), ct).ConfigureAwait(false);
         }
         catch (UsenetArticleNotFoundException e)

--- a/tests/NzbWebDAV.Tests/Database/FileBlobStoreTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/FileBlobStoreTests.cs
@@ -63,4 +63,18 @@ public sealed class FileBlobStoreTests : IDisposable
             Assert.Empty(Directory.EnumerateFiles(blobsRoot, "*", SearchOption.AllDirectories));
         }
     }
+
+    [Fact]
+    public async Task ConcurrentDelete_ReportsOnlyOnePhysicalRemoval()
+    {
+        var id = Guid.NewGuid();
+        await _store.WriteBlob(id, new MemoryStream("concurrent-delete"u8.ToArray()));
+
+        var results = await Task.WhenAll(
+            Task.Run(() => _store.Delete(id)),
+            Task.Run(() => _store.Delete(id)));
+
+        Assert.Equal(1, results.Count(result => result));
+        Assert.Null(_store.ReadBlob(id));
+    }
 }

--- a/tests/NzbWebDAV.Tests/Database/FileBlobStoreTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/FileBlobStoreTests.cs
@@ -40,7 +40,8 @@ public sealed class FileBlobStoreTests : IDisposable
             Assert.Equal(payload, buffer.ToArray());
         }
 
-        _store.Delete(id);
+        Assert.True(_store.Delete(id));
+        Assert.False(_store.Delete(id));
         Assert.Null(_store.ReadBlob(id));
     }
 

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
@@ -816,7 +816,7 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
         public Task<T?> ReadBlob<T>(Guid id) =>
             Task.FromException<T?>(new OutOfMemoryException("simulated payload allocation failure"));
 
-        public void Delete(Guid id) => throw new NotSupportedException();
+        public bool Delete(Guid id) => throw new NotSupportedException();
     }
 
     private async Task<(HealthCheckService Service, ScriptedPar2RepairService Par2)> NewServiceAsync(

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckMissingPayloadTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckMissingPayloadTests.cs
@@ -5,6 +5,7 @@ using NzbWebDAV.Database.Interceptors;
 using NzbWebDAV.Database.MigrationHelpers;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Exceptions;
+using NzbWebDAV.Services;
 
 namespace NzbWebDAV.Tests.Services;
 
@@ -22,17 +23,19 @@ public sealed class HealthCheckMissingPayloadTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+        _context = new DavDatabaseContext(CreateOptions());
+        await _context.Database.MigrateAsync();
+        _dbClient = new DavDatabaseClient(_context);
+    }
+
+    private DbContextOptions<DavDatabaseContext> CreateOptions() =>
+        new DbContextOptionsBuilder<DavDatabaseContext>()
             .UseSqlite($"Data Source={_databasePath}")
             .AddInterceptors(new SqliteForeignKeyEnabler())
             .ReplaceService<
                 IMigrationsSqlGenerator,
                 SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
             .Options;
-        _context = new DavDatabaseContext(options);
-        await _context.Database.MigrateAsync();
-        _dbClient = new DavDatabaseClient(_context);
-    }
 
     public async Task DisposeAsync()
     {
@@ -88,6 +91,81 @@ public sealed class HealthCheckMissingPayloadTests : IAsyncLifetime
         Assert.Equal(DavItem.ItemSubType.MultipartFile, ex.StoreKind);
         Assert.Contains(payloadId.ToString(), ex.Message, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public async Task MissingPayloadConfirmation_SurvivesContextReopen()
+    {
+        var item = NewUsenetFile(DavItem.ItemSubType.NzbFile, fileBlobId: Guid.NewGuid());
+        _context.HealthCheckResults.AddRange(
+            MissingPayloadResult(item, DateTimeOffset.UtcNow.AddMinutes(-2)),
+            MissingPayloadResult(item, DateTimeOffset.UtcNow.AddMinutes(-1)));
+        await _context.SaveChangesAsync();
+
+        await _context.DisposeAsync();
+        _context = new DavDatabaseContext(CreateOptions());
+        _dbClient = new DavDatabaseClient(_context);
+
+        var confirmations = await HealthCheckService.GetMissingPayloadConfirmationAsync(
+            _context, item.Id, CancellationToken.None);
+
+        Assert.Equal(3, confirmations);
+    }
+
+    [Fact]
+    public async Task MissingPayloadConfirmation_ResetsAfterUnrelatedResult()
+    {
+        var item = NewUsenetFile(DavItem.ItemSubType.NzbFile, fileBlobId: Guid.NewGuid());
+        _context.HealthCheckResults.AddRange(
+            MissingPayloadResult(item, DateTimeOffset.UtcNow.AddMinutes(-3)),
+            new HealthCheckResult
+            {
+                Id = Guid.NewGuid(),
+                CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-2),
+                DavItemId = item.Id,
+                Path = item.Path,
+                Result = HealthCheckResult.HealthResult.Healthy,
+                RepairStatus = HealthCheckResult.RepairAction.None,
+                Message = "File is healthy.",
+            },
+            MissingPayloadResult(item, DateTimeOffset.UtcNow.AddMinutes(-1)));
+        await _context.SaveChangesAsync();
+
+        var confirmations = await HealthCheckService.GetMissingPayloadConfirmationAsync(
+            _context, item.Id, CancellationToken.None);
+
+        Assert.Equal(2, confirmations);
+    }
+
+    [Fact]
+    public void MissingPayloadRecheckDelay_UsesDailyThenWeeklySchedule()
+    {
+        Assert.Equal(
+            TimeSpan.FromDays(1),
+            HealthCheckService.GetMissingPayloadRecheckDelay(1));
+        Assert.Equal(
+            TimeSpan.FromDays(1),
+            HealthCheckService.GetMissingPayloadRecheckDelay(2));
+        Assert.Equal(
+            TimeSpan.FromDays(7),
+            HealthCheckService.GetMissingPayloadRecheckDelay(3));
+        Assert.Equal(
+            TimeSpan.FromDays(7),
+            HealthCheckService.GetMissingPayloadRecheckDelay(4));
+    }
+
+    private static HealthCheckResult MissingPayloadResult(
+        DavItem item,
+        DateTimeOffset createdAt) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            CreatedAt = createdAt,
+            DavItemId = item.Id,
+            Path = item.Path,
+            Result = HealthCheckResult.HealthResult.Unhealthy,
+            RepairStatus = HealthCheckResult.RepairAction.ActionNeeded,
+            Message = HealthCheckService.MissingPayloadMessagePrefix + " details",
+        };
 
     private static DavItem NewUsenetFile(DavItem.ItemSubType subType, Guid? fileBlobId)
     {


### PR DESCRIPTION
## Summary
- Persist consecutive missing-payload confirmations in health history across restarts.
- Keep missing local payloads as operator-actionable health failures without Arr repair or deletion, with weekly backoff after three confirmations.
- Audit physical payload cleanup and distinguish real deletion from an idempotent no-op.

Fixes #1189

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter \"FullyQualifiedName~HealthCheckMissingPayloadTests\"` (7 passed)
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter \"FullyQualifiedName~HealthCheckMissingPayloadTests|FullyQualifiedName~BlobCleanupServiceTests|FullyQualifiedName~FileBlobStoreTests\"` (15 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health checks now track confirmed missing payloads and adjust recheck frequency from daily to weekly after repeated confirmations.
  * Blob deletion now reports whether a blob was successfully removed.

* **Bug Fixes**
  * Improved cleanup logging distinguishes successful deletions from blobs that were already absent.
  * Missing-payload confirmations persist correctly and reset after unrelated health results.

* **Tests**
  * Added coverage for deletion results, concurrent deletion, confirmation persistence, reset behavior, and recheck scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->