### PR TITLE
fix(ui): per-provider MB/s chart stays continuous when there is no traffic

### DIFF
--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.test.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.test.tsx
@@ -60,6 +60,7 @@ describe("ProviderScoreboard", () => {
       markup.indexOf("overflow-x-auto"),
     );
     expect(markup).toContain("2.25 MB/s");
+    expect(markup).not.toContain("min-w-[800px]");
   });
 
   it("captions retained history when the series is truncated", () => {

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
@@ -60,13 +60,13 @@ export function ProviderScoreboard({
           <p className="py-6 text-center text-xs text-base-content/50">No providers configured.</p>
         ) : (
           <>
-            <div className="overflow-x-auto">
-              <table className="table table-pin-cols table-sm min-w-[800px]">
+            <div className="w-full min-w-0 overflow-x-auto">
+              <table className="table table-pin-cols table-sm w-full">
                 <thead>
                   <tr>
                     <th>Provider</th>
-                    <th className="w-[120px]">Activity</th>
-                    <th className="w-[120px]">
+                    <th className="w-[120px] min-w-0 px-1">Activity</th>
+                    <th className="w-[120px] min-w-0 px-1">
                       <Tooltip content={outageHelp}>
                         <span>Outages</span>
                       </Tooltip>
@@ -74,13 +74,13 @@ export function ProviderScoreboard({
                     <th>Articles</th>
                     <th>Read</th>
                     <th>Share</th>
-                    <th className="w-[120px]">
+                    <th className="w-[120px] min-w-0 px-1">
                       <Tooltip content={speedHelp}>
                         <span>MB/s</span>
                       </Tooltip>
                     </th>
-                    <th className="w-[120px]">Errors</th>
-                    <th className="w-[120px]">Retries</th>
+                    <th className="w-[120px] min-w-0 px-1">Errors</th>
+                    <th className="w-[120px] min-w-0 px-1">Retries</th>
                     <th>
                       <Tooltip content="Mean duration of successful fetches only. Includes connection-pool wait inside the provider call — not pure wire RTT. Misses and errors are excluded.">
                         <span>Avg ok ms</span>
@@ -131,10 +131,10 @@ export function ProviderScoreboard({
                             )}
                           </div>
                         </th>
-                        <td>
+                        <td className="min-w-0 px-1">
                           <Sparkline values={p.spark} tone="success" />
                         </td>
-                        <td>
+                        <td className="min-w-0 px-1">
                           <Tooltip content={outageHelp}>
                             <OutageBuckets values={p.outageSpark ?? []} />
                           </Tooltip>
@@ -144,7 +144,7 @@ export function ProviderScoreboard({
                         <td>
                           <ShareBar share={share} />
                         </td>
-                        <td>
+                        <td className="min-w-0 px-1">
                           <Tooltip content={speedHelp}>
                             <div className="flex flex-col gap-0.5">
                               <Sparkline values={p.speedSpark ?? []} tone="success" />
@@ -154,7 +154,7 @@ export function ProviderScoreboard({
                             </div>
                           </Tooltip>
                         </td>
-                        <td>
+                        <td className="min-w-0 px-1">
                           <div className="flex flex-col gap-0.5">
                             <Sparkline values={p.errorSpark ?? []} tone="error" eventsOnly />
                             <div
@@ -170,7 +170,7 @@ export function ProviderScoreboard({
                             </div>
                           </div>
                         </td>
-                        <td>
+                        <td className="min-w-0 px-1">
                           <div className="flex flex-col gap-0.5">
                             <Sparkline values={p.retrySpark ?? []} tone="warning" eventsOnly />
                             <div

--- a/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.test.tsx
+++ b/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.test.tsx
@@ -57,4 +57,25 @@ describe("ProviderSpeedChart", () => {
     expect(d).toContain("0.0,156.0");
     expect(d).toContain("400.0,156.0");
   });
+
+  it("centers a single-bucket sample on the chart", () => {
+    const markup = renderToStaticMarkup(
+      <ProviderSpeedChart
+        providerLabel="Alpha"
+        points={[point(7)]}
+        bucketSizeMs={60_000}
+        historyTruncated={false}
+        window="1h"
+      />,
+    );
+    const d = speedPathD(markup);
+    const xs = [...d.matchAll(/[ML]([\d.]+),/g)].map((match) => Number(match[1]));
+
+    expect(d).not.toBe("");
+    expect(xs.length).toBe(2);
+    expect(Math.min(...xs)).toBeGreaterThan(0);
+    expect(Math.max(...xs)).toBeLessThan(800);
+    expect(xs.some((x) => x < 400)).toBe(true);
+    expect(xs.some((x) => x > 400)).toBe(true);
+  });
 });

--- a/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.test.tsx
+++ b/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.test.tsx
@@ -17,7 +17,7 @@ function speedPathD(markup: string): string {
 }
 
 describe("ProviderSpeedChart", () => {
-  it("does not connect positive runs through a single idle bucket", () => {
+  it("connects positive runs through idle buckets at the baseline", () => {
     const markup = renderToStaticMarkup(
       <ProviderSpeedChart
         providerLabel="Alpha"
@@ -30,9 +30,10 @@ describe("ProviderSpeedChart", () => {
     const d = speedPathD(markup);
 
     expect(d).not.toBe("");
-    expect((d.match(/M/g) ?? []).length).toBe(2);
+    expect((d.match(/M/g) ?? []).length).toBe(1);
     // Three buckets span 800 viewBox units, so the idle bucket is at x=400.
-    expect(d).not.toContain("400.0,");
+    expect(d).toContain("400.0,156.0");
+    expect(d.startsWith("M0.0,")).toBe(true);
   });
 
   it("keeps a terminal isolated sample inside the viewBox", () => {
@@ -53,5 +54,7 @@ describe("ProviderSpeedChart", () => {
     expect(Math.min(...xs)).toBeGreaterThanOrEqual(0);
     expect(Math.max(...xs)).toBeLessThanOrEqual(800);
     expect(Math.min(...xs)).toBeLessThan(800);
+    expect(d).toContain("0.0,156.0");
+    expect(d).toContain("400.0,156.0");
   });
 });

--- a/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.tsx
+++ b/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.tsx
@@ -269,17 +269,21 @@ function buildSpeedPath(
   y: (v: number) => number,
 ): string {
   if (points.length === 0) return "";
-  const parts = points.map((p, i) => {
-    const x = (i * xStep).toFixed(1);
-    const yy = y(p?.speedMbPerSec ?? 0).toFixed(1);
-    return `${i === 0 ? "M" : "L"}${x},${yy}`;
-  });
   if (points.length === 1) {
     const yy = y(points[0]?.speedMbPerSec ?? 0).toFixed(1);
-    const x2 = Math.min(VB_W, Math.max(xStep * 0.15, 1)).toFixed(1);
-    parts.push(`L${x2},${yy}`);
+    const mid = VB_W / 2;
+    const extension = 1;
+    const x1 = Math.max(0, mid - extension).toFixed(1);
+    const x2 = Math.min(VB_W, mid + extension).toFixed(1);
+    return `M${x1},${yy} L${x2},${yy}`;
   }
-  return parts.join(" ");
+  return points
+    .map((p, i) => {
+      const x = (i * xStep).toFixed(1);
+      const yy = y(p?.speedMbPerSec ?? 0).toFixed(1);
+      return `${i === 0 ? "M" : "L"}${x},${yy}`;
+    })
+    .join(" ");
 }
 
 function indexOfBucket(points: ProviderSpeedPoint[], bucket: number | null): number | null {

--- a/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.tsx
+++ b/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.tsx
@@ -196,7 +196,7 @@ export function ProviderSpeedChart({
                     y2={TOP_PAD.toFixed(1)}
                     className={styles.gridline}
                   />
-                  {maxSpeed > 0 && speedPath && (
+                  {speedPath && (
                     <path d={speedPath} className={styles.lineSpeed} data-series="speed" />
                   )}
                 </svg>
@@ -268,34 +268,16 @@ function buildSpeedPath(
   xStep: number,
   y: (v: number) => number,
 ): string {
-  const parts: string[] = [];
-  let inSegment = false;
-  for (let i = 0; i < points.length; i++) {
-    const p = points[i];
-    if (!p) continue;
-    const value = p.speedMbPerSec;
+  if (points.length === 0) return "";
+  const parts = points.map((p, i) => {
     const x = (i * xStep).toFixed(1);
-    const yy = y(value).toFixed(1);
-    if (value > 0) {
-      if (!inSegment) {
-        parts.push(`M${x},${yy}`);
-        inSegment = true;
-        const next = points[i + 1];
-        const nextZero = i === points.length - 1 || !next || next.speedMbPerSec <= 0;
-        if (nextZero) {
-          const extension = Math.max(xStep * 0.15, 1);
-          const x2 = Math.max(
-            0,
-            Math.min(VB_W, i * xStep + (i === points.length - 1 && i > 0 ? -extension : extension)),
-          ).toFixed(1);
-          parts.push(`L${x2},${yy}`);
-        }
-      } else {
-        parts.push(`L${x},${yy}`);
-      }
-    } else {
-      inSegment = false;
-    }
+    const yy = y(p?.speedMbPerSec ?? 0).toFixed(1);
+    return `${i === 0 ? "M" : "L"}${x},${yy}`;
+  });
+  if (points.length === 1) {
+    const yy = y(points[0]?.speedMbPerSec ?? 0).toFixed(1);
+    const x2 = Math.min(VB_W, Math.max(xStep * 0.15, 1)).toFixed(1);
+    parts.push(`L${x2},${yy}`);
   }
   return parts.join(" ");
 }


### PR DESCRIPTION
## Summary
- The expanded per-provider Effective MB/s chart now draws idle buckets as 0, so the line rides the baseline instead of breaking into floating segments.
- The Providers table no longer forces an 800px minimum width; sparkline columns use tighter padding so a leftover horizontal scrollbar does not appear when every column already fits.

## Test plan
- [ ] Overview → Providers → expand a provider: Effective MB/s line should match Activity (spikes rise from a continuous zero baseline).
- [ ] Hover an idle bucket and confirm `0.00 MB/s` / `0 B fetched`.
- [ ] At a typical desktop width, the Providers card has no horizontal scrollbar while all columns remain visible.
- [ ] At a narrow viewport, the table still scrolls horizontally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider speed charts so activity remains connected through idle periods and zero-speed data.
  * Ensured isolated and single-point speed readings render correctly and remain centered.
  * Updated the provider scoreboard layout to use available width without unnecessary horizontal scrolling.
  * Tightened table spacing for clearer visibility across activity, outage, speed, error, and retry metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->