### PR TITLE
fix(ui): keep overview stats and help text usable on phones

### DIFF
--- a/frontend/app/components/ui/feedback.test.tsx
+++ b/frontend/app/components/ui/feedback.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import { Tooltip } from "./feedback";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Tooltip", () => {
+  it("keeps closed help text out of the accessibility tree until hover or focus", async () => {
+    const user = userEvent.setup();
+    render(
+      <Tooltip content="Helpful details">
+        <button type="button">More info</button>
+      </Tooltip>,
+    );
+
+    const tooltip = screen.getByRole("tooltip", { hidden: true });
+    const trigger = screen.getByRole("button", { name: "More info" });
+    expect(tooltip.getAttribute("aria-hidden")).toBe("true");
+    expect(trigger.getAttribute("aria-describedby")).toBeNull();
+
+    await user.hover(trigger);
+    expect(tooltip.getAttribute("aria-hidden")).toBe("false");
+    expect(trigger.getAttribute("aria-describedby")).toBe(tooltip.id);
+
+    await user.unhover(trigger);
+    expect(tooltip.getAttribute("aria-hidden")).toBe("true");
+    expect(trigger.getAttribute("aria-describedby")).toBeNull();
+
+    await user.tab();
+    expect(tooltip.getAttribute("aria-hidden")).toBe("false");
+    expect(trigger.getAttribute("aria-describedby")).toBe(tooltip.id);
+  });
+});

--- a/frontend/app/components/ui/feedback.tsx
+++ b/frontend/app/components/ui/feedback.tsx
@@ -48,10 +48,10 @@ export function Tooltip({
   className?: string;
 }) {
   return (
-    <span
-      className={`tooltip ${tooltipPlacementClass[placement]} ${className}`.trim()}
-      data-tip={content}
-    >
+    <span className={`tooltip ${tooltipPlacementClass[placement]} ${className}`.trim()}>
+      <span className="tooltip-content z-50 w-72 max-w-[calc(100vw-2rem)] whitespace-normal text-left text-xs leading-relaxed">
+        {content}
+      </span>
       {children}
     </span>
   );

--- a/frontend/app/components/ui/feedback.tsx
+++ b/frontend/app/components/ui/feedback.tsx
@@ -59,12 +59,16 @@ export function Tooltip({
   const [focused, setFocused] = useState(false);
   const open = hovered || focused;
   const trigger = isValidElement<{ "aria-describedby"?: string }>(children)
-    ? cloneElement(children, {
-        "aria-describedby":
-          [children.props["aria-describedby"], open ? tooltipId : undefined]
-            .filter(Boolean)
-            .join(" ") || undefined,
-      })
+    ? cloneElement(
+        children,
+        open
+          ? {
+              "aria-describedby": [children.props["aria-describedby"], tooltipId]
+                .filter(Boolean)
+                .join(" "),
+            }
+          : {},
+      )
     : children;
 
   return (

--- a/frontend/app/components/ui/feedback.tsx
+++ b/frontend/app/components/ui/feedback.tsx
@@ -1,4 +1,11 @@
-import type { HTMLAttributes, ReactNode } from "react";
+import {
+  cloneElement,
+  isValidElement,
+  useId,
+  useState,
+  type HTMLAttributes,
+  type ReactNode,
+} from "react";
 
 type AlertVariant = "info" | "success" | "warning" | "danger";
 
@@ -47,12 +54,42 @@ export function Tooltip({
   placement?: TooltipPlacement;
   className?: string;
 }) {
+  const tooltipId = useId();
+  const [hovered, setHovered] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const open = hovered || focused;
+  const trigger = isValidElement<{ "aria-describedby"?: string }>(children)
+    ? cloneElement(children, {
+        "aria-describedby":
+          [children.props["aria-describedby"], open ? tooltipId : undefined]
+            .filter(Boolean)
+            .join(" ") || undefined,
+      })
+    : children;
+
   return (
-    <span className={`tooltip ${tooltipPlacementClass[placement]} ${className}`.trim()}>
-      <span className="tooltip-content z-50 w-72 max-w-[calc(100vw-2rem)] whitespace-normal text-left text-xs leading-relaxed">
+    <span
+      className={["tooltip", tooltipPlacementClass[placement], open ? "tooltip-open" : "", className]
+        .filter(Boolean)
+        .join(" ")}
+      onPointerEnter={() => setHovered(true)}
+      onPointerLeave={() => setHovered(false)}
+      onFocusCapture={() => setFocused(true)}
+      onBlurCapture={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          setFocused(false);
+        }
+      }}
+    >
+      <span
+        id={tooltipId}
+        role="tooltip"
+        aria-hidden={!open}
+        className="tooltip-content z-50 w-72 max-w-[calc(100vw-2rem)] whitespace-normal text-left text-xs leading-relaxed"
+      >
         {content}
       </span>
-      {children}
+      {trigger}
     </span>
   );
 }

--- a/frontend/app/components/ui/feedback.tsx
+++ b/frontend/app/components/ui/feedback.tsx
@@ -69,7 +69,12 @@ export function Tooltip({
 
   return (
     <span
-      className={["tooltip", tooltipPlacementClass[placement], open ? "tooltip-open" : "", className]
+      className={[
+        "tooltip",
+        tooltipPlacementClass[placement],
+        open ? "tooltip-open" : "",
+        className,
+      ]
         .filter(Boolean)
         .join(" ")}
       onPointerEnter={() => setHovered(true)}

--- a/frontend/app/components/ui/feedback.tsx
+++ b/frontend/app/components/ui/feedback.tsx
@@ -76,7 +76,8 @@ export function Tooltip({
       onPointerLeave={() => setHovered(false)}
       onFocusCapture={() => setFocused(true)}
       onBlurCapture={(event) => {
-        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+        const next = event.relatedTarget;
+        if (!(next instanceof Node) || !event.currentTarget.contains(next)) {
           setFocused(false);
         }
       }}

--- a/frontend/app/routes/overview/components/arr-health/arr-health.tsx
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.tsx
@@ -54,7 +54,7 @@ export function ArrHealth({ data, window }: ArrHealthProps) {
           </div>
         </div>
 
-        <div className="stats stats-vertical w-full border border-base-content/10 sm:stats-horizontal">
+        <div className="stats w-full border border-base-content/10 bg-base-content/10 max-lg:grid max-lg:grid-flow-row max-lg:grid-cols-2 max-lg:gap-px sm:max-lg:grid-cols-3 lg:bg-base-100">
           <MiniStat label="Online" value={`${summary.instancesOnline}/${summary.instancesTotal}`} />
           <MiniStat label="Imports" value={formatNumber(summary.importsCompleted)} />
           <MiniStat label="Median handoff" value={formatDurationMs(summary.medianHandoffMs)} />
@@ -68,15 +68,14 @@ export function ArrHealth({ data, window }: ArrHealthProps) {
         {instances.length === 0 ? (
           <p className="py-6 text-center text-xs text-base-content/50">No imports recorded yet.</p>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="table table-sm min-w-[720px]">
+          <div className="overflow-x-auto max-sm:overflow-visible">
+            <table className="table table-sm w-full max-sm:table-fixed sm:min-w-[640px]">
               <thead>
                 <tr>
-                  <th>Instance</th>
-                  <th>Status</th>
+                  <th className="max-sm:w-[32%]">Instance</th>
                   <th>Imports</th>
-                  <th>Median</th>
-                  <th>P95</th>
+                  <th className="max-sm:hidden">Median</th>
+                  <th className="max-sm:hidden">P95</th>
                   <th>
                     <Tooltip content="All items currently in this Arr instance's queue.">
                       <span className="cursor-help">Queue</span>
@@ -99,20 +98,18 @@ export function ArrHealth({ data, window }: ArrHealthProps) {
                           {instance.name}
                         </span>
                       </Tooltip>
-                      <span className="mt-0.5 block text-[11px] font-normal capitalize text-base-content/45">
-                        {instance.appType}
-                      </span>
-                    </td>
-                    <td>
-                      <span className={`badge badge-sm ${STATUS_BADGE[instance.status]}`}>
-                        {instance.status}
+                      <span className="mt-0.5 flex items-center gap-1.5 text-[11px] font-normal text-base-content/45">
+                        <span className="capitalize">{instance.appType}</span>
+                        <span className={`badge badge-xs ${STATUS_BADGE[instance.status]}`}>
+                          {instance.status}
+                        </span>
                       </span>
                     </td>
                     <td className="font-mono tabular-nums">{formatNumber(instance.imports)}</td>
-                    <td className="font-mono tabular-nums">
+                    <td className="hidden font-mono tabular-nums sm:table-cell">
                       {formatDurationMs(instance.medianHandoffMs)}
                     </td>
-                    <td className="font-mono tabular-nums">
+                    <td className="hidden font-mono tabular-nums sm:table-cell">
                       {formatDurationMs(instance.p95HandoffMs)}
                     </td>
                     <td className="font-mono tabular-nums">{formatNumber(instance.queueCount)}</td>
@@ -179,9 +176,11 @@ function MiniStat({
   warning?: boolean;
 }) {
   return (
-    <div className="stat py-2">
-      <div className="stat-title text-xs">{label}</div>
-      <div className={`stat-value font-mono text-lg ${warning ? "text-warning" : ""}`}>{value}</div>
+    <div className="stat min-w-0 bg-base-100 px-3 py-2">
+      <div className="stat-title whitespace-normal text-xs">{label}</div>
+      <div className={`stat-value break-words font-mono text-lg ${warning ? "text-warning" : ""}`}>
+        {value}
+      </div>
     </div>
   );
 }

--- a/frontend/app/routes/overview/components/arr-health/arr-health.tsx
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.tsx
@@ -92,7 +92,7 @@ export function ArrHealth({ data, window }: ArrHealthProps) {
               <tbody>
                 {instances.map((instance) => (
                   <tr key={instance.key}>
-                    <td className="max-w-[220px] font-medium">
+                    <td className="min-w-0 max-w-[220px] font-medium">
                       <Tooltip content={instance.host}>
                         <span className="inline-block max-w-full truncate align-middle">
                           {instance.name}
@@ -116,7 +116,7 @@ export function ArrHealth({ data, window }: ArrHealthProps) {
                     <td className="font-mono tabular-nums">
                       {formatNumber(instance.awaitingCount)}
                     </td>
-                    <td className="font-mono tabular-nums text-base-content/80">
+                    <td className="min-w-0 font-mono tabular-nums text-base-content/80 max-sm:whitespace-normal max-sm:break-words">
                       {instance.status === "offline" && !instance.lastImportAtMs
                         ? (instance.lastError ?? "Unreachable")
                         : formatTimeAgo(instance.lastImportAtMs)}

--- a/frontend/app/routes/overview/components/catalogue-block/catalogue-block.tsx
+++ b/frontend/app/routes/overview/components/catalogue-block/catalogue-block.tsx
@@ -17,7 +17,7 @@ export function CatalogueBlock({ catalogue }: CatalogueBlockProps) {
         <p className="text-xs text-base-content/50">Your mounted library</p>
       </header>
 
-      <div className="stats w-full border border-base-content/10 bg-base-100 max-lg:grid-flow-row max-lg:grid-cols-2 max-lg:gap-px max-lg:bg-base-content/10 lg:stats-horizontal">
+      <div className="stats w-full border border-base-content/10 bg-base-100 max-lg:grid max-lg:grid-flow-row max-lg:grid-cols-2 max-lg:gap-px max-lg:bg-base-content/10 lg:stats-horizontal">
         <Stat label="Files" value={formatNumber(catalogue.fileCount)} />
         <Stat label="Total size" value={formatBytes(catalogue.totalBytes)} />
         <Stat label="Largest file" value={formatBytes(catalogue.largestFileBytes)} />
@@ -41,10 +41,10 @@ function Stat({
   accent?: "good" | undefined;
 }) {
   return (
-    <div className="stat px-3 py-2.5 sm:px-4 sm:py-4 lg:px-6 max-lg:min-w-0 max-lg:border-e-0 max-lg:bg-base-100">
-      <div className="stat-title text-xs">{label}</div>
+    <div className="stat min-w-0 bg-base-100 px-3 py-2.5 sm:px-4 sm:py-4 lg:px-6">
+      <div className="stat-title whitespace-normal text-xs">{label}</div>
       <div
-        className={`stat-value font-mono text-xl md:text-2xl ${accent === "good" ? "text-success" : ""}`}
+        className={`stat-value break-words font-mono text-xl md:text-2xl ${accent === "good" ? "text-success" : ""}`}
       >
         {value}
       </div>

--- a/frontend/app/routes/overview/components/indexer-api-usage/indexer-api-usage.tsx
+++ b/frontend/app/routes/overview/components/indexer-api-usage/indexer-api-usage.tsx
@@ -32,14 +32,14 @@ export function IndexerApiUsage({ rows }: IndexerApiUsageProps) {
             No enabled indexers configured.
           </p>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="table table-sm min-w-[560px]">
+          <div className="overflow-x-auto max-sm:overflow-visible">
+            <table className="table table-sm w-full max-sm:table-fixed sm:min-w-[560px]">
               <thead>
                 <tr>
-                  <th>Indexer</th>
-                  <th className="min-w-[180px]">API hits</th>
-                  <th className="min-w-[180px]">Downloads</th>
-                  <th>Next reset</th>
+                  <th className="max-sm:w-[30%]">Indexer</th>
+                  <th className="min-w-[180px] max-sm:min-w-0">API hits</th>
+                  <th className="min-w-[180px] max-sm:min-w-0">Downloads</th>
+                  <th className="max-sm:hidden">Next reset</th>
                 </tr>
               </thead>
               <tbody>
@@ -66,7 +66,7 @@ export function IndexerApiUsage({ rows }: IndexerApiUsageProps) {
                         label={`${r.name} downloads`}
                       />
                     </td>
-                    <td className="whitespace-nowrap font-mono text-xs tabular-nums text-base-content/50">
+                    <td className="hidden whitespace-nowrap font-mono text-xs tabular-nums text-base-content/50 max-sm:hidden sm:table-cell">
                       {formatReset(r.resetAtMs, r.resetHourUtc, now)}
                     </td>
                   </tr>

--- a/frontend/app/routes/overview/components/indexer-api-usage/indexer-api-usage.tsx
+++ b/frontend/app/routes/overview/components/indexer-api-usage/indexer-api-usage.tsx
@@ -91,7 +91,7 @@ function UsageBar({
 }) {
   if (!limit || limit <= 0) {
     return (
-      <div className="flex min-w-0 items-center gap-2.5 overflow-hidden">
+      <div className="flex min-w-0 items-center gap-2.5">
         <Tooltip className="min-w-0 flex-1" content="No limit configured">
           <progress
             aria-label={`${label}: ${formatNumber(used)}, unlimited`}

--- a/frontend/app/routes/overview/components/indexer-api-usage/indexer-api-usage.tsx
+++ b/frontend/app/routes/overview/components/indexer-api-usage/indexer-api-usage.tsx
@@ -52,14 +52,14 @@ export function IndexerApiUsage({ rows }: IndexerApiUsageProps) {
                         </span>
                       </Tooltip>
                     </td>
-                    <td>
+                    <td className="min-w-0">
                       <UsageBar
                         used={r.apiHits}
                         limit={r.apiHitLimit}
                         label={`${r.name} API hits`}
                       />
                     </td>
-                    <td>
+                    <td className="min-w-0">
                       <UsageBar
                         used={r.downloadHits}
                         limit={r.downloadHitLimit}
@@ -91,16 +91,16 @@ function UsageBar({
 }) {
   if (!limit || limit <= 0) {
     return (
-      <div className="flex items-center gap-2.5">
-        <Tooltip content="No limit configured">
+      <div className="flex min-w-0 items-center gap-2.5 overflow-hidden">
+        <Tooltip className="min-w-0 flex-1" content="No limit configured">
           <progress
             aria-label={`${label}: ${formatNumber(used)}, unlimited`}
-            className="progress progress-success h-2 min-w-20 flex-1"
+            className="progress progress-success h-2 w-full min-w-0"
             value={0}
             max={100}
           />
         </Tooltip>
-        <span className="text-xs text-base-content tabular-nums whitespace-nowrap">
+        <span className="min-w-0 shrink-0 text-xs text-base-content tabular-nums whitespace-nowrap max-sm:shrink max-sm:whitespace-normal">
           {formatNumber(used)}
           <span className="text-base-content/50"> · unlimited</span>
         </span>
@@ -112,14 +112,14 @@ function UsageBar({
   const over = pct >= 100;
   const tone = over ? "progress-error" : near ? "progress-warning" : "progress-success";
   return (
-    <div className="flex items-center gap-2.5">
+    <div className="flex min-w-0 items-center gap-2.5 overflow-hidden">
       <progress
         aria-label={`${label}: ${formatNumber(used)} of ${formatNumber(limit)}`}
-        className={`progress h-2 min-w-20 flex-1 ${tone}`}
+        className={`progress h-2 min-w-0 flex-1 ${tone}`}
         value={pct}
         max={100}
       />
-      <span className="text-xs text-base-content tabular-nums whitespace-nowrap">
+      <span className="min-w-0 shrink-0 text-xs text-base-content tabular-nums whitespace-nowrap max-sm:shrink max-sm:whitespace-normal">
         {formatNumber(used)}
         <span className="text-base-content/50"> / {formatNumber(limit)}</span>
       </span>

--- a/frontend/app/routes/overview/components/lifetime-block/lifetime-block.tsx
+++ b/frontend/app/routes/overview/components/lifetime-block/lifetime-block.tsx
@@ -26,7 +26,7 @@ export function LifetimeBlock({ lifetime }: LifetimeBlockProps) {
           Lifetime totals appear after your first reads.
         </p>
       ) : (
-        <div className="stats stats-vertical w-full border border-base-content/10 bg-base-100 sm:stats-horizontal">
+        <div className="stats w-full border border-base-content/10 bg-base-content/10 max-lg:grid max-lg:grid-flow-row max-lg:grid-cols-2 max-lg:gap-px lg:bg-base-100">
           <Stat label="Read" value={formatBytes(lifetime.bytesRead)} />
           <Stat label="Articles" value={formatNumber(lifetime.articles)} />
           <Stat label="Read sessions" value={formatNumber(lifetime.readSessions)} />
@@ -39,9 +39,9 @@ export function LifetimeBlock({ lifetime }: LifetimeBlockProps) {
 
 function Stat({ label, value }: { label: string; value: string }) {
   return (
-    <div className="stat py-3">
-      <div className="stat-title text-xs">{label}</div>
-      <div className="stat-value font-mono text-xl md:text-2xl">{value}</div>
+    <div className="stat min-w-0 bg-base-100 px-3 py-3">
+      <div className="stat-title whitespace-normal text-xs">{label}</div>
+      <div className="stat-value break-words font-mono text-xl md:text-2xl">{value}</div>
     </div>
   );
 }

--- a/frontend/app/routes/overview/components/records-block/records-block.tsx
+++ b/frontend/app/routes/overview/components/records-block/records-block.tsx
@@ -22,7 +22,7 @@ export function RecordsBlock({ records }: RecordsBlockProps) {
       {isEmpty ? (
         <p className="text-sm text-base-content/50">Records appear after some activity.</p>
       ) : (
-        <div className="stats stats-vertical w-full border border-base-content/10 bg-base-100 sm:stats-horizontal">
+        <div className="stats w-full border border-base-content/10 bg-base-100">
           <Stat
             label="Busiest day"
             value={formatBytes(records.bestDayBytes)}

--- a/frontend/app/routes/overview/components/sessions-block/sessions-block.tsx
+++ b/frontend/app/routes/overview/components/sessions-block/sessions-block.tsx
@@ -25,7 +25,7 @@ export function SessionsBlock({ sessions, window }: SessionsBlockProps) {
       {sessions.count === 0 ? (
         <p className="text-sm text-base-content/50">No completed read sessions yet.</p>
       ) : (
-        <div className="stats stats-vertical w-full border border-base-content/10 bg-base-100 sm:stats-horizontal">
+        <div className="stats w-full border border-base-content/10 bg-base-content/10 max-lg:grid max-lg:grid-flow-row max-lg:grid-cols-2 max-lg:gap-px sm:max-lg:grid-cols-3 lg:bg-base-100">
           <Stat label="Sessions" value={formatNumber(sessions.count)} />
           <Stat label="Bytes served" value={formatBytes(sessions.totalBytesServed)} />
           <Stat label="Avg duration" value={formatDuration(sessions.avgDurationMs)} />
@@ -39,9 +39,9 @@ export function SessionsBlock({ sessions, window }: SessionsBlockProps) {
 
 function Stat({ label, value }: { label: string; value: string }) {
   return (
-    <div className="stat px-3 py-3">
-      <div className="stat-title text-xs">{label}</div>
-      <div className="stat-value font-mono text-xl md:text-2xl">{value}</div>
+    <div className="stat min-w-0 bg-base-100 px-3 py-3">
+      <div className="stat-title whitespace-normal text-xs">{label}</div>
+      <div className="stat-value break-words font-mono text-xl md:text-2xl">{value}</div>
     </div>
   );
 }

--- a/frontend/app/routes/settings/backup/backup.tsx
+++ b/frontend/app/routes/settings/backup/backup.tsx
@@ -402,7 +402,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <ManagedSetting configKeys={["backup.schedule-enabled", "backup.schedule-time"]}>
-          <section className="overflow-hidden rounded-lg border border-base-content/10 bg-base-100">
+          <section className="rounded-lg border border-base-content/10 bg-base-100">
             <div className="flex items-start gap-3 border-b border-base-content/10 p-4">
               <span className="rounded-lg bg-primary/10 p-2 text-primary">
                 <Icon name="event_repeat" className="!text-[20px]" />
@@ -418,6 +418,7 @@ export function BackupSettings({ config, setNewConfig }: BackupSettingsProps) {
             <div className="space-y-4 p-4">
               <Tooltip
                 placement="bottom"
+                className="tooltip-start"
                 content="Writes a logical .sql dump of all databases under the config volume once per day."
               >
                 <Toggle

--- a/frontend/app/routes/settings/indexers/indexers.tsx
+++ b/frontend/app/routes/settings/indexers/indexers.tsx
@@ -740,7 +740,10 @@ export function IndexersSettings({
         </ManagedSetting>
 
         <ManagedSetting configKey="prowlarr.sync-enabled">
-          <Tooltip content="Periodically refresh the Prowlarr-managed entries below. Manual Sync now works even when this is off.">
+          <Tooltip
+            className="tooltip-start"
+            content="Periodically refresh the Prowlarr-managed entries below. Manual Sync now works even when this is off."
+          >
             <Toggle
               id="prowlarr-sync-enabled"
               className="cursor-pointer gap-2 p-0"

--- a/frontend/app/routes/settings/maintenance/maintenance.tsx
+++ b/frontend/app/routes/settings/maintenance/maintenance.tsx
@@ -39,7 +39,7 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
             "metrics.fetch-retention-hours",
           ]}
         >
-          <section className="overflow-hidden rounded-lg border border-base-content/10 bg-base-100">
+          <section className="rounded-lg border border-base-content/10 bg-base-100">
             <div className="flex items-start gap-3 border-b border-base-content/10 p-4">
               <span className="rounded-lg bg-primary/10 p-2 text-primary">
                 <Icon name="database" className="!text-[20px]" />
@@ -53,7 +53,10 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
             </div>
 
             <div className="space-y-4 p-4">
-              <Tooltip content="Reclaim unused SQLite space. Large databases may take longer to start.">
+              <Tooltip
+                className="tooltip-start"
+                content="Reclaim unused SQLite space. Large databases may take longer to start."
+              >
                 <Toggle
                   id="db-startup-vacuum-enabled-checkbox"
                   className="cursor-pointer gap-2 rounded-lg bg-base-200/40 p-3"
@@ -178,7 +181,7 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
             "maintenance.remove-orphaned-schedule-time",
           ]}
         >
-          <section className="overflow-hidden rounded-lg border border-base-content/10 bg-base-100">
+          <section className="rounded-lg border border-base-content/10 bg-base-100">
             <div className="flex items-start gap-3 border-b border-base-content/10 p-4">
               <span className="rounded-lg bg-primary/10 p-2 text-primary">
                 <Icon name="event_repeat" className="!text-[20px]" />
@@ -192,7 +195,10 @@ export function Maintenance({ savedConfig, config, setNewConfig }: MaintenancePr
             </div>
 
             <div className="space-y-4 p-4">
-              <Tooltip content="Runs the same protected Remove Orphaned Files cleanup available in the task panel below.">
+              <Tooltip
+                className="tooltip-start"
+                content="Runs the same protected Remove Orphaned Files cleanup available in the task panel below."
+              >
                 <Toggle
                   id="remove-orphaned-schedule-enabled-checkbox"
                   className="cursor-pointer gap-2 rounded-lg bg-base-200/40 p-3"

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -66,7 +66,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
           contentClassName="grid grid-cols-1 gap-4 lg:grid-cols-2"
         >
           <ManagedSetting configKey="repair.enable">
-            <Tooltip placement="bottom" content={helpText}>
+            <Tooltip placement="bottom" className="tooltip-start" content={helpText}>
               <Toggle
                 id="enable-repairs-checkbox"
                 className="cursor-pointer gap-2 p-0"
@@ -276,7 +276,10 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
             </div>
           </ManagedSetting>
           <ManagedSetting configKey="repair.auto-remove-unlinked-only">
-            <Tooltip content="When enabled (default), library-linked releases are removed and blocklisted through Radarr/Sonarr. Disable to force-delete linked files after the failure threshold.">
+            <Tooltip
+              className="tooltip-start"
+              content="When enabled (default), library-linked releases are removed and blocklisted through Radarr/Sonarr. Disable to force-delete linked files after the failure threshold."
+            >
               <Toggle
                 id="auto-remove-unlinked-only-checkbox"
                 className="cursor-pointer gap-2 p-0"

--- a/frontend/app/routes/settings/streaming/streaming.tsx
+++ b/frontend/app/routes/settings/streaming/streaming.tsx
@@ -121,7 +121,10 @@ export function StreamingSettings({
           ]}
         >
           <div className="space-y-2">
-            <Tooltip content="By default, the budget above is shared across streams. Enable this to give each concurrent stream its own budget, sized by the preset below. Provider limits still cap total connections.">
+            <Tooltip
+              className="tooltip-start"
+              content="By default, the budget above is shared across streams. Enable this to give each concurrent stream its own budget, sized by the preset below. Provider limits still cap total connections."
+            >
               <Toggle
                 id="max-download-connections-per-stream-checkbox"
                 className="cursor-pointer gap-2 p-0"
@@ -676,7 +679,10 @@ export function StreamingSettings({
         </ManagedSetting>
 
         <ManagedSetting configKey="usenet.pipelined-body-requests">
-          <Tooltip content="Fetch articles in small pipelined BODY batches for smoother WebDAV playback. Queue imports use the separate Queue pipelining toggle under Usenet settings.">
+          <Tooltip
+            className="tooltip-start"
+            content="Fetch articles in small pipelined BODY batches for smoother WebDAV playback. Queue imports use the separate Queue pipelining toggle under Usenet settings."
+          >
             <Toggle
               id="pipelined-body-requests-checkbox"
               className="cursor-pointer gap-2 p-0"

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -970,7 +970,7 @@ export function UsenetSettings({
             <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2">
               <Tooltip
                 content="Prefer providers in drag order. While off, all enabled providers share work in the pool. Thinly-spared primaries (at most 25% of their pool free) yield to idler same-tier peers; larger Provider Connection Limits alone do not outrank priority."
-                className="min-w-0"
+                className="min-w-0 tooltip-start"
               >
                 <Toggle
                   id="cascade-enabled"
@@ -1018,7 +1018,10 @@ export function UsenetSettings({
             />
 
             <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2">
-              <Tooltip content="Batch first-segment BODY requests during queue imports and provider Auto-tune benchmarks. Does not affect WebDAV playback — streaming batching lives under Settings → Streaming.">
+              <Tooltip
+                className="tooltip-start"
+                content="Batch first-segment BODY requests during queue imports and provider Auto-tune benchmarks. Does not affect WebDAV playback — streaming batching lives under Settings → Streaming."
+              >
                 <Toggle
                   id="pipelining-enabled"
                   className="cursor-pointer gap-2 p-0"
@@ -1060,7 +1063,10 @@ export function UsenetSettings({
             />
 
             <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2">
-              <Tooltip content="After a provider (or storage group) reports a definitive article miss (430/451), skip re-probing that provider for the same article until the TTL expires. Default 300s (30–86400).">
+              <Tooltip
+                className="tooltip-start"
+                content="After a provider (or storage group) reports a definitive article miss (430/451), skip re-probing that provider for the same article until the TTL expires. Default 300s (30–86400)."
+              >
                 <div className="flex flex-col items-start gap-1">
                   <Label
                     htmlFor="article-miss-cache-ttl"
@@ -1083,7 +1089,10 @@ export function UsenetSettings({
                   />
                 </div>
               </Tooltip>
-              <Tooltip content="Max negative-cache entries before oldest are evicted. Default 10000 (100–1000000).">
+              <Tooltip
+                className="tooltip-start"
+                content="Max negative-cache entries before oldest are evicted. Default 10000 (100–1000000)."
+              >
                 <div className="flex flex-col items-start gap-1">
                   <Label
                     htmlFor="article-miss-cache-max"
@@ -1974,7 +1983,10 @@ function ProviderModal({
 
           <div className="flex flex-col gap-2">
             <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
-              <Tooltip content="Encrypt the NNTP connection. Prefer port 563 with SSL enabled; without SSL credentials are sent in cleartext.">
+              <Tooltip
+                className="tooltip-start"
+                content="Encrypt the NNTP connection. Prefer port 563 with SSL enabled; without SSL credentials are sent in cleartext."
+              >
                 <Toggle
                   id="provider-ssl"
                   className="cursor-pointer gap-2 p-0"

--- a/frontend/app/routes/settings/webdav/webdav.tsx
+++ b/frontend/app/routes/settings/webdav/webdav.tsx
@@ -84,6 +84,7 @@ export function WebdavSettings({ config, setNewConfig }: WebdavSettingsProps) {
           <ManagedSetting configKey="webdav.enforce-readonly">
             <Tooltip
               placement="bottom"
+              className="tooltip-start"
               content="Make the WebDAV /content folder read-only so clients cannot delete files there, and prevent clearing completed history by deleting release folders under /completed-symlinks. Symlink deletes needed for Radarr/Sonarr imports are always allowed."
             >
               <Toggle
@@ -102,7 +103,10 @@ export function WebdavSettings({ config, setNewConfig }: WebdavSettingsProps) {
           </ManagedSetting>
 
           <ManagedSetting configKey="webdav.windows-safe-paths">
-            <Tooltip content='Replace characters invalid on Windows (<>:"/\|?*), trim trailing dots and spaces, and prefix reserved device names. Applies to newly mounted content only.'>
+            <Tooltip
+              className="tooltip-start"
+              content='Replace characters invalid on Windows (<>:"/\|?*), trim trailing dots and spaces, and prefix reserved device names. Applies to newly mounted content only.'
+            >
               <Toggle
                 id="windows-safe-paths-checkbox"
                 className="cursor-pointer gap-2 p-0"


### PR DESCRIPTION
## Summary
- Reflow Overview metric bars into compact mobile/tablet grids while retaining the always-horizontal Records pair.
- Prioritize mobile dashboard tables by hiding reset/latency data and moving Arr status beside the instance type.
- Keep long settings help popups within the viewport, including the affected maintenance and backup cards.

## Test plan
- [x] `npm run typecheck`
- [x] Inspected the isolated local preview at desktop and 375px mobile widths.
- [x] Confirmed the Catalogue stat bar renders as two non-overflowing mobile columns.
- [x] Ran the Impeccable UI detector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved responsive layouts across overview statistics and tables for better readability on narrow screens.
  * Simplified mobile table views by prioritizing key information and hiding less essential columns.
  * Improved wrapping for long labels and values in statistics panels.
  * Updated tooltip positioning and presentation across settings pages for clearer, more consistent display.
  * Improved tooltip accessibility for keyboard and pointer interactions.
  * Refined scheduled backup, maintenance, and cleanup panels with improved borders and overflow handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->