### PR TITLE
fix(ui): Arr Health card no longer shows a stray horizontal scrollbar

### DIFF
--- a/frontend/app/routes/overview/components/arr-health/arr-health.test.tsx
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.test.tsx
@@ -128,6 +128,8 @@ describe("ArrHealth", () => {
     expect(markup).toMatch(/max-sm:!inline-block[^>]*>pending</);
     expect(markup).toMatch(/max-sm:!inline-block[^>]*>schedule</);
     expect(markup).toContain("max-sm:sr-only");
+    expect(markup).not.toContain("overflow-x-auto");
+    expect(markup).not.toContain("min-w-[640px]");
   });
 
   it("shows the empty state when no instances have imported yet", () => {

--- a/frontend/app/routes/overview/components/arr-health/arr-health.tsx
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.tsx
@@ -68,8 +68,8 @@ export function ArrHealth({ data, window }: ArrHealthProps) {
         {instances.length === 0 ? (
           <p className="py-6 text-center text-xs text-base-content/50">No imports recorded yet.</p>
         ) : (
-          <div className="overflow-x-auto max-sm:overflow-visible">
-            <table className="table table-sm w-full max-sm:table-fixed sm:min-w-[640px]">
+          <div className="min-w-0">
+            <table className="table table-sm w-full min-w-0 max-sm:table-fixed">
               <thead>
                 <tr>
                   <th className="max-sm:w-[42%]">Instance</th>


### PR DESCRIPTION
## Summary
- The Arr Health instance table used `overflow-x-auto` plus a 640px min-width, which painted a near-full-track horizontal scrollbar even when every column already fit the card.
- Hidden header tooltips still inflate `scrollWidth`, so the table now sizes to the card instead of opening a scrollport.
- Mobile still uses `table-fixed` column widths so the instance pills stay on-screen.

## Test plan
- [ ] Open Overview with Arr instances configured (or `?mockArrHealth` in local DEV) and confirm the Arr Health table has no horizontal scrollbar when the columns fit.
- [ ] Resize across desktop and a ~390px phone width: instance names still truncate, Median/P95 still hide on small screens, and the card does not grow a stray bar.
- [ ] Hover Imports / Queue / Awaiting / Last import headers and an instance URL — tooltips still appear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Arr Health instances table on small screens by removing horizontal scrolling and allowing the table to fit available space.
  * Preserved full-width and fixed-layout behavior for responsive display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->