### PR TITLE
fix(ui): compact idle Right now, keep Arr Health on-screen, and tooltip the rename setting

### DIFF
--- a/frontend/app/routes/_index/components/top-navigation/top-navigation.module.css
+++ b/frontend/app/routes/_index/components/top-navigation/top-navigation.module.css
@@ -1,0 +1,31 @@
+.updateAvailable {
+  background-image: linear-gradient(
+    110deg,
+    var(--color-primary) 0%,
+    var(--color-info) 35%,
+    var(--color-success) 65%,
+    var(--color-info) 85%,
+    var(--color-primary) 100%
+  );
+  background-size: 300% 100%;
+  background-position: 0% 50%;
+  background-clip: padding-box;
+  animation: updateAvailableShift 6s ease-in-out infinite;
+  box-shadow: none;
+}
+
+@keyframes updateAvailableShift {
+  0%,
+  100% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .updateAvailable {
+    animation: none;
+  }
+}

--- a/frontend/app/routes/_index/components/top-navigation/top-navigation.module.css
+++ b/frontend/app/routes/_index/components/top-navigation/top-navigation.module.css
@@ -10,11 +10,11 @@
   background-size: 300% 100%;
   background-position: 0% 50%;
   background-clip: padding-box;
-  animation: updateAvailableShift 6s ease-in-out infinite;
+  animation: update-available-shift 6s ease-in-out infinite;
   box-shadow: none;
 }
 
-@keyframes updateAvailableShift {
+@keyframes update-available-shift {
   0%,
   100% {
     background-position: 0% 50%;

--- a/frontend/app/routes/_index/components/top-navigation/top-navigation.module.css.d.ts
+++ b/frontend/app/routes/_index/components/top-navigation/top-navigation.module.css.d.ts
@@ -1,0 +1,4 @@
+declare const styles: {
+  readonly updateAvailable: string;
+};
+export = styles;

--- a/frontend/app/routes/_index/components/top-navigation/top-navigation.test.tsx
+++ b/frontend/app/routes/_index/components/top-navigation/top-navigation.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createMemoryRouter, RouterProvider } from "react-router";
 import { TopNavigation } from "./top-navigation";
+import styles from "./top-navigation.module.css";
 
 vi.mock("../live-usenet-connections/live-usenet-connections", () => ({
   LiveUsenetConnections: () => null,
@@ -47,5 +48,76 @@ describe("TopNavigation version summary", () => {
 
     expect(screen.getAllByText("0.8.0")).toHaveLength(2);
     expect(screen.getByText("InfiniDysk Stable")).toBeTruthy();
+
+    const versionInButton = screen.getByLabelText("App menu").querySelector(".font-mono");
+    expect(versionInButton?.className).toContain("text-xs");
+    expect(versionInButton?.className).toContain("sm:text-sm");
+
+    const appMenu = screen.getByLabelText("App menu");
+    expect(appMenu.className).toContain("border-base-content/10");
+    expect(appMenu.className).toContain("bg-base-200");
+    expect(appMenu.className).not.toContain("from-primary");
+  });
+
+  it("hides the Update available label below the sm breakpoint", () => {
+    const router = createMemoryRouter(
+      [
+        {
+          path: "*",
+          element: (
+            <TopNavigation
+              isHamburgerMenuOpen={false}
+              onHamburgerMenuClick={() => undefined}
+              drawerToggleId="drawer"
+              version="1.2.7"
+              updateAvailable={{
+                kind: "release",
+                latestVersion: "1.2.8",
+                releaseUrl: "https://example.com",
+              }}
+            />
+          ),
+        },
+      ],
+      { initialEntries: ["/"] },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    const label = screen.getByText("Update available");
+    expect(label.className).toContain("hidden");
+    expect(label.className).toContain("sm:inline");
+    expect(screen.getByLabelText("Update available").className).toContain("max-sm:btn-square");
+    expect(screen.getByLabelText("Update available").className).toContain("border-base-content/10");
+    expect(screen.getByLabelText("Update available").className).toContain("bg-clip-padding");
+    expect(screen.getByLabelText("Update available").className).toContain(styles.updateAvailable);
+  });
+
+  it("sizes the user avatar to the header control height", () => {
+    const router = createMemoryRouter(
+      [
+        {
+          path: "*",
+          element: (
+            <TopNavigation
+              isHamburgerMenuOpen={false}
+              onHamburgerMenuClick={() => undefined}
+              drawerToggleId="drawer"
+              version="1.2.7"
+              username="admin"
+            />
+          ),
+        },
+      ],
+      { initialEntries: ["/"] },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    const menu = screen.getByLabelText("User menu");
+    expect(menu.className).toContain("h-10");
+    expect(menu.className).toContain("min-h-10");
+    expect(menu.className).toContain("w-10");
+    expect(menu.querySelector(".avatar-placeholder > div")?.className).toContain("w-10");
   });
 });

--- a/frontend/app/routes/_index/components/top-navigation/top-navigation.tsx
+++ b/frontend/app/routes/_index/components/top-navigation/top-navigation.tsx
@@ -5,6 +5,7 @@ import { LiveUsenetConnections } from "../live-usenet-connections/live-usenet-co
 import { Icon } from "~/components/ui";
 import { isComparableVersion, type UpdateAvailable } from "~/utils/update-check";
 import { withUrlBase } from "~/utils/url-base";
+import styles from "./top-navigation.module.css";
 
 export type TopNavigationProps = RequiredTopNavProps & {
   version?: string;
@@ -93,18 +94,18 @@ export const TopNavigation = memo(function TopNavigation(props: TopNavigationPro
           <summary
             className={
               hasUpdate
-                ? "btn btn-primary h-10 min-h-10 shrink-0 list-none gap-2 rounded-box px-4 whitespace-nowrap"
-                : "list-none rounded-box bg-gradient-to-br from-primary via-info to-success p-px"
+                ? `btn btn-primary h-10 min-h-10 max-sm:btn-square shrink-0 list-none gap-2 rounded-box border border-base-content/10 bg-clip-padding px-4 max-sm:px-0 whitespace-nowrap ${styles.updateAvailable}`
+                : "btn h-10 min-h-10 shrink-0 list-none gap-2 rounded-box border border-base-content/10 bg-base-200 px-4 whitespace-nowrap hover:bg-base-200"
             }
             aria-label={hasUpdate ? "Update available" : "App menu"}
           >
             {hasUpdate ? (
               <>
                 <Icon name="arrow_circle_up" className="!text-[20px]" />
-                <span className="text-sm font-semibold">Update available</span>
+                <span className="hidden text-sm font-semibold sm:inline">Update available</span>
               </>
             ) : (
-              <span className="btn btn-ghost h-10 min-h-10 shrink-0 gap-2 rounded-[calc(var(--radius-box)-1px)] border-0 bg-base-200 px-4 whitespace-nowrap hover:bg-base-200 pointer-events-none">
+              <>
                 <span className="inline-flex items-center gap-2 whitespace-nowrap">
                   <span className="hidden text-[10px] font-semibold uppercase tracking-[0.14em] text-base-content/40 sm:inline">
                     {channelLabel}
@@ -113,12 +114,12 @@ export const TopNavigation = memo(function TopNavigation(props: TopNavigationPro
                     className="hidden h-3 w-px bg-base-content/15 sm:block"
                     aria-hidden="true"
                   />
-                  <span className="font-mono text-sm tracking-tight text-base-content/80">
+                  <span className="font-mono text-xs tracking-tight text-base-content/80 sm:text-sm">
                     {displayVersion}
                   </span>
                 </span>
                 <Icon name="expand_more" className="!text-[18px] text-base-content/50" />
-              </span>
+              </>
             )}
           </summary>
           <ul className="dropdown-content menu z-50 mt-2 w-64 rounded-box border border-base-content/10 bg-base-200 p-2 shadow-lg">
@@ -182,10 +183,13 @@ export const TopNavigation = memo(function TopNavigation(props: TopNavigationPro
               <input name="confirm" value="true" type="hidden" />
             </Form>
             <details className="dropdown dropdown-end" name="top-nav">
-              <summary className="btn btn-ghost btn-circle btn-sm list-none" aria-label="User menu">
+              <summary
+                className="btn btn-ghost btn-circle h-10 min-h-10 w-10 p-0 list-none"
+                aria-label="User menu"
+              >
                 <div className="avatar avatar-placeholder">
-                  <div className="w-8 rounded-full bg-neutral text-neutral-content">
-                    <span className="text-xs">{initial}</span>
+                  <div className="w-10 rounded-full bg-neutral text-neutral-content">
+                    <span className="text-sm">{initial}</span>
                   </div>
                 </div>
               </summary>

--- a/frontend/app/routes/overview/components/arr-health/arr-health.mock.ts
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.mock.ts
@@ -1,0 +1,130 @@
+import type { ArrHealthResponse } from "~/clients/backend-client.server";
+
+const now = () => Date.now();
+
+/** Local-preview payload for `?mockArrHealth` — not served in production. */
+export function mockArrHealthData(): ArrHealthResponse {
+  const t = now();
+  const radarr = "radarr|http://127.0.0.1:7878";
+  const sonarr = "sonarr|http://127.0.0.1:8989";
+  const sonarr4k = "sonarr|http://127.0.0.1:8990";
+  const radarrUhd = "radarr|http://127.0.0.1:7879";
+
+  return {
+    configured: true,
+    summary: {
+      instancesOnline: 3,
+      instancesTotal: 4,
+      importsCompleted: 42,
+      medianHandoffMs: 40_000,
+      p95HandoffMs: 71_000,
+      awaitingImport: 3,
+      awaitingShown: 3,
+      degraded: 1,
+    },
+    instances: [
+      {
+        key: radarr,
+        name: "http://127.0.0.1:7878",
+        appType: "radarr",
+        host: "http://127.0.0.1:7878",
+        status: "healthy",
+        imports: 1,
+        medianHandoffMs: 4_800,
+        p95HandoffMs: 4_800,
+        queueCount: 0,
+        awaitingCount: 0,
+        hasWarnings: false,
+        hasErrors: false,
+        lastImportAtMs: t - 5 * 60 * 60_000,
+        lastError: null,
+      },
+      {
+        key: sonarr,
+        name: "http://127.0.0.1:8989",
+        appType: "sonarr",
+        host: "http://127.0.0.1:8989",
+        status: "healthy",
+        imports: 12,
+        medianHandoffMs: 40_000,
+        p95HandoffMs: 71_000,
+        queueCount: 0,
+        awaitingCount: 0,
+        hasWarnings: false,
+        hasErrors: false,
+        lastImportAtMs: t - 10 * 60 * 60_000,
+        lastError: null,
+      },
+      {
+        key: sonarr4k,
+        name: "http://127.0.0.1:8990",
+        appType: "sonarr",
+        host: "http://127.0.0.1:8990",
+        status: "degraded",
+        imports: 29,
+        medianHandoffMs: 41_000,
+        p95HandoffMs: 138_000,
+        queueCount: 3,
+        awaitingCount: 3,
+        hasWarnings: false,
+        hasErrors: false,
+        lastImportAtMs: t - 19 * 60_000,
+        lastError: null,
+      },
+      {
+        key: radarrUhd,
+        name: "http://127.0.0.1:7879",
+        appType: "radarr",
+        host: "http://127.0.0.1:7879",
+        status: "offline",
+        imports: 0,
+        medianHandoffMs: null,
+        p95HandoffMs: null,
+        queueCount: 0,
+        awaitingCount: 0,
+        hasWarnings: false,
+        hasErrors: false,
+        lastImportAtMs: null,
+        lastError: "Unreachable",
+      },
+    ],
+    awaiting: [
+      {
+        title: "Andor.S02E04.2160p.DSNP.WEB-DL",
+        downloadId: "nzb-andor-s02e04",
+        instanceKey: sonarr4k,
+        instanceName: "http://127.0.0.1:8990",
+        waitingMs: 47 * 60_000,
+        isUnusual: true,
+        trackedDownloadState: "importPending",
+        statusReason: "Invalid data found when processing input",
+      },
+      {
+        title: "Severance.S02E01.2160p.ATVP.WEB-DL",
+        downloadId: "nzb-severance-s02e01",
+        instanceKey: sonarr4k,
+        instanceName: "http://127.0.0.1:8990",
+        waitingMs: 12 * 60_000,
+        isUnusual: false,
+        trackedDownloadState: "importing",
+        statusReason: null,
+      },
+      {
+        title: "The.Bear.S03E01.1080p.WEB-DL",
+        downloadId: "nzb-bear-s03e01",
+        instanceKey: sonarr4k,
+        instanceName: "http://127.0.0.1:8990",
+        waitingMs: 4 * 60_000,
+        isUnusual: false,
+        trackedDownloadState: "importPending",
+        statusReason: null,
+      },
+    ],
+  };
+}
+
+export function mockArrHealthRequested(): boolean {
+  if (typeof window === "undefined") return false;
+  if (!import.meta.env.DEV) return false;
+  return new URLSearchParams(window.location.search).has("mockArrHealth");
+}

--- a/frontend/app/routes/overview/components/arr-health/arr-health.test.tsx
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.test.tsx
@@ -24,7 +24,7 @@ function render(data: ArrHealthResponse, window: "24h" | "all" = "24h") {
 }
 
 describe("ArrHealth", () => {
-  it("renders healthy, degraded, offline, and pending badges with summary chips", () => {
+  it("colors instance names as status badges and keeps metric icon headers", () => {
     const markup = render({
       configured: true,
       summary: {
@@ -114,11 +114,20 @@ describe("ArrHealth", () => {
     expect(markup).toContain("badge-warning");
     expect(markup).toContain("badge-error");
     expect(markup).toContain("badge-ghost");
-    expect(markup).toContain("healthy");
-    expect(markup).toContain("degraded");
-    expect(markup).toContain("offline");
-    expect(markup).toContain("pending");
+    expect(markup).toContain("Sonarr Main, healthy");
+    expect(markup).toContain("Sonarr 4K, degraded");
+    expect(markup).toContain("Radarr, offline");
+    expect(markup).toContain("Radarr New, pending");
+    expect(markup).not.toMatch(/>healthy</);
     expect(markup).toContain("Unreachable");
+    expect(markup).toContain("max-sm:w-[42%]");
+    expect(markup).toContain("max-sm:w-[11%]");
+    expect(markup).toContain("max-sm:w-[25%]");
+    expect(markup).toMatch(/max-sm:!inline-block[^>]*>download</);
+    expect(markup).toMatch(/max-sm:!inline-block[^>]*>queue</);
+    expect(markup).toMatch(/max-sm:!inline-block[^>]*>pending</);
+    expect(markup).toMatch(/max-sm:!inline-block[^>]*>schedule</);
+    expect(markup).toContain("max-sm:sr-only");
   });
 
   it("shows the empty state when no instances have imported yet", () => {

--- a/frontend/app/routes/overview/components/arr-health/arr-health.tsx
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.tsx
@@ -5,7 +5,7 @@ import type {
 } from "~/clients/backend-client.server";
 import { formatDurationMs, formatNumber, formatTimeAgo } from "../../utils/format";
 import { settingsPath } from "~/navigation/settings-tabs";
-import { Tooltip } from "~/components/ui";
+import { Badge, Icon, Tooltip } from "~/components/ui";
 import { WidgetLink } from "../widget-link/widget-link";
 
 export type ArrHealthProps = {
@@ -72,51 +72,70 @@ export function ArrHealth({ data, window }: ArrHealthProps) {
             <table className="table table-sm w-full max-sm:table-fixed sm:min-w-[640px]">
               <thead>
                 <tr>
-                  <th className="max-sm:w-[32%]">Instance</th>
-                  <th>Imports</th>
+                  <th className="max-sm:w-[42%]">Instance</th>
+                  <MetricHeader
+                    label="Imports"
+                    icon="download"
+                    tooltip="Completed imports in this window."
+                    className="max-sm:w-[11%] max-sm:px-1"
+                  />
                   <th className="max-sm:hidden">Median</th>
                   <th className="max-sm:hidden">P95</th>
-                  <th>
-                    <Tooltip content="All items currently in this Arr instance's queue.">
-                      <span className="cursor-help">Queue</span>
-                    </Tooltip>
-                  </th>
-                  <th>
-                    <Tooltip content="Completed downloads that Arr is still importing or has marked import pending.">
-                      <span className="cursor-help">Awaiting</span>
-                    </Tooltip>
-                  </th>
-                  <th>Last import</th>
+                  <MetricHeader
+                    label="Queue"
+                    icon="queue"
+                    tooltip="All items currently in this Arr instance's queue."
+                    className="max-sm:w-[11%] max-sm:px-1"
+                  />
+                  <MetricHeader
+                    label="Awaiting"
+                    icon="pending"
+                    tooltip="Completed downloads that Arr is still importing or has marked import pending."
+                    className="max-sm:w-[11%] max-sm:px-1"
+                  />
+                  <MetricHeader
+                    label="Last import"
+                    icon="schedule"
+                    tooltip="When this instance last completed an import."
+                    className="max-sm:w-[25%] max-sm:px-1"
+                  />
                 </tr>
               </thead>
               <tbody>
                 {instances.map((instance) => (
                   <tr key={instance.key}>
-                    <td className="min-w-0 max-w-[220px] font-medium">
-                      <Tooltip content={instance.host}>
-                        <span className="inline-block max-w-full truncate align-middle">
-                          {instance.name}
-                        </span>
+                    <td className="min-w-0 overflow-hidden sm:max-w-[220px]">
+                      <Tooltip
+                        content={`${instance.host} (${instance.status})`}
+                        className="block max-w-full min-w-0"
+                      >
+                        <Badge
+                          className={`badge-xs sm:badge-sm ${STATUS_BADGE[instance.status]} max-w-full min-w-0 overflow-hidden font-mono`}
+                          aria-label={`${instance.name}, ${instance.status}`}
+                        >
+                          <span className="truncate">{instance.name}</span>
+                        </Badge>
                       </Tooltip>
-                      <span className="mt-0.5 flex items-center gap-1.5 text-[11px] font-normal text-base-content/45">
-                        <span className="capitalize">{instance.appType}</span>
-                        <span className={`badge badge-xs ${STATUS_BADGE[instance.status]}`}>
-                          {instance.status}
-                        </span>
+                      <span className="mt-0.5 block truncate text-[11px] font-normal capitalize text-base-content/45">
+                        {instance.appType}
                       </span>
                     </td>
-                    <td className="font-mono tabular-nums">{formatNumber(instance.imports)}</td>
+                    <td className="font-mono tabular-nums max-sm:px-1">
+                      {formatNumber(instance.imports)}
+                    </td>
                     <td className="hidden font-mono tabular-nums sm:table-cell">
                       {formatDurationMs(instance.medianHandoffMs)}
                     </td>
                     <td className="hidden font-mono tabular-nums sm:table-cell">
                       {formatDurationMs(instance.p95HandoffMs)}
                     </td>
-                    <td className="font-mono tabular-nums">{formatNumber(instance.queueCount)}</td>
-                    <td className="font-mono tabular-nums">
+                    <td className="font-mono tabular-nums max-sm:px-1">
+                      {formatNumber(instance.queueCount)}
+                    </td>
+                    <td className="font-mono tabular-nums max-sm:px-1">
                       {formatNumber(instance.awaitingCount)}
                     </td>
-                    <td className="min-w-0 font-mono tabular-nums text-base-content/80 max-sm:whitespace-normal max-sm:break-words">
+                    <td className="min-w-0 font-mono tabular-nums text-base-content/80 max-sm:px-1 max-sm:whitespace-nowrap">
                       {instance.status === "offline" && !instance.lastImportAtMs
                         ? (instance.lastError ?? "Unreachable")
                         : formatTimeAgo(instance.lastImportAtMs)}
@@ -163,6 +182,32 @@ export function ArrHealth({ data, window }: ArrHealthProps) {
         )}
       </div>
     </section>
+  );
+}
+
+function MetricHeader({
+  label,
+  icon,
+  tooltip,
+  className = "",
+}: {
+  label: string;
+  icon: string;
+  tooltip: string;
+  className?: string;
+}) {
+  return (
+    <th className={className}>
+      <Tooltip content={tooltip}>
+        <span className="inline-flex cursor-help items-center">
+          <Icon
+            name={icon}
+            className="!hidden !text-[16px] text-base-content/70 max-sm:!inline-block"
+          />
+          <span className="max-sm:sr-only">{label}</span>
+        </span>
+      </Tooltip>
+    </th>
   );
 }
 

--- a/frontend/app/routes/overview/components/arr-health/arr-health.tsx
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.tsx
@@ -135,7 +135,7 @@ export function ArrHealth({ data, window }: ArrHealthProps) {
                     <td className="font-mono tabular-nums max-sm:px-1">
                       {formatNumber(instance.awaitingCount)}
                     </td>
-                    <td className="min-w-0 font-mono tabular-nums text-base-content/80 max-sm:px-1 max-sm:whitespace-nowrap">
+                    <td className="min-w-0 font-mono tabular-nums text-base-content/80 max-sm:truncate max-sm:px-1">
                       {instance.status === "offline" && !instance.lastImportAtMs
                         ? (instance.lastError ?? "Unreachable")
                         : formatTimeAgo(instance.lastImportAtMs)}

--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.mock.ts
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.mock.ts
@@ -1,0 +1,174 @@
+import type { ActiveRead } from "~/clients/backend-client.server";
+
+type MockLiveReadRow = {
+  read: ActiveRead;
+  rate: number;
+  history: number[];
+};
+
+function fixtureRead(
+  id: string,
+  fileName: string,
+  path: string,
+  currentOffset: number,
+  fileSize: number | null,
+  clientUserAgent: string,
+  clientIp: string,
+  providers: ActiveRead["providers"],
+  overrides?: { startedMinutesAgo?: number; bytesRead?: number; bytesFetched?: number },
+): ActiveRead {
+  const now = Date.now();
+  return {
+    id,
+    fileName,
+    path,
+    startedAt: now - (overrides?.startedMinutesAgo ?? 20) * 60_000,
+    lastActivityAt: now,
+    bytesRead: overrides?.bytesRead ?? currentOffset,
+    bytesFetched: overrides?.bytesFetched ?? 0,
+    currentOffset,
+    fileSize,
+    clientUserAgent,
+    clientIp,
+    providers,
+  };
+}
+
+function historyAround(rate: number, samples = 45): number[] {
+  return Array.from({ length: samples }, (_, i) =>
+    Math.max(0, rate * (0.72 + 0.55 * Math.abs(Math.sin(i / 4)))),
+  );
+}
+
+/** Local-preview rows for `?mockReads=7` — not served in production. */
+export const MOCK_LIVE_READ_ROWS: MockLiveReadRow[] = [
+  {
+    read: fixtureRead(
+      "a1b2c3d4-0001-4000-8000-000000000001",
+      "The.Prestige.2006.1080p.BluRay.x264-GRP.mkv",
+      "/completed-symlinks/movies/The.Prestige.2006.1080p.BluRay.x264-GRP.mkv",
+      3_200_000_000,
+      8_400_000_000,
+      "Plex/1.107.0",
+      "192.168.1.20",
+      [
+        { host: "news.eweka.nl", nickname: "Eweka", segments: 41 },
+        { host: "news.newshosting.com", nickname: "Newshosting", segments: 18 },
+      ],
+      { startedMinutesAgo: 84, bytesFetched: 3_800_000_000 },
+    ),
+    rate: 7_200_000,
+    history: historyAround(7_200_000),
+  },
+  {
+    read: fixtureRead(
+      "a1b2c3d4-0002-4000-8000-000000000002",
+      "The.Last.of.Us.S01E03.1080p.WEB-DL.DDP5.1.H.264-GRP.mkv",
+      "/completed-symlinks/tv/The.Last.of.Us.S01E03.1080p.WEB-DL.DDP5.1.H.264-GRP.mkv",
+      412_000_000,
+      1_100_000_000,
+      "Infuse/8.0",
+      "192.168.1.34",
+      [{ host: "news.eweka.nl", nickname: "Eweka", segments: 22 }],
+      { startedMinutesAgo: 20, bytesFetched: 600_000_000 },
+    ),
+    rate: 4_100_000,
+    history: historyAround(4_100_000),
+  },
+  {
+    read: fixtureRead(
+      "a1b2c3d4-0003-4000-8000-000000000003",
+      "Dune.Part.Two.2024.2160p.WEB-DL.DDP5.1.Atmos.H.265-GRP.mkv",
+      "/completed-symlinks/movies/Dune.Part.Two.2024.2160p.WEB-DL.DDP5.1.Atmos.H.265-GRP.mkv",
+      1_100_000_000,
+      3_800_000_000,
+      "VLC/3.0.20",
+      "192.168.1.51",
+      [
+        { host: "news.newshosting.com", nickname: "Newshosting", segments: 17 },
+        { host: "news.usenetserver.com", nickname: "UsenetServer", segments: 9 },
+      ],
+      { startedMinutesAgo: 33, bytesRead: 2_900_000_000, bytesFetched: 2_950_000_000 },
+    ),
+    rate: 2_800_000,
+    history: historyAround(2_800_000),
+  },
+  {
+    read: fixtureRead(
+      "a1b2c3d4-0004-4000-8000-000000000004",
+      "Severance.S02E01.2160p.ATVP.WEB-DL.DDP5.1.H.265-GRP.mkv",
+      "/completed-symlinks/tv/Severance.S02E01.2160p.ATVP.WEB-DL.DDP5.1.H.265-GRP.mkv",
+      218_000_000,
+      890_000_000,
+      "rclone/1.68",
+      "192.168.1.10",
+      [{ host: "news.usenetserver.com", nickname: "UsenetServer", segments: 13 }],
+      { startedMinutesAgo: 5, bytesFetched: 300_000_000 },
+    ),
+    rate: 1_900_000,
+    history: historyAround(1_900_000),
+  },
+  {
+    read: fixtureRead(
+      "a1b2c3d4-0005-4000-8000-000000000005",
+      "9f2c7a1e4b.mkv",
+      "/completed-symlinks/movies/Interstellar.2014.1080p.BluRay.x264-GRP/9f2c7a1e4b.mkv",
+      900_000_000,
+      5_200_000_000,
+      "Kodi/21.0",
+      "192.168.1.64",
+      [{ host: "news.eweka.nl", nickname: "Eweka", segments: 30 }],
+      { startedMinutesAgo: 12, bytesFetched: 1_200_000_000 },
+    ),
+    rate: 5_400_000,
+    history: historyAround(5_400_000),
+  },
+  {
+    read: fixtureRead(
+      "a1b2c3d4-0006-4000-8000-000000000006",
+      "Andor.S02E04.2160p.DSNP.WEB-DL.DDP5.1.Atmos.H.265-GRP.mkv",
+      "/completed-symlinks/tv/Andor.S02E04.2160p.DSNP.WEB-DL.DDP5.1.Atmos.H.265-GRP.mkv",
+      86_000_000,
+      2_140_000_000,
+      "Jellyfin/10.9.11",
+      "192.168.1.88",
+      [{ host: "news.eweka.nl", nickname: "Eweka", segments: 8 }],
+      { startedMinutesAgo: 2, bytesFetched: 140_000_000 },
+    ),
+    rate: 12_400_000,
+    history: historyAround(12_400_000),
+  },
+  {
+    read: fixtureRead(
+      "a1b2c3d4-0007-4000-8000-000000000007",
+      "The.Bear.S03E01.1080p.WEB-DL.DDP5.1.H.264-GRP.mkv",
+      "/completed-symlinks/tv/The.Bear.S03E01.1080p.WEB-DL.DDP5.1.H.264-GRP.mkv",
+      42_000_000,
+      null,
+      "Emby/4.8",
+      "10.0.0.14",
+      [
+        { host: "news.eweka.nl", nickname: "Eweka", segments: 4 },
+        { host: "news.blocknews.net", nickname: "Blocknews", segments: 2 },
+      ],
+      { startedMinutesAgo: 0, bytesFetched: 48_000_000 },
+    ),
+    rate: 3_100_000,
+    history: historyAround(3_100_000, 8),
+  },
+];
+
+export function mockReadsRequested(): number | null {
+  if (typeof window === "undefined") return null;
+  if (!import.meta.env.DEV) return null;
+  const raw = new URLSearchParams(window.location.search).get("mockReads");
+  if (raw == null) return null;
+  if (raw === "") return MOCK_LIVE_READ_ROWS.length;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) return MOCK_LIVE_READ_ROWS.length;
+  return Math.min(n, MOCK_LIVE_READ_ROWS.length);
+}
+
+export function mockLiveReadRows(count: number): MockLiveReadRow[] {
+  return MOCK_LIVE_READ_ROWS.slice(0, count);
+}

--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.test.tsx
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.test.tsx
@@ -1,5 +1,7 @@
+// @vitest-environment jsdom
+import { cleanup, render } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ActiveRead } from "~/clients/backend-client.server";
 import { LiveReadsPanel, LiveReadsPanelContent, type LiveReadRow } from "./live-reads-panel";
 
@@ -122,6 +124,11 @@ const fixtureRows: LiveReadRow[] = [
 ];
 
 describe("LiveReadsPanel", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
   it("renders the empty state when there are no active reads", () => {
     const markup = renderToStaticMarkup(<LiveReadsPanel />);
 
@@ -133,21 +140,26 @@ describe("LiveReadsPanel", () => {
     const markup = renderToStaticMarkup(<LiveReadsPanelContent rows={fixtureRows} />);
 
     expect(markup).toContain("5 active");
-    expect(markup).toContain("h-[30rem]");
-    expect(markup).toContain("overflow-y-auto");
+    expect(markup).not.toContain("h-[21rem]");
+    expect(markup).not.toContain("sm:h-[30rem]");
+    expect(markup).toContain("overflow-x-hidden");
+    expect(markup).toContain("pr-4");
     expect(markup).toContain("The.Prestige.2006.1080p.BluRay.x264-GRP.mkv");
     expect(markup).toContain("Severance.S02E01.2160p.ATVP.WEB-DL.DDP5.1.H.265-GRP.mkv");
     // Speed, progress, and computed time left
     expect(markup).toContain("7.2 MB/s");
+    expect(markup).toContain("text-secondary");
     expect(markup).toContain("3.2 GB");
     expect(markup).toContain("/ 8.4 GB");
     expect(markup).toContain("12m left");
     expect(markup).toContain("6m left");
-    // Meta line: client, provider badges, session id
+    // Meta line: client and provider badges
     expect(markup).toContain("Plex");
     expect(markup).toContain("192.168.1.20");
+    expect(markup).toContain("hidden font-mono text-base-content/40 sm:inline");
     expect(markup).toContain("Eweka");
-    expect(markup).toContain("a1b2c3d4");
+    expect(markup).not.toContain("Copy session id");
+    expect(markup).not.toContain("a1b2c3d4");
   });
 
   it("places the newest read first", () => {
@@ -158,11 +170,14 @@ describe("LiveReadsPanel", () => {
     );
   });
 
-  it("labels media rows with MOVIE / EPISODE badges", () => {
+  it("does not label rows as MOVIE or EPISODE", () => {
     const markup = renderToStaticMarkup(<LiveReadsPanelContent rows={fixtureRows} />);
 
-    expect(markup.match(/MOVIE/g)).toHaveLength(3);
-    expect(markup.match(/EPISODE/g)).toHaveLength(2);
+    expect(markup).not.toContain("MOVIE");
+    expect(markup).not.toContain("EPISODE");
+    expect(markup).toContain("font-bold");
+    expect(markup).toContain("w-20 shrink-0");
+    expect(markup).toContain("lg:w-28");
   });
 
   it("renders a speed sparkline per row", () => {
@@ -177,6 +192,7 @@ describe("LiveReadsPanel", () => {
     expect(markup).toContain("1h 24m in");
     expect(markup).toContain("5m in");
     expect(markup).toContain("fetched 3.8 GB");
+    expect(markup).toContain("max-sm:hidden");
   });
 
   it("notes total bytes served when the player is scrubbing", () => {
@@ -202,4 +218,43 @@ describe("LiveReadsPanel", () => {
     expect(markup).toContain("—");
     expect(markup).not.toContain("left</span>");
   });
+
+  it("does not lock height until the first snapshot is ready", () => {
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue(rectWithHeight(240));
+
+    const { container } = render(
+      <LiveReadsPanelContent rows={fixtureRows.slice(0, 2)} snapshotReady={false} />,
+    );
+    const section = container.querySelector("section");
+    expect(section?.style.height).toBe("");
+  });
+
+  it("locks the first snapshot height when more reads arrive", () => {
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue(rectWithHeight(240));
+
+    const { container, rerender } = render(
+      <LiveReadsPanelContent rows={fixtureRows.slice(0, 2)} snapshotReady />,
+    );
+    const section = container.querySelector("section");
+    expect(section?.style.height).toBe("240px");
+    expect(section?.className).toContain("overflow-hidden");
+
+    rerender(<LiveReadsPanelContent rows={fixtureRows} snapshotReady />);
+    expect(section?.style.height).toBe("240px");
+    expect(container.querySelector("ul")?.className).toContain("overflow-y-auto");
+  });
 });
+
+function rectWithHeight(height: number): DOMRect {
+  return {
+    x: 0,
+    y: 0,
+    width: 400,
+    height,
+    top: 0,
+    left: 0,
+    right: 400,
+    bottom: height,
+    toJSON: () => ({}),
+  };
+}

--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
@@ -230,7 +230,10 @@ function ReadRow({
           <span className="block max-w-full truncate">
             {clientLabelFromUserAgent(r.clientUserAgent)}
             {r.clientIp ? (
-              <span className="hidden font-mono text-base-content/40 sm:inline"> · {r.clientIp}</span>
+              <span className="hidden font-mono text-base-content/40 sm:inline">
+                {" "}
+                · {r.clientIp}
+              </span>
             ) : null}
           </span>
         </Tooltip>

--- a/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
+++ b/frontend/app/routes/overview/components/live-reads-panel/live-reads-panel.tsx
@@ -1,12 +1,12 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { ActiveRead, ActiveReadsMessage } from "~/clients/backend-client.server";
 import { formatBytes, formatSessionAge, formatTimeLeft } from "../../utils/format";
-import { mediaTypeFromFileName } from "../../utils/media-type";
 import { displayNameForRead } from "../../utils/display-name";
 import { clientIdentityTooltip, clientLabelFromUserAgent } from "~/utils/client-label";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
 import { Tooltip } from "~/components/ui";
 import { Sparkline } from "../provider-scoreboard/provider-scoreboard";
+import { mockLiveReadRows, mockReadsRequested } from "./live-reads-panel.mock";
 
 const TOPIC_ACTIVE_READS = "ar";
 
@@ -23,21 +23,32 @@ const HISTORY_LIMIT = 60;
 
 /**
  * Live "right now" panel — full-width rows refreshed via the ActiveReads WS
- * topic. Keeps an empty state when no reads are active so the dashboard stack
- * stays stable. When `paused`, the subscription is disabled so layout edit
- * borders stay stable.
+ * topic. Sizes to the first snapshot of reads, then freezes that height until
+ * the next page load so later sessions scroll instead of stretching the card.
+ * When `paused`, the subscription is disabled so layout edit borders stay stable.
  */
 export function LiveReadsPanel({ paused = false }: { paused?: boolean }) {
   const [rows, setRows] = useState<LiveReadRow[]>([]);
+  const [mockCount, setMockCount] = useState<number | null>(null);
+  const [snapshotReady, setSnapshotReady] = useState(false);
   // Track previous bytesRead per session for live MiB/s computation.
   const prevRef = useRef<Map<string, { bytes: number; at: number; rate: number }>>(new Map());
   // Per-session rate samples for the sparkline, keyed by session id.
   const historyRef = useRef<Map<string, number[]>>(new Map());
 
+  useEffect(() => {
+    const count = mockReadsRequested();
+    if (count == null) return;
+    setMockCount(count);
+    setRows(mockLiveReadRows(count));
+    setSnapshotReady(true);
+  }, []);
+
   useWebsocketTopic(
     TOPIC_ACTIVE_READS,
     "state",
     (message) => {
+      if (mockReadsRequested() != null) return;
       try {
         // ActiveReads websocket topic payload shape (backend contract)
         const payload = JSON.parse(message) as ActiveReadsMessage;
@@ -65,49 +76,60 @@ export function LiveReadsPanel({ paused = false }: { paused?: boolean }) {
         prevRef.current = next;
         historyRef.current = nextHistory;
         setRows(nextRows);
+        setSnapshotReady(true);
       } catch {
         /* ignore */
       }
     },
-    { enabled: !paused },
+    { enabled: !paused && mockCount == null },
   );
 
-  return <LiveReadsPanelContent rows={rows} />;
+  return <LiveReadsPanelContent rows={rows} snapshotReady={snapshotReady} />;
 }
 
-export function LiveReadsPanelContent({ rows }: { rows: LiveReadRow[] }) {
-  const [copiedId, setCopiedId] = useState<string | null>(null);
-  const [copyNotice, setCopyNotice] = useState<{ seq: number; text: string } | null>(null);
-  const copySeqRef = useRef(0);
-  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+export function LiveReadsPanelContent({
+  rows,
+  snapshotReady = true,
+}: {
+  rows: LiveReadRow[];
+  snapshotReady?: boolean;
+}) {
   const displayedRows = [...rows].sort((a, b) => b.read.startedAt - a.read.startedAt);
+  const cardRef = useRef<HTMLElement>(null);
+  const [lockedHeight, setLockedHeight] = useState<number | null>(null);
 
-  useEffect(() => {
-    return () => {
-      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+  useLayoutEffect(() => {
+    if (!snapshotReady || lockedHeight != null) return;
+    const card = cardRef.current;
+    if (!card) return;
+
+    const lockFromCard = (): boolean => {
+      const height = card.getBoundingClientRect().height;
+      if (height < 1) return false;
+      setLockedHeight(height);
+      return true;
     };
-  }, []);
 
-  const copySessionId = async (id: string) => {
-    try {
-      await navigator.clipboard.writeText(id);
-    } catch {
-      return;
-    }
-    copySeqRef.current += 1;
-    setCopiedId(id);
-    setCopyNotice({ seq: copySeqRef.current, text: "Session id copied" });
-    if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
-    copyTimerRef.current = setTimeout(() => {
-      setCopiedId((current) => (current === id ? null : current));
-      copyTimerRef.current = null;
-    }, 1500);
-  };
+    if (lockFromCard()) return;
+
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      if (lockFromCard()) observer.disconnect();
+    });
+    observer.observe(card);
+    return () => observer.disconnect();
+  }, [snapshotReady, lockedHeight]);
+
+  const heightLocked = lockedHeight != null;
 
   return (
-    <section className="card h-[30rem] w-full min-w-0 border border-base-content/10 bg-base-100 shadow-sm">
-      <div className="card-body flex min-h-0 flex-col gap-3 p-4">
-        <div className="flex items-center gap-2.5">
+    <section
+      ref={cardRef}
+      className={`card w-full min-w-0 border border-base-content/10 bg-base-100 shadow-sm${heightLocked ? " overflow-hidden" : ""}`}
+      style={heightLocked ? { height: lockedHeight } : undefined}
+    >
+      <div className="card-body flex h-full min-h-0 flex-col gap-3 p-4">
+        <div className="flex shrink-0 items-center gap-2.5">
           <span className="status status-success animate-pulse" aria-hidden="true" />
           <h3 className="card-title m-0 text-base">Right now</h3>
           {rows.length > 0 && (
@@ -117,27 +139,20 @@ export function LiveReadsPanelContent({ rows }: { rows: LiveReadRow[] }) {
           )}
         </div>
 
-        <div key={copyNotice?.seq ?? 0} className="sr-only" aria-live="polite">
-          {copyNotice?.text ?? ""}
-        </div>
-
         {rows.length === 0 ? (
           <p className="m-0 text-sm text-base-content/50">
             No files are being read right now. Open a mounted file to see live progress here.
           </p>
         ) : (
-          <ul className="yes-scrollbar m-0 min-h-0 w-full flex-1 list-none divide-y divide-base-content/10 overflow-y-auto p-0">
+          <ul
+            className={
+              heightLocked
+                ? "yes-scrollbar m-0 min-h-0 w-full min-w-0 flex-1 list-none divide-y divide-base-content/10 overflow-x-hidden overflow-y-auto py-0 pr-4 pl-0"
+                : "m-0 w-full min-w-0 list-none divide-y divide-base-content/10 overflow-x-hidden py-0 pr-4 pl-0"
+            }
+          >
             {displayedRows.map(({ read, rate, history }) => (
-              <ReadRow
-                key={read.id}
-                read={read}
-                rate={rate}
-                history={history}
-                copied={copiedId === read.id}
-                onCopySessionId={(id) => {
-                  void copySessionId(id);
-                }}
-              />
+              <ReadRow key={read.id} read={read} rate={rate} history={history} />
             ))}
           </ul>
         )}
@@ -150,17 +165,12 @@ function ReadRow({
   read: r,
   rate,
   history,
-  copied,
-  onCopySessionId,
 }: {
   read: ActiveRead;
   rate: number;
   history: number[];
-  copied: boolean;
-  onCopySessionId: (id: string) => void;
 }) {
   const display = displayNameForRead(r.fileName, r.path);
-  const mediaType = mediaTypeFromFileName(display.name);
   // Use the latest read position (what the player is requesting right now) —
   // not cumulative bytes transferred — so the bar reflects actual playback
   // location, immune to seeks/replays.
@@ -176,66 +186,60 @@ function ReadRow({
   const scrubbing = r.bytesRead > r.currentOffset + Math.max(64_000_000, r.currentOffset * 0.2);
 
   return (
-    <li className="flex flex-col gap-1.5 py-3 first:pt-0 last:pb-0">
-      <div className="flex flex-col gap-1.5 lg:flex-row lg:items-center lg:gap-x-4">
-        <div className="flex min-w-0 items-center gap-2 lg:flex-1">
-          {mediaType && (
-            <span
-              className={`badge badge-sm shrink-0 ${
-                mediaType === "movie" ? "badge-primary" : "badge-secondary"
-              }`}
-            >
-              {mediaType === "movie" ? "MOVIE" : "EPISODE"}
-            </span>
-          )}
-          <Tooltip
-            className="min-w-0 flex-1"
-            content={display.isReleaseFallback ? `${r.path}\n(obfuscated file name)` : r.path}
-          >
-            <span className="block truncate text-sm font-medium text-base-content">
-              {display.name}
-            </span>
-          </Tooltip>
-        </div>
-        <div className="flex min-w-0 flex-wrap items-center gap-x-4 gap-y-1 font-mono text-xs tabular-nums">
+    <li className="flex min-w-0 flex-col gap-1 overflow-x-hidden py-2 first:pt-0 last:pb-0">
+      <div className="flex min-w-0 flex-col gap-1 lg:flex-row lg:items-center lg:gap-x-4">
+        <Tooltip
+          className="min-w-0 overflow-hidden lg:flex-1"
+          content={display.isReleaseFallback ? `${r.path}\n(obfuscated file name)` : r.path}
+        >
+          <span className="block truncate text-xs font-bold text-base-content">{display.name}</span>
+        </Tooltip>
+
+        <div className="flex w-full min-w-0 items-center gap-x-2.5 font-mono text-xs tabular-nums lg:w-auto lg:shrink-0 lg:gap-x-3">
           {history.length >= 2 && (
-            <span className="hidden sm:block">
-              <Sparkline values={history} tone="success" />
+            <span className="hidden shrink-0 sm:block">
+              <Sparkline values={history} tone="secondary" />
             </span>
           )}
-          <span className="font-medium text-success">{formatBytes(rate)}/s</span>
-          <span className="font-medium text-base-content">
+          <span className="w-[4.5rem] shrink-0 font-medium text-secondary lg:w-[5.5rem]">
+            {formatBytes(rate)}/s
+          </span>
+          <span className="min-w-0 flex-1 truncate font-medium text-base-content lg:w-[8.5rem] lg:flex-none">
             {formatBytes(r.currentOffset)}
             {r.fileSize ? (
               <span className="font-normal text-base-content/50"> / {formatBytes(r.fileSize)}</span>
             ) : null}
           </span>
-          <span className="text-base-content/50">{timeLeft ?? "—"}</span>
+          <div className="flex w-20 shrink-0 flex-col gap-1 lg:w-28">
+            <progress
+              className="progress progress-success h-1 w-full"
+              value={pct ?? 0}
+              max={100}
+              aria-label={pct === null ? "Loading progress" : undefined}
+            />
+            <span className="text-end leading-none text-base-content/50">{timeLeft ?? "—"}</span>
+          </div>
         </div>
       </div>
 
-      {pct !== null ? (
-        <progress className="progress progress-success h-1 w-full" value={pct} max={100} />
-      ) : (
-        <span
-          className="loading loading-bars loading-sm text-success"
-          role="status"
-          aria-label="Loading progress"
-        />
-      )}
-
-      <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-base-content/50">
-        <Tooltip content={clientIdentityTooltip(r.clientUserAgent, r.clientIp) ?? ""}>
-          <span className="truncate">
+      <div className="flex min-w-0 flex-wrap items-center gap-x-2.5 gap-y-0.5 overflow-hidden text-xs text-base-content/50">
+        <Tooltip
+          className="min-w-0 max-w-full overflow-hidden"
+          content={clientIdentityTooltip(r.clientUserAgent, r.clientIp) ?? ""}
+        >
+          <span className="block max-w-full truncate">
             {clientLabelFromUserAgent(r.clientUserAgent)}
             {r.clientIp ? (
-              <span className="font-mono text-base-content/40"> · {r.clientIp}</span>
+              <span className="hidden font-mono text-base-content/40 sm:inline"> · {r.clientIp}</span>
             ) : null}
           </span>
         </Tooltip>
-        {sessionAge && <span>{sessionAge}</span>}
+        {sessionAge && <span className="shrink-0">{sessionAge}</span>}
         {bytesFetched > 0 && (
-          <Tooltip content="Bytes pulled from Usenet for this session, including readahead">
+          <Tooltip
+            className="max-sm:hidden"
+            content="Bytes pulled from Usenet for this session, including readahead"
+          >
             <span className="font-mono tabular-nums">fetched {formatBytes(bytesFetched)}</span>
           </Tooltip>
         )}
@@ -244,39 +248,22 @@ function ReadRow({
             <span className="font-mono tabular-nums">{formatBytes(r.bytesRead)} served</span>
           </Tooltip>
         )}
-        {r.providers.length > 0 && (
-          <span className="flex min-w-0 flex-wrap gap-1">
-            {r.providers.slice(0, 6).map((p, i) => {
-              const label = p.nickname?.trim() || p.host;
-              return (
-                <Tooltip
-                  key={`${p.host}-${i}`}
-                  content={`${label} (${p.host}): ${p.segments} segments`}
-                >
-                  <span className="badge badge-ghost badge-sm gap-1.5 font-mono tabular-nums">
-                    <span className="max-w-[8rem] truncate">{label}</span>
-                    <span className="font-medium">{p.segments}</span>
-                  </span>
-                </Tooltip>
-              );
-            })}
-          </span>
-        )}
-        <Tooltip content={`Copy session id: ${r.id}`}>
-          <button
-            type="button"
-            className="btn btn-link btn-xs h-auto min-h-0 px-0 font-mono"
-            aria-label={`Copy session id: ${r.id}${copied ? " (copied)" : ""}`}
-            onClick={() => onCopySessionId(r.id)}
-          >
-            {copied ? "Copied" : shortSessionId(r.id)}
-          </button>
-        </Tooltip>
+        {r.providers.length > 0 &&
+          r.providers.slice(0, 6).map((p, i) => {
+            const label = p.nickname?.trim() || p.host;
+            return (
+              <Tooltip
+                key={`${p.host}-${i}`}
+                content={`${label} (${p.host}): ${p.segments} segments`}
+              >
+                <span className="badge badge-ghost badge-xs max-w-full gap-1 font-mono tabular-nums">
+                  <span className="max-w-[7rem] truncate">{label}</span>
+                  <span className="font-medium">{p.segments}</span>
+                </span>
+              </Tooltip>
+            );
+          })}
       </div>
     </li>
   );
-}
-
-function shortSessionId(id: string): string {
-  return id.length > 8 ? id.slice(0, 8) : id;
 }

--- a/frontend/app/routes/overview/components/live-tiles/live-tiles.tsx
+++ b/frontend/app/routes/overview/components/live-tiles/live-tiles.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useState } from "react";
 import { formatBytes } from "../../utils/format";
+import { mockReadsRequested } from "../live-reads-panel/live-reads-panel.mock";
 
 export type LiveTilesProps = {
   tiles: {
@@ -13,6 +15,11 @@ export type LiveTilesProps = {
 };
 
 export function LiveTiles({ tiles }: LiveTilesProps) {
+  const [mockReads, setMockReads] = useState<number | null>(null);
+  useEffect(() => {
+    setMockReads(mockReadsRequested());
+  }, []);
+  const activeReads = mockReads ?? tiles.activeReads;
   const bytesPerSec = tiles.bytesServedPerMinute / 60;
   const articlesPerSec = tiles.articlesPerMinute / 60;
   const leased = tiles.inFlightArticleBytes ?? 0;
@@ -27,8 +34,8 @@ export function LiveTiles({ tiles }: LiveTilesProps) {
     >
       <Tile
         label="Active reads"
-        value={tiles.activeReads.toString()}
-        accent={tiles.activeReads > 0 ? "live" : undefined}
+        value={activeReads.toString()}
+        accent={activeReads > 0 ? "live" : undefined}
       />
       <Tile
         label="Articles / s"

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.test.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.test.tsx
@@ -122,4 +122,11 @@ describe("Sparkline event mode", () => {
     expect(markup).toContain("var(--color-base-content)");
     expect(markup).toContain("var(--color-error)");
   });
+
+  it("uses the secondary token for throughput sparklines", () => {
+    const markup = renderToStaticMarkup(<Sparkline values={[1, 2, 3]} tone="secondary" />);
+
+    expect(markup).toContain("var(--color-secondary)");
+    expect(markup).not.toContain("var(--color-success)");
+  });
 });

--- a/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
+++ b/frontend/app/routes/overview/components/provider-scoreboard/provider-scoreboard.tsx
@@ -147,8 +147,8 @@ export function ProviderScoreboard({
                         <td className="min-w-0 px-1">
                           <Tooltip content={speedHelp}>
                             <div className="flex flex-col gap-0.5">
-                              <Sparkline values={p.speedSpark ?? []} tone="success" />
-                              <div className="font-mono text-[11px] tabular-nums text-base-content/60">
+                              <Sparkline values={p.speedSpark ?? []} tone="secondary" />
+                              <div className="font-mono text-[11px] tabular-nums text-secondary">
                                 {formatSpeed(p.speedMbPerSec)}
                               </div>
                             </div>
@@ -339,7 +339,7 @@ export function OutageBuckets({ values }: { values: number[] }) {
   );
 }
 
-type SparklineTone = "success" | "error" | "warning";
+type SparklineTone = "success" | "secondary" | "error" | "warning";
 
 function buildEventPath(values: number[], step: number, y: (value: number) => number) {
   const parts: string[] = [];
@@ -425,5 +425,6 @@ export function Sparkline({
 function sparklineColor(tone: SparklineTone) {
   if (tone === "error") return "var(--color-error)";
   if (tone === "warning") return "var(--color-warning)";
+  if (tone === "secondary") return "var(--color-secondary)";
   return "var(--color-success)";
 }

--- a/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.module.css
+++ b/frontend/app/routes/overview/components/provider-speed-chart/provider-speed-chart.module.css
@@ -31,7 +31,7 @@
 }
 
 .lineSpeed {
-  stroke: var(--color-success);
+  stroke: var(--color-secondary);
   stroke-width: 1.5;
   fill: none;
   vector-effect: non-scaling-stroke;
@@ -59,7 +59,7 @@
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: var(--color-success);
+  background: var(--color-secondary);
   box-shadow: 0 0 0 2px var(--color-base-100);
 }
 
@@ -68,7 +68,7 @@
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: var(--color-success);
+  background: var(--color-secondary);
   transform: translate(-50%, -50%);
   pointer-events: none;
   box-shadow: 0 0 0 2px var(--color-base-100);

--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -40,6 +40,7 @@ import { LifetimeBlock } from "./components/lifetime-block/lifetime-block";
 import { RecordsBlock } from "./components/records-block/records-block";
 import { FailoverSaves } from "./components/failover-saves/failover-saves";
 import { ArrHealth } from "./components/arr-health/arr-health";
+import { mockArrHealthData, mockArrHealthRequested } from "./components/arr-health/arr-health.mock";
 import { SortableRow } from "./components/sortable-row/sortable-row";
 import { SectionLoadError } from "./components/section-load-error/section-load-error";
 import { Icon, Tooltip } from "~/components/ui";
@@ -131,6 +132,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
   const [staticLoaded, setStaticLoaded] = useState(false);
   const [arrHealth, setArrHealth] = useState<ArrHealthResponse | null>(null);
   const [arrHealthLoaded, setArrHealthLoaded] = useState(false);
+  const [mockArrHealth, setMockArrHealth] = useState<ArrHealthResponse | null>(null);
   const [windowError, setWindowError] = useState(false);
   const [detailError, setDetailError] = useState(false);
   const [staticError, setStaticError] = useState(false);
@@ -151,6 +153,11 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
   detailLoadedRef.current = detailLoaded;
   staticLoadedRef.current = staticLoaded;
   arrHealthLoadedRef.current = arrHealthLoaded;
+
+  useEffect(() => {
+    if (!mockArrHealthRequested()) return;
+    setMockArrHealth(mockArrHealthData());
+  }, []);
 
   const liveTiles = stats.tiles;
   const isLongWindow = window === "7d" || window === "30d" || window === "all";
@@ -231,6 +238,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
 
   // Arr Health: poll on the same 30s cadence, only when Arr instances are configured.
   useEffect(() => {
+    if (mockArrHealth != null) return;
     if (!loaderData.hasConfiguredArrs) return;
     let cancelled = false;
     arrHealthLoadedRef.current = false;
@@ -271,7 +279,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
       clearInterval(interval);
       document.removeEventListener("visibilitychange", onVisible);
     };
-  }, [window, loaderData.hasConfiguredArrs, arrHealthRetry]);
+  }, [window, loaderData.hasConfiguredArrs, arrHealthRetry, mockArrHealth]);
 
   // Detail (latency + errors): once per 24h window selection — not on the 30s poll.
   useEffect(() => {
@@ -480,7 +488,9 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
         ) : (
           <Skeleton height={180} />
         ),
-      arrHealth: loaderData.hasConfiguredArrs ? (
+      arrHealth: mockArrHealth ? (
+        <ArrHealth data={mockArrHealth} window={window} />
+      ) : loaderData.hasConfiguredArrs ? (
         arrHealthError && !arrHealthLoaded ? (
           <SectionLoadError label="Arr health" onRetry={() => setArrHealthRetry((n) => n + 1)} />
         ) : arrHealthLoaded && arrHealth ? (
@@ -547,6 +557,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
       arrHealth,
       arrHealthLoaded,
       arrHealthError,
+      mockArrHealth,
       selectedProvider,
     ],
   );
@@ -559,7 +570,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
     const filtered = order.filter((id) => {
       if (!loaderData.hasConfiguredIndexers && (id === "indexers" || id === "indexerApiUsage"))
         return false;
-      if (!loaderData.hasConfiguredArrs && id === "arrHealth") return false;
+      if (!loaderData.hasConfiguredArrs && !mockArrHealth && id === "arrHealth") return false;
       return true;
     });
     if (!mobileStack || editMode) return filtered;
@@ -569,6 +580,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
   }, [
     loaderData.hasConfiguredIndexers,
     loaderData.hasConfiguredArrs,
+    mockArrHealth,
     order,
     mobileStack,
     editMode,

--- a/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
+++ b/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
@@ -309,28 +309,24 @@ export function SabnzbdSettings({ config, setNewConfig }: SabnzbdSettingsProps) 
         </ManagedSetting>
 
         <ManagedSetting configKey="api.rename-single-video-to-release">
-          <Toggle
-            id="rename-single-video-to-release-checkbox"
-            className="cursor-pointer gap-2 p-0"
-            checked={(config["api.rename-single-video-to-release"] ?? "true") !== "false"}
-            onChange={(e) =>
-              setNewConfig({
-                ...config,
-                "api.rename-single-video-to-release": String(e.target.checked),
-              })
-            }
-            label={
-              <span>
-                <span className="block text-sm font-medium text-base-content">
+          <Tooltip content="When a job mounts exactly one video, name it after the download folder. Multi-video jobs (season packs) are never renamed.">
+            <Toggle
+              id="rename-single-video-to-release-checkbox"
+              className="cursor-pointer gap-2 p-0"
+              checked={(config["api.rename-single-video-to-release"] ?? "true") !== "false"}
+              onChange={(e) =>
+                setNewConfig({
+                  ...config,
+                  "api.rename-single-video-to-release": String(e.target.checked),
+                })
+              }
+              label={
+                <span className="text-sm text-base-content">
                   Rename a single video to the release name
                 </span>
-                <span className="block text-[11px] leading-relaxed text-base-content/45">
-                  When a job mounts exactly one video, name it after the download folder.
-                  Multi-video jobs (season packs) are never renamed.
-                </span>
-              </span>
-            }
-          />
+              }
+            />
+          </Tooltip>
         </ManagedSetting>
 
         <ManagedSetting configKey="api.duplicate-nzb-behavior">


### PR DESCRIPTION
## Summary
- Closes #1262 — idle Right now no longer reserves a tall empty card; with live reads the panel locks to the first snapshot height so later sessions scroll instead of stretching the layout.
- Closes #1263 — Arr Health stays inside the card on phones (icon metric headers, tighter count columns, truncated instance names). Status color is on the instance name pill instead of a separate badge.
- Closes #1264 — “Rename a single video to the release name” uses the same hover/focus tooltip as the other SABnzbd toggles.

Local-only Overview previews (`?mockReads=` / `?mockArrHealth`) stay behind the Vite DEV flag and are not used in production builds.

## Test plan
- [ ] Overview with no active reads: Right now is compact, matching neighboring cards.
- [ ] Overview with live reads: first snapshot sets card height; additional sessions scroll inside the list.
- [ ] Arr Health on a ~390px viewport: instance names do not overlap the imports column; last-import values stay on one line.
- [ ] Arr Health on desktop: text column headers, status-colored instance name pills, no overflow.
- [ ] Settings → SABnzbd: hover/focus “Rename a single video to the release name” shows the help tooltip; the muted paragraph under the label is gone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI Improvements**
  - Updated navigation with responsive sizing, larger avatars, and animated update-available styling.
  - Improved Arr health displays with status badges, tooltips, responsive layouts, and mobile readability.
  - Redesigned live-read rows for clearer transfer metrics, progress, scrolling, and responsive presentation.
  - Refined provider speed charts and sparklines with secondary-theme colors.
  - Added explanatory tooltip guidance to the single-video rename setting.

- **Development**
  - Added mock data options for Arr health and live-read displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->