### PR TITLE
fix(queue): stop reprocessing releases that already failed health validation

### DIFF
--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -77,6 +77,8 @@ public class QueueItemProcessor(
     private static readonly TimeSpan DiskOrCorruptionBackoff = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan StageWarningInterval = TimeSpan.FromMinutes(2);
 
+    internal static readonly TimeSpan RejectedReleaseRecheckWindow = TimeSpan.FromDays(14);
+
     /// <summary>
     /// Set by the queue's stuck watchdog when this worker's cancellation should
     /// fail the item into history (repeated stalls) rather than leave it queued
@@ -90,6 +92,41 @@ public class QueueItemProcessor(
     /// called for a plain cancellation that leaves the item queued for retry.
     /// </summary>
     internal Action? OnTerminal { get; set; }
+
+    internal static async Task ThrowIfRecentlyRejectedAsync(
+        DavDatabaseClient dbClient,
+        QueueItem queueItem,
+        DateTimeOffset now,
+        CancellationToken ct)
+    {
+        var cutoff = now - RejectedReleaseRecheckWindow;
+        var rejection = await dbClient.Ctx.HealthCheckResults
+            .AsNoTracking()
+            .Where(result => result.RepairStatus == HealthCheckResult.RepairAction.Repaired)
+            .Where(result => result.CreatedAt >= cutoff)
+            .Where(result =>
+                result.NzbFileName == queueItem.FileName
+                || (result.NzbFileName == null
+                    && result.JobName != null
+                    && result.JobName == queueItem.JobName))
+            .OrderByDescending(result => result.CreatedAt)
+            .Select(result => new
+            {
+                result.CreatedAt,
+                result.NzbFileName,
+                result.JobName,
+            })
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+
+        if (rejection is null)
+            return;
+
+        throw new NonRetryableDownloadException(
+            $"This release failed health validation on {rejection.CreatedAt:yyyy-MM-dd HH:mm} UTC " +
+            "and its original download was removed and blocklisted. Refusing to process the " +
+            $"same release again for {RejectedReleaseRecheckWindow.TotalDays:0} days.");
+    }
 
     internal static List<string> SelectArticlesForExistenceCheck(
         IEnumerable<IReadOnlyList<string>> segmentsByFile,
@@ -394,6 +431,8 @@ public class QueueItemProcessor(
         // https://github.com/infinidysk/infinidysk/issues/101
         var articlesToPrecheck = nzbFiles.SelectMany(x => x.Segments).Select(x => x.MessageId);
         HealthCheckService.CheckCachedMissingSegmentIds(articlesToPrecheck);
+        await ThrowIfRecentlyRejectedAsync(dbClient, queueItem, DateTimeOffset.UtcNow, ct)
+            .ConfigureAwait(false);
 
         await RunStageAsync("sibling-donors",
             () => SiblingDonorAttacher.AttachToNewImportAsync(

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -105,7 +105,8 @@ public class QueueItemProcessor(
             .Where(result => result.RepairStatus == HealthCheckResult.RepairAction.Repaired)
             .Where(result => result.CreatedAt >= cutoff)
             .Where(result =>
-                result.NzbFileName == queueItem.FileName
+                (result.NzbFileName != null
+                    && result.NzbFileName == queueItem.FileName)
                 || (result.NzbFileName == null
                     && result.JobName != null
                     && result.JobName == queueItem.JobName))

--- a/tests/NzbWebDAV.Tests/Queue/RejectedReleaseFailFastTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/RejectedReleaseFailFastTests.cs
@@ -209,6 +209,20 @@ public sealed class RejectedReleaseFailFastTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task NullQueueFileName_DoesNotMatchNullPersistedNzbFileName()
+    {
+        await SeedRejectionAsync(
+            HealthCheckResult.RepairAction.Repaired,
+            Now.AddDays(-1),
+            nzbFileName: null,
+            jobName: "other-release");
+        var queueItem = NewQueueItem(jobName: "queue-release");
+        queueItem.FileName = null!;
+
+        await AssertDoesNotThrowAsync(queueItem);
+    }
+
+    [Fact]
     public async Task DifferentReleaseIdentity_DoesNotThrow()
     {
         await SeedRejectionAsync(

--- a/tests/NzbWebDAV.Tests/Queue/RejectedReleaseFailFastTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/RejectedReleaseFailFastTests.cs
@@ -1,0 +1,222 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Queue;
+
+namespace NzbWebDAV.Tests.Queue;
+
+public sealed class RejectedReleaseFailFastTests : IAsyncLifetime
+{
+    private static readonly DateTimeOffset Now =
+        new(2026, 8, 27, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly string _databasePath =
+        Path.Join(Path.GetTempPath(), $"nzbdav-rejected-release-{Guid.NewGuid():N}.sqlite");
+    private DavDatabaseContext _context = null!;
+    private DavDatabaseClient _dbClient = null!;
+
+    public async Task InitializeAsync()
+    {
+        _context = new DavDatabaseContext(CreateOptions());
+        await _context.Database.MigrateAsync();
+        _dbClient = new DavDatabaseClient(_context);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        try { File.Delete(_databasePath); } catch (IOException) { /* best effort */ }
+    }
+
+    private DbContextOptions<DavDatabaseContext> CreateOptions() =>
+        new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_databasePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+
+    private async Task ReopenContextAsync()
+    {
+        await _context.DisposeAsync();
+        _context = new DavDatabaseContext(CreateOptions());
+        await _context.Database.MigrateAsync();
+        _dbClient = new DavDatabaseClient(_context);
+    }
+
+    private async Task SeedRejectionAsync(
+        HealthCheckResult.RepairAction action,
+        DateTimeOffset createdAt,
+        string? nzbFileName,
+        string? jobName)
+    {
+        _context.HealthCheckResults.Add(new HealthCheckResult
+        {
+            Id = Guid.NewGuid(),
+            CreatedAt = createdAt,
+            DavItemId = Guid.NewGuid(),
+            Path = "/content/release.mkv",
+            NzbFileName = nzbFileName,
+            JobName = jobName,
+            Result = HealthCheckResult.HealthResult.Unhealthy,
+            RepairStatus = action,
+            Message = "Repair removed and blocklisted the release.",
+        });
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+    }
+
+    private static QueueItem NewQueueItem(
+        string fileName = "release.nzb",
+        string jobName = "release") =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            CreatedAt = Now.UtcDateTime,
+            FileName = fileName,
+            JobName = jobName,
+            Category = "tv",
+        };
+
+    private Task AssertThrowsAsync(QueueItem queueItem)
+    {
+        return Assert.ThrowsAsync<NonRetryableDownloadException>(
+            () => QueueItemProcessor.ThrowIfRecentlyRejectedAsync(
+                _dbClient, queueItem, Now, CancellationToken.None));
+    }
+
+    private Task AssertDoesNotThrowAsync(QueueItem queueItem) =>
+        QueueItemProcessor.ThrowIfRecentlyRejectedAsync(
+            _dbClient, queueItem, Now, CancellationToken.None);
+
+    [Fact]
+    public async Task RecentRepairedWithExactNzbFileName_Throws()
+    {
+        await SeedRejectionAsync(
+            HealthCheckResult.RepairAction.Repaired,
+            Now.AddDays(-1),
+            "release.nzb",
+            "release");
+
+        var exception = await Assert.ThrowsAsync<NonRetryableDownloadException>(
+            () => QueueItemProcessor.ThrowIfRecentlyRejectedAsync(
+                _dbClient, NewQueueItem(), Now, CancellationToken.None));
+
+        Assert.Contains("removed and blocklisted", exception.Message);
+        Assert.Contains("14 days", exception.Message);
+    }
+
+    [Fact]
+    public async Task RecentRepaired_StillThrowsAfterContextReopen()
+    {
+        await SeedRejectionAsync(
+            HealthCheckResult.RepairAction.Repaired,
+            Now.AddDays(-1),
+            "release.nzb",
+            "release");
+        await ReopenContextAsync();
+
+        await AssertThrowsAsync(NewQueueItem());
+    }
+
+    [Fact]
+    public async Task RowExactlyAtCutoff_Throws()
+    {
+        await SeedRejectionAsync(
+            HealthCheckResult.RepairAction.Repaired,
+            Now - QueueItemProcessor.RejectedReleaseRecheckWindow,
+            "release.nzb",
+            "release");
+
+        await AssertThrowsAsync(NewQueueItem());
+    }
+
+    [Fact]
+    public async Task RowOneSecondOlderThanCutoff_DoesNotThrow()
+    {
+        await SeedRejectionAsync(
+            HealthCheckResult.RepairAction.Repaired,
+            Now - QueueItemProcessor.RejectedReleaseRecheckWindow - TimeSpan.FromSeconds(1),
+            "release.nzb",
+            "release");
+
+        await AssertDoesNotThrowAsync(NewQueueItem());
+    }
+
+    [Fact]
+    public async Task RecentDeleted_DoesNotThrow()
+    {
+        await SeedRejectionAsync(
+            HealthCheckResult.RepairAction.Deleted,
+            Now.AddDays(-1),
+            "release.nzb",
+            "release");
+
+        await AssertDoesNotThrowAsync(NewQueueItem());
+    }
+
+    [Fact]
+    public async Task RecentRepairedViaPar2_DoesNotThrow()
+    {
+        await SeedRejectionAsync(
+            HealthCheckResult.RepairAction.RepairedViaPar2,
+            Now.AddDays(-1),
+            "release.nzb",
+            "release");
+
+        await AssertDoesNotThrowAsync(NewQueueItem());
+    }
+
+    [Fact]
+    public async Task DifferentNzbFileNameWithSameJobName_DoesNotThrow()
+    {
+        await SeedRejectionAsync(
+            HealthCheckResult.RepairAction.Repaired,
+            Now.AddDays(-1),
+            "other-release.nzb",
+            "release");
+
+        await AssertDoesNotThrowAsync(NewQueueItem());
+    }
+
+    [Fact]
+    public async Task NullNzbFileNameWithMatchingJobName_Throws()
+    {
+        await SeedRejectionAsync(
+            HealthCheckResult.RepairAction.Repaired,
+            Now.AddDays(-1),
+            nzbFileName: null,
+            jobName: "release");
+
+        await AssertThrowsAsync(NewQueueItem());
+    }
+
+    [Fact]
+    public async Task BothPersistedIdentitiesNull_DoesNotThrow()
+    {
+        await SeedRejectionAsync(
+            HealthCheckResult.RepairAction.Repaired,
+            Now.AddDays(-1),
+            nzbFileName: null,
+            jobName: null);
+
+        await AssertDoesNotThrowAsync(NewQueueItem());
+    }
+
+    [Fact]
+    public async Task DifferentReleaseIdentity_DoesNotThrow()
+    {
+        await SeedRejectionAsync(
+            HealthCheckResult.RepairAction.Repaired,
+            Now.AddDays(-1),
+            "other-release.nzb",
+            "other-release");
+
+        await AssertDoesNotThrowAsync(NewQueueItem());
+    }
+}


### PR DESCRIPTION
## Summary
- Check persisted health repair history before any NNTP work for a queue item.
- Reject only the same release that was recently removed and blocklisted after health repair.
- Keep the existing fast in-memory segment guard and cover restart, cutoff, identity, and excluded-action boundaries.

Fixes #1193

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter \"FullyQualifiedName~RejectedReleaseFailFastTests|FullyQualifiedName~HealthCheckRejectedReleaseSeedTests\"` (13 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Queue processing now fails fast for releases recently removed and blocklisted after a repaired health check.
  * Rejection checks match releases by filename or job name within a 14-day lookback window.
  * Older, deleted, alternatively repaired, or unrelated releases continue processing normally.

* **Tests**
  * Added coverage for rejection timing, identity matching, persistence, and exception behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->