### PR TITLE
fix(db): skip a maintenance sweep instead of stopping the host when SQLite is busy

### DIFF
--- a/backend/Extensions/ExceptionExtensions.cs
+++ b/backend/Extensions/ExceptionExtensions.cs
@@ -75,6 +75,21 @@ public static class ExceptionExtensions
     }
 
     /// <summary>
+    /// True only for SQLite BUSY/LOCKED contention. SqliteErrorCode is the
+    /// primary result code, so extended BUSY/LOCKED variants are included.
+    /// </summary>
+    internal static bool IsSqliteBusyOrLockedException(this Exception exception)
+    {
+        for (var current = exception; current != null; current = current.InnerException)
+        {
+            if (current is SqliteException { SqliteErrorCode: 5 or 6 })
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// True for write contention that can be retried by the caller's next sweep
     /// (SQLITE_BUSY / SQLITE_LOCKED). SQLITE_READONLY (8) and SQLITE_FULL (13) are
     /// operator-facing disk errors that do not heal on retry — see
@@ -83,12 +98,11 @@ public static class ExceptionExtensions
     /// </summary>
     public static bool IsTransientDatabaseException(this Exception exception)
     {
+        if (exception.IsSqliteBusyOrLockedException())
+            return true;
+
         for (var current = exception; current != null; current = current.InnerException)
         {
-            if (current is SqliteException sqlite
-                && sqlite.SqliteErrorCode is 5 or 6)
-                return true;
-
             if (current is PostgresException postgres
                 && postgres.SqlState is PostgresErrorCodes.SerializationFailure
                     or PostgresErrorCodes.DeadlockDetected

--- a/backend/Services/SqliteMaintenanceService.cs
+++ b/backend/Services/SqliteMaintenanceService.cs
@@ -1,8 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Database;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.Utils;
-using Serilog;
 
 namespace NzbWebDAV.Services;
 
@@ -17,6 +17,9 @@ public class SqliteMaintenanceService(IDbContextFactory<DavDatabaseContext> dbCo
     private static readonly TimeSpan InitialDelay = TimeSpan.FromMinutes(2);
     private static readonly TimeSpan TickInterval = TimeSpan.FromHours(6);
 
+    internal const int MaxTransientRetries = 3;
+    internal static readonly TimeSpan TransientRetryBaseDelay = TimeSpan.FromMilliseconds(250);
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         try
@@ -30,7 +33,15 @@ public class SqliteMaintenanceService(IDbContextFactory<DavDatabaseContext> dbCo
 
         while (!stoppingToken.IsCancellationRequested)
         {
-            await SafeSweepAsync().ConfigureAwait(false);
+            try
+            {
+                await SafeSweepAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (
+                SigtermUtil.IsSigtermTriggered() || stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
 
             try
             {
@@ -43,17 +54,68 @@ public class SqliteMaintenanceService(IDbContextFactory<DavDatabaseContext> dbCo
         }
     }
 
-    private async Task SafeSweepAsync()
+    private Task SafeSweepAsync(CancellationToken stoppingToken) =>
+        RunWithSqliteContentionRetryAsync(
+            async cancellationToken =>
+            {
+                await using var db = dbContextFactory.CreateDbContext();
+                await using var metrics = new MetricsDbContext();
+                await SweepAsync(db, metrics, cancellationToken).ConfigureAwait(false);
+            },
+            stoppingToken);
+
+    internal static async Task RunWithSqliteContentionRetryAsync(
+        Func<CancellationToken, Task> sweep,
+        CancellationToken cancellationToken,
+        Func<TimeSpan, CancellationToken, Task>? delayAsync = null)
     {
-        try
+        ArgumentNullException.ThrowIfNull(sweep);
+        delayAsync ??= static (delay, token) => Task.Delay(delay, token);
+
+        var maxAttempts = MaxTransientRetries + 1;
+        for (var attempt = 1; ; attempt++)
         {
-            await using var db = dbContextFactory.CreateDbContext();
-            await using var metrics = new MetricsDbContext();
-            await SweepAsync(db, metrics).ConfigureAwait(false);
-        }
-        catch (Exception ex) when (ex is DbUpdateException or InvalidOperationException)
-        {
-            Log.Warning(ex, "SqliteMaintenanceService sweep failed");
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                await sweep(cancellationToken).ConfigureAwait(false);
+                return;
+            }
+            catch (Exception ex) when (
+                ex is not OutOfMemoryException &&
+                ex.IsSqliteBusyOrLockedException())
+            {
+                // If shutdown raced the SQLite failure, convert it to normal
+                // cancellation instead of retrying or treating contention as success.
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (attempt >= maxAttempts)
+                {
+                    ex.LogWarningKnownOrStack(
+                        "SQLite maintenance sweep skipped after {AttemptCount} attempts; " +
+                        "the next scheduled sweep will try again",
+                        attempt);
+                    return;
+                }
+
+                var delay = TimeSpan.FromMilliseconds(
+                    TransientRetryBaseDelay.TotalMilliseconds * attempt);
+
+                // Warn on first observation only. The terminal branch above warns
+                // separately if all attempts are exhausted.
+                if (attempt == 1)
+                {
+                    ex.LogWarningKnownOrStack(
+                        "SQLite maintenance sweep deferred by database contention " +
+                        "(attempt {Attempt}/{MaxAttempts}); retrying in {RetryDelayMs} ms",
+                        attempt,
+                        maxAttempts,
+                        (long)delay.TotalMilliseconds);
+                }
+
+                await delayAsync(delay, cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 

--- a/tests/NzbWebDAV.Tests/Extensions/ExceptionExtensionsTests.cs
+++ b/tests/NzbWebDAV.Tests/Extensions/ExceptionExtensionsTests.cs
@@ -1,5 +1,6 @@
 using System.Net.Sockets;
 using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 
@@ -205,6 +206,47 @@ public class ExceptionExtensionsTests
 
         Assert.True(ex.IsTransientDatabaseException());
         Assert.False(ex.IsKnownSqliteDiskException());
+    }
+
+    [Theory]
+    [InlineData(5, 261)] // SQLITE_BUSY_RECOVERY
+    [InlineData(5, 517)] // SQLITE_BUSY_SNAPSHOT
+    [InlineData(6, 262)] // SQLITE_LOCKED_SHAREDCACHE
+    [InlineData(6, 518)] // SQLITE_LOCKED_VTAB
+    public void IsSqliteBusyOrLockedException_UsesPrimaryCode(
+        int primaryCode,
+        int extendedCode)
+    {
+        var exception = new SqliteException("sqlite contention", primaryCode, extendedCode);
+
+        Assert.Equal(primaryCode, exception.SqliteErrorCode);
+        Assert.Equal(extendedCode, exception.SqliteExtendedErrorCode);
+        Assert.True(exception.IsSqliteBusyOrLockedException());
+        Assert.True(exception.IsTransientDatabaseException());
+    }
+
+    [Fact]
+    public void IsSqliteBusyOrLockedException_RecognizesWrappedBusy()
+    {
+        var inner = new SqliteException("sqlite contention", 5, 261);
+        var outer = new DbUpdateException("wrapper", inner);
+
+        Assert.True(outer.IsSqliteBusyOrLockedException());
+        Assert.True(outer.IsTransientDatabaseException());
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(8)]
+    [InlineData(11)]
+    [InlineData(13)]
+    [InlineData(19)]
+    [InlineData(26)]
+    public void IsSqliteBusyOrLockedException_RejectsNonContentionCodes(int primaryCode)
+    {
+        var exception = new SqliteException("other sqlite error", primaryCode);
+
+        Assert.False(exception.IsSqliteBusyOrLockedException());
     }
 
     [Theory]

--- a/tests/NzbWebDAV.Tests/Services/SqliteMaintenanceServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SqliteMaintenanceServiceTests.cs
@@ -187,7 +187,7 @@ public sealed class SqliteMaintenanceServiceTests
     {
         var calls = 0;
         var (delays, delayAsync) = CreateRecordingDelay();
-        var thrown = new OutOfMemoryException("oom");
+        var thrown = new OutOfMemoryException("oom", new SqliteException("sqlite contention", 5, 261));
 
         var actual = await Assert.ThrowsAsync<OutOfMemoryException>(() =>
             SqliteMaintenanceService.RunWithSqliteContentionRetryAsync(

--- a/tests/NzbWebDAV.Tests/Services/SqliteMaintenanceServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SqliteMaintenanceServiceTests.cs
@@ -1,0 +1,318 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Services;
+using NzbWebDAV.Tests.TestUtils;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace NzbWebDAV.Tests.Services;
+
+[Collection(nameof(GlobalLoggerCollection))]
+public sealed class SqliteMaintenanceServiceTests
+{
+    [Fact]
+    public async Task RunWithSqliteContentionRetryAsync_BusyThenSuccess_RetriesOnce()
+    {
+        var calls = 0;
+        var (delays, delayAsync) = CreateRecordingDelay();
+        var busy = new SqliteException("sqlite contention", 5, 261);
+
+        await SqliteMaintenanceService.RunWithSqliteContentionRetryAsync(
+            _ =>
+            {
+                calls++;
+                if (calls == 1)
+                    throw busy;
+                return Task.CompletedTask;
+            },
+            CancellationToken.None,
+            delayAsync);
+
+        Assert.Equal(2, calls);
+        Assert.Equal([SqliteMaintenanceService.TransientRetryBaseDelay], delays);
+    }
+
+    [Fact]
+    public async Task RunWithSqliteContentionRetryAsync_LockedThenSuccess_RetriesOnce()
+    {
+        var calls = 0;
+        var (delays, delayAsync) = CreateRecordingDelay();
+        var locked = new SqliteException("sqlite contention", 6, 262);
+
+        await SqliteMaintenanceService.RunWithSqliteContentionRetryAsync(
+            _ =>
+            {
+                calls++;
+                if (calls == 1)
+                    throw locked;
+                return Task.CompletedTask;
+            },
+            CancellationToken.None,
+            delayAsync);
+
+        Assert.Equal(2, calls);
+        Assert.Equal([SqliteMaintenanceService.TransientRetryBaseDelay], delays);
+    }
+
+    [Fact]
+    public async Task RunWithSqliteContentionRetryAsync_WrappedContention_Retries()
+    {
+        var calls = 0;
+        var (delays, delayAsync) = CreateRecordingDelay();
+        var wrapped = new DbUpdateException(
+            "wrapper",
+            new SqliteException("sqlite contention", 5, 261));
+
+        await SqliteMaintenanceService.RunWithSqliteContentionRetryAsync(
+            _ =>
+            {
+                calls++;
+                if (calls == 1)
+                    throw wrapped;
+                return Task.CompletedTask;
+            },
+            CancellationToken.None,
+            delayAsync);
+
+        Assert.Equal(2, calls);
+        Assert.Equal([SqliteMaintenanceService.TransientRetryBaseDelay], delays);
+    }
+
+    [Fact]
+    public async Task RunWithSqliteContentionRetryAsync_PersistentContention_StopsAtBudget()
+    {
+        var calls = 0;
+        var (delays, delayAsync) = CreateRecordingDelay();
+        var busy = new SqliteException("sqlite contention", 5, 261);
+
+        await SqliteMaintenanceService.RunWithSqliteContentionRetryAsync(
+            _ =>
+            {
+                calls++;
+                throw busy;
+            },
+            CancellationToken.None,
+            delayAsync);
+
+        Assert.Equal(SqliteMaintenanceService.MaxTransientRetries + 1, calls);
+        Assert.Equal(
+            [
+                SqliteMaintenanceService.TransientRetryBaseDelay,
+                SqliteMaintenanceService.TransientRetryBaseDelay * 2,
+                SqliteMaintenanceService.TransientRetryBaseDelay * 3,
+            ],
+            delays);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(8)]
+    [InlineData(11)]
+    [InlineData(13)]
+    [InlineData(19)]
+    [InlineData(26)]
+    public async Task RunWithSqliteContentionRetryAsync_UnexpectedSqliteError_Propagates(int primaryCode)
+    {
+        var calls = 0;
+        var (delays, delayAsync) = CreateRecordingDelay();
+        var thrown = new SqliteException("unexpected sqlite error", primaryCode);
+
+        var actual = await Assert.ThrowsAsync<SqliteException>(() =>
+            SqliteMaintenanceService.RunWithSqliteContentionRetryAsync(
+                _ =>
+                {
+                    calls++;
+                    throw thrown;
+                },
+                CancellationToken.None,
+                delayAsync));
+
+        Assert.Same(thrown, actual);
+        Assert.Equal(1, calls);
+        Assert.Empty(delays);
+    }
+
+    [Fact]
+    public async Task RunWithSqliteContentionRetryAsync_CancellationDuringBackoff_DoesNotRetry()
+    {
+        using var cts = new CancellationTokenSource();
+        var calls = 0;
+        var delayCalls = 0;
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            SqliteMaintenanceService.RunWithSqliteContentionRetryAsync(
+                _ =>
+                {
+                    calls++;
+                    throw new SqliteException("sqlite contention", 5, 261);
+                },
+                cts.Token,
+                (_, token) =>
+                {
+                    delayCalls++;
+                    cts.Cancel();
+                    token.ThrowIfCancellationRequested();
+                    return Task.CompletedTask;
+                }));
+
+        Assert.Equal(1, calls);
+        Assert.Equal(1, delayCalls);
+    }
+
+    [Fact]
+    public async Task RunWithSqliteContentionRetryAsync_PreCancelledToken_DoesNotInvokeSweep()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var calls = 0;
+        var (delays, delayAsync) = CreateRecordingDelay();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            SqliteMaintenanceService.RunWithSqliteContentionRetryAsync(
+                _ =>
+                {
+                    calls++;
+                    return Task.CompletedTask;
+                },
+                cts.Token,
+                delayAsync));
+
+        Assert.Equal(0, calls);
+        Assert.Empty(delays);
+    }
+
+    [Fact]
+    public async Task RunWithSqliteContentionRetryAsync_OutOfMemory_PropagatesImmediately()
+    {
+        var calls = 0;
+        var (delays, delayAsync) = CreateRecordingDelay();
+        var thrown = new OutOfMemoryException("oom");
+
+        var actual = await Assert.ThrowsAsync<OutOfMemoryException>(() =>
+            SqliteMaintenanceService.RunWithSqliteContentionRetryAsync(
+                _ =>
+                {
+                    calls++;
+                    throw thrown;
+                },
+                CancellationToken.None,
+                delayAsync));
+
+        Assert.Same(thrown, actual);
+        Assert.Equal(1, calls);
+        Assert.Empty(delays);
+    }
+
+    [Fact]
+    public async Task RunWithSqliteContentionRetryAsync_ContentionWarningIsSingleLineWithoutStack()
+    {
+        var events = await CaptureLogsAsync(async () =>
+        {
+            var calls = 0;
+            var busy = new SqliteException("database is locked", 5, 261);
+            await SqliteMaintenanceService.RunWithSqliteContentionRetryAsync(
+                _ =>
+                {
+                    calls++;
+                    if (calls == 1)
+                        throw busy;
+                    return Task.CompletedTask;
+                },
+                CancellationToken.None,
+                CreateRecordingDelay().DelayAsync);
+        });
+
+        var warning = Assert.Single(
+            events,
+            e => e.Level == LogEventLevel.Warning
+                 && e.MessageTemplate.Text.Contains("deferred by database contention"));
+        Assert.Null(warning.Exception);
+        var rendered = warning.RenderMessage();
+        Assert.Contains("attempt 1/4", rendered, StringComparison.Ordinal);
+        Assert.Contains("250", rendered, StringComparison.Ordinal);
+        Assert.Contains("database is locked", rendered, StringComparison.Ordinal);
+        Assert.True(warning.Properties.ContainsKey("Reason"));
+    }
+
+    [Fact]
+    public async Task RunWithSqliteContentionRetryAsync_PersistentContention_LogsFirstAndTerminalWarnings()
+    {
+        var events = await CaptureLogsAsync(async () =>
+        {
+            var busy = new SqliteException("database is locked", 5, 261);
+            await SqliteMaintenanceService.RunWithSqliteContentionRetryAsync(
+                _ => throw busy,
+                CancellationToken.None,
+                CreateRecordingDelay().DelayAsync);
+        });
+
+        var warnings = events
+            .Where(e => e.Level == LogEventLevel.Warning)
+            .ToList();
+        Assert.Equal(2, warnings.Count);
+        Assert.All(warnings, warning =>
+        {
+            Assert.Null(warning.Exception);
+            Assert.True(warning.Properties.ContainsKey("Reason"));
+        });
+        Assert.Contains(
+            warnings,
+            e => e.MessageTemplate.Text.Contains("deferred by database contention"));
+        Assert.Contains(
+            warnings,
+            e => e.MessageTemplate.Text.Contains("skipped after"));
+    }
+
+    private static (List<TimeSpan> Delays, Func<TimeSpan, CancellationToken, Task> DelayAsync) CreateRecordingDelay()
+    {
+        var delays = new List<TimeSpan>();
+        Task DelayAsync(TimeSpan delay, CancellationToken token)
+        {
+            token.ThrowIfCancellationRequested();
+            delays.Add(delay);
+            return Task.CompletedTask;
+        }
+
+        return (delays, DelayAsync);
+    }
+
+    private static async Task<IReadOnlyList<LogEvent>> CaptureLogsAsync(Func<Task> action)
+    {
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Warning()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        try
+        {
+            await action().ConfigureAwait(false);
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+
+        return sink.Events;
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events) return _events.ToArray();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events) _events.Add(logEvent);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Hardens an audit-identified path so SQLite `BUSY`/`LOCKED` during periodic maintenance no longer faults the background service (and therefore the host). This does not assert a known production crash.
- Retries the full idempotent sweep with fresh contexts up to four attempts (250/500/750 ms), then skips that cycle and waits for the next six-hour schedule.
- Unexpected SQLite errors and `OutOfMemoryException` still propagate so the default `StopHost` policy stays in effect.

Fixes #1232

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~SqliteMaintenanceServiceTests|FullyQualifiedName~ExceptionExtensionsTests"` (57 passed)
- [ ] CI backend build/tests on this PR (warnings-as-errors, including `MaintenanceSweep_PopulatesSqliteStat1`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SQLite maintenance operations now automatically retry temporary database lock and busy errors.
  * Cancellation requests are handled promptly during maintenance and shutdown.
  * Unexpected database errors continue to surface instead of being treated as temporary failures.
* **Reliability**
  * Improved detection of SQLite contention errors, including wrapped and extended error codes.
  * Added clearer warnings when retries begin or are exhausted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->