### PR TITLE
fix(health): stop deleting linked files after inconclusive Arr lookups

### DIFF
--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -37,7 +37,6 @@ internal enum HealthCheckRefillOutcome
 public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
 {
     private const int MaximumMissingSegmentIds = 100_000;
-    private const int NoMatchConfirmationsRequired = 2;
     internal const string MissingPayloadMessagePrefix = "Streaming payload missing.";
     private const int MissingPayloadConfirmationsRequired = 3;
     private static readonly TimeSpan MissingPayloadInitialRecheck = TimeSpan.FromDays(1);
@@ -137,7 +136,6 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
 
     private static readonly HashSet<string> _missingSegmentIds = [];
     private static readonly Queue<string> _missingSegmentOrder = [];
-    private static readonly ConcurrentDictionary<Guid, int> _arrNoMatchConfirmations = new();
     private static readonly ConcurrentDictionary<string, List<DateTimeOffset>> _recentRepairRemovalsByPath = new();
 
     internal TimeSpan CoordinatorPollInterval { get; set; } = TimeSpan.FromSeconds(1);
@@ -1123,7 +1121,6 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             davItem.LastHealthCheck = utcNow;
             davItem.NextHealthCheck = ComputeNextHealthCheck(davItem.ReleaseDate, utcNow);
             _failureTracker.ClearFailure(davItem.Id);
-            _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);
 
             // A previously degraded file that now sweeps clean has recovered (provider-side
             // restoration): drop the stale hole and corrupt records. The probed container
@@ -1228,7 +1225,6 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 davItem.LastHealthCheck = utcNow;
                 davItem.NextHealthCheck = ComputeNextHealthCheck(davItem.ReleaseDate, utcNow);
                 _failureTracker.ClearFailure(davItem.Id);
-                _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);
                 await RecordHealthResult(
                     dbClient, davItem,
                     HealthCheckResult.HealthResult.Healthy,
@@ -1319,7 +1315,6 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             davItem.LastHealthCheck = utcNow;
             davItem.NextHealthCheck = ComputeNextHealthCheck(davItem.ReleaseDate, utcNow);
             _failureTracker.ClearFailure(davItem.Id);
-            _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);
             // The patched segments are served locally now; any earlier hole/corrupt record is obsolete.
             if (par2Outcome is Par2RepairOutcome.Repaired
                 && (nzbFile.MissingSegmentIndices != null || nzbFile.CorruptSegmentIndices != null))
@@ -2150,9 +2145,6 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             : LibraryLinkRepairDisposition.RepairLinked;
     }
 
-    internal static bool ShouldDeleteAfterArrNoMatch(int confirmationCount) =>
-        confirmationCount >= NoMatchConfirmationsRequired;
-
     /// <summary>
     /// True when the linked library path has already had <see cref="RepairRecurrenceLimit"/>
     /// downloads removed by repair within <see cref="RepairRecurrenceWindow"/>. The path is the
@@ -2220,8 +2212,48 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
         /// Leave it in place rather than searching again without blocklisting the failed release.
         /// </summary>
         DeferMissingDownloadHistory,
-        /// <summary>No reachable Arr instance confirmed ownership; leave the organized link in place.</summary>
+        /// <summary>
+        /// At least one Arr root folder contained the organized path, but no instance returned an
+        /// exact media-file match. Leave the organized link in place.
+        /// </summary>
         DeferNoMatchingMediaItem,
+        /// <summary>
+        /// Arr was reachable, but no reported root folder contains the organized path seen by
+        /// InfiniDysk. The containers may expose the same host directory under different paths.
+        /// </summary>
+        DeferRootPathMismatch,
+    }
+
+    /// <summary>
+    /// True when <paramref name="candidatePath"/> is the same as <paramref name="rootPath"/> or a
+    /// child of it at a directory boundary. Arr paths are compared as opaque strings: no filesystem
+    /// resolution, separator rewriting, or case folding.
+    /// </summary>
+    internal static bool IsPathWithinRoot(string candidatePath, string rootPath)
+    {
+        if (string.IsNullOrEmpty(candidatePath) || string.IsNullOrEmpty(rootPath))
+            return false;
+
+        var normalizedRoot = rootPath.Length > 1
+            ? rootPath.TrimEnd('/', '\\')
+            : rootPath;
+
+        // Fail closed on degenerate roots such as "//" that trim to nothing;
+        // an empty prefix would otherwise match every path.
+        if (normalizedRoot.Length == 0)
+            return false;
+
+        if (string.Equals(candidatePath, normalizedRoot, StringComparison.Ordinal))
+            return true;
+
+        if (!candidatePath.StartsWith(normalizedRoot, StringComparison.Ordinal))
+            return false;
+
+        if (normalizedRoot is "/" or "\\")
+            return true;
+
+        return candidatePath.Length > normalizedRoot.Length &&
+               candidatePath[normalizedRoot.Length] is '/' or '\\';
     }
 
     /// <summary>
@@ -2237,13 +2269,13 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
         Func<ArrClient, IReadOnlyList<string>, bool>? shouldRequestSearch = null,
         ArrInstanceBackoff? arrBackoff = null)
     {
-        // Track whether a no-owner result is authoritative enough to explain to the operator.
-        // Neither outcome permits deletion: a successful-but-incomplete library/Arr view is
-        // indistinguishable from a genuine orphan at this point.
         var anInstanceFailed = false;
+        var sawConfiguredClient = false;
+        var matchedArrRootFolder = false;
 
         foreach (var arrClient in arrClients)
         {
+            sawConfiguredClient = true;
             ct.ThrowIfCancellationRequested();
 
             // Skip the root-folder query for an instance that is timing out or refusing
@@ -2276,15 +2308,21 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 continue;
             }
 
-            // Skip null/empty paths: StartsWith(null) throws, and StartsWith("") matches everything.
-            // A null/empty path is a malformed response we can't rule this instance in or out
-            // with, so if nothing else matches, treat it like an unreachable instance rather
-            // than falling through to a delete this instance may not have sanctioned.
-            if (!rootFolders.Any(x => !string.IsNullOrEmpty(x.Path) && symlinkOrStrmPath.StartsWith(x.Path, StringComparison.Ordinal)))
+            var hasMatchingRoot = rootFolders.Any(root =>
+                !string.IsNullOrEmpty(root.Path) &&
+                IsPathWithinRoot(symlinkOrStrmPath, root.Path));
+
+            if (!hasMatchingRoot)
             {
-                if (rootFolders.Any(x => string.IsNullOrEmpty(x.Path))) anInstanceFailed = true;
+                // A null/empty root path is a malformed response: this instance can be
+                // neither ruled in nor ruled out, so it must defer as unreachable rather
+                // than count toward a path-mismatch diagnosis.
+                if (rootFolders.Any(x => string.IsNullOrEmpty(x.Path)))
+                    anInstanceFailed = true;
                 continue;
             }
+
+            matchedArrRootFolder = true;
 
             if (downloadId == null)
                 return ArrLinkedRepairDecision.DeferMissingDownloadHistory;
@@ -2319,11 +2357,14 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
 
             // A root-folder match with no exact media-item match may be caused by path
             // normalization, stale Arr data, or a transient partial response. Keep checking
-            // other configured instances, but never use this single miss to authorize deletion.
+            // other configured instances, but never use this miss to authorize deletion.
         }
 
         if (anInstanceFailed)
             return ArrLinkedRepairDecision.DeferUnreachable;
+
+        if (sawConfiguredClient && !matchedArrRootFolder)
+            return ArrLinkedRepairDecision.DeferRootPathMismatch;
 
         return ArrLinkedRepairDecision.DeferNoMatchingMediaItem;
     }
@@ -2388,7 +2429,6 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             davItem.LastHealthCheck = utcNow;
             davItem.NextHealthCheck = ComputeNextHealthCheck(davItem.ReleaseDate, utcNow);
             _failureTracker.ClearFailure(davItem.Id);
-            _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);
             await RecordHealthResult(
                 dbClient, davItem,
                 HealthCheckResult.HealthResult.Healthy,
@@ -2484,8 +2524,6 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             var linkDisposition = GetLibraryLinkRepairDisposition(
                 symlinkOrStrmPath,
                 forceDelete || (forceDeleteIfUnlinked && symlinkOrStrmPath == null));
-            if (linkDisposition != LibraryLinkRepairDisposition.RepairLinked)
-                _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);
             if (linkDisposition == LibraryLinkRepairDisposition.ForceDelete)
             {
                 if (symlinkOrStrmPath != null)
@@ -2622,9 +2660,6 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                     arrConfig.EffectiveQueueReplacementSearchWindow()),
                 _arrBackoff).ConfigureAwait(false);
 
-            if (arrDecision != ArrLinkedRepairDecision.DeferNoMatchingMediaItem)
-                _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);
-
             if (arrDecision is ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded
                 or ArrLinkedRepairDecision.RemoveAndBlocklistSucceededSearchWithheld)
             {
@@ -2691,20 +2726,11 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 return;
             }
 
-            // A reachable Arr returning no exact media-item match is inconclusive once, because
-            // path normalization or a partial Arr response can produce a false miss. Require a
-            // second consecutive fully reachable miss before deliberately removing a confirmed
-            // Arr orphan. This also gives genuine orphan links a cleanup path; the maintenance
-            // task cannot see them as unlinked while the organized link still exists.
-            var noMatchConfirmations = _arrNoMatchConfirmations.AddOrUpdate(
-                davItem.Id,
-                1,
-                (_, previous) => previous + 1);
-            if (!ShouldDeleteAfterArrNoMatch(noMatchConfirmations))
+            if (arrDecision == ArrLinkedRepairDecision.DeferRootPathMismatch)
             {
-                var noMatchUtcNow = DateTimeOffset.UtcNow;
-                davItem.LastHealthCheck = noMatchUtcNow;
-                davItem.NextHealthCheck = noMatchUtcNow + TimeSpan.FromDays(1);
+                var utcNow = DateTimeOffset.UtcNow;
+                davItem.LastHealthCheck = utcNow;
+                davItem.NextHealthCheck = utcNow + TimeSpan.FromDays(1);
                 await RecordHealthResult(
                     dbClient, davItem,
                     HealthCheckResult.HealthResult.Unhealthy,
@@ -2712,32 +2738,28 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                     string.Join(" ", [
                         "File failed health validation.",
                         $"Corresponding {linkType} found within Library Dir.",
-                        "No configured Radarr/Sonarr instance confirmed a matching media-item.",
-                        $"Leaving the webdav-file and {linkType} in place after no-match confirmation {noMatchConfirmations}/{NoMatchConfirmationsRequired}."
+                        "No enabled Radarr/Sonarr root folder contains the library path reported by InfiniDysk.",
+                        "The containers may expose the same host library under different absolute paths; configure InfiniDysk and Arr to use the same absolute container path.",
+                        $"The webdav-file and {linkType} were left in place, and replacement search was skipped because the Arr media item could not be identified safely."
                     ]), ct).ConfigureAwait(false);
                 return;
             }
 
-            _arrNoMatchConfirmations.TryRemove(davItem.Id, out _);
-            await Task.Run(() => File.Delete(linkedPath)).ConfigureAwait(false);
-            DeletionAuditLog.Record(
-                "health-repair",
-                davItem,
-                "health validation failed; no Arr media-item after repeated reachable confirmations");
-            RemoveDavItemWithGeneratedSidecars(dbClient, davItem);
-            _failureTracker.ClearFailure(davItem.Id);
-            var confirmedOrphanUtcNow = DateTimeOffset.UtcNow;
-            davItem.LastHealthCheck = confirmedOrphanUtcNow;
-            davItem.NextHealthCheck = confirmedOrphanUtcNow + TimeSpan.FromDays(1);
+            // A containing Arr root existed, but no instance confirmed an exact media-file match.
+            // That miss is inconclusive (path mapping, stale Arr data, or a genuine orphan) and
+            // must never authorize deletion of a still-linked library file.
+            var noMatchUtcNow = DateTimeOffset.UtcNow;
+            davItem.LastHealthCheck = noMatchUtcNow;
+            davItem.NextHealthCheck = noMatchUtcNow + TimeSpan.FromDays(1);
             await RecordHealthResult(
                 dbClient, davItem,
                 HealthCheckResult.HealthResult.Unhealthy,
-                HealthCheckResult.RepairAction.Deleted,
+                HealthCheckResult.RepairAction.ActionNeeded,
                 string.Join(" ", [
                     "File failed health validation.",
                     $"Corresponding {linkType} found within Library Dir.",
-                    "No configured Radarr/Sonarr instance confirmed a matching media-item.",
-                    $"Deleted the webdav-file and {linkType} after {noMatchConfirmations} consecutive confirmations."
+                    "An Arr root folder contains the library path, but no configured Radarr/Sonarr instance confirmed an exact matching media item.",
+                    $"The webdav-file and {linkType} were left in place because an inconclusive lookup cannot authorize automatic deletion."
                 ]), ct).ConfigureAwait(false);
         }
         catch (Exception e) when (e is not OutOfMemoryException)

--- a/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
@@ -176,28 +176,58 @@ public class ArrLinkedRepairDecisionTests
     }
 
     [Fact]
-    public async Task NoMatchingRoot_DefersWithoutDelete()
+    public async Task NoMatchingRoot_ReturnsRootPathMismatchWithoutCallingArrRepair()
     {
+        const string localPath = "/mnt/data/tv/Example/Example.S01E01.mkv";
         var clients = new ArrClient[]
         {
             new ScriptedArrClient(
                 host: "http://sonarr",
                 rootFolders: () => Task.FromResult(new List<ArrRootFolder>
                 {
-                    new() { Path = "/media/tv" },
+                    new() { Path = "/data/media/tv" },
                 }),
-                removeAndBlocklist: (_, _) => Task.FromResult(ArrRepairOutcome.MediaItemNotFound)),
+                removeAndBlocklist: (_, _) => throw new InvalidOperationException("should not be called")),
         };
 
         var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
-            clients, LibraryPath, DownloadId, CancellationToken.None);
+            clients, localPath, DownloadId, CancellationToken.None);
 
-        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferNoMatchingMediaItem, decision);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferRootPathMismatch, decision);
     }
 
     [Fact]
-    public async Task ExactMediaPathMiss_DefersWithoutDelete()
+    public async Task MultipleReachableClientsWithNoMatchingRoot_ReturnRootPathMismatch()
     {
+        const string localPath = "/mnt/data/tv/Example/Example.S01E01.mkv";
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://sonarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/data/media/tv" },
+                }),
+                removeAndBlocklist: (_, _) => throw new InvalidOperationException("should not be called")),
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/data/media/movies" },
+                }),
+                removeAndBlocklist: (_, _) => throw new InvalidOperationException("should not be called")),
+        };
+
+        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, localPath, DownloadId, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferRootPathMismatch, decision);
+    }
+
+    [Fact]
+    public async Task MatchingRootWithExactMediaMiss_ReturnsNoMatchingMediaItem()
+    {
+        var removeCalls = 0;
         var clients = new ArrClient[]
         {
             new ScriptedArrClient(
@@ -206,13 +236,114 @@ public class ArrLinkedRepairDecisionTests
                 {
                     new() { Path = "/media/movies" },
                 }),
-                removeAndBlocklist: (_, _) => Task.FromResult(ArrRepairOutcome.MediaItemNotFound)),
+                removeAndBlocklist: (_, _) =>
+                {
+                    removeCalls++;
+                    return Task.FromResult(ArrRepairOutcome.MediaItemNotFound);
+                }),
         };
 
         var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
             clients, LibraryPath, DownloadId, CancellationToken.None);
 
+        Assert.Equal(1, removeCalls);
         Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferNoMatchingMediaItem, decision);
+    }
+
+    [Fact]
+    public async Task OneMatchingRootAndOneUnrelatedRoot_ReturnsNoMatchingMediaItem()
+    {
+        var movieRemoveCalls = 0;
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://sonarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/tv" },
+                }),
+                removeAndBlocklist: (_, _) => throw new InvalidOperationException("tv instance should not be called")),
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, _) =>
+                {
+                    movieRemoveCalls++;
+                    return Task.FromResult(ArrRepairOutcome.MediaItemNotFound);
+                }),
+        };
+
+        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, DownloadId, CancellationToken.None);
+
+        Assert.Equal(1, movieRemoveCalls);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferNoMatchingMediaItem, decision);
+    }
+
+    [Fact]
+    public async Task UnreachableClientTakesPrecedenceOverRootPathMismatch()
+    {
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://unreachable",
+                rootFolders: () => throw new HttpRequestException("connection refused"),
+                removeAndBlocklist: (_, _) => throw new InvalidOperationException("should not be called")),
+            new ScriptedArrClient(
+                host: "http://sonarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/tv" },
+                }),
+                removeAndBlocklist: (_, _) => throw new InvalidOperationException("should not be called")),
+        };
+
+        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, DownloadId, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, decision);
+    }
+
+    [Fact]
+    public async Task EmptyRootPathAmongNonMatchingRoots_DefersUnreachable()
+    {
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = null },
+                    new() { Path = "/media/tv" },
+                }),
+                removeAndBlocklist: (_, _) => throw new InvalidOperationException("should not be called")),
+        };
+
+        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, DownloadId, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, decision);
+    }
+
+    [Fact]
+    public async Task CancelledToken_ThrowsWithoutCallingArr()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => throw new InvalidOperationException("should not be called"),
+                removeAndBlocklist: (_, _) => throw new InvalidOperationException("should not be called")),
+        };
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            HealthCheckService.DecideArrLinkedRepairAsync(
+                clients, LibraryPath, DownloadId, cts.Token));
     }
 
     [Fact]
@@ -250,6 +381,23 @@ public class ArrLinkedRepairDecisionTests
             [], LibraryPath, DownloadId, CancellationToken.None);
 
         Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferNoMatchingMediaItem, decision);
+    }
+
+    [Theory]
+    [InlineData("/media/movies/title/file.mkv", "/media/movies", true)]
+    [InlineData("/media/movies/title/file.mkv", "/media/movies/", true)]
+    [InlineData("/media/movies", "/media/movies", true)]
+    [InlineData("/media/movies/title/file.mkv", "/", true)]
+    [InlineData("/media/movies-old/title/file.mkv", "/media/movies", false)]
+    [InlineData("/mnt/data/title/file.mkv", "/data/media", false)]
+    [InlineData("/Media/movies/title/file.mkv", "/media/movies", false)]
+    [InlineData("/media/movies/title/file.mkv", "//", false)]
+    public void IsPathWithinRoot_UsesOrdinalDirectoryBoundaries(
+        string candidate,
+        string root,
+        bool expected)
+    {
+        Assert.Equal(expected, HealthCheckService.IsPathWithinRoot(candidate, root));
     }
 
     private sealed class ScriptedArrClient(

--- a/tests/NzbWebDAV.Tests/Services/UrgentRepairDispositionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/UrgentRepairDispositionTests.cs
@@ -80,14 +80,4 @@ public class UrgentRepairDispositionTests
             HealthCheckService.LibraryLinkRepairDisposition.RepairLinked,
             HealthCheckService.GetLibraryLinkRepairDisposition("/library/movie.mkv", forceDelete: false));
     }
-
-    [Theory]
-    [InlineData(0, false)]
-    [InlineData(1, false)]
-    [InlineData(2, true)]
-    [InlineData(3, true)]
-    public void ArrNoMatch_RequiresRepeatedConfirmation(int count, bool expected)
-    {
-        Assert.Equal(expected, HealthCheckService.ShouldDeleteAfterArrNoMatch(count));
-    }
 }


### PR DESCRIPTION
## Summary
- Background Repairs no longer deletes a still-linked library file just because Radarr or Sonarr failed to match its path. A repeated lookup miss is treated as inconclusive, including when InfiniDysk and Arr see the same host directory through different container prefixes.
- Root-folder mismatches now record `ActionNeeded` with a Health reason that the containers may expose the library under different absolute paths. Exact media-item misses also stay `ActionNeeded` indefinitely.
- Successful Arr remove/blocklist, filename blocklist deletion, and explicit streaming-failure force-delete are unchanged.

Genuine stale links that Arr cannot identify now require operator review. Automatic deletion cannot distinguish them from valid files hidden by container path differences.

Fixes #1221

## Test plan
- [x] Focused tests: `ArrLinkedRepairDecisionTests` and `UrgentRepairDispositionTests` (35 passed)
- [ ] Confirm an unhealthy item with InfiniDysk path `/mnt/data/...` and Arr root `/data/media/...` stays in place across repeated Background Repairs, with `ActionNeeded` and a path-mismatch reason
- [ ] Confirm a matching Arr root with no exact media item also stays `ActionNeeded` and is never deleted on retry
- [ ] Confirm a reachable Arr that owns the file still remove/blocklists and records `Repaired`
- [ ] Confirm an unreachable Arr instance still defers without deleting
- [ ] Confirm filename blocklist and explicit streaming-failure force-delete still delete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repair handling for Arr-linked files when media items are missing or paths do not match.
  * Prevented linked files from being deleted in ambiguous no-match and root-path mismatch cases.
  * Added safer path-boundary validation to avoid treating similarly named paths as matches.
  * Added clearer health results explaining deferred repair decisions.

* **Tests**
  * Expanded coverage for multiple clients, unreachable services, empty roots, cancellation, and path matching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->