### PR TITLE
fix(db): keep scheduled backups running when the backup directory is temporarily unavailable

### DIFF
--- a/backend/Services/DatabaseBackupSchedulerService.cs
+++ b/backend/Services/DatabaseBackupSchedulerService.cs
@@ -15,9 +15,21 @@ namespace NzbWebDAV.Services;
 /// </summary>
 public class DatabaseBackupSchedulerService : BackgroundService
 {
+    internal static readonly TimeSpan ErrorRetryDelay = TimeSpan.FromSeconds(10);
+    internal static readonly TimeSpan InitializationWarningInterval = TimeSpan.FromMinutes(5);
+
+    internal enum InitializationEvent
+    {
+        AttemptStarted,
+        Succeeded,
+        RetryScheduled,
+    }
+
     private readonly ConfigManager _configManager;
     private readonly WebsocketManager _websocketManager;
     private readonly DatabaseBackupStore _store;
+    private readonly TimeProvider _timeProvider;
+    private readonly Action<InitializationEvent>? _initializationObserver;
     private CancellationTokenSource _rescheduleCts = new();
     // NOTE: swapped-out instances are intentionally not disposed (ExecuteAsync may
     // still read .Token after the swap); the current instance is disposed in Dispose.
@@ -25,15 +37,30 @@ public class DatabaseBackupSchedulerService : BackgroundService
     private static readonly TimeSpan MaxSleepSlice = TimeSpan.FromMinutes(30);
     private DateTime? _lastLoggedNextRun;
     private DateTime? _lastRun;
+    private DateTimeOffset? _nextInitializationWarningAt;
+    private int _initializationFailureCount;
+    private int _suppressedInitializationWarnings;
 
     public DatabaseBackupSchedulerService(
         ConfigManager configManager,
         WebsocketManager websocketManager,
         DatabaseBackupStore store)
+        : this(configManager, websocketManager, store, TimeProvider.System, null)
+    {
+    }
+
+    internal DatabaseBackupSchedulerService(
+        ConfigManager configManager,
+        WebsocketManager websocketManager,
+        DatabaseBackupStore store,
+        TimeProvider timeProvider,
+        Action<InitializationEvent>? initializationObserver = null)
     {
         _configManager = configManager;
         _websocketManager = websocketManager;
         _store = store;
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _initializationObserver = initializationObserver;
 
         _configManager.OnConfigChanged += (_, args) =>
         {
@@ -51,12 +78,21 @@ public class DatabaseBackupSchedulerService : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        _store.EnsureInitialized();
+        var storeInitialized = false;
 
         while (!stoppingToken.IsCancellationRequested)
         {
             try
             {
+                if (!storeInitialized)
+                {
+                    _initializationObserver?.Invoke(InitializationEvent.AttemptStarted);
+                    _store.EnsureInitialized();
+                    storeInitialized = true;
+                    LogInitializationRecoveryIfNeeded();
+                    _initializationObserver?.Invoke(InitializationEvent.Succeeded);
+                }
+
                 var reschedule = Volatile.Read(ref _rescheduleCts);
 
                 if (!_configManager.IsDatabaseBackupScheduleEnabled())
@@ -121,10 +157,57 @@ public class DatabaseBackupSchedulerService : BackgroundService
             }
             catch (Exception e) when (e is not OutOfMemoryException)
             {
-                e.LogWarningKnownOrStack("DatabaseBackupScheduler: error running scheduled task");
-                await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken).ConfigureAwait(false);
+                var initializationFailed = !storeInitialized;
+                if (initializationFailed)
+                    LogInitializationFailure(e);
+                else
+                    e.LogWarningKnownOrStack(
+                        "DatabaseBackupScheduler: error running scheduled task");
+
+                var retryDelay = Task.Delay(ErrorRetryDelay, _timeProvider, stoppingToken);
+                if (initializationFailed)
+                    _initializationObserver?.Invoke(InitializationEvent.RetryScheduled);
+                await retryDelay.ConfigureAwait(false);
             }
         }
+    }
+
+    private void LogInitializationFailure(Exception exception)
+    {
+        _initializationFailureCount++;
+        var now = _timeProvider.GetUtcNow();
+        if (_nextInitializationWarningAt is { } next && now < next)
+        {
+            _suppressedInitializationWarnings++;
+            return;
+        }
+
+        var suppressed = _suppressedInitializationWarnings;
+        _suppressedInitializationWarnings = 0;
+        _nextInitializationWarningAt = now + InitializationWarningInterval;
+
+        exception.LogWarningKnownOrStack(
+            "DatabaseBackupScheduler: cannot initialize backup directory {BackupPath}; " +
+            "scheduled backups are paused and initialization will retry; " +
+            "{Suppressed} repeat(s) suppressed",
+            _store.BackupsRoot,
+            suppressed);
+    }
+
+    private void LogInitializationRecoveryIfNeeded()
+    {
+        if (_initializationFailureCount == 0)
+            return;
+
+        Log.Information(
+            "DatabaseBackupScheduler: backup directory {BackupPath} initialized after " +
+            "{FailureCount} failed attempt(s)",
+            _store.BackupsRoot,
+            _initializationFailureCount);
+
+        _nextInitializationWarningAt = null;
+        _initializationFailureCount = 0;
+        _suppressedInitializationWarnings = 0;
     }
 
     public override void Dispose()

--- a/tests/NzbWebDAV.Tests/Services/DatabaseBackupSchedulerServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/DatabaseBackupSchedulerServiceTests.cs
@@ -1,0 +1,360 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Services;
+using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Tests.TestUtils;
+using NzbWebDAV.Websocket;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace NzbWebDAV.Tests.Services;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class DatabaseBackupSchedulerServiceTests : IDisposable
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
+    private readonly string? _previousConfigPath;
+    private readonly List<string> _tempRoots = [];
+
+    public DatabaseBackupSchedulerServiceTests()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+    }
+
+    [Fact]
+    public async Task StartAsync_MissingBackupsDirectory_CreatesDirectoryWithoutWarning()
+    {
+        var configRoot = CreateConfigRoot();
+        var store = new DatabaseBackupStore();
+        var observer = new InitObserver();
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        using var service = new DatabaseBackupSchedulerService(
+            new ConfigManager(),
+            new WebsocketManager(),
+            store,
+            TimeProvider.System,
+            observer.Observe);
+
+        try
+        {
+            await service.StartAsync(CancellationToken.None).WaitAsync(Timeout);
+            await observer.Succeeded.Task.WaitAsync(Timeout);
+
+            Assert.True(Directory.Exists(store.BackupsRoot));
+            Assert.Equal(1, observer.AttemptCount);
+            Assert.Equal(1, observer.SuccessCount);
+            Assert.Equal(0, observer.RetryCount);
+            Assert.NotNull(service.ExecuteTask);
+            Assert.False(service.ExecuteTask.IsFaulted);
+            Assert.Empty(InitializationWarnings(sink.Events, store.BackupsRoot));
+            Assert.StartsWith(configRoot, store.BackupsRoot);
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None).WaitAsync(Timeout);
+            Log.Logger = previous;
+        }
+    }
+
+    [Fact]
+    public async Task StartAsync_BackupsPathIsFile_RetriesAndRecoversAfterRepair()
+    {
+        var configRoot = CreateConfigRoot();
+        var blocker = Path.Join(configRoot, "backups");
+        File.WriteAllText(blocker, "blocks Directory.CreateDirectory");
+
+        var clock = new ControllableTimeProvider();
+        var store = new DatabaseBackupStore();
+        var observer = new InitObserver();
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        using var service = new DatabaseBackupSchedulerService(
+            new ConfigManager(),
+            new WebsocketManager(),
+            store,
+            clock,
+            observer.Observe);
+
+        try
+        {
+            await service.StartAsync(CancellationToken.None).WaitAsync(Timeout);
+            await observer.RetryScheduled.Task.WaitAsync(Timeout);
+
+            Assert.False(service.ExecuteTask!.IsCompleted);
+            Assert.False(service.ExecuteTask.IsFaulted);
+
+            var warning = Assert.Single(InitializationWarnings(sink.Events, store.BackupsRoot));
+            Assert.Equal(LogEventLevel.Warning, warning.Level);
+            Assert.Null(warning.Exception);
+            var reason = warning.Properties["Reason"].LiteralValue() as string;
+            Assert.False(string.IsNullOrWhiteSpace(reason));
+
+            File.Delete(blocker);
+            clock.Advance(DatabaseBackupSchedulerService.ErrorRetryDelay - TimeSpan.FromMilliseconds(1));
+            Assert.False(Directory.Exists(store.BackupsRoot));
+            Assert.Equal(1, observer.AttemptCount);
+
+            clock.Advance(TimeSpan.FromMilliseconds(1));
+            await observer.Succeeded.Task.WaitAsync(Timeout);
+
+            Assert.Equal(2, observer.AttemptCount);
+            Assert.Equal(1, observer.RetryCount);
+            Assert.True(Directory.Exists(store.BackupsRoot));
+            Assert.False(service.ExecuteTask.IsFaulted);
+
+            var recovery = Assert.Single(
+                sink.Events,
+                e => e.Level == LogEventLevel.Information
+                     && e.MessageTemplate.Text.Contains("initialized after")
+                     && Equals(e.Properties["BackupPath"].LiteralValue(), store.BackupsRoot));
+            var failureCount = Assert.IsType<int>(recovery.Properties["FailureCount"].LiteralValue());
+            Assert.True(failureCount > 0);
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None).WaitAsync(Timeout);
+            Log.Logger = previous;
+        }
+    }
+
+    [Fact]
+    public async Task StopAsync_WhileInitializationRetryIsPending_DoesNotHangOrLogCancellation()
+    {
+        var configRoot = CreateConfigRoot();
+        var blocker = Path.Join(configRoot, "backups");
+        File.WriteAllText(blocker, "blocks Directory.CreateDirectory");
+
+        var clock = new ControllableTimeProvider();
+        var store = new DatabaseBackupStore();
+        var observer = new InitObserver();
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        using var service = new DatabaseBackupSchedulerService(
+            new ConfigManager(),
+            new WebsocketManager(),
+            store,
+            clock,
+            observer.Observe);
+
+        try
+        {
+            await service.StartAsync(CancellationToken.None).WaitAsync(Timeout);
+            await observer.RetryScheduled.Task.WaitAsync(Timeout);
+
+            Assert.Equal(1, observer.AttemptCount);
+            Assert.Equal(1, observer.RetryCount);
+            Assert.Single(InitializationWarnings(sink.Events, store.BackupsRoot));
+
+            await service.StopAsync(CancellationToken.None).WaitAsync(Timeout);
+
+            Assert.True(service.ExecuteTask!.IsCanceled);
+            Assert.False(service.ExecuteTask.IsFaulted);
+            Assert.Equal(1, observer.AttemptCount);
+            Assert.Equal(1, observer.RetryCount);
+            Assert.Equal(0, observer.SuccessCount);
+            Assert.Single(InitializationWarnings(sink.Events, store.BackupsRoot));
+            Assert.DoesNotContain(
+                sink.Events,
+                e => e.Exception is OperationCanceledException
+                     || (e.Level == LogEventLevel.Warning
+                         && e.MessageTemplate.Text.Contains("cannot initialize backup directory")
+                         && e.Exception is OperationCanceledException));
+        }
+        finally
+        {
+            if (service.ExecuteTask is { IsCompleted: false })
+                await service.StopAsync(CancellationToken.None).WaitAsync(Timeout);
+            Log.Logger = previous;
+        }
+    }
+
+    [Fact]
+    public async Task PersistentInitializationFailure_ThrottlesWarningsButContinuesRetrying()
+    {
+        var configRoot = CreateConfigRoot();
+        var blocker = Path.Join(configRoot, "backups");
+        File.WriteAllText(blocker, "blocks Directory.CreateDirectory");
+
+        var clock = new ControllableTimeProvider();
+        var store = new DatabaseBackupStore();
+        var observer = new InitObserver();
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        using var service = new DatabaseBackupSchedulerService(
+            new ConfigManager(),
+            new WebsocketManager(),
+            store,
+            clock,
+            observer.Observe);
+
+        try
+        {
+            await service.StartAsync(CancellationToken.None).WaitAsync(Timeout);
+            await observer.RetryScheduled.Task.WaitAsync(Timeout);
+            Assert.Single(InitializationWarnings(sink.Events, store.BackupsRoot));
+
+            for (var i = 0; i < 3; i++)
+            {
+                observer.ArmNextRetry();
+                clock.Advance(DatabaseBackupSchedulerService.ErrorRetryDelay);
+                await observer.RetryScheduled.Task.WaitAsync(Timeout);
+            }
+
+            Assert.True(observer.AttemptCount > 1);
+            Assert.Equal(observer.AttemptCount, observer.RetryCount);
+            Assert.Single(InitializationWarnings(sink.Events, store.BackupsRoot));
+
+            observer.ArmNextRetry();
+            clock.Advance(DatabaseBackupSchedulerService.InitializationWarningInterval);
+            await observer.RetryScheduled.Task.WaitAsync(Timeout);
+
+            var warnings = InitializationWarnings(sink.Events, store.BackupsRoot);
+            Assert.Equal(2, warnings.Count);
+            var reminder = warnings[^1];
+            Assert.Null(reminder.Exception);
+            var suppressed = Assert.IsType<int>(reminder.Properties["Suppressed"].LiteralValue());
+            Assert.True(suppressed > 0);
+
+            File.Delete(blocker);
+            clock.Advance(DatabaseBackupSchedulerService.ErrorRetryDelay);
+            await observer.Succeeded.Task.WaitAsync(Timeout);
+
+            Assert.True(Directory.Exists(store.BackupsRoot));
+            Assert.False(service.ExecuteTask!.IsFaulted);
+            var recovery = Assert.Single(
+                sink.Events,
+                e => e.Level == LogEventLevel.Information
+                     && e.MessageTemplate.Text.Contains("initialized after")
+                     && Equals(e.Properties["BackupPath"].LiteralValue(), store.BackupsRoot));
+            var failureCount = Assert.IsType<int>(recovery.Properties["FailureCount"].LiteralValue());
+            Assert.True(failureCount > 0);
+            Assert.Equal(observer.AttemptCount - 1, failureCount);
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None).WaitAsync(Timeout);
+            Log.Logger = previous;
+        }
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        foreach (var root in _tempRoots)
+        {
+            try
+            {
+                if (Directory.Exists(root))
+                    Directory.Delete(root, recursive: true);
+            }
+            catch (IOException)
+            {
+                // best effort cleanup
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // best effort cleanup
+            }
+        }
+    }
+
+    private string CreateConfigRoot()
+    {
+        var root = Path.Join(Path.GetTempPath(), $"nzbdav-backup-scheduler-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        _tempRoots.Add(root);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", root);
+        return root;
+    }
+
+    private static List<LogEvent> InitializationWarnings(IReadOnlyList<LogEvent> events, string backupPath) =>
+        events.Where(e =>
+                e.Level == LogEventLevel.Warning
+                && e.MessageTemplate.Text.Contains("cannot initialize backup directory")
+                && Equals(e.Properties.GetValueOrDefault("BackupPath")?.LiteralValue(), backupPath))
+            .ToList();
+
+    private sealed class InitObserver
+    {
+        private int _attempts;
+        private int _retries;
+        private int _successes;
+        private TaskCompletionSource _retryScheduled = NewTcs();
+
+        public int AttemptCount => Volatile.Read(ref _attempts);
+        public int RetryCount => Volatile.Read(ref _retries);
+        public int SuccessCount => Volatile.Read(ref _successes);
+        public TaskCompletionSource RetryScheduled => _retryScheduled;
+        public TaskCompletionSource Succeeded { get; } = NewTcs();
+
+        public void Observe(DatabaseBackupSchedulerService.InitializationEvent state)
+        {
+            switch (state)
+            {
+                case DatabaseBackupSchedulerService.InitializationEvent.AttemptStarted:
+                    Interlocked.Increment(ref _attempts);
+                    break;
+                case DatabaseBackupSchedulerService.InitializationEvent.RetryScheduled:
+                    Interlocked.Increment(ref _retries);
+                    _retryScheduled.TrySetResult();
+                    break;
+                case DatabaseBackupSchedulerService.InitializationEvent.Succeeded:
+                    Interlocked.Increment(ref _successes);
+                    Succeeded.TrySetResult();
+                    break;
+            }
+        }
+
+        public void ArmNextRetry() =>
+            _retryScheduled = NewTcs();
+
+        private static TaskCompletionSource NewTcs() =>
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events) return _events.ToArray();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events) _events.Add(logEvent);
+        }
+    }
+}
+
+file static class DatabaseBackupSchedulerLogExtensions
+{
+    public static object? LiteralValue(this LogEventPropertyValue value) =>
+        value is ScalarValue scalar ? scalar.Value : value.ToString();
+}


### PR DESCRIPTION
## Summary
- Retry backup-directory initialization inside the scheduler loop so a temporary filesystem failure under `{CONFIG_PATH}/backups` no longer faults the hosted service.
- Known `IOException` / `UnauthorizedAccessException` failures log as stack-free Warnings (throttled to once per five minutes) and recover with one Information event after the path is repaired.
- Adds focused scheduler tests using a regular-file blocker, virtual time, and initialization observer signals.

Fixes #1233

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~DatabaseBackupSchedulerServiceTests` (4 passed)
- [ ] PR CI (`ci.yml`) backend build/tests, including the new scheduler cases
- [ ] Confirm a regular file at `{CONFIG_PATH}/backups` keeps the scheduler alive, retries every 10s, and creates `backups/` after the blocker is removed
- [ ] Confirm host shutdown during a pending init retry completes without treating cancellation as an initialization failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Database backup scheduling now continues starting even when database initialization temporarily fails.
  - Failed initialization attempts automatically retry after 10 seconds.
  - Services recover automatically once the underlying issue is resolved.
  - Cancellation during retries now completes cleanly without hanging or generating unnecessary cancellation warnings.
  - Repeated failure warnings are throttled to reduce log noise.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->