### PR TITLE
fix(ui): stabilize the overview dashboard layout

### DIFF
--- a/frontend/app/routes/_index/components/page-layout/page-layout.tsx
+++ b/frontend/app/routes/_index/components/page-layout/page-layout.tsx
@@ -48,7 +48,7 @@ export function PageLayout(props: PageLayoutProps) {
           onChange={(event) => setIsHamburgerMenuOpen(event.target.checked)}
         />
         <div className="drawer-content flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
-          <main className="yes-scrollbar relative h-full min-h-0 min-w-0 overflow-y-auto bg-base-300">
+          <main className="yes-scrollbar relative h-full min-h-0 min-w-0 overflow-x-hidden overflow-y-auto bg-base-300">
             <div className="flex min-h-full flex-col">
               <div className="min-h-0 flex-1">{props.bodyChild}</div>
               {props.serviceProvider?.name && (

--- a/frontend/app/routes/overview/components/catalogue-block/catalogue-block.tsx
+++ b/frontend/app/routes/overview/components/catalogue-block/catalogue-block.tsx
@@ -17,7 +17,7 @@ export function CatalogueBlock({ catalogue }: CatalogueBlockProps) {
         <p className="text-xs text-base-content/50">Your mounted library</p>
       </header>
 
-      <div className="stats stats-vertical w-full border border-base-content/10 bg-base-100 sm:stats-horizontal">
+      <div className="stats w-full border border-base-content/10 bg-base-100 max-lg:grid-flow-row max-lg:grid-cols-2 max-lg:gap-px max-lg:bg-base-content/10 lg:stats-horizontal">
         <Stat label="Files" value={formatNumber(catalogue.fileCount)} />
         <Stat label="Total size" value={formatBytes(catalogue.totalBytes)} />
         <Stat label="Largest file" value={formatBytes(catalogue.largestFileBytes)} />
@@ -41,7 +41,7 @@ function Stat({
   accent?: "good" | undefined;
 }) {
   return (
-    <div className="stat py-3">
+    <div className="stat px-3 py-2.5 sm:px-4 sm:py-4 lg:px-6 max-lg:min-w-0 max-lg:border-e-0 max-lg:bg-base-100">
       <div className="stat-title text-xs">{label}</div>
       <div
         className={`stat-value font-mono text-xl md:text-2xl ${accent === "good" ? "text-success" : ""}`}

--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.test.tsx
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.test.tsx
@@ -133,6 +133,8 @@ describe("LiveReadsPanel", () => {
     const markup = renderToStaticMarkup(<LiveReadsPanelContent rows={fixtureRows} />);
 
     expect(markup).toContain("5 active");
+    expect(markup).toContain("h-[30rem]");
+    expect(markup).toContain("overflow-y-auto");
     expect(markup).toContain("The.Prestige.2006.1080p.BluRay.x264-GRP.mkv");
     expect(markup).toContain("Severance.S02E01.2160p.ATVP.WEB-DL.DDP5.1.H.265-GRP.mkv");
     // Speed, progress, and computed time left
@@ -146,6 +148,14 @@ describe("LiveReadsPanel", () => {
     expect(markup).toContain("192.168.1.20");
     expect(markup).toContain("Eweka");
     expect(markup).toContain("a1b2c3d4");
+  });
+
+  it("places the newest read first", () => {
+    const markup = renderToStaticMarkup(<LiveReadsPanelContent rows={fixtureRows} />);
+
+    expect(
+      markup.indexOf("Severance.S02E01.2160p.ATVP.WEB-DL.DDP5.1.H.265-GRP.mkv"),
+    ).toBeLessThan(markup.indexOf("The.Prestige.2006.1080p.BluRay.x264-GRP.mkv"));
   });
 
   it("labels media rows with MOVIE / EPISODE badges", () => {

--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.test.tsx
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.test.tsx
@@ -153,9 +153,9 @@ describe("LiveReadsPanel", () => {
   it("places the newest read first", () => {
     const markup = renderToStaticMarkup(<LiveReadsPanelContent rows={fixtureRows} />);
 
-    expect(
-      markup.indexOf("Severance.S02E01.2160p.ATVP.WEB-DL.DDP5.1.H.265-GRP.mkv"),
-    ).toBeLessThan(markup.indexOf("The.Prestige.2006.1080p.BluRay.x264-GRP.mkv"));
+    expect(markup.indexOf("Severance.S02E01.2160p.ATVP.WEB-DL.DDP5.1.H.265-GRP.mkv")).toBeLessThan(
+      markup.indexOf("The.Prestige.2006.1080p.BluRay.x264-GRP.mkv"),
+    );
   });
 
   it("labels media rows with MOVIE / EPISODE badges", () => {

--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
@@ -80,6 +80,7 @@ export function LiveReadsPanelContent({ rows }: { rows: LiveReadRow[] }) {
   const [copyNotice, setCopyNotice] = useState<{ seq: number; text: string } | null>(null);
   const copySeqRef = useRef(0);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const displayedRows = [...rows].sort((a, b) => b.read.startedAt - a.read.startedAt);
 
   useEffect(() => {
     return () => {
@@ -104,8 +105,8 @@ export function LiveReadsPanelContent({ rows }: { rows: LiveReadRow[] }) {
   };
 
   return (
-    <section className="card w-full min-w-0 border border-base-content/10 bg-base-100 shadow-sm">
-      <div className="card-body gap-3 p-4">
+    <section className="card h-[30rem] w-full min-w-0 border border-base-content/10 bg-base-100 shadow-sm">
+      <div className="card-body flex min-h-0 flex-col gap-3 p-4">
         <div className="flex items-center gap-2.5">
           <span className="status status-success animate-pulse" aria-hidden="true" />
           <h3 className="card-title m-0 text-base">Right now</h3>
@@ -125,8 +126,8 @@ export function LiveReadsPanelContent({ rows }: { rows: LiveReadRow[] }) {
             No files are being read right now. Open a mounted file to see live progress here.
           </p>
         ) : (
-          <ul className="m-0 w-full list-none divide-y divide-base-content/10 p-0">
-            {rows.map(({ read, rate, history }) => (
+          <ul className="yes-scrollbar m-0 min-h-0 w-full flex-1 list-none divide-y divide-base-content/10 overflow-y-auto p-0">
+            {displayedRows.map(({ read, rate, history }) => (
               <ReadRow
                 key={read.id}
                 read={read}
@@ -196,7 +197,7 @@ function ReadRow({
             </span>
           </Tooltip>
         </div>
-        <div className="flex shrink-0 flex-wrap items-center gap-x-4 gap-y-1 font-mono text-xs tabular-nums">
+        <div className="flex min-w-0 flex-wrap items-center gap-x-4 gap-y-1 font-mono text-xs tabular-nums">
           {history.length >= 2 && (
             <span className="hidden sm:block">
               <Sparkline values={history} tone="success" />

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
@@ -60,7 +60,7 @@ export function ProviderScoreboard({
           <p className="py-6 text-center text-xs text-base-content/50">No providers configured.</p>
         ) : (
           <>
-            <div className="w-full min-w-0 overflow-x-auto">
+            <div className="w-full min-w-0 overflow-x-auto lg:overflow-x-hidden">
               <table className="table table-pin-cols table-sm w-full">
                 <thead>
                   <tr>


### PR DESCRIPTION
## Summary
- keep the Right now panel fixed-height, newest-first, and internally scrollable
- eliminate incidental desktop horizontal overflow while preserving narrow-screen table scrolling
- arrange Catalogue metrics in a compact grid on tablet and mobile

## Test plan
- [x] Checked IDE diagnostics for modified files
- [x] Ran the layout detector for modified dashboard components
- [ ] Sign in to the local preview and verify the overview at desktop and tablet widths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved responsive layout for catalogue statistics across screen sizes.
  * Updated the live reads panel to show newest activity first.
  * Added scrolling for longer live-read lists while preserving a consistent panel height.
  * Improved text wrapping and reduced unwanted horizontal overflow across dashboard sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->