### PR TITLE
chore(docker): annotate rolling dev images with build metadata

### DIFF
--- a/.github/workflows/cut-prerelease.yml
+++ b/.github/workflows/cut-prerelease.yml
@@ -100,6 +100,7 @@ jobs:
         ghcr.io/${{ github.repository }}:dev
         docker.io/infinidysk/infinidysk:dev
       nzbdav_version: ${{ needs.resolve.outputs.dev_label }}
+      image_description: InfiniDysk development build ${{ needs.resolve.outputs.dev_label }}
       checkout_ref: ${{ needs.resolve.outputs.sha }}
       dockerhub_username: infinidysk
     secrets:

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -95,7 +95,7 @@ jobs:
             NZBDAV_COMMIT_SHA=${{ inputs.checkout_ref || github.sha }}
             REPO_URL=https://github.com/${{ github.repository }}
           labels: ${{ inputs.image_description != '' && format('org.opencontainers.image.description={0}', inputs.image_description) || '' }}
-          annotations: ${{ inputs.image_description != '' && format('org.opencontainers.image.description={0}', inputs.image_description) || '' }}
+          annotations: ${{ inputs.image_description != '' && format('index:org.opencontainers.image.description={0}', inputs.image_description) || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -11,6 +11,21 @@ on:
         description: NZBDAV_VERSION build arg
         required: true
         type: string
+      image_description:
+        description: OCI image description (applied to the image and multi-arch manifest)
+        required: false
+        type: string
+        default: ""
+      dev_image_description:
+        description: OCI description for rolling dev image manifests
+        required: false
+        type: string
+        default: ""
+      dev_tags:
+        description: Rolling dev image tags to annotate (newline-separated)
+        required: false
+        type: string
+        default: ""
       checkout_ref:
         description: Git ref to build (defaults to triggering commit)
         required: false
@@ -79,8 +94,27 @@ jobs:
             NZBDAV_VERSION=${{ inputs.nzbdav_version }}
             NZBDAV_COMMIT_SHA=${{ inputs.checkout_ref || github.sha }}
             REPO_URL=https://github.com/${{ github.repository }}
+          labels: ${{ inputs.image_description != '' && format('org.opencontainers.image.description={0}', inputs.image_description) || '' }}
+          annotations: ${{ inputs.image_description != '' && format('org.opencontainers.image.description={0}', inputs.image_description) || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Annotate rolling dev image manifests
+        if: inputs.dev_image_description != '' && inputs.dev_tags != ''
+        env:
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+          DEV_IMAGE_DESCRIPTION: ${{ inputs.dev_image_description }}
+          DEV_TAGS: ${{ inputs.dev_tags }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            image="${tag%:*}"
+            docker buildx imagetools create \
+              --annotation "index:org.opencontainers.image.description=${DEV_IMAGE_DESCRIPTION}" \
+              --tag "$tag" \
+              "${image}@${BUILD_DIGEST}"
+          done <<< "$DEV_TAGS"
 
       # The legacy namespace lives in the old org, which this repo's
       # GITHUB_TOKEN cannot write to; re-login with an old-org PAT. Docker

--- a/.github/workflows/refresh-dev.yml
+++ b/.github/workflows/refresh-dev.yml
@@ -94,6 +94,7 @@ jobs:
         ghcr.io/${{ github.repository }}:dev
         docker.io/infinidysk/infinidysk:dev
       nzbdav_version: ${{ needs.resolve.outputs.dev_label }}
+      image_description: InfiniDysk development build ${{ needs.resolve.outputs.dev_label }}
       dockerhub_username: infinidysk
     secrets:
       registry_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,10 @@ jobs:
         ghcr.io/nzbdav/nzbdav:v${{ needs.release-please.outputs.major }}
         ghcr.io/nzbdav/nzbdav:v${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}
       nzbdav_version: ${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}.${{ needs.release-please.outputs.patch }}
+      dev_image_description: InfiniDysk development build ${{ needs.release-please.outputs.dev_label }}
+      dev_tags: |
+        ghcr.io/${{ github.repository }}:dev
+        docker.io/infinidysk/infinidysk:dev
       checkout_ref: ${{ needs.release-please.outputs.sha }}
       dockerhub_username: infinidysk
     secrets:
@@ -178,6 +182,10 @@ jobs:
         ghcr.io/nzbdav/nzbdav:v${{ needs.resolve-version.outputs.major }}
         ghcr.io/nzbdav/nzbdav:v${{ needs.resolve-version.outputs.major }}.${{ needs.resolve-version.outputs.minor }}
       nzbdav_version: ${{ needs.resolve-version.outputs.version }}
+      dev_image_description: InfiniDysk development build ${{ needs.resolve-version.outputs.dev_label }}
+      dev_tags: |
+        ghcr.io/${{ github.repository }}:dev
+        docker.io/infinidysk/infinidysk:dev
       checkout_ref: ${{ needs.resolve-version.outputs.ref }}
       dockerhub_username: infinidysk
     secrets:


### PR DESCRIPTION
## Summary
- add versioned OCI description labels and manifest annotations to direct dev image builds
- preserve dev-only metadata when stable releases refresh the rolling dev tags
- cover manual refresh, release candidate, release, and republish workflows

## Test plan
- [x] Checked workflow YAML diagnostics
- [x] Ran `git diff --check`
- [ ] Verify the next dev build displays its description in GHCR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker images now include descriptive metadata to make image purpose and development versions easier to identify.
  * Development image tags are explicitly tracked and annotated with the corresponding built image.
  * Release and development builds consistently publish descriptions and labels across supported image variants.

* **Chores**
  * Improved automated container build and release workflows for clearer image versioning and registry information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->