### PR TITLE
fix(ui): align the global bandwidth limit field

### DIFF
--- a/frontend/app/routes/settings/streaming/streaming.tsx
+++ b/frontend/app/routes/settings/streaming/streaming.tsx
@@ -522,7 +522,7 @@ export function StreamingSettings({
             </label>
             <Input
               {...className([
-                "w-full",
+                "w-full max-w-48",
                 !isValidUsenetBandwidthLimitMbps(bandwidthLimit) && "input-error",
               ])}
               type="text"


### PR DESCRIPTION
## Summary
- Match the Global Usenet bandwidth limit field width to neighboring Streaming settings.

## Test plan
- [x] Checked IDE diagnostics.
- [x] Reviewed the targeted Tailwind width change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Constrained the bandwidth-limit input width for a more compact, consistent settings layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->