### PR TITLE
feat(health): expose segment-buffer eviction causes and throttle forced GC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ The committed admin OpenAPI contract lives at `contracts/openapi/admin-v1.json` 
 cd frontend && npm run generate:api
 ```
 
-The export command starts the test host, normalizes the document (stable key order, empty `servers`, contract version `1.0.0`), and fails if the result does not match the committed file unless you are rewriting it. Frontend `lint` / `typecheck` / `test` / `build` regenerate `app/generated/admin-api.ts` automatically (gitignored).
+The export command starts the test host, normalizes the document (stable key order, empty `servers`, contract version `2.0.0`), and fails if the result does not match the committed file unless you are rewriting it. Frontend `lint` / `typecheck` / `test` / `build` regenerate `app/generated/admin-api.ts` automatically (gitignored).
 
 Stream tracing is **opt-in** and off by default. Toggle it from **Settings → Support** for 15/30/60 minutes (no restart; it auto-expires and never survives a restart), or set `STREAM_TRACE_EVENTS` to a positive value for an always-on capture from startup. When tracing is off, no trace events are recorded and the trace APIs report `enabled: false`.
 

--- a/backend.Benchmarks/SegmentBufferPoolRetentionBenchmarks.cs
+++ b/backend.Benchmarks/SegmentBufferPoolRetentionBenchmarks.cs
@@ -1,0 +1,134 @@
+using BenchmarkDotNet.Attributes;
+using NzbWebDAV.Streams;
+
+namespace NzbWebDAV.Benchmarks;
+
+[MemoryDiagnoser]
+public class SegmentBufferPoolRetentionBenchmarks
+{
+    private const int BurstCount = 65;
+    private const int RepeatRounds = 3;
+    private const int Size256 = 256 * 1024;
+    private const int Size512 = 512 * 1024;
+    private const int Size768 = 768 * 1024;
+    private static readonly int[] MixedSizes = [Size256, Size512, Size768];
+
+    private int[] _burstSchedule = null!;
+    private int[] _mixedSchedule = null!;
+    private BenchmarkManualTimeProvider _clock = null!;
+    private SegmentBufferPool _pool = null!;
+    private long _warmAllocationCount;
+
+    public enum BenchmarkRetentionPolicy
+    {
+        Legacy,
+        CapacityOnly,
+    }
+
+    [Params(BenchmarkRetentionPolicy.Legacy, BenchmarkRetentionPolicy.CapacityOnly)]
+    public BenchmarkRetentionPolicy Policy { get; set; }
+
+    [Params(1, 8)]
+    public int ConcurrentStreams { get; set; }
+
+    private SegmentBufferRetentionPolicy RuntimePolicy => Policy switch
+    {
+        BenchmarkRetentionPolicy.Legacy => SegmentBufferRetentionPolicy.Legacy,
+        BenchmarkRetentionPolicy.CapacityOnly => SegmentBufferRetentionPolicy.CapacityOnly,
+        _ => throw new ArgumentOutOfRangeException(nameof(Policy)),
+    };
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _burstSchedule = Enumerable.Repeat(Size256, BurstCount).ToArray();
+        var random = new Random(42);
+        _mixedSchedule = Enumerable.Range(0, 24)
+            .Select(_ => MixedSizes[random.Next(MixedSizes.Length)])
+            .ToArray();
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        const long maxIdleBytes = 128L * 1024 * 1024;
+        _clock = new BenchmarkManualTimeProvider();
+        _pool = new SegmentBufferPool(
+            maxIdleBytes,
+            RuntimePolicy,
+            timeProvider: _clock);
+        RunBurst(_pool, _burstSchedule);
+        RunBurst(_pool, _mixedSchedule);
+        _warmAllocationCount = _pool.Snapshot().AllocationCount;
+    }
+
+    [Benchmark]
+    public long BurstGapRepeat()
+    {
+        for (var round = 0; round < RepeatRounds; round++)
+        {
+            _clock.Advance(TimeSpan.FromMinutes(3));
+            if (ConcurrentStreams == 1)
+            {
+                RunBurst(_pool, _burstSchedule);
+                RunBurst(_pool, _mixedSchedule);
+            }
+            else
+            {
+                RunConcurrentBurst(_pool, _burstSchedule, ConcurrentStreams);
+                RunConcurrentBurst(_pool, _mixedSchedule, ConcurrentStreams);
+            }
+        }
+
+        var snapshot = _pool.Snapshot();
+        if (snapshot.IdleBytes > snapshot.MaxIdleBytes)
+        {
+            throw new InvalidOperationException(
+                $"IdleBytes {snapshot.IdleBytes} exceeded maxIdleBytes {snapshot.MaxIdleBytes}.");
+        }
+
+        if (snapshot.CheckedOutBytes != 0 || snapshot.RentCount != snapshot.ReturnCount)
+        {
+            throw new InvalidOperationException(
+                $"Rent/return imbalance: {snapshot.RentCount}/{snapshot.ReturnCount} outstanding {snapshot.CheckedOutBytes}.");
+        }
+
+        if (Policy == BenchmarkRetentionPolicy.CapacityOnly &&
+            ConcurrentStreams == 1 &&
+            snapshot.AllocationCount != _warmAllocationCount)
+        {
+            throw new InvalidOperationException(
+                $"CapacityOnly allocated after warm-up: warm={_warmAllocationCount} final={snapshot.AllocationCount}.");
+        }
+
+        return snapshot.ReuseCount
+               + snapshot.AllocationCount
+               + snapshot.StaleExpiredBytes
+               + snapshot.ClassLimitDroppedBytes
+               + snapshot.CapacityEvictedBytes
+               + snapshot.IdleBytes;
+    }
+
+    private static void RunBurst(SegmentBufferPool pool, int[] schedule)
+    {
+        var rented = new byte[schedule.Length][];
+        for (var i = 0; i < schedule.Length; i++)
+            rented[i] = pool.Rent(schedule[i]);
+        foreach (var buffer in rented)
+            pool.Return(buffer);
+    }
+
+    private static void RunConcurrentBurst(SegmentBufferPool pool, int[] schedule, int concurrency)
+    {
+        Parallel.For(0, concurrency, _ => RunBurst(pool, schedule));
+    }
+
+    private sealed class BenchmarkManualTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now = DateTimeOffset.UnixEpoch;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public override long GetTimestamp() => _now.UtcTicks;
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+        public void Advance(TimeSpan duration) => _now += duration;
+    }
+}

--- a/backend/Api/Controllers/GcDiagnostics/GcDiagnosticsController.cs
+++ b/backend/Api/Controllers/GcDiagnostics/GcDiagnosticsController.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+using System.Globalization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Services.Diagnostics;
@@ -10,44 +10,39 @@ namespace NzbWebDAV.Api.Controllers.GcDiagnostics;
 [Route("api/gc-diagnostics")]
 public sealed class GcDiagnosticsController(
     InFlightArticleBudget inFlightArticleBudget,
-    GcDiagnosticsStore store) : BaseApiController
+    GcDiagnosticsStore store,
+    IGcDiagnosticsExecutor executor) : PostOnlyApiController
 {
     protected override Task<IActionResult> HandleRequest()
     {
-        if (!HttpMethods.IsPost(HttpContext.Request.Method))
+        var admission = store.TryBegin();
+        if (admission.Status != GcDiagnosticsAdmission.Started)
         {
-            return Task.FromResult<IActionResult>(
-                StatusCode(StatusCodes.Status405MethodNotAllowed,
-                    new BaseApiResponse { Status = false, Error = "POST required" }));
-        }
+            if (admission.RetryAfterSeconds is { } retryAfter)
+                Response.Headers.RetryAfter = retryAfter.ToString(CultureInfo.InvariantCulture);
 
-        if (!store.TryBegin())
-        {
+            var error = admission.Status == GcDiagnosticsAdmission.AlreadyRunning
+                ? "A GC diagnostics run is already in progress."
+                : "A GC diagnostics run recently completed. Wait before retrying.";
             return Task.FromResult<IActionResult>(
                 StatusCode(StatusCodes.Status429TooManyRequests,
                     new BaseApiResponse
                     {
                         Status = false,
-                        Error = "A GC diagnostics run is already in progress.",
+                        Error = error,
                     }));
         }
 
         try
         {
-            var before = GcSnapshotBuilder.Capture();
-            var stopwatch = Stopwatch.StartNew();
-            GC.Collect(2, GCCollectionMode.Aggressive, blocking: true, compacting: true);
-            GC.WaitForPendingFinalizers();
-            GC.Collect(2, GCCollectionMode.Aggressive, blocking: true, compacting: true);
-            stopwatch.Stop();
-
+            var execution = executor.Execute();
             var bufferPool = BufferPoolDiagnostics.Shared.Snapshot();
             var segmentPool = (PooledBufferStream.DefaultPool as SegmentBufferPool)?.Snapshot();
             var result = new GcDiagnosticsResult(
                 DateTimeOffset.UtcNow,
-                before,
-                GcSnapshotBuilder.Capture(),
-                stopwatch.ElapsedMilliseconds,
+                execution.Before,
+                execution.After,
+                execution.PauseMs,
                 new GcBufferRetention(
                     inFlightArticleBudget.LeasedBytes,
                     inFlightArticleBudget.CapBytes,
@@ -59,7 +54,11 @@ public sealed class GcDiagnosticsController(
                     bufferPool.RequestedBytes,
                     bufferPool.RentedBytes,
                     bufferPool.BucketWasteBytes),
-                segmentPool);
+                segmentPool)
+            {
+                CollectionMode = "Aggressive",
+                FullBlockingCollectionsRequested = 2,
+            };
             store.Store(result);
 
             return Task.FromResult<IActionResult>(Ok(GcDiagnosticsResponse.FromResult(result)));

--- a/backend/Api/Controllers/GcDiagnostics/GcDiagnosticsResponse.cs
+++ b/backend/Api/Controllers/GcDiagnostics/GcDiagnosticsResponse.cs
@@ -12,6 +12,8 @@ public sealed class GcDiagnosticsResponse : BaseApiResponse
     public required GcBufferRetention Retention { get; init; }
     public SegmentBufferPoolSnapshot? SegmentBufferPool { get; init; }
     public required string Warning { get; init; }
+    public required string CollectionMode { get; init; }
+    public required int FullBlockingCollectionsRequested { get; init; }
 
     internal static GcDiagnosticsResponse FromResult(GcDiagnosticsResult result) => new()
     {
@@ -21,6 +23,10 @@ public sealed class GcDiagnosticsResponse : BaseApiResponse
         PauseMs = result.PauseMs,
         Retention = result.Retention,
         SegmentBufferPool = result.SegmentBufferPool,
-        Warning = "Forced a blocking compacting GC; managed threads were paused. Do not poll this endpoint.",
+        Warning =
+            "Forced two aggressive full blocking collections; .NET 10 compacts the SOH and LOH for this mode, " +
+            "and managed threads were paused. Do not poll this endpoint.",
+        CollectionMode = result.CollectionMode,
+        FullBlockingCollectionsRequested = result.FullBlockingCollectionsRequested,
     };
 }

--- a/backend/Api/OpenApi/AdminApiContractCatalog.cs
+++ b/backend/Api/OpenApi/AdminApiContractCatalog.cs
@@ -7,7 +7,7 @@ namespace NzbWebDAV.Api.OpenApi;
 /// </summary>
 public static class AdminApiContractCatalog
 {
-    public const string ContractVersion = "1.0.0";
+    public const string ContractVersion = "2.0.0";
     public const string RelativeContractPath = "contracts/openapi/admin-v1.json";
 
     public sealed record Operation(string Method, string Path, string OperationId);

--- a/backend/Api/OpenApi/AdminOpenApiOperationTransformer.cs
+++ b/backend/Api/OpenApi/AdminOpenApiOperationTransformer.cs
@@ -30,6 +30,7 @@ internal sealed class AdminOpenApiOperationTransformer : IOpenApiOperationTransf
         if (!operation.Responses.ContainsKey("200"))
             operation.Responses["200"] = new OpenApiResponse { Description = "Success." };
         ApplyMissingPayloadContractOverrides(operation, route, verb);
+        ApplyGcDiagnosticsContractOverrides(operation, route, verb);
         AddProblemResponse(operation, "400", "Bad request.");
         AddProblemResponse(operation, "401", "Unauthorized.");
         AddProblemResponse(operation, "403", "Forbidden.");
@@ -135,6 +136,44 @@ internal sealed class AdminOpenApiOperationTransformer : IOpenApiOperationTransf
             Type = JsonSchemaType.Object,
             Properties = properties,
             Required = required,
+        };
+    }
+
+    private static void ApplyGcDiagnosticsContractOverrides(
+        OpenApiOperation operation,
+        string route,
+        string verb)
+    {
+        if (verb != "post" || route != "api/gc-diagnostics")
+            return;
+
+        operation.Responses ??= [];
+        operation.Responses["429"] = new OpenApiResponse
+        {
+            Description =
+                "Too many requests. Concurrent execution and the 10-minute cooldown both return 429. " +
+                "Retry-After is a non-negative integer number of seconds. Cooldown rejections always " +
+                "include it; concurrent rejections include it when a remaining wait is known.",
+            Headers = new Dictionary<string, IOpenApiHeader>
+            {
+                ["Retry-After"] = new OpenApiHeader
+                {
+                    Description = "Non-negative integer number of seconds to wait before retrying.",
+                    Required = false,
+                    Schema = new OpenApiSchema
+                    {
+                        Type = JsonSchemaType.Integer,
+                        Minimum = "0",
+                    },
+                },
+            },
+            Content = new Dictionary<string, OpenApiMediaType>
+            {
+                ["application/problem+json"] = new OpenApiMediaType
+                {
+                    Schema = new OpenApiSchemaReference("ProblemDetails"),
+                },
+            },
         };
     }
 

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -194,26 +194,7 @@ public partial class Program
                 return;
             }
 
-            var poolOverride = EnvironmentUtil.GetEnvironmentVariable("NZBDAV_SEGMENT_BUFFER_POOL");
-            if (string.Equals(poolOverride, "shared", StringComparison.OrdinalIgnoreCase))
-            {
-                // Explicit assignment is deliberate: DefaultPool is documented as
-                // set-once-at-startup, and this is the one sanctioned alternate
-                // assignment so tests or later refactors cannot leave it on the
-                // custom pool despite NZBDAV_SEGMENT_BUFFER_POOL=shared.
-                PooledBufferStream.DefaultPool = SharedArrayPoolAdapter.Instance;
-                Log.Information(
-                    "Segment buffer pool override active: using ArrayPool<byte>.Shared " +
-                    "(NZBDAV_SEGMENT_BUFFER_POOL=shared).");
-            }
-            else
-            {
-                PooledBufferStream.DefaultPool = new SegmentBufferPool(
-                    maxIdleBytes: Math.Clamp(
-                        configManager.GetInFlightArticleBudgetBytes() / 2,
-                        32L * 1024 * 1024,
-                        256L * 1024 * 1024));
-            }
+            ConfigureSegmentBufferPool(configManager);
 
             // WebApplicationFactory runs from the test output directory, where the
             // backend's published rapidyenc native asset is not present.
@@ -320,7 +301,8 @@ public partial class Program
                 .AddSingleton<SharedStreamRegistry>()
                 .AddSingleton<StreamingReadinessCheck>()
                 .AddSingleton(_ => new RuntimeUsageTracker())
-                .AddSingleton<GcDiagnosticsStore>()
+                .AddSingleton(sp => new GcDiagnosticsStore(TimeProvider.System))
+                .AddSingleton<IGcDiagnosticsExecutor, AggressiveGcDiagnosticsExecutor>()
                 .AddHostedService<RuntimeUsageSampler>()
                 .AddSingleton<ProviderUsageTracker>(sp =>
                     new ProviderUsageTracker(sp.GetRequiredService<ActiveReadRegistry>()))
@@ -1005,6 +987,47 @@ public partial class Program
 
             throw;
         }
+    }
+
+    private static void ConfigureSegmentBufferPool(ConfigManager configManager)
+    {
+        var poolOverride = EnvironmentUtil.GetEnvironmentVariable(
+            SegmentBufferPoolSelector.EnvironmentVariableName);
+        var poolMode = SegmentBufferPoolSelector.Resolve(poolOverride, out var unknownValue);
+        if (unknownValue)
+        {
+            Log.Warning(
+                "Unknown {Variable} value {Value}; using {Default}.",
+                SegmentBufferPoolSelector.EnvironmentVariableName,
+                poolOverride,
+                SegmentBufferPoolSelector.BoundedLegacyValue);
+        }
+
+        if (poolMode == SegmentBufferPoolSelector.Mode.Shared)
+        {
+            // Explicit assignment is deliberate: DefaultPool is documented as
+            // set-once-at-startup, and this is the one sanctioned alternate
+            // assignment so tests or later refactors cannot leave it on the
+            // custom pool despite NZBDAV_SEGMENT_BUFFER_POOL=shared.
+            PooledBufferStream.DefaultPool = SharedArrayPoolAdapter.Instance;
+            Log.Information(
+                "Segment buffer pool override active: using ArrayPool<byte>.Shared " +
+                "(NZBDAV_SEGMENT_BUFFER_POOL=shared).");
+            return;
+        }
+
+        var maxIdleBytes = Math.Clamp(
+            configManager.GetInFlightArticleBudgetBytes() / 2,
+            32L * 1024 * 1024,
+            256L * 1024 * 1024);
+        var retention = poolMode == SegmentBufferPoolSelector.Mode.BoundedCapacity
+            ? SegmentBufferRetentionPolicy.CapacityOnly
+            : SegmentBufferRetentionPolicy.Legacy;
+        PooledBufferStream.DefaultPool = new SegmentBufferPool(maxIdleBytes, retention);
+        Log.Information(
+            "Segment buffer pool mode={Mode} maxIdleBytes={MaxIdleBytes}",
+            SegmentBufferPoolSelector.ToLogValue(poolMode),
+            maxIdleBytes);
     }
 
     private static async Task<bool> IsDatabaseStartupVacuumEnabledAsync()

--- a/backend/Services/Diagnostics/GcDiagnosticsStore.cs
+++ b/backend/Services/Diagnostics/GcDiagnosticsStore.cs
@@ -1,15 +1,101 @@
+using System.Diagnostics;
 using NzbWebDAV.Streams;
 
 namespace NzbWebDAV.Services.Diagnostics;
 
+public interface IGcDiagnosticsExecutor
+{
+    GcCollectionExecution Execute();
+}
+
+public readonly record struct GcCollectionExecution(
+    GcSnapshot Before,
+    GcSnapshot After,
+    long PauseMs);
+
+internal sealed class AggressiveGcDiagnosticsExecutor : IGcDiagnosticsExecutor
+{
+    public GcCollectionExecution Execute()
+    {
+        var before = GcSnapshotBuilder.Capture();
+        var stopwatch = Stopwatch.StartNew();
+#pragma warning disable CA2001 // this is the authenticated manual diagnostics path
+        // codeql[cs/call-to-gc]
+        GC.Collect(
+            GC.MaxGeneration,
+            GCCollectionMode.Aggressive,
+            blocking: true,
+            compacting: true);
+        GC.WaitForPendingFinalizers();
+        // codeql[cs/call-to-gc]
+        GC.Collect(
+            GC.MaxGeneration,
+            GCCollectionMode.Aggressive,
+            blocking: true,
+            compacting: true);
+#pragma warning restore CA2001
+        stopwatch.Stop();
+        return new GcCollectionExecution(
+            before,
+            GcSnapshotBuilder.Capture(),
+            stopwatch.ElapsedMilliseconds);
+    }
+}
+
 public sealed class GcDiagnosticsStore : IDisposable
 {
-    private GcDiagnosticsResult? _lastResult;
+    public static readonly TimeSpan Cooldown = TimeSpan.FromMinutes(10);
+
+    private readonly TimeProvider _timeProvider;
+    private readonly object _gate = new();
     private readonly SemaphoreSlim _runGate = new(1, 1);
+    private long? _lastAttemptTimestamp;
+    private GcDiagnosticsResult? _lastResult;
+
+    public GcDiagnosticsStore() : this(TimeProvider.System)
+    {
+    }
+
+    public GcDiagnosticsStore(TimeProvider timeProvider)
+    {
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+    }
 
     public GcDiagnosticsResult? LastResult => Volatile.Read(ref _lastResult);
 
-    public bool TryBegin() => _runGate.Wait(0);
+    internal GcDiagnosticsAdmissionResult TryBegin()
+    {
+        if (!_runGate.Wait(0))
+        {
+            lock (_gate)
+            {
+                return new GcDiagnosticsAdmissionResult(
+                    GcDiagnosticsAdmission.AlreadyRunning,
+                    RemainingCooldownSecondsLocked());
+            }
+        }
+
+        lock (_gate)
+        {
+            if (_lastAttemptTimestamp is { } last)
+            {
+                var elapsed = _timeProvider.GetElapsedTime(last);
+                if (elapsed < Cooldown)
+                {
+                    var remaining = Cooldown - elapsed;
+                    var seconds = Math.Max(1, (int)Math.Ceiling(remaining.TotalSeconds));
+                    _runGate.Release();
+                    return new GcDiagnosticsAdmissionResult(
+                        GcDiagnosticsAdmission.Cooldown,
+                        seconds);
+                }
+            }
+
+            _lastAttemptTimestamp = _timeProvider.GetTimestamp();
+        }
+
+        return new GcDiagnosticsAdmissionResult(GcDiagnosticsAdmission.Started, RetryAfterSeconds: null);
+    }
 
     public void End() => _runGate.Release();
 
@@ -23,7 +109,27 @@ public sealed class GcDiagnosticsStore : IDisposable
     {
         _runGate.Dispose();
     }
+
+    private int? RemainingCooldownSecondsLocked()
+    {
+        if (_lastAttemptTimestamp is not { } last) return null;
+        var elapsed = _timeProvider.GetElapsedTime(last);
+        var remaining = Cooldown - elapsed;
+        if (remaining <= TimeSpan.Zero) return null;
+        return Math.Max(1, (int)Math.Ceiling(remaining.TotalSeconds));
+    }
 }
+
+internal enum GcDiagnosticsAdmission
+{
+    Started,
+    AlreadyRunning,
+    Cooldown,
+}
+
+internal readonly record struct GcDiagnosticsAdmissionResult(
+    GcDiagnosticsAdmission Status,
+    int? RetryAfterSeconds);
 
 public sealed record GcDiagnosticsResult(
     DateTimeOffset RunAtUtc,
@@ -31,7 +137,11 @@ public sealed record GcDiagnosticsResult(
     GcSnapshot After,
     long PauseMs,
     GcBufferRetention Retention,
-    SegmentBufferPoolSnapshot? SegmentBufferPool);
+    SegmentBufferPoolSnapshot? SegmentBufferPool)
+{
+    public string CollectionMode { get; init; } = "Aggressive";
+    public int FullBlockingCollectionsRequested { get; init; } = 2;
+}
 
 public sealed record GcSnapshot(
     IReadOnlyList<GcGenerationInfo> Generations,
@@ -43,7 +153,16 @@ public sealed record GcSnapshot(
     long TotalCommittedBytes,
     long TotalAvailableMemoryBytes,
     long FragmentationBytes,
-    double PauseTimePercentage);
+    double PauseTimePercentage)
+{
+    public long Index { get; init; }
+    public int Generation { get; init; }
+    public bool Compacted { get; init; }
+    public bool Concurrent { get; init; }
+    public long MemoryLoadBytes { get; init; }
+    public long HighMemoryLoadThresholdBytes { get; init; }
+    public long? WorkingSetBytes { get; init; }
+}
 
 public sealed record GcGenerationInfo(
     string Name,

--- a/backend/Services/Diagnostics/GcSnapshotBuilder.cs
+++ b/backend/Services/Diagnostics/GcSnapshotBuilder.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace NzbWebDAV.Services.Diagnostics;
 
 internal static class GcSnapshotBuilder
@@ -25,7 +27,29 @@ internal static class GcSnapshotBuilder
             info.TotalCommittedBytes,
             info.TotalAvailableMemoryBytes,
             info.FragmentedBytes,
-            info.PauseTimePercentage);
+            info.PauseTimePercentage)
+        {
+            Index = info.Index,
+            Generation = info.Generation,
+            Compacted = info.Compacted,
+            Concurrent = info.Concurrent,
+            MemoryLoadBytes = info.MemoryLoadBytes,
+            HighMemoryLoadThresholdBytes = info.HighMemoryLoadThresholdBytes,
+            WorkingSetBytes = TryGetWorkingSetBytes(),
+        };
+    }
+
+    private static long? TryGetWorkingSetBytes()
+    {
+        try
+        {
+            using var process = Process.GetCurrentProcess();
+            return process.WorkingSet64;
+        }
+        catch (Exception e) when (e is InvalidOperationException or PlatformNotSupportedException)
+        {
+            return null;
+        }
     }
 
     private static string GenerationName(int generation) => generation switch

--- a/backend/Services/Diagnostics/OomDiagnostics.cs
+++ b/backend/Services/Diagnostics/OomDiagnostics.cs
@@ -19,27 +19,90 @@ internal static class OomDiagnostics
         {
             var info = GC.GetGCMemoryInfo();
             var addressSpace = AddressSpaceDiagnostics.Capture();
+            var pool = PooledBufferStream.DefaultPool as SegmentBufferPool;
+            var poolSnapshot = pool?.SnapshotForOom();
+            long lohSize = -1;
+            long lohFragmentation = -1;
+            if (info.GenerationInfo.Length > 3)
+            {
+                lohSize = info.GenerationInfo[3].SizeAfterBytes;
+                lohFragmentation = info.GenerationInfo[3].FragmentationAfterBytes;
+            }
+
             Log.Warning(
-                "OutOfMemoryException during {Context}. Heap={Heap:N0} Committed={Committed:N0} " +
-                "Available={Available:N0} Fragmentation={Fragmentation:N0} " +
-                "InFlight={InFlight:N0} Cap={Cap:N0} Virtual={Virtual:N0} RLIMIT_AS={AddressSpaceLimit:N0} " +
-                "RegionRange={RegionRange:N0} HeapHardLimit={HeapHardLimit:N0}",
+                "OutOfMemoryException during {Context}. " +
+                "LastGcIndex={GcIndex} LastGcGeneration={GcGeneration} " +
+                "LastGcCompacted={GcCompacted} LastGcConcurrent={GcConcurrent} " +
+                "LastGcHeap={Heap:N0} LastGcFragmentation={Fragmentation:N0} " +
+                "LastGcLohSize={LohSize:N0} LastGcLohFragmentation={LohFragmentation:N0} " +
+                "LastGcMemoryLoad={MemoryLoad:N0} LastGcHighMemoryLoadThreshold={HighMemoryLoadThreshold:N0} " +
+                "LastGcCommitted={Committed:N0} LastGcAvailableCeiling={Available:N0} " +
+                "CurrentWorkingSet={WorkingSet:N0} PoolIdle={PoolIdle:N0} " +
+                "PoolOutstandingUnreturned={PoolOutstanding:N0} " +
+                "PoolAllocationAttempts={PoolAllocationAttempts:N0} " +
+                "PoolAllocationFailures={PoolAllocationFailures:N0} " +
+                "PoolAllocations={PoolAllocations:N0} PoolTrimmed={PoolTrimmed:N0} " +
+                "InFlight={InFlight:N0} Cap={Cap:N0} Virtual={Virtual:N0} " +
+                "RLIMIT_AS={AddressSpaceLimit:N0} RegionRange={RegionRange:N0} " +
+                "HeapHardLimit={HeapHardLimit:N0} LohHardLimit={LohHardLimit:N0} " +
+                "LohHardLimitPercent={LohHardLimitPercent:N0}",
                 context,
+                info.Index,
+                info.Generation,
+                info.Compacted,
+                info.Concurrent,
                 info.HeapSizeBytes,
+                info.FragmentedBytes,
+                lohSize,
+                lohFragmentation,
+                info.MemoryLoadBytes,
+                info.HighMemoryLoadThresholdBytes,
                 info.TotalCommittedBytes,
                 info.TotalAvailableMemoryBytes,
-                info.FragmentedBytes,
+                addressSpace.WorkingSetBytes ?? -1,
+                poolSnapshot?.IdleBytes ?? -1,
+                poolSnapshot?.CheckedOutBytes ?? -1,
+                poolSnapshot?.AllocationAttemptCount ?? -1,
+                poolSnapshot?.AllocationFailureCount ?? -1,
+                poolSnapshot?.AllocationCount ?? -1,
+                poolSnapshot?.TrimmedBytes ?? -1,
                 InFlightArticleBudget.Current?.LeasedBytes ?? -1,
                 InFlightArticleBudget.Current?.CapBytes ?? -1,
                 addressSpace.VirtualMemoryBytes ?? -1,
                 addressSpace.AddressSpaceLimitBytes ?? -1,
                 addressSpace.GcRegionRangeBytes ?? -1,
-                addressSpace.GcHeapHardLimitBytes ?? -1);
+                addressSpace.GcHeapHardLimitBytes ?? -1,
+                addressSpace.GcHeapHardLimitLohBytes ?? -1,
+                addressSpace.GcHeapHardLimitLohPercent ?? -1);
             Log.Debug(exception, "OutOfMemoryException stack during {Context}", context);
         }
         catch
         {
             // Memory diagnostics must never mask the original OOM.
         }
+    }
+
+    public static void LogSegmentBufferAllocationFailure(
+        OutOfMemoryException exception,
+        int requestedBytes,
+        int roundedBytes,
+        SegmentBufferPoolOomSnapshot snapshot)
+    {
+        Log.Warning(
+            "OutOfMemoryException allocating segment buffer. " +
+            "Requested={RequestedBytes:N0} Rounded={RoundedBytes:N0} " +
+            "PoolIdle={PoolIdle:N0} PoolOutstandingUnreturned={PoolOutstanding:N0} " +
+            "PoolAllocationAttempts={PoolAllocationAttempts:N0} " +
+            "PoolAllocationFailures={PoolAllocationFailures:N0} " +
+            "PoolAllocations={PoolAllocations:N0} PoolTrimmed={PoolTrimmed:N0}",
+            requestedBytes,
+            roundedBytes,
+            snapshot.IdleBytes,
+            snapshot.CheckedOutBytes,
+            snapshot.AllocationAttemptCount,
+            snapshot.AllocationFailureCount,
+            snapshot.AllocationCount,
+            snapshot.TrimmedBytes);
+        Log.Debug(exception, "OutOfMemoryException stack allocating segment buffer");
     }
 }

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -439,18 +439,38 @@ public sealed class SupportPackService(
             segmentBufferPool = segmentPool is null ? null : new
             {
                 idleBytes = segmentPool.Value.IdleBytes,
+                maxIdleBytes = segmentPool.Value.MaxIdleBytes,
                 trimmedBytes = segmentPool.Value.TrimmedBytes,
+                staleExpiredBytes = segmentPool.Value.StaleExpiredBytes,
+                classLimitDroppedBytes = segmentPool.Value.ClassLimitDroppedBytes,
+                capacityEvictedBytes = segmentPool.Value.CapacityEvictedBytes,
+                droppedTooLargeBytes = segmentPool.Value.DroppedTooLargeBytes,
                 checkedOutBytes = segmentPool.Value.CheckedOutBytes,
                 rentCount = segmentPool.Value.RentCount,
                 returnCount = segmentPool.Value.ReturnCount,
                 rejectedReturnCount = segmentPool.Value.RejectedReturnCount,
                 reuseCount = segmentPool.Value.ReuseCount,
                 allocationCount = segmentPool.Value.AllocationCount,
+                allocationAttemptCount = segmentPool.Value.AllocationAttemptCount,
+                allocationFailureCount = segmentPool.Value.AllocationFailureCount,
                 sizeClasses = segmentPool.Value.SizeClasses.Select(c => new
                 {
                     bufferSize = c.BufferSize,
                     bufferCount = c.BufferCount,
                     idleBytes = c.IdleBytes,
+                }),
+                lifetimeSizeClasses = segmentPool.Value.LifetimeSizeClasses.Select(c => new
+                {
+                    bufferSize = c.BufferSize,
+                    rentCount = c.RentCount,
+                    returnCount = c.ReturnCount,
+                    reuseCount = c.ReuseCount,
+                    allocationAttemptCount = c.AllocationAttemptCount,
+                    allocationCount = c.AllocationCount,
+                    allocationFailureCount = c.AllocationFailureCount,
+                    staleExpiredBytes = c.StaleExpiredBytes,
+                    classLimitDroppedBytes = c.ClassLimitDroppedBytes,
+                    capacityEvictedBytes = c.CapacityEvictedBytes,
                 }),
             },
             runtimeSampler = BuildRuntimeSamplerDiagnostics(usage),
@@ -620,6 +640,16 @@ public sealed class SupportPackService(
         try
         {
             var info = GC.GetGCMemoryInfo();
+            IReadOnlyDictionary<string, object>? gcConfig = null;
+            try
+            {
+                gcConfig = GC.GetConfigurationVariables();
+            }
+            catch (Exception e) when (e is InvalidOperationException or NotSupportedException)
+            {
+                // GC configuration variables are optional on unsupported runtimes.
+            }
+
             var generations = new List<object>(info.GenerationInfo.Length);
             for (var generation = 0; generation < info.GenerationInfo.Length; generation++)
             {
@@ -637,6 +667,13 @@ public sealed class SupportPackService(
                 isServerGc = GCSettings.IsServerGC,
                 latencyMode = GCSettings.LatencyMode.ToString(),
                 rolling,
+                index = info.Index,
+                generation = info.Generation,
+                compacted = info.Compacted,
+                concurrent = info.Concurrent,
+                memoryLoadBytes = info.MemoryLoadBytes,
+                highMemoryLoadThresholdBytes = info.HighMemoryLoadThresholdBytes,
+                totalAvailableMemoryBytes = info.TotalAvailableMemoryBytes,
                 gen0Collections = GC.CollectionCount(0),
                 gen1Collections = GC.CollectionCount(1),
                 gen2Collections = GC.CollectionCount(2),
@@ -646,10 +683,15 @@ public sealed class SupportPackService(
                 heapLimitBytes = MemoryBudget.HeapLimitBytes,
                 heapHardLimitBytes = addressSpace.GcHeapHardLimitBytes,
                 heapHardLimitPercent = addressSpace.GcHeapHardLimitPercent,
+                heapHardLimitLohBytes = addressSpace.GcHeapHardLimitLohBytes,
+                heapHardLimitLohPercent = addressSpace.GcHeapHardLimitLohPercent,
                 regionRangeBytes = addressSpace.GcRegionRangeBytes,
                 regionSizeBytes = addressSpace.GcRegionSizeBytes,
                 heapSizeBytes = info.HeapSizeBytes,
                 committedBytes = info.TotalCommittedBytes,
+                conserveMemory = ReadGcConfigurationNumber(gcConfig, "GCConserveMem"),
+                highMemoryPercent = ReadGcConfigurationNumber(gcConfig, "GCHighMemPercent"),
+                lohThresholdBytes = ReadGcConfigurationNumber(gcConfig, "LOHThreshold"),
                 generations,
             };
         }
@@ -667,6 +709,24 @@ public sealed class SupportPackService(
             3 => "loh",
             4 => "poh",
             _ => $"gen{generation}",
+        };
+    }
+
+    private static long? ReadGcConfigurationNumber(
+        IReadOnlyDictionary<string, object>? config,
+        string name)
+    {
+        if (config is null || !config.TryGetValue(name, out var value)) return null;
+        return value switch
+        {
+            long l => l,
+            ulong ul => ul > long.MaxValue ? long.MaxValue : (long)ul,
+            int i => i,
+            uint ui => ui,
+            string s when long.TryParse(
+                s, System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out var parsed) => parsed,
+            _ => null,
         };
     }
 

--- a/backend/Streams/SegmentBufferPool.cs
+++ b/backend/Streams/SegmentBufferPool.cs
@@ -492,8 +492,14 @@ public readonly record struct SegmentBufferPoolSnapshot(
     public long DroppedTooLargeBytes { get; init; }
     public long AllocationAttemptCount { get; init; }
     public long AllocationFailureCount { get; init; }
-    public IReadOnlyList<SegmentBufferPoolLifetimeClassSnapshot> LifetimeSizeClasses { get; init; } =
-        [];
+
+    private readonly IReadOnlyList<SegmentBufferPoolLifetimeClassSnapshot>? _lifetimeSizeClasses;
+
+    public IReadOnlyList<SegmentBufferPoolLifetimeClassSnapshot> LifetimeSizeClasses
+    {
+        get => _lifetimeSizeClasses ?? [];
+        init => _lifetimeSizeClasses = value;
+    }
 }
 
 public readonly record struct SegmentBufferPoolClassSnapshot(

--- a/backend/Streams/SegmentBufferPool.cs
+++ b/backend/Streams/SegmentBufferPool.cs
@@ -1,6 +1,20 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using NzbWebDAV.Services.Diagnostics;
 
 namespace NzbWebDAV.Streams;
+
+internal enum SegmentBufferRetentionPolicy
+{
+    Legacy,
+    CapacityOnly,
+}
+
+internal delegate void SegmentBufferAllocationFailureLogger(
+    OutOfMemoryException exception,
+    int requestedBytes,
+    int roundedBytes,
+    SegmentBufferPoolOomSnapshot snapshot);
 
 /// <summary>
 /// Evaluation pool for Usenet segment drains. Uses 256 KiB size classes, strictly
@@ -19,36 +33,73 @@ public sealed class SegmentBufferPool : ISegmentBufferPool
 
     private readonly object _gate = new();
     private readonly long _maxIdleBytes;
+    private readonly SegmentBufferRetentionPolicy _retentionPolicy;
     private readonly int _maxBuffersPerClass;
     private readonly TimeSpan _staleAfter;
     private readonly TimeProvider _timeProvider;
+    private readonly Func<int, byte[]> _allocator;
+    private readonly SegmentBufferAllocationFailureLogger _onAllocationFailure;
     private readonly Dictionary<int, Queue<IdleBuffer>> _buckets = [];
+    private readonly Dictionary<int, LifetimeClassStats> _lifetimeClasses = [];
     private readonly ConditionalWeakTable<byte[], object> _checkedOut = new();
 
     private long _idleBytes;
     private long _trimmedBytes;
+    private long _staleExpiredBytes;
+    private long _classLimitDroppedBytes;
+    private long _capacityEvictedBytes;
+    private long _droppedTooLargeBytes;
     private long _checkedOutBytes;
     private long _rentCount;
     private long _returnCount;
     private long _rejectedReturnCount;
     private long _reuseCount;
     private long _allocationCount;
+    private long _allocationAttemptCount;
+    private long _allocationFailureCount;
+    private long _returnSequence;
 
     public SegmentBufferPool(
         long maxIdleBytes,
         TimeSpan? staleAfter = null,
         int maxBuffersPerClass = DefaultMaxBuffersPerClass,
         TimeProvider? timeProvider = null)
+        : this(
+            maxIdleBytes,
+            SegmentBufferRetentionPolicy.Legacy,
+            staleAfter,
+            maxBuffersPerClass,
+            timeProvider,
+            allocator: null)
+    {
+    }
+
+    internal SegmentBufferPool(
+        long maxIdleBytes,
+        SegmentBufferRetentionPolicy retentionPolicy,
+        TimeSpan? staleAfter = null,
+        int maxBuffersPerClass = DefaultMaxBuffersPerClass,
+        TimeProvider? timeProvider = null,
+        Func<int, byte[]>? allocator = null,
+        SegmentBufferAllocationFailureLogger? onAllocationFailure = null)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(maxIdleBytes);
-        ArgumentOutOfRangeException.ThrowIfLessThan(maxBuffersPerClass, 1);
+        if (retentionPolicy is not (
+            SegmentBufferRetentionPolicy.Legacy or SegmentBufferRetentionPolicy.CapacityOnly))
+        {
+            throw new ArgumentOutOfRangeException(nameof(retentionPolicy));
+        }
 
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxBuffersPerClass, 1);
         _maxIdleBytes = maxIdleBytes;
+        _retentionPolicy = retentionPolicy;
         _maxBuffersPerClass = maxBuffersPerClass;
         _staleAfter = staleAfter ?? DefaultStaleAfter;
         if (_staleAfter < TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(staleAfter));
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _allocator = allocator ?? (static length => new byte[length]);
+        _onAllocationFailure = onAllocationFailure ?? LogAllocationFailureDefault;
     }
 
     public byte[] Rent(int minimumLength)
@@ -58,31 +109,35 @@ public sealed class SegmentBufferPool : ISegmentBufferPool
         ArgumentOutOfRangeException.ThrowIfGreaterThan(minimumLength, Array.MaxLength);
 
         var sizeClass = RoundToSizeClass(minimumLength);
-        var now = _timeProvider.GetUtcNow();
+        if (TryRentIdle(sizeClass, out var reused))
+            return reused;
 
-        lock (_gate)
+        RecordAllocationAttempt(sizeClass);
+        byte[] allocated;
+        try
         {
-            TrimStaleLocked(now);
-            if (_buckets.TryGetValue(sizeClass, out var bucket) && bucket.Count > 0)
-            {
-                var idle = bucket.Dequeue();
-                _idleBytes -= idle.Buffer.Length;
-                _checkedOut.Add(idle.Buffer, CheckedOutMarker);
-                _checkedOutBytes += idle.Buffer.Length;
-                _rentCount++;
-                _reuseCount++;
-                return idle.Buffer;
-            }
+            allocated = _allocator(sizeClass);
+        }
+        catch (OutOfMemoryException oom)
+        {
+            var snapshot = RecordAllocationFailureAndSnapshotForOom(sizeClass);
+            TryLogAllocationFailure(oom, minimumLength, sizeClass, snapshot);
+            throw;
         }
 
-        var allocated = new byte[sizeClass];
         lock (_gate)
         {
             _checkedOut.Add(allocated, CheckedOutMarker);
             _checkedOutBytes += allocated.Length;
             _rentCount++;
             _allocationCount++;
+            if (TryGetPoolableLifetimeLocked(sizeClass) is { } lifetime)
+            {
+                lifetime.RentCount++;
+                lifetime.AllocationCount++;
+            }
         }
+
         return allocated;
     }
 
@@ -91,7 +146,6 @@ public sealed class SegmentBufferPool : ISegmentBufferPool
         ArgumentNullException.ThrowIfNull(buffer);
         if (buffer.Length == 0) return;
 
-        var now = _timeProvider.GetUtcNow();
         lock (_gate)
         {
             if (!_checkedOut.Remove(buffer))
@@ -105,31 +159,18 @@ public sealed class SegmentBufferPool : ISegmentBufferPool
 
             _checkedOutBytes -= buffer.Length;
             _returnCount++;
-            TrimStaleLocked(now);
+            if (TryGetPoolableLifetimeLocked(buffer.Length) is { } lifetime)
+                lifetime.ReturnCount++;
 
-            if (buffer.Length > _maxIdleBytes)
+            if (_retentionPolicy == SegmentBufferRetentionPolicy.Legacy)
             {
-                _trimmedBytes += buffer.Length;
+                var returnedAt = _timeProvider.GetUtcNow();
+                TrimStaleLocked(returnedAt);
+                ReturnIdleLocked(buffer, returnedAt);
                 return;
             }
 
-            if (_buckets.TryGetValue(buffer.Length, out var existingBucket) &&
-                existingBucket.Count >= _maxBuffersPerClass)
-            {
-                _trimmedBytes += buffer.Length;
-                return;
-            }
-
-            ReclaimForLocked(buffer.Length);
-            if (_idleBytes + buffer.Length > _maxIdleBytes)
-            {
-                _trimmedBytes += buffer.Length;
-                return;
-            }
-
-            var bucket = GetOrCreateBucketLocked(buffer.Length);
-            bucket.Enqueue(new IdleBuffer(buffer, now));
-            _idleBytes += buffer.Length;
+            ReturnIdleLocked(buffer, returnedAt: default);
         }
     }
 
@@ -143,6 +184,20 @@ public sealed class SegmentBufferPool : ISegmentBufferPool
                 .Select(x => new SegmentBufferPoolClassSnapshot(
                     x.Key, x.Value.Count, (long)x.Key * x.Value.Count))
                 .ToArray();
+            var lifetime = _lifetimeClasses
+                .OrderBy(x => x.Key)
+                .Select(x => new SegmentBufferPoolLifetimeClassSnapshot(
+                    x.Key,
+                    x.Value.RentCount,
+                    x.Value.ReturnCount,
+                    x.Value.ReuseCount,
+                    x.Value.AllocationAttemptCount,
+                    x.Value.AllocationCount,
+                    x.Value.AllocationFailureCount,
+                    x.Value.StaleExpiredBytes,
+                    x.Value.ClassLimitDroppedBytes,
+                    x.Value.CapacityEvictedBytes))
+                .ToArray();
             return new SegmentBufferPoolSnapshot(
                 _idleBytes,
                 _trimmedBytes,
@@ -152,8 +207,24 @@ public sealed class SegmentBufferPool : ISegmentBufferPool
                 _rejectedReturnCount,
                 _reuseCount,
                 _allocationCount,
-                classes);
+                classes)
+            {
+                MaxIdleBytes = _maxIdleBytes,
+                StaleExpiredBytes = _staleExpiredBytes,
+                ClassLimitDroppedBytes = _classLimitDroppedBytes,
+                CapacityEvictedBytes = _capacityEvictedBytes,
+                DroppedTooLargeBytes = _droppedTooLargeBytes,
+                AllocationAttemptCount = _allocationAttemptCount,
+                AllocationFailureCount = _allocationFailureCount,
+                LifetimeSizeClasses = lifetime,
+            };
         }
+    }
+
+    internal SegmentBufferPoolOomSnapshot SnapshotForOom()
+    {
+        lock (_gate)
+            return CaptureOomSnapshotLocked();
     }
 
     internal static int RoundToSizeClass(int size)
@@ -167,6 +238,58 @@ public sealed class SegmentBufferPool : ISegmentBufferPool
         return rounded <= Array.MaxLength ? (int)rounded : size;
     }
 
+    private bool TryRentIdle(int sizeClass, out byte[] buffer)
+    {
+        lock (_gate)
+        {
+            if (_retentionPolicy == SegmentBufferRetentionPolicy.Legacy)
+                TrimStaleLocked(_timeProvider.GetUtcNow());
+
+            if (_buckets.TryGetValue(sizeClass, out var bucket) && bucket.Count > 0)
+            {
+                var idle = bucket.Dequeue();
+                _idleBytes -= idle.Buffer.Length;
+                _checkedOut.Add(idle.Buffer, CheckedOutMarker);
+                _checkedOutBytes += idle.Buffer.Length;
+                _rentCount++;
+                _reuseCount++;
+                if (TryGetPoolableLifetimeLocked(sizeClass) is { } lifetime)
+                {
+                    lifetime.RentCount++;
+                    lifetime.ReuseCount++;
+                }
+
+                buffer = idle.Buffer;
+                return true;
+            }
+        }
+
+        buffer = null!;
+        return false;
+    }
+
+    private void ReturnIdleLocked(byte[] buffer, DateTimeOffset returnedAt)
+    {
+        if (buffer.Length > _maxIdleBytes)
+        {
+            RecordDroppedTooLargeLocked(buffer.Length);
+            return;
+        }
+
+        if (_retentionPolicy == SegmentBufferRetentionPolicy.Legacy &&
+            IsClassAtLegacyLimitLocked(buffer.Length))
+        {
+            RecordClassLimitDroppedLocked(buffer.Length);
+            return;
+        }
+
+        ReclaimForLocked(buffer.Length);
+        var returnSequence = ++_returnSequence;
+        GetOrCreateBucketLocked(buffer.Length)
+            .Enqueue(new IdleBuffer(buffer, returnSequence, returnedAt));
+        _idleBytes += buffer.Length;
+    }
+
     private Queue<IdleBuffer> GetOrCreateBucketLocked(int sizeClass)
     {
         if (_buckets.TryGetValue(sizeClass, out var bucket)) return bucket;
@@ -175,16 +298,20 @@ public sealed class SegmentBufferPool : ISegmentBufferPool
         return bucket;
     }
 
+    private bool IsClassAtLegacyLimitLocked(int bufferLength) =>
+        _buckets.TryGetValue(bufferLength, out var existingBucket) &&
+        existingBucket.Count >= _maxBuffersPerClass;
+
     private void ReclaimForLocked(int incomingBytes)
     {
-        while (_idleBytes + incomingBytes > _maxIdleBytes)
+        while (_idleBytes > 0 && incomingBytes > _maxIdleBytes - _idleBytes)
         {
             Queue<IdleBuffer>? oldest = null;
             foreach (var bucket in _buckets.Values)
             {
                 if (bucket.Count == 0) continue;
                 if (oldest is null ||
-                    bucket.Peek().ReturnedAt < oldest.Peek().ReturnedAt)
+                    bucket.Peek().ReturnSequence < oldest.Peek().ReturnSequence)
                 {
                     oldest = bucket;
                 }
@@ -193,7 +320,7 @@ public sealed class SegmentBufferPool : ISegmentBufferPool
             if (oldest is null) return;
             var evicted = oldest.Dequeue();
             _idleBytes -= evicted.Buffer.Length;
-            _trimmedBytes += evicted.Buffer.Length;
+            RecordCapacityEvictedLocked(evicted.Buffer.Length);
         }
     }
 
@@ -207,12 +334,136 @@ public sealed class SegmentBufferPool : ISegmentBufferPool
             {
                 var evicted = bucket.Dequeue();
                 _idleBytes -= evicted.Buffer.Length;
-                _trimmedBytes += evicted.Buffer.Length;
+                RecordStaleExpiredLocked(evicted.Buffer.Length);
             }
         }
     }
 
-    private readonly record struct IdleBuffer(byte[] Buffer, DateTimeOffset ReturnedAt);
+    private void RecordAllocationAttempt(int sizeClass)
+    {
+        lock (_gate)
+        {
+            _allocationAttemptCount++;
+            if (TryGetPoolableLifetimeLocked(sizeClass) is { } lifetime)
+                lifetime.AllocationAttemptCount++;
+        }
+    }
+
+    private SegmentBufferPoolOomSnapshot RecordAllocationFailureAndSnapshotForOom(int sizeClass)
+    {
+        lock (_gate)
+        {
+            _allocationFailureCount++;
+            if (TryGetPoolableLifetimeLocked(sizeClass) is { } lifetime)
+                lifetime.AllocationFailureCount++;
+            return CaptureOomSnapshotLocked();
+        }
+    }
+
+    private SegmentBufferPoolOomSnapshot CaptureOomSnapshotLocked() =>
+        new(
+            _idleBytes,
+            _trimmedBytes,
+            _checkedOutBytes,
+            _rentCount,
+            _returnCount,
+            _rejectedReturnCount,
+            _reuseCount,
+            _allocationCount,
+            _allocationAttemptCount,
+            _allocationFailureCount,
+            _maxIdleBytes,
+            _staleExpiredBytes,
+            _classLimitDroppedBytes,
+            _capacityEvictedBytes,
+            _droppedTooLargeBytes);
+
+    private LifetimeClassStats? TryGetPoolableLifetimeLocked(int sizeClass)
+    {
+        if (sizeClass > _maxIdleBytes) return null;
+        if (_lifetimeClasses.TryGetValue(sizeClass, out var stats))
+            return stats;
+
+        stats = new LifetimeClassStats();
+        _lifetimeClasses.Add(sizeClass, stats);
+        return stats;
+    }
+
+    private void RecordStaleExpiredLocked(int bytes)
+    {
+        _trimmedBytes += bytes;
+        _staleExpiredBytes += bytes;
+        if (TryGetPoolableLifetimeLocked(bytes) is { } lifetime)
+            lifetime.StaleExpiredBytes += bytes;
+    }
+
+    private void RecordClassLimitDroppedLocked(int bytes)
+    {
+        _trimmedBytes += bytes;
+        _classLimitDroppedBytes += bytes;
+        if (TryGetPoolableLifetimeLocked(bytes) is { } lifetime)
+            lifetime.ClassLimitDroppedBytes += bytes;
+    }
+
+    private void RecordCapacityEvictedLocked(int bytes)
+    {
+        _trimmedBytes += bytes;
+        _capacityEvictedBytes += bytes;
+        if (TryGetPoolableLifetimeLocked(bytes) is { } lifetime)
+            lifetime.CapacityEvictedBytes += bytes;
+    }
+
+    private void RecordDroppedTooLargeLocked(int bytes)
+    {
+        _trimmedBytes += bytes;
+        _droppedTooLargeBytes += bytes;
+    }
+
+    [SuppressMessage(
+        "Design",
+        "CA1031:Do not catch general exception types",
+        Justification = "Diagnostic logging must not replace the original OutOfMemoryException.")]
+    private void TryLogAllocationFailure(
+        OutOfMemoryException oom,
+        int requestedBytes,
+        int roundedBytes,
+        SegmentBufferPoolOomSnapshot snapshot)
+    {
+        try
+        {
+            _onAllocationFailure(oom, requestedBytes, roundedBytes, snapshot);
+        }
+        catch
+        {
+            // Diagnostic preparation must never replace the original OOM.
+        }
+    }
+
+    private static void LogAllocationFailureDefault(
+        OutOfMemoryException oom,
+        int requestedBytes,
+        int roundedBytes,
+        SegmentBufferPoolOomSnapshot snapshot) =>
+        OomDiagnostics.LogSegmentBufferAllocationFailure(
+            oom, requestedBytes, roundedBytes, snapshot);
+
+    private sealed class LifetimeClassStats
+    {
+        public long RentCount;
+        public long ReturnCount;
+        public long ReuseCount;
+        public long AllocationAttemptCount;
+        public long AllocationCount;
+        public long AllocationFailureCount;
+        public long StaleExpiredBytes;
+        public long ClassLimitDroppedBytes;
+        public long CapacityEvictedBytes;
+    }
+
+    private readonly record struct IdleBuffer(
+        byte[] Buffer,
+        long ReturnSequence,
+        DateTimeOffset ReturnedAt);
 }
 
 /// <param name="CheckedOutBytes">
@@ -232,9 +483,49 @@ public readonly record struct SegmentBufferPoolSnapshot(
     long RejectedReturnCount,
     long ReuseCount,
     long AllocationCount,
-    IReadOnlyList<SegmentBufferPoolClassSnapshot> SizeClasses);
+    IReadOnlyList<SegmentBufferPoolClassSnapshot> SizeClasses)
+{
+    public long MaxIdleBytes { get; init; }
+    public long StaleExpiredBytes { get; init; }
+    public long ClassLimitDroppedBytes { get; init; }
+    public long CapacityEvictedBytes { get; init; }
+    public long DroppedTooLargeBytes { get; init; }
+    public long AllocationAttemptCount { get; init; }
+    public long AllocationFailureCount { get; init; }
+    public IReadOnlyList<SegmentBufferPoolLifetimeClassSnapshot> LifetimeSizeClasses { get; init; } =
+        [];
+}
 
 public readonly record struct SegmentBufferPoolClassSnapshot(
     int BufferSize,
     int BufferCount,
     long IdleBytes);
+
+public readonly record struct SegmentBufferPoolLifetimeClassSnapshot(
+    int BufferSize,
+    long RentCount,
+    long ReturnCount,
+    long ReuseCount,
+    long AllocationAttemptCount,
+    long AllocationCount,
+    long AllocationFailureCount,
+    long StaleExpiredBytes,
+    long ClassLimitDroppedBytes,
+    long CapacityEvictedBytes);
+
+internal readonly record struct SegmentBufferPoolOomSnapshot(
+    long IdleBytes,
+    long TrimmedBytes,
+    long CheckedOutBytes,
+    long RentCount,
+    long ReturnCount,
+    long RejectedReturnCount,
+    long ReuseCount,
+    long AllocationCount,
+    long AllocationAttemptCount,
+    long AllocationFailureCount,
+    long MaxIdleBytes,
+    long StaleExpiredBytes,
+    long ClassLimitDroppedBytes,
+    long CapacityEvictedBytes,
+    long DroppedTooLargeBytes);

--- a/backend/Streams/SegmentBufferPoolSelector.cs
+++ b/backend/Streams/SegmentBufferPoolSelector.cs
@@ -1,0 +1,41 @@
+namespace NzbWebDAV.Streams;
+
+internal static class SegmentBufferPoolSelector
+{
+    internal const string EnvironmentVariableName = "NZBDAV_SEGMENT_BUFFER_POOL";
+    internal const string BoundedLegacyValue = "bounded-legacy";
+    internal const string BoundedCapacityValue = "bounded-capacity";
+    internal const string SharedValue = "shared";
+
+    internal enum Mode
+    {
+        BoundedLegacy,
+        BoundedCapacity,
+        Shared,
+    }
+
+    internal static Mode Resolve(string? value, out bool unknownValue)
+    {
+        unknownValue = false;
+        if (string.IsNullOrEmpty(value))
+            return Mode.BoundedLegacy;
+
+        if (value.Equals(SharedValue, StringComparison.OrdinalIgnoreCase))
+            return Mode.Shared;
+        if (value.Equals(BoundedLegacyValue, StringComparison.OrdinalIgnoreCase))
+            return Mode.BoundedLegacy;
+        if (value.Equals(BoundedCapacityValue, StringComparison.OrdinalIgnoreCase))
+            return Mode.BoundedCapacity;
+
+        unknownValue = true;
+        return Mode.BoundedLegacy;
+    }
+
+    internal static string ToLogValue(Mode mode) => mode switch
+    {
+        Mode.BoundedLegacy => BoundedLegacyValue,
+        Mode.BoundedCapacity => BoundedCapacityValue,
+        Mode.Shared => SharedValue,
+        _ => BoundedLegacyValue,
+    };
+}

--- a/backend/Streams/SegmentBufferPoolSelector.cs
+++ b/backend/Streams/SegmentBufferPoolSelector.cs
@@ -17,9 +17,10 @@ internal static class SegmentBufferPoolSelector
     internal static Mode Resolve(string? value, out bool unknownValue)
     {
         unknownValue = false;
-        if (string.IsNullOrEmpty(value))
+        if (string.IsNullOrWhiteSpace(value))
             return Mode.BoundedLegacy;
 
+        value = value.Trim();
         if (value.Equals(SharedValue, StringComparison.OrdinalIgnoreCase))
             return Mode.Shared;
         if (value.Equals(BoundedLegacyValue, StringComparison.OrdinalIgnoreCase))

--- a/backend/Utils/AddressSpaceDiagnostics.cs
+++ b/backend/Utils/AddressSpaceDiagnostics.cs
@@ -16,15 +16,22 @@ internal static class AddressSpaceDiagnostics
         long? GcRegionSizeBytes,
         long? GcHeapHardLimitBytes,
         long? GcHeapHardLimitPercent,
-        long? GcCommittedBytes);
+        long? GcCommittedBytes)
+    {
+        public long? GcHeapHardLimitLohBytes { get; init; }
+        public long? GcHeapHardLimitLohPercent { get; init; }
+        public long? WorkingSetBytes { get; init; }
+    }
 
     internal static Snapshot Capture()
     {
         long? virtualMemoryBytes = null;
+        long? workingSetBytes = null;
         try
         {
             using var process = Process.GetCurrentProcess();
             virtualMemoryBytes = process.VirtualMemorySize64;
+            workingSetBytes = process.WorkingSet64;
         }
         catch (Exception e) when (e is InvalidOperationException or PlatformNotSupportedException)
         {
@@ -50,7 +57,12 @@ internal static class AddressSpaceDiagnostics
             GetConfigurationValue(config, "GCRegionSize"),
             GetConfigurationValue(config, "GCHeapHardLimit"),
             GetConfigurationValue(config, "GCHeapHardLimitPercent"),
-            committedBytes);
+            committedBytes)
+        {
+            GcHeapHardLimitLohBytes = GetConfigurationValue(config, "GCHeapHardLimitLOH"),
+            GcHeapHardLimitLohPercent = GetConfigurationValue(config, "GCHeapHardLimitLOHPercent"),
+            WorkingSetBytes = workingSetBytes,
+        };
     }
 
     internal static long? ParseLinuxAddressSpaceLimit(string limits)

--- a/contracts/openapi/admin-v1.json
+++ b/contracts/openapi/admin-v1.json
@@ -281,7 +281,7 @@
   "info": {
     "description": "Contributor-facing reference for the InfiniDysk admin REST API. SABnzbd compatibility, WebDAV, streaming, adapters, and file-transfer routes are intentionally excluded.",
     "title": "InfiniDysk Admin API",
-    "version": "1.0.0"
+    "version": "2.0.0"
   },
   "openapi": "3.1.1",
   "paths": {
@@ -2234,78 +2234,6 @@
       }
     },
     "/api/gc-diagnostics": {
-      "get": {
-        "operationId": "get-api-gc-diagnostics",
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            },
-            "description": "Bad request."
-          },
-          "401": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            },
-            "description": "Unauthorized."
-          },
-          "403": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            },
-            "description": "Forbidden."
-          },
-          "404": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            },
-            "description": "Not found."
-          },
-          "409": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            },
-            "description": "Conflict."
-          },
-          "500": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            },
-            "description": "Unexpected server error. Detail is sanitized; use traceId."
-          }
-        },
-        "summary": "Gc Diagnostics",
-        "tags": [
-          "GcDiagnostics"
-        ]
-      },
       "post": {
         "operationId": "post-api-gc-diagnostics",
         "responses": {
@@ -2361,6 +2289,25 @@
               }
             },
             "description": "Conflict."
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Too many requests. Concurrent execution and the 10-minute cooldown both return 429. Retry-After is a non-negative integer number of seconds. Cooldown rejections always include it; concurrent rejections include it when a remaining wait is known.",
+            "headers": {
+              "Retry-After": {
+                "description": "Non-negative integer number of seconds to wait before retrying.",
+                "schema": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              }
+            }
           },
           "500": {
             "content": {

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -97,11 +97,12 @@ or restrict backend capabilities when enforcement is required.
 | `USENET_DISABLE_CRC_VALIDATION` [since 0.8.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.8.0){ .nzbdav-since } | unset | `1` skips yEnc CRC checks (emergency) |
 | `THREADPOOL_MIN_THREADS` | `max(2×CPU, 50)` | Override min worker/IOCP threads |
 | `THREADPOOL_MAX_THREADS` | `max(50×CPU, 1000)` | Override max threads |
+| `NZBDAV_SEGMENT_BUFFER_POOL` [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since } | `bounded-legacy` | Segment-buffer retention. Unset and `bounded-legacy` keep the production age-plus-per-class policy. `bounded-capacity` is a restart-only canary that keeps the same 32–256 MiB idle-byte cap without the two-minute expiry or 64-buffer class ceiling. `shared` uses `ArrayPool<byte>.Shared` as an emergency escape hatch. Unknown values log a Warning and use `bounded-legacy`. |
 | `DOTNET_GCHeapHardLimit` | runtime default | .NET managed-heap ceiling; hexadecimal bytes |
 | `DOTNET_GCHeapHardLimitPercent` | runtime/container default | .NET managed-heap ceiling as a hexadecimal percentage |
 | `DOTNET_GCRegionRange` | runtime default | .NET regions-GC virtual reservation; hexadecimal bytes |
 | `DOTNET_GCRegionSize` | runtime default | .NET SOH region size; hexadecimal bytes |
-| `DOTNET_GCConserveMemory` | `0` | .NET heap-conservation level (0–9) |
+| `DOTNET_GCConserveMemory` | `0` | .NET heap-conservation level (0–9). Read only at process start; a change requires a restart. Higher values compact the LOH more aggressively and can increase collection frequency and pause duration — start as a measured canary, not a fleet default. |
 | `DOTNET_gcServer` | image default (`1`) | Enables (`1`) or disables (`0`) server GC |
 | `MAX_REQUEST_BODY_SIZE` | 300 MiB | Max request body bytes |
 | `QUEUE_ITEM_STUCK_MINUTES` [since 1.1.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.1.0){ .nzbdav-since } | `5` | Minutes without queue progress before the stuck-item watchdog pauses and cancels the worker |

--- a/docs/operations/memory-constrained-hosts.md
+++ b/docs/operations/memory-constrained-hosts.md
@@ -47,7 +47,13 @@ memory rather than `RLIMIT_AS`.
 Set these values before the backend starts. Confirm the active values in
 Settings → Support → downloaded `environment.json`: `runtime.addressSpaceLimitBytes`
 is the finite `RLIMIT_AS` when Linux exposes one, and the `gc` section reports
-the region range, size, hard limit, committed heap, and detected heap limit.
+the region range, size, hard limit, committed heap, detected heap limit,
+collection identity, memory-load, and LOH-specific hard limits.
+
+`DOTNET_GCConserveMemory` is a restart-required runtime canary, not an
+InfiniDysk default. The image does not set it. A value in the 5–7 range can
+reduce LOH fragmentation at the cost of more frequent collections and longer
+pauses; measure playback and import latency before keeping it.
 
 ## Repeated 64 MiB `PROT_NONE` mappings
 

--- a/docs/operations/memory-constrained-hosts.md
+++ b/docs/operations/memory-constrained-hosts.md
@@ -32,6 +32,7 @@ environment:
   DOTNET_GCHeapHardLimit: "20000000"
   # 1 GiB regions reservation (2× the heap ceiling)
   DOTNET_GCRegionRange: "40000000"
+  # Upper bound (0–9). Prefer 5–7 as a first measured canary; see below.
   DOTNET_GCConserveMemory: "9"
   # Bound worker growth separately from the GC heap.
   THREADPOOL_MAX_THREADS: "200"

--- a/tests/NzbWebDAV.Tests/Api/AdminOpenApiIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AdminOpenApiIntegrationTests.cs
@@ -59,6 +59,15 @@ public sealed class AdminOpenApiIntegrationTests(NzbDavWebApplicationFactory fac
             Assert.False(paths.TryGetProperty("/api/search/{token}/lookup", out _));
             Assert.False(paths.TryGetProperty("/api/download-support-pack", out _));
 
+            Assert.True(paths.TryGetProperty("/api/gc-diagnostics", out var gcDiagnostics));
+            Assert.False(gcDiagnostics.TryGetProperty("get", out _));
+            var gcPost = gcDiagnostics.GetProperty("post");
+            Assert.True(gcPost.GetProperty("responses").TryGetProperty("429", out var tooMany));
+            Assert.True(tooMany.GetProperty("headers").TryGetProperty("Retry-After", out _));
+            Assert.Equal(
+                "application/problem+json",
+                tooMany.GetProperty("content").EnumerateObject().First().Name);
+
             var apiKey = root.GetProperty("components")
                 .GetProperty("securitySchemes")
                 .GetProperty("ApiKey");

--- a/tests/NzbWebDAV.Tests/Api/AdminOpenApiNormalizerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AdminOpenApiNormalizerTests.cs
@@ -26,7 +26,7 @@ public sealed class AdminOpenApiNormalizerTests
             {
               "info": {
                 "title": "t",
-                "version": "1.0.0"
+                "version": "2.0.0"
               },
               "openapi": "3.1.0",
               "paths": {

--- a/tests/NzbWebDAV.Tests/Api/GcDiagnosticsHttpIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GcDiagnosticsHttpIntegrationTests.cs
@@ -1,6 +1,10 @@
 using System.Net;
 using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using NzbWebDAV.Services.Diagnostics;
 using NzbWebDAV.Tests.TestUtils;
 
@@ -32,9 +36,9 @@ public sealed class GcDiagnosticsHttpIntegrationTests(NzbDavWebApplicationFactor
     [Fact]
     public async Task GcDiagnostics_AuthorizedPost_ReturnsSnapshotsAndStoresResult()
     {
-        using var client = factory.CreateClient();
-        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/gc-diagnostics");
-        request.Headers.Add("x-api-key", NzbDavWebApplicationFactory.ApiKey);
+        using var host = CreateIsolatedHost(factory, new ControllableTimeProvider(), new ImmediateGcDiagnosticsExecutor());
+        using var client = host.CreateClient();
+        using var request = AuthenticatedPost();
         using var response = await client.SendAsync(request);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -42,17 +46,137 @@ public sealed class GcDiagnosticsHttpIntegrationTests(NzbDavWebApplicationFactor
         var root = json.RootElement;
         Assert.True(root.GetProperty("status").GetBoolean());
         Assert.True(root.GetProperty("pauseMs").GetInt64() >= 0);
-        Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("warning").GetString()));
-        Assert.Equal(JsonValueKind.Object, root.GetProperty("before").ValueKind);
-        Assert.Equal(JsonValueKind.Object, root.GetProperty("after").ValueKind);
+        var warning = root.GetProperty("warning").GetString();
+        Assert.Contains("two aggressive full blocking collections", warning, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("LOH", warning, StringComparison.Ordinal);
+        Assert.Contains("paused", warning, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("Aggressive", root.GetProperty("collectionMode").GetString());
+        Assert.Equal(2, root.GetProperty("fullBlockingCollectionsRequested").GetInt32());
+        AssertSnapshotShape(root.GetProperty("before"));
+        AssertSnapshotShape(root.GetProperty("after"));
         Assert.Equal(JsonValueKind.Object, root.GetProperty("retention").ValueKind);
-        Assert.Equal(JsonValueKind.Array, root.GetProperty("after").GetProperty("generations").ValueKind);
         Assert.True(root.TryGetProperty("segmentBufferPool", out var segmentPool));
         Assert.True(
             segmentPool.ValueKind is JsonValueKind.Object or JsonValueKind.Null,
             $"segmentBufferPool should be an object or null, was {segmentPool.ValueKind}");
 
-        var store = factory.Services.GetRequiredService<GcDiagnosticsStore>();
+        var store = host.Services.GetRequiredService<GcDiagnosticsStore>();
         Assert.NotNull(store.LastResult);
+        Assert.Equal("Aggressive", store.LastResult!.CollectionMode);
+        Assert.Equal(2, store.LastResult.FullBlockingCollectionsRequested);
+    }
+
+    [Fact]
+    public async Task GcDiagnostics_ConcurrentPost_Returns429()
+    {
+        var executor = new BlockingGcDiagnosticsExecutor();
+        using var host = CreateIsolatedHost(factory, new ControllableTimeProvider(), executor);
+        using var client = host.CreateClient();
+
+        var firstTask = client.SendAsync(AuthenticatedPost());
+        await executor.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        using var concurrent = await client.SendAsync(AuthenticatedPost());
+        Assert.Equal(HttpStatusCode.TooManyRequests, concurrent.StatusCode);
+        using var concurrentJson = await JsonDocument.ParseAsync(await concurrent.Content.ReadAsStreamAsync());
+        Assert.Equal(StatusCodes.Status429TooManyRequests, concurrentJson.RootElement.GetProperty("status").GetInt32());
+        Assert.Contains(
+            "already in progress",
+            concurrentJson.RootElement.GetProperty("detail").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+
+        executor.Release.TrySetResult();
+        using var first = await firstTask;
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+    }
+
+    [Fact]
+    public async Task GcDiagnostics_CooldownPost_Returns429WithRetryAfter()
+    {
+        var clock = new ControllableTimeProvider();
+        using var host = CreateIsolatedHost(factory, clock, new ImmediateGcDiagnosticsExecutor());
+        using var client = host.CreateClient();
+
+        using var first = await client.SendAsync(AuthenticatedPost());
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+
+        using var cooldown = await client.SendAsync(AuthenticatedPost());
+        Assert.Equal(HttpStatusCode.TooManyRequests, cooldown.StatusCode);
+        Assert.NotNull(cooldown.Headers.RetryAfter);
+        Assert.True(cooldown.Headers.RetryAfter!.Delta is { } delay && delay > TimeSpan.Zero);
+        using var cooldownJson = await JsonDocument.ParseAsync(await cooldown.Content.ReadAsStreamAsync());
+        Assert.Equal(StatusCodes.Status429TooManyRequests, cooldownJson.RootElement.GetProperty("status").GetInt32());
+        Assert.Contains(
+            "recently completed",
+            cooldownJson.RootElement.GetProperty("detail").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+
+        clock.Advance(GcDiagnosticsStore.Cooldown);
+        using var afterCooldown = await client.SendAsync(AuthenticatedPost());
+        Assert.Equal(HttpStatusCode.OK, afterCooldown.StatusCode);
+    }
+
+    private static void AssertSnapshotShape(JsonElement snapshot)
+    {
+        Assert.Equal(JsonValueKind.Object, snapshot.ValueKind);
+        Assert.Equal(JsonValueKind.Array, snapshot.GetProperty("generations").ValueKind);
+        Assert.True(snapshot.TryGetProperty("memoryLoadBytes", out _));
+        Assert.True(snapshot.TryGetProperty("highMemoryLoadThresholdBytes", out _));
+        Assert.True(snapshot.TryGetProperty("index", out _));
+        Assert.True(snapshot.TryGetProperty("generation", out _));
+        Assert.True(snapshot.TryGetProperty("compacted", out _));
+        Assert.True(snapshot.TryGetProperty("concurrent", out _));
+        var names = snapshot.GetProperty("generations").EnumerateArray()
+            .Select(entry => entry.GetProperty("name").GetString())
+            .ToList();
+        if (names.Count > 3)
+            Assert.Contains("loh", names);
+    }
+
+    private static HttpRequestMessage AuthenticatedPost()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/gc-diagnostics");
+        request.Headers.Add("x-api-key", NzbDavWebApplicationFactory.ApiKey);
+        return request;
+    }
+
+    private static WebApplicationFactory<Program> CreateIsolatedHost(
+        NzbDavWebApplicationFactory factory,
+        TimeProvider clock,
+        IGcDiagnosticsExecutor executor)
+    {
+        var store = new GcDiagnosticsStore(clock);
+        return factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<GcDiagnosticsStore>();
+                services.RemoveAll<IGcDiagnosticsExecutor>();
+                services.AddSingleton(store);
+                services.AddSingleton<IGcDiagnosticsExecutor>(executor);
+            });
+        });
+    }
+
+    private sealed class ImmediateGcDiagnosticsExecutor : IGcDiagnosticsExecutor
+    {
+        public GcCollectionExecution Execute()
+        {
+            var snapshot = GcSnapshotBuilder.Capture();
+            return new GcCollectionExecution(snapshot, snapshot, PauseMs: 0);
+        }
+    }
+
+    private sealed class BlockingGcDiagnosticsExecutor : IGcDiagnosticsExecutor
+    {
+        public TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public GcCollectionExecution Execute()
+        {
+            Started.TrySetResult();
+            Release.Task.GetAwaiter().GetResult();
+            var snapshot = GcSnapshotBuilder.Capture();
+            return new GcCollectionExecution(snapshot, snapshot, PauseMs: 1);
+        }
     }
 }

--- a/tests/NzbWebDAV.Tests/Api/GcDiagnosticsHttpIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GcDiagnosticsHttpIntegrationTests.cs
@@ -77,7 +77,7 @@ public sealed class GcDiagnosticsHttpIntegrationTests(NzbDavWebApplicationFactor
         try
         {
             await executor.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
-            using var concurrent = await client.SendAsync(AuthenticatedPost());
+            using var concurrent = await client.SendAsync(AuthenticatedPost()).WaitAsync(TimeSpan.FromSeconds(5));
             Assert.Equal(HttpStatusCode.TooManyRequests, concurrent.StatusCode);
             using var concurrentJson = await JsonDocument.ParseAsync(await concurrent.Content.ReadAsStreamAsync());
             Assert.Equal(StatusCodes.Status429TooManyRequests, concurrentJson.RootElement.GetProperty("status").GetInt32());

--- a/tests/NzbWebDAV.Tests/Api/GcDiagnosticsHttpIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GcDiagnosticsHttpIntegrationTests.cs
@@ -74,18 +74,24 @@ public sealed class GcDiagnosticsHttpIntegrationTests(NzbDavWebApplicationFactor
         using var client = host.CreateClient();
 
         var firstTask = client.SendAsync(AuthenticatedPost());
-        await executor.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        using var concurrent = await client.SendAsync(AuthenticatedPost());
-        Assert.Equal(HttpStatusCode.TooManyRequests, concurrent.StatusCode);
-        using var concurrentJson = await JsonDocument.ParseAsync(await concurrent.Content.ReadAsStreamAsync());
-        Assert.Equal(StatusCodes.Status429TooManyRequests, concurrentJson.RootElement.GetProperty("status").GetInt32());
-        Assert.Contains(
-            "already in progress",
-            concurrentJson.RootElement.GetProperty("detail").GetString(),
-            StringComparison.OrdinalIgnoreCase);
+        try
+        {
+            await executor.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            using var concurrent = await client.SendAsync(AuthenticatedPost());
+            Assert.Equal(HttpStatusCode.TooManyRequests, concurrent.StatusCode);
+            using var concurrentJson = await JsonDocument.ParseAsync(await concurrent.Content.ReadAsStreamAsync());
+            Assert.Equal(StatusCodes.Status429TooManyRequests, concurrentJson.RootElement.GetProperty("status").GetInt32());
+            Assert.Contains(
+                "already in progress",
+                concurrentJson.RootElement.GetProperty("detail").GetString(),
+                StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            executor.Release.TrySetResult();
+        }
 
-        executor.Release.TrySetResult();
-        using var first = await firstTask;
+        using var first = await firstTask.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.Equal(HttpStatusCode.OK, first.StatusCode);
     }
 

--- a/tests/NzbWebDAV.Tests/Services/GcDiagnosticsStoreTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/GcDiagnosticsStoreTests.cs
@@ -1,0 +1,105 @@
+using NzbWebDAV.Services.Diagnostics;
+using NzbWebDAV.Tests.TestUtils;
+
+namespace NzbWebDAV.Tests.Services;
+
+public sealed class GcDiagnosticsStoreTests
+{
+    [Fact]
+    public void TryBegin_FirstAdmissionStarts()
+    {
+        using var store = new GcDiagnosticsStore(new ControllableTimeProvider());
+        var result = store.TryBegin();
+        Assert.Equal(GcDiagnosticsAdmission.Started, result.Status);
+        Assert.Null(result.RetryAfterSeconds);
+        store.End();
+    }
+
+    [Fact]
+    public void TryBegin_RejectsConcurrentAdmission()
+    {
+        using var store = new GcDiagnosticsStore(new ControllableTimeProvider());
+        Assert.Equal(GcDiagnosticsAdmission.Started, store.TryBegin().Status);
+        var rejected = store.TryBegin();
+        Assert.Equal(GcDiagnosticsAdmission.AlreadyRunning, rejected.Status);
+        Assert.Equal((int)GcDiagnosticsStore.Cooldown.TotalSeconds, rejected.RetryAfterSeconds);
+        store.End();
+    }
+
+    [Fact]
+    public void TryBegin_ConcurrentCallers_AdmitExactlyOnce()
+    {
+        using var store = new GcDiagnosticsStore(new ControllableTimeProvider());
+        var barrier = new Barrier(2);
+        var results = new GcDiagnosticsAdmission[2];
+        Parallel.For(0, 2, i =>
+        {
+            barrier.SignalAndWait();
+            results[i] = store.TryBegin().Status;
+        });
+
+        Assert.Equal(1, results.Count(status => status == GcDiagnosticsAdmission.Started));
+        Assert.Equal(1, results.Count(status => status == GcDiagnosticsAdmission.AlreadyRunning));
+        store.End();
+    }
+
+    [Fact]
+    public void TryBegin_RejectsCooldownThenAdmitsAtExactBoundary()
+    {
+        var clock = new ControllableTimeProvider();
+        using var store = new GcDiagnosticsStore(clock);
+        Assert.Equal(GcDiagnosticsAdmission.Started, store.TryBegin().Status);
+        store.End();
+
+        clock.Advance(GcDiagnosticsStore.Cooldown - TimeSpan.FromTicks(1));
+        var cooldown = store.TryBegin();
+        Assert.Equal(GcDiagnosticsAdmission.Cooldown, cooldown.Status);
+        Assert.Equal(1, cooldown.RetryAfterSeconds);
+
+        clock.Advance(TimeSpan.FromTicks(1));
+        var admitted = store.TryBegin();
+        Assert.Equal(GcDiagnosticsAdmission.Started, admitted.Status);
+        Assert.Null(admitted.RetryAfterSeconds);
+        store.End();
+    }
+
+    [Fact]
+    public void TryBegin_UsesMonotonicTimestampNotWallClock()
+    {
+        var clock = new SplitTimeProvider();
+        using var store = new GcDiagnosticsStore(clock);
+        Assert.Equal(GcDiagnosticsAdmission.Started, store.TryBegin().Status);
+        store.End();
+
+        clock.UtcNow -= TimeSpan.FromHours(1);
+        var cooldown = store.TryBegin();
+        Assert.Equal(GcDiagnosticsAdmission.Cooldown, cooldown.Status);
+
+        clock.Timestamp += (long)(GcDiagnosticsStore.Cooldown.TotalSeconds * clock.TimestampFrequency);
+        var admitted = store.TryBegin();
+        Assert.Equal(GcDiagnosticsAdmission.Started, admitted.Status);
+        store.End();
+    }
+
+    [Fact]
+    public void TryBegin_StartsCooldownEvenWhenAttemptFailsToFinish()
+    {
+        var clock = new ControllableTimeProvider();
+        using var store = new GcDiagnosticsStore(clock);
+        Assert.Equal(GcDiagnosticsAdmission.Started, store.TryBegin().Status);
+        store.End();
+
+        var cooldown = store.TryBegin();
+        Assert.Equal(GcDiagnosticsAdmission.Cooldown, cooldown.Status);
+        Assert.NotNull(cooldown.RetryAfterSeconds);
+    }
+
+    private sealed class SplitTimeProvider : TimeProvider
+    {
+        public DateTimeOffset UtcNow { get; set; } = DateTimeOffset.UnixEpoch;
+        public long Timestamp { get; set; }
+        public override DateTimeOffset GetUtcNow() => UtcNow;
+        public override long GetTimestamp() => Timestamp;
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/GcDiagnosticsStoreTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/GcDiagnosticsStoreTests.cs
@@ -30,13 +30,8 @@ public sealed class GcDiagnosticsStoreTests
     public void TryBegin_ConcurrentCallers_AdmitExactlyOnce()
     {
         using var store = new GcDiagnosticsStore(new ControllableTimeProvider());
-        var barrier = new Barrier(2);
         var results = new GcDiagnosticsAdmission[2];
-        Parallel.For(0, 2, i =>
-        {
-            barrier.SignalAndWait();
-            results[i] = store.TryBegin().Status;
-        });
+        BarrierThreads.Run(2, i => results[i] = store.TryBegin().Status);
 
         Assert.Equal(1, results.Count(status => status == GcDiagnosticsAdmission.Started));
         Assert.Equal(1, results.Count(status => status == GcDiagnosticsAdmission.AlreadyRunning));

--- a/tests/NzbWebDAV.Tests/Services/OomDiagnosticsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/OomDiagnosticsTests.cs
@@ -20,7 +20,18 @@ public sealed class OomDiagnosticsTests
             e => e.MessageTemplate.Text.Contains("OutOfMemoryException during"));
         Assert.Equal(LogEventLevel.Warning, entry.Level);
         Assert.Contains("OutOfMemoryException during", entry.MessageTemplate.Text);
+        Assert.Contains("LastGcAvailableCeiling", entry.MessageTemplate.Text);
         Assert.Null(entry.Exception);
+        Assert.True(entry.Properties.ContainsKey("GcIndex"));
+        Assert.True(entry.Properties.ContainsKey("GcGeneration"));
+        Assert.True(entry.Properties.ContainsKey("LohSize"));
+        Assert.True(entry.Properties.ContainsKey("LohFragmentation"));
+        Assert.True(entry.Properties.ContainsKey("MemoryLoad"));
+        Assert.True(entry.Properties.ContainsKey("HighMemoryLoadThreshold"));
+        Assert.True(entry.Properties.ContainsKey("WorkingSet"));
+        Assert.True(entry.Properties.ContainsKey("LohHardLimit"));
+        Assert.True(entry.Properties.ContainsKey("LohHardLimitPercent"));
+        Assert.True(entry.Properties.ContainsKey("PoolOutstanding"));
         Assert.Contains(events, e =>
             e.Level == LogEventLevel.Debug &&
             e.MessageTemplate.Text.Contains("OutOfMemoryException stack") &&

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -172,6 +172,18 @@ public sealed class SupportPackContentsTests : IDisposable
         Assert.True(gc.GetProperty("heapLimitBytes").GetInt64() > 0);
         Assert.True(gc.TryGetProperty("regionRangeBytes", out _));
         Assert.True(gc.TryGetProperty("regionSizeBytes", out _));
+        Assert.True(gc.TryGetProperty("index", out _));
+        Assert.True(gc.TryGetProperty("generation", out _));
+        Assert.True(gc.TryGetProperty("compacted", out _));
+        Assert.True(gc.TryGetProperty("concurrent", out _));
+        Assert.True(gc.TryGetProperty("memoryLoadBytes", out _));
+        Assert.True(gc.TryGetProperty("highMemoryLoadThresholdBytes", out _));
+        Assert.True(gc.TryGetProperty("totalAvailableMemoryBytes", out _));
+        Assert.True(gc.TryGetProperty("conserveMemory", out _));
+        Assert.True(gc.TryGetProperty("lohThresholdBytes", out _));
+        Assert.True(gc.TryGetProperty("heapHardLimitLohBytes", out _));
+        Assert.True(gc.TryGetProperty("heapHardLimitLohPercent", out _));
+        Assert.False(gc.TryGetProperty("DOTNET_GCConserveMemory", out _));
         // Article buffers land on the large-object heap, so its size must be visible.
         var generations = gc.GetProperty("generations").EnumerateArray()
             .Select(entry => entry.GetProperty("name").GetString())
@@ -257,14 +269,28 @@ public sealed class SupportPackContentsTests : IDisposable
             Assert.Equal(1, snapshot.GetProperty("rentCount").GetInt64());
             Assert.Equal(1, snapshot.GetProperty("returnCount").GetInt64());
             Assert.True(snapshot.TryGetProperty("trimmedBytes", out _));
+            Assert.True(snapshot.TryGetProperty("maxIdleBytes", out var maxIdle));
+            Assert.Equal(4 * 1024 * 1024, maxIdle.GetInt64());
+            Assert.True(snapshot.TryGetProperty("staleExpiredBytes", out _));
+            Assert.True(snapshot.TryGetProperty("classLimitDroppedBytes", out _));
+            Assert.True(snapshot.TryGetProperty("capacityEvictedBytes", out _));
+            Assert.True(snapshot.TryGetProperty("droppedTooLargeBytes", out _));
             Assert.True(snapshot.TryGetProperty("rejectedReturnCount", out _));
             Assert.True(snapshot.TryGetProperty("reuseCount", out _));
             Assert.True(snapshot.TryGetProperty("allocationCount", out _));
+            Assert.True(snapshot.TryGetProperty("allocationAttemptCount", out _));
+            Assert.True(snapshot.TryGetProperty("allocationFailureCount", out _));
 
             var sizeClass = Assert.Single(snapshot.GetProperty("sizeClasses").EnumerateArray());
             Assert.Equal(buffer.Length, sizeClass.GetProperty("bufferSize").GetInt32());
             Assert.Equal(1, sizeClass.GetProperty("bufferCount").GetInt32());
             Assert.Equal(buffer.Length, sizeClass.GetProperty("idleBytes").GetInt64());
+
+            var lifetime = Assert.Single(snapshot.GetProperty("lifetimeSizeClasses").EnumerateArray());
+            Assert.Equal(buffer.Length, lifetime.GetProperty("bufferSize").GetInt32());
+            Assert.Equal(1, lifetime.GetProperty("rentCount").GetInt64());
+            Assert.Equal(1, lifetime.GetProperty("returnCount").GetInt64());
+            Assert.Equal(1, lifetime.GetProperty("allocationCount").GetInt64());
         }
         finally
         {

--- a/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolAllocationFailureTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolAllocationFailureTests.cs
@@ -106,6 +106,8 @@ public sealed class SegmentBufferPoolSelectorTests
     [Theory]
     [InlineData(null, "bounded-legacy", false)]
     [InlineData("", "bounded-legacy", false)]
+    [InlineData(" ", "bounded-legacy", false)]
+    [InlineData(" bounded-capacity ", "bounded-capacity", false)]
     [InlineData("bounded-legacy", "bounded-legacy", false)]
     [InlineData("BOUNDED-LEGACY", "bounded-legacy", false)]
     [InlineData("bounded-capacity", "bounded-capacity", false)]

--- a/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolAllocationFailureTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolAllocationFailureTests.cs
@@ -1,0 +1,126 @@
+using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.TestUtils;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace NzbWebDAV.Tests.Streams;
+
+[Collection(nameof(GlobalLoggerCollection))]
+public sealed class SegmentBufferPoolAllocationFailureTests
+{
+    [Fact]
+    public void Rent_AllocationOom_RethrowsSameInstanceAndRecordsTelemetry()
+    {
+        var expected = new OutOfMemoryException("segment alloc");
+        var pool = new SegmentBufferPool(
+            maxIdleBytes: 4 * 1024 * 1024,
+            retentionPolicy: SegmentBufferRetentionPolicy.Legacy,
+            allocator: _ => throw expected);
+
+        OutOfMemoryException? actual = null;
+        var events = CaptureLogs(() =>
+            actual = Assert.Throws<OutOfMemoryException>(() => pool.Rent(750_000)));
+
+        Assert.Same(expected, actual);
+        var snapshot = pool.Snapshot();
+        Assert.Equal(1, snapshot.AllocationAttemptCount);
+        Assert.Equal(1, snapshot.AllocationFailureCount);
+        Assert.Equal(0, snapshot.AllocationCount);
+        Assert.Equal(0, snapshot.RentCount);
+        Assert.Equal(0, snapshot.CheckedOutBytes);
+
+        var warning = Assert.Single(
+            events,
+            e => e.Level == LogEventLevel.Warning &&
+                 e.MessageTemplate.Text.Contains("allocating segment buffer", StringComparison.Ordinal));
+        Assert.Null(warning.Exception);
+        Assert.Equal(750_000, ToInt64(warning.Properties["RequestedBytes"]));
+        Assert.Equal(768 * 1024, ToInt64(warning.Properties["RoundedBytes"]));
+        Assert.Contains(events, e =>
+            e.Level == LogEventLevel.Debug &&
+            e.Exception is OutOfMemoryException);
+    }
+
+    [Fact]
+    public void Rent_AllocationOom_DiagnosticHelperThrow_StillRethrowsOriginal()
+    {
+        var expected = new OutOfMemoryException("segment alloc");
+        var pool = new SegmentBufferPool(
+            maxIdleBytes: 4 * 1024 * 1024,
+            retentionPolicy: SegmentBufferRetentionPolicy.Legacy,
+            allocator: _ => throw expected,
+            onAllocationFailure: (_, _, _, _) => throw new InvalidOperationException("diag"));
+
+        var actual = Assert.Throws<OutOfMemoryException>(() => pool.Rent(256 * 1024));
+        Assert.Same(expected, actual);
+        Assert.Equal(1, pool.Snapshot().AllocationFailureCount);
+        Assert.Equal(0, pool.Snapshot().AllocationCount);
+    }
+
+    private static long ToInt64(LogEventPropertyValue value) =>
+        Convert.ToInt64(Assert.IsType<ScalarValue>(value).Value, System.Globalization.CultureInfo.InvariantCulture);
+
+    private static IReadOnlyList<LogEvent> CaptureLogs(Action action)
+    {
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        try
+        {
+            action();
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+
+        return sink.Events;
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events) return _events.ToArray();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events) _events.Add(logEvent);
+        }
+    }
+}
+
+public sealed class SegmentBufferPoolSelectorTests
+{
+    [Theory]
+    [InlineData(null, "bounded-legacy", false)]
+    [InlineData("", "bounded-legacy", false)]
+    [InlineData("bounded-legacy", "bounded-legacy", false)]
+    [InlineData("BOUNDED-LEGACY", "bounded-legacy", false)]
+    [InlineData("bounded-capacity", "bounded-capacity", false)]
+    [InlineData("Bounded-Capacity", "bounded-capacity", false)]
+    [InlineData("shared", "shared", false)]
+    [InlineData("SHARED", "shared", false)]
+    [InlineData("experimental", "bounded-legacy", true)]
+    [InlineData("legacy", "bounded-legacy", true)]
+    public void Resolve_CoversDocumentedValuesAndUnknownFallback(
+        string? value,
+        string expected,
+        bool unknown)
+    {
+        var mode = SegmentBufferPoolSelector.Resolve(value, out var unknownValue);
+        Assert.Equal(expected, SegmentBufferPoolSelector.ToLogValue(mode));
+        Assert.Equal(unknown, unknownValue);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolTests.cs
@@ -27,6 +27,8 @@ public class SegmentBufferPoolTests
         var snapshot = pool.Snapshot();
         Assert.Equal(512 * 1024, snapshot.IdleBytes);
         Assert.Equal(256 * 1024, snapshot.TrimmedBytes);
+        Assert.Equal(256 * 1024, snapshot.CapacityEvictedBytes);
+        Assert.Equal(snapshot.IdleBytes, snapshot.SizeClasses.Sum(c => c.IdleBytes));
         Assert.Equal(2, snapshot.SizeClasses.Single().BufferCount);
     }
 
@@ -65,6 +67,7 @@ public class SegmentBufferPoolTests
 
         Assert.NotSame(first, second);
         Assert.Equal(first.Length, pool.Snapshot().TrimmedBytes);
+        Assert.Equal(first.Length, pool.Snapshot().StaleExpiredBytes);
         pool.Return(second);
     }
 
@@ -84,6 +87,7 @@ public class SegmentBufferPoolTests
         var snapshot = pool.Snapshot();
         Assert.Equal(2 * 256 * 1024, snapshot.IdleBytes);
         Assert.Equal(256 * 1024, snapshot.TrimmedBytes);
+        Assert.Equal(256 * 1024, snapshot.ClassLimitDroppedBytes);
     }
 
     [Fact]
@@ -238,6 +242,237 @@ public class SegmentBufferPoolTests
         {
             custom.Return(customBuffer);
             SharedArrayPoolAdapter.Instance.Return(sharedBuffer);
+        }
+    }
+
+    [Fact]
+    public void Rent_ReusesIdleBufferAfterLongGap()
+    {
+        var clock = new ManualTimeProvider();
+        var pool = new SegmentBufferPool(
+            maxIdleBytes: 4 * 1024 * 1024,
+            retentionPolicy: SegmentBufferRetentionPolicy.CapacityOnly,
+            timeProvider: clock);
+        var first = pool.Rent(750_000);
+        pool.Return(first);
+        clock.Advance(TimeSpan.FromDays(1));
+
+        var second = pool.Rent(750_000);
+
+        Assert.Same(first, second);
+        var snapshot = pool.Snapshot();
+        Assert.Equal(1, snapshot.AllocationCount);
+        Assert.Equal(1, snapshot.ReuseCount);
+        Assert.Equal(0, snapshot.TrimmedBytes);
+        pool.Return(second);
+    }
+
+    [Fact]
+    public void Return_AllowsOneClassToExceedLegacy64BufferLimitWithinByteCap()
+    {
+        const int bufferSize = 256 * 1024;
+        const int count = 65;
+        var pool = new SegmentBufferPool(
+            maxIdleBytes: 32 * 1024 * 1024,
+            retentionPolicy: SegmentBufferRetentionPolicy.CapacityOnly);
+        var buffers = Enumerable.Range(0, count).Select(_ => pool.Rent(bufferSize)).ToArray();
+        foreach (var buffer in buffers)
+            pool.Return(buffer);
+
+        var idle = pool.Snapshot();
+        Assert.Equal(count, idle.SizeClasses.Single().BufferCount);
+        Assert.Equal(0, idle.TrimmedBytes);
+
+        var reused = Enumerable.Range(0, count).Select(_ => pool.Rent(bufferSize)).ToArray();
+        var snapshot = pool.Snapshot();
+        Assert.Equal(count, snapshot.AllocationCount);
+        Assert.Equal(count, snapshot.ReuseCount);
+        Assert.Equal(0, snapshot.TrimmedBytes);
+        foreach (var buffer in reused)
+            pool.Return(buffer);
+    }
+
+    [Fact]
+    public void Return_EvictsGloballyOldestClassForCapacity()
+    {
+        var pool = new SegmentBufferPool(
+            maxIdleBytes: 768 * 1024,
+            retentionPolicy: SegmentBufferRetentionPolicy.CapacityOnly);
+        var firstSmall = pool.Rent(256 * 1024);
+        var medium = pool.Rent(512 * 1024);
+        var secondSmall = pool.Rent(256 * 1024);
+        pool.Return(firstSmall);
+        pool.Return(medium);
+        pool.Return(secondSmall);
+
+        var snapshot = pool.Snapshot();
+        Assert.Equal(768 * 1024, snapshot.IdleBytes);
+        Assert.Equal(256 * 1024, snapshot.CapacityEvictedBytes);
+        Assert.Equal(256 * 1024, snapshot.TrimmedBytes);
+
+        var reusedMedium = pool.Rent(512 * 1024);
+        var reusedSmall = pool.Rent(256 * 1024);
+        Assert.Same(medium, reusedMedium);
+        Assert.Same(secondSmall, reusedSmall);
+        Assert.NotSame(firstSmall, reusedSmall);
+        pool.Return(reusedMedium);
+        pool.Return(reusedSmall);
+    }
+
+    [Fact]
+    public void Return_DropsBufferLargerThanEntireCap()
+    {
+        var pool = new SegmentBufferPool(maxIdleBytes: 100_000);
+        var buffer = pool.Rent(256 * 1024);
+        pool.Return(buffer);
+
+        var snapshot = pool.Snapshot();
+        Assert.Equal(0, snapshot.IdleBytes);
+        Assert.Equal(buffer.Length, snapshot.DroppedTooLargeBytes);
+        Assert.Equal(buffer.Length, snapshot.TrimmedBytes);
+        Assert.Empty(snapshot.SizeClasses);
+        Assert.Empty(snapshot.LifetimeSizeClasses);
+    }
+
+    [Fact]
+    public void LifetimeSnapshot_IncludesPoolableClassWithZeroIdleBuffers()
+    {
+        var pool = new SegmentBufferPool(maxIdleBytes: 4 * 1024 * 1024);
+        var first = pool.Rent(256 * 1024);
+        pool.Return(first);
+        var second = pool.Rent(256 * 1024);
+
+        var snapshot = pool.Snapshot();
+        Assert.Empty(snapshot.SizeClasses);
+        var lifetime = Assert.Single(snapshot.LifetimeSizeClasses);
+        Assert.Equal(first.Length, lifetime.BufferSize);
+        Assert.Equal(2, lifetime.RentCount);
+        Assert.Equal(1, lifetime.ReturnCount);
+        Assert.Equal(1, lifetime.ReuseCount);
+        Assert.Equal(1, lifetime.AllocationCount);
+        pool.Return(second);
+    }
+
+    [Fact]
+    public void Snapshot_ReasonCountersSumToTrimmedBytes()
+    {
+        var clock = new ManualTimeProvider();
+        var pool = new SegmentBufferPool(
+            maxIdleBytes: 512 * 1024,
+            staleAfter: TimeSpan.FromMinutes(1),
+            maxBuffersPerClass: 1,
+            timeProvider: clock);
+
+        var stale = pool.Rent(256 * 1024);
+        pool.Return(stale);
+        clock.Advance(TimeSpan.FromMinutes(2));
+        var replacement = pool.Rent(256 * 1024);
+        pool.Return(replacement);
+
+        var classKeep = pool.Rent(256 * 1024);
+        var classDrop = pool.Rent(256 * 1024);
+        pool.Return(classKeep);
+        pool.Return(classDrop);
+
+        var capacityIncoming = pool.Rent(512 * 1024);
+        pool.Return(capacityIncoming);
+
+        var tooLarge = pool.Rent(768 * 1024);
+        pool.Return(tooLarge);
+
+        var snapshot = pool.Snapshot();
+        Assert.Equal(replacement.Length, snapshot.StaleExpiredBytes);
+        Assert.Equal(classDrop.Length, snapshot.ClassLimitDroppedBytes);
+        Assert.Equal(classKeep.Length, snapshot.CapacityEvictedBytes);
+        Assert.Equal(tooLarge.Length, snapshot.DroppedTooLargeBytes);
+        Assert.Equal(
+            snapshot.StaleExpiredBytes
+            + snapshot.ClassLimitDroppedBytes
+            + snapshot.CapacityEvictedBytes
+            + snapshot.DroppedTooLargeBytes,
+            snapshot.TrimmedBytes);
+        Assert.Equal(512 * 1024, snapshot.MaxIdleBytes);
+        Assert.True(snapshot.IdleBytes <= snapshot.MaxIdleBytes);
+        Assert.DoesNotContain(snapshot.LifetimeSizeClasses, c => c.BufferSize > snapshot.MaxIdleBytes);
+    }
+
+    [Fact]
+    public void ConcurrentReturns_NeverExceedCapAndBalanceReasonCounters()
+    {
+        const int size = 256 * 1024;
+        const int count = 8;
+        const int capCount = 4;
+        var pool = new SegmentBufferPool(
+            maxIdleBytes: capCount * (long)size,
+            retentionPolicy: SegmentBufferRetentionPolicy.CapacityOnly);
+        var buffers = Enumerable.Range(0, count).Select(_ => pool.Rent(size)).ToArray();
+        var barrier = new Barrier(count);
+        Parallel.For(0, count, i =>
+        {
+            barrier.SignalAndWait();
+            pool.Return(buffers[i]);
+        });
+
+        var snapshot = pool.Snapshot();
+        Assert.Equal(capCount * (long)size, snapshot.IdleBytes);
+        Assert.Equal((count - capCount) * (long)size, snapshot.CapacityEvictedBytes);
+        Assert.Equal(0, snapshot.StaleExpiredBytes);
+        Assert.Equal(0, snapshot.ClassLimitDroppedBytes);
+        Assert.Equal(0, snapshot.DroppedTooLargeBytes);
+        Assert.Equal(snapshot.CapacityEvictedBytes, snapshot.TrimmedBytes);
+        Assert.Equal(snapshot.IdleBytes, snapshot.SizeClasses.Sum(c => c.IdleBytes));
+        Assert.True(snapshot.IdleBytes <= snapshot.MaxIdleBytes);
+        Assert.Equal(count, snapshot.ReturnCount);
+    }
+
+    [Fact]
+    public void ConcurrentDuplicateReturn_IsAcceptedExactlyOnce()
+    {
+        var pool = new SegmentBufferPool(maxIdleBytes: 1024 * 1024);
+        var buffer = pool.Rent(256 * 1024);
+        var barrier = new Barrier(2);
+        Parallel.For(0, 2, _ =>
+        {
+            barrier.SignalAndWait();
+            pool.Return(buffer);
+        });
+
+        var snapshot = pool.Snapshot();
+        Assert.Equal(1, snapshot.ReturnCount);
+        Assert.Equal(1, snapshot.RejectedReturnCount);
+        Assert.Equal(1, snapshot.SizeClasses.Single().BufferCount);
+        Assert.Equal(buffer.Length, snapshot.IdleBytes);
+    }
+
+    [Fact]
+    public void CapacityOnly_DoesNotReadWallClock()
+    {
+        var spy = new ThrowingUtcNowProvider();
+        var pool = new SegmentBufferPool(
+            maxIdleBytes: 512 * 1024,
+            retentionPolicy: SegmentBufferRetentionPolicy.CapacityOnly,
+            timeProvider: spy);
+        var first = pool.Rent(256 * 1024);
+        var second = pool.Rent(256 * 1024);
+        var third = pool.Rent(512 * 1024);
+        pool.Return(first);
+        pool.Return(second);
+        pool.Return(third);
+        var reused = pool.Rent(512 * 1024);
+        pool.Return(reused);
+
+        Assert.Equal(0, spy.UtcNowCalls);
+        Assert.Same(third, reused);
+        Assert.True(pool.Snapshot().CapacityEvictedBytes > 0);
+    }
+
+    private sealed class ThrowingUtcNowProvider : TimeProvider
+    {
+        public int UtcNowCalls;
+        public override DateTimeOffset GetUtcNow()
+        {
+            Interlocked.Increment(ref UtcNowCalls);
+            throw new InvalidOperationException("CapacityOnly must not read wall-clock time.");
         }
     }
 

--- a/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolTests.cs
@@ -1,4 +1,5 @@
 using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.TestUtils;
 
 namespace NzbWebDAV.Tests.Streams;
 
@@ -320,6 +321,14 @@ public class SegmentBufferPoolTests
     }
 
     [Fact]
+    public void DefaultSnapshot_LifetimeSizeClassesIsEmpty()
+    {
+        var snapshot = default(SegmentBufferPoolSnapshot);
+        Assert.NotNull(snapshot.LifetimeSizeClasses);
+        Assert.Empty(snapshot.LifetimeSizeClasses);
+    }
+
+    [Fact]
     public void Return_DropsBufferLargerThanEntireCap()
     {
         var pool = new SegmentBufferPool(maxIdleBytes: 100_000);
@@ -406,12 +415,7 @@ public class SegmentBufferPoolTests
             maxIdleBytes: capCount * (long)size,
             retentionPolicy: SegmentBufferRetentionPolicy.CapacityOnly);
         var buffers = Enumerable.Range(0, count).Select(_ => pool.Rent(size)).ToArray();
-        var barrier = new Barrier(count);
-        Parallel.For(0, count, i =>
-        {
-            barrier.SignalAndWait();
-            pool.Return(buffers[i]);
-        });
+        BarrierThreads.Run(count, i => pool.Return(buffers[i]));
 
         var snapshot = pool.Snapshot();
         Assert.Equal(capCount * (long)size, snapshot.IdleBytes);
@@ -430,12 +434,7 @@ public class SegmentBufferPoolTests
     {
         var pool = new SegmentBufferPool(maxIdleBytes: 1024 * 1024);
         var buffer = pool.Rent(256 * 1024);
-        var barrier = new Barrier(2);
-        Parallel.For(0, 2, _ =>
-        {
-            barrier.SignalAndWait();
-            pool.Return(buffer);
-        });
+        BarrierThreads.Run(2, _ => pool.Return(buffer));
 
         var snapshot = pool.Snapshot();
         Assert.Equal(1, snapshot.ReturnCount);

--- a/tests/NzbWebDAV.Tests/TestUtils/BarrierThreads.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/BarrierThreads.cs
@@ -1,10 +1,17 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace NzbWebDAV.Tests.TestUtils;
 
 internal static class BarrierThreads
 {
+    [SuppressMessage(
+        "Design",
+        "CA1031:Do not catch general exception types",
+        Justification = "Worker exceptions must be marshalled to the test thread instead of terminating the host.")]
     public static void Run(int count, Action<int> body, TimeSpan? joinTimeout = null)
     {
         var timeout = joinTimeout ?? TimeSpan.FromSeconds(10);
+        var exceptions = new Exception?[count];
         using var barrier = new Barrier(count);
         var threads = new Thread[count];
         for (var i = 0; i < count; i++)
@@ -12,8 +19,15 @@ internal static class BarrierThreads
             var index = i;
             threads[i] = new Thread(() =>
             {
-                barrier.SignalAndWait();
-                body(index);
+                try
+                {
+                    barrier.SignalAndWait();
+                    body(index);
+                }
+                catch (Exception ex)
+                {
+                    exceptions[index] = ex;
+                }
             })
             {
                 IsBackground = true,
@@ -21,10 +35,17 @@ internal static class BarrierThreads
             threads[i].Start();
         }
 
+        var timedOut = false;
         foreach (var thread in threads)
         {
             if (!thread.Join(timeout))
-                throw new TimeoutException($"Barrier worker did not complete within {timeout}.");
+                timedOut = true;
         }
+
+        var failures = exceptions.OfType<Exception>().ToArray();
+        if (failures.Length > 0)
+            throw new AggregateException(failures);
+        if (timedOut)
+            throw new TimeoutException($"Barrier worker did not complete within {timeout}.");
     }
 }

--- a/tests/NzbWebDAV.Tests/TestUtils/BarrierThreads.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/BarrierThreads.cs
@@ -1,0 +1,30 @@
+namespace NzbWebDAV.Tests.TestUtils;
+
+internal static class BarrierThreads
+{
+    public static void Run(int count, Action<int> body, TimeSpan? joinTimeout = null)
+    {
+        var timeout = joinTimeout ?? TimeSpan.FromSeconds(10);
+        using var barrier = new Barrier(count);
+        var threads = new Thread[count];
+        for (var i = 0; i < count; i++)
+        {
+            var index = i;
+            threads[i] = new Thread(() =>
+            {
+                barrier.SignalAndWait();
+                body(index);
+            })
+            {
+                IsBackground = true,
+            };
+            threads[i].Start();
+        }
+
+        foreach (var thread in threads)
+        {
+            if (!thread.Join(timeout))
+                throw new TimeoutException($"Barrier worker did not complete within {timeout}.");
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/TestUtils/BarrierThreadsTests.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/BarrierThreadsTests.cs
@@ -1,0 +1,17 @@
+namespace NzbWebDAV.Tests.TestUtils;
+
+public sealed class BarrierThreadsTests
+{
+    [Fact]
+    public void Run_MarshalsWorkerExceptionsToCaller()
+    {
+        var ex = Assert.Throws<AggregateException>(() =>
+            BarrierThreads.Run(2, i =>
+            {
+                if (i == 0)
+                    throw new InvalidOperationException("worker-0");
+            }));
+
+        Assert.Contains(ex.InnerExceptions, inner => inner is InvalidOperationException);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Utils/AddressSpaceDiagnosticsTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/AddressSpaceDiagnosticsTests.cs
@@ -34,5 +34,8 @@ public sealed class AddressSpaceDiagnosticsTests
 
         Assert.True(snapshot.VirtualMemoryBytes is null or >= 0);
         Assert.True(snapshot.GcCommittedBytes is null or >= 0);
+        Assert.True(snapshot.WorkingSetBytes is null or >= 0);
+        Assert.True(snapshot.GcHeapHardLimitLohBytes is null or >= 0);
+        Assert.True(snapshot.GcHeapHardLimitLohPercent is null or >= 0);
     }
 }


### PR DESCRIPTION
## Summary
- Segment-buffer snapshots now split trim causes (stale expiry, per-class limit, byte-cap eviction, oversize drop), show lifetime size-class activity, and record requested vs rounded sizes when a pool allocation throws `OutOfMemoryException`.
- Production still uses the current age-plus-per-class policy. `NZBDAV_SEGMENT_BUFFER_POOL=bounded-capacity` is a restart-only canary that keeps the same idle-byte cap; `bounded-legacy` remains the rollback, and `shared` remains the emergency hatch.
- `POST /api/gc-diagnostics` is POST-only, single-flight plus a 10-minute cooldown (429 + `Retry-After`), and now states that it runs two aggressive full blocking collections that compact SOH and LOH on .NET 10. Admin OpenAPI contract version is `2.0.0`.

This PR is the first instrumentation/canary step for #1226; it should not mark that issue done. Capacity-only must not become the default until the matched soak and 512 MiB constrained-host gates pass. Queue-worker liveness after OOM stays with #1128.

## Test plan
- [ ] Confirm unset / unknown `NZBDAV_SEGMENT_BUFFER_POOL` still trims after two minutes and enforces the 64-buffer class ceiling
- [ ] Confirm `bounded-capacity` reuses the same class after a long idle gap while staying under the idle-byte cap
- [ ] Confirm `POST /api/gc-diagnostics` still requires the API key; a second call within 10 minutes returns 429 with `Retry-After`; GET still returns 405
- [ ] Confirm a support pack includes `maxIdleBytes`, reason counters, `lifetimeSizeClasses`, and GC index / memory-load / LOH fields
- [ ] Do not poll `/api/gc-diagnostics` during any import/playback observation window

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GC diagnostics now use POST and report collection details, pause information, and memory metrics.
  * Concurrent or recently repeated requests receive a clear 429 response with optional retry guidance.
  * Added shared and capacity-based segment buffer-pool modes for improved reuse and memory control.
  * Support packs and out-of-memory diagnostics include expanded GC, memory, and buffer-pool information.
* **Documentation**
  * Updated administration API documentation to version 2.0.0.
  * Documented buffer-pool settings and memory-constrained hosting recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->