### PR TITLE
fix(ui): reject a missing frontend/backend API key before the UI starts listening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         working-directory: frontend
         env:
           BACKEND_URL: http://localhost:9
-        run: node --input-type=module -e "const m = await import('./build/server/index.js'); if (typeof m.app !== 'function' || typeof m.initializeWebsocketServer !== 'function') { console.error('build/server/index.js is missing custom server exports (app, initializeWebsocketServer)'); process.exit(1); }"
+        run: node --input-type=module -e "const m = await import('./build/server/index.js'); if (typeof m.app !== 'function' || typeof m.initializeWebsocketServer !== 'function' || typeof m.configureRuntime !== 'function') { console.error('build/server/index.js is missing custom server exports (app, initializeWebsocketServer, configureRuntime)'); process.exit(1); }"
 
       - name: Test frontend with coverage
         working-directory: frontend

--- a/frontend/app/auth/downloads.server.test.ts
+++ b/frontend/app/auth/downloads.server.test.ts
@@ -1,16 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { getDownloadKey } from "./downloads.server";
 
 describe("getDownloadKey", () => {
-  it("returns a hex HMAC of the path", () => {
-    vi.stubEnv("FRONTEND_BACKEND_API_KEY", "unit-test-key");
-    try {
-      const key = getDownloadKey("/content/movie.mkv");
-      expect(key).toMatch(/^[a-f0-9]{64}$/);
-      expect(getDownloadKey("/content/movie.mkv")).toBe(key);
-      expect(getDownloadKey("/content/other.mkv")).not.toBe(key);
-    } finally {
-      vi.unstubAllEnvs();
-    }
+  it("returns a hex HMAC of the path and credential", () => {
+    const key = getDownloadKey("/content/movie.mkv", "unit-test-key");
+    expect(key).toMatch(/^[a-f0-9]{64}$/);
+    expect(getDownloadKey("/content/movie.mkv", "unit-test-key")).toBe(key);
+    expect(getDownloadKey("/content/other.mkv", "unit-test-key")).not.toBe(key);
+    expect(getDownloadKey("/content/movie.mkv", "other-unit-test-key")).not.toBe(key);
   });
 });

--- a/frontend/app/auth/downloads.server.ts
+++ b/frontend/app/auth/downloads.server.ts
@@ -1,6 +1,5 @@
 import { createHmac } from "node:crypto";
 
-export function getDownloadKey(path: string): string {
-  const apiKey = process.env["FRONTEND_BACKEND_API_KEY"] || "";
-  return createHmac("sha256", apiKey).update(path).digest("hex");
+export function getDownloadKey(path: string, frontendBackendApiKey: string): string {
+  return createHmac("sha256", frontendBackendApiKey).update(path).digest("hex");
 }

--- a/frontend/app/clients/backend-client.server.test.ts
+++ b/frontend/app/clients/backend-client.server.test.ts
@@ -8,6 +8,7 @@ import {
   parseBackendFailure,
   parseBackendSuccess,
 } from "./backend-client.server";
+import { installFrontendRuntimeConfig } from "../../server/runtime-config";
 
 const fetchMock = vi.fn<typeof fetch>();
 
@@ -21,7 +22,8 @@ function jsonResponse(body: unknown, status = 200): Response {
 beforeEach(() => {
   vi.stubGlobal("fetch", fetchMock);
   vi.stubEnv("BACKEND_URL", "http://backend");
-  vi.stubEnv("FRONTEND_BACKEND_API_KEY", "test-api-key");
+  vi.stubEnv("FRONTEND_BACKEND_API_KEY", "poisoned-env-key");
+  installFrontendRuntimeConfig({ frontendBackendApiKey: "test-api-key" });
 });
 
 afterEach(() => {

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { getFrontendRuntimeConfig } from "../../server/runtime-config";
 import { adminApi } from "~/clients/admin-operations";
 import { toStreamTracingStatus, type StreamTracingStatus } from "~/utils/stream-tracing-status";
 
@@ -235,7 +236,7 @@ async function call<T = Record<string, unknown>>(
     response = await fetch(process.env["BACKEND_URL"] + path, {
       ...init,
       headers: {
-        "x-api-key": process.env["FRONTEND_BACKEND_API_KEY"] || "",
+        "x-api-key": getFrontendRuntimeConfig().frontendBackendApiKey,
         ...(init?.headers ?? {}),
       },
     });

--- a/frontend/app/routes/explore/route.tsx
+++ b/frontend/app/routes/explore/route.tsx
@@ -9,6 +9,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { lookup as getMimeType } from "mime-types";
 import { getDownloadKey } from "~/auth/downloads.server";
+import { getFrontendRuntimeConfig } from "../../../server/runtime-config";
 import { Loading } from "~/components/loading/loading";
 import { formatFileSize } from "~/utils/file-size";
 import { parseExploreWebdavPath } from "~/utils/path";
@@ -55,6 +56,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   }
   const path = parsed.path;
   try {
+    const { frontendBackendApiKey } = getFrontendRuntimeConfig();
     return {
       parentDirectories: getParentDirectories(path),
       error: null,
@@ -63,7 +65,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
         return {
           ...x,
           mimeType: getMimeType(x.name) || "",
-          downloadKey: getDownloadKey(getRelativePath(path, x.name)),
+          downloadKey: getDownloadKey(getRelativePath(path, x.name), frontendBackendApiKey),
         };
       }),
     };

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -12,6 +12,21 @@ import {
   isWithinBackendStartupGrace,
   shouldEmitThrottledBackendUnavailableLog,
 } from "./server/startup-grace.js";
+import { readFrontendRuntimeConfig, type FrontendRuntimeConfig } from "./server/runtime-config.js";
+
+function readRuntimeConfigOrExit(): FrontendRuntimeConfig {
+  try {
+    return readFrontendRuntimeConfig(process.env);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Invalid frontend configuration.";
+    logger.error(message);
+    process.exit(1);
+  }
+}
+
+// Required frontend/backend shared credential. Validate before Vite, HTTP, or
+// WebSocket work so a missing key cannot crash later as a raw TypeError.
+const RUNTIME_CONFIG = readRuntimeConfigOrExit();
 
 // Short-circuit the type-checking of the built output.
 const BUILD_PATH = "../build/server/index.js";
@@ -121,6 +136,7 @@ router.all("/ws", websocketUpgradeGuard);
 interface ServerBuildModule {
   app: express.Express;
   bakedUrlBase?: string;
+  configureRuntime(config: FrontendRuntimeConfig): void;
   initializeWebsocketServer(websocketServer: WebSocketServer): void;
 }
 
@@ -136,6 +152,11 @@ const setServerModule = (serverModule: ServerBuildModule) => {
   if (_websocketServer != null) serverModule.initializeWebsocketServer(_websocketServer);
   _serverModule = serverModule;
 };
+function prepareServerModule(serverModule: ServerBuildModule): void {
+  assertUrlBaseMatchesBuild(serverModule.bakedUrlBase);
+  serverModule.configureRuntime(RUNTIME_CONFIG);
+  setServerModule(serverModule);
+}
 
 // Handle development vs production
 if (DEVELOPMENT) {
@@ -154,8 +175,7 @@ if (DEVELOPMENT) {
       const serverModule = (await viteDevServer.ssrLoadModule(
         "./server/app.ts",
       )) as ServerBuildModule;
-      assertUrlBaseMatchesBuild(serverModule.bakedUrlBase);
-      setServerModule(serverModule);
+      prepareServerModule(serverModule);
       return await serverModule["app"](req, res, next);
     } catch (error) {
       if (typeof error === "object" && error instanceof Error) {
@@ -169,9 +189,8 @@ if (DEVELOPMENT) {
   router.use("/assets", express.static("build/client/assets", { immutable: true, maxAge: "1y" }));
   router.use(express.static("build/client", { maxAge: "1h" }));
   const serverModule = await import(BUILD_PATH);
-  assertUrlBaseMatchesBuild(serverModule.bakedUrlBase);
+  prepareServerModule(serverModule);
   router.use(serverModule.app);
-  setServerModule(serverModule);
 }
 
 // Mount the router. When URL_BASE is empty we mount at root (no prefix).

--- a/frontend/server/app.runtime-config.test.ts
+++ b/frontend/server/app.runtime-config.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WebSocketServer } from "ws";
+
+const initialize = vi.fn();
+
+vi.stubEnv("SESSION_KEY", "test-session-key");
+vi.stubEnv("BACKEND_URL", "http://127.0.0.1:9");
+
+vi.mock("./websocket.server", () => ({
+  websocketServer: {
+    initialize,
+  },
+}));
+
+describe("server bundle runtime handshake", () => {
+  beforeEach(() => {
+    initialize.mockReset();
+  });
+
+  it("passes the installed key into websocket initialization", async () => {
+    const { configureRuntime, initializeWebsocketServer } = await import("./app");
+    configureRuntime({ frontendBackendApiKey: "bundle-test-key" });
+    const fakeWss = {} as WebSocketServer;
+    initializeWebsocketServer(fakeWss);
+    expect(initialize).toHaveBeenCalledWith(fakeWss, {
+      backendApiKey: "bundle-test-key",
+    });
+  });
+});

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -5,6 +5,8 @@ import express from "express";
 import { ipKeyGenerator, rateLimit } from "express-rate-limit";
 import { createProxyMiddleware } from "http-proxy-middleware";
 import { websocketServer } from "./websocket.server";
+import type { WebSocketServer } from "ws";
+import { getFrontendRuntimeConfig, installFrontendRuntimeConfig } from "./runtime-config";
 import {
   isBackendApiDocsPath,
   isReadOnlyDeniedBackendMutation,
@@ -33,7 +35,14 @@ export const app = express();
 // a mismatch — the two halves of the setting cannot work independently.
 export const bakedUrlBase = URL_BASE;
 app.disable("x-powered-by");
-export const initializeWebsocketServer = websocketServer.initialize;
+export const configureRuntime = installFrontendRuntimeConfig;
+
+export function initializeWebsocketServer(websocketServerInstance: WebSocketServer): void {
+  const { frontendBackendApiKey } = getFrontendRuntimeConfig();
+  websocketServer.initialize(websocketServerInstance, {
+    backendApiKey: frontendBackendApiKey,
+  });
+}
 
 const trustProxy =
   process.env["TRUST_PROXY"] === "1" ||
@@ -138,7 +147,7 @@ app.use(async (req, res, next) => {
       return;
     }
 
-    await setApiKeyForAuthenticatedRequests(req);
+    await setApiKeyForAuthenticatedRequests(req, getFrontendRuntimeConfig().frontendBackendApiKey);
 
     if (isReadOnlyDeniedBackendMutation(req.method, req.path)) {
       const user = await getSessionUser(req);
@@ -168,7 +177,7 @@ app.use(authMiddleware);
 // WebDAV and API clients.
 app.use(async (req, res, next) => {
   if (isBackendApiDocsPath(req.path)) {
-    await setApiKeyForAuthenticatedRequests(req);
+    await setApiKeyForAuthenticatedRequests(req, getFrontendRuntimeConfig().frontendBackendApiKey);
     return forwardToBackend(req, res, next);
   }
   next();

--- a/frontend/server/inject-api-key.server.test.ts
+++ b/frontend/server/inject-api-key.server.test.ts
@@ -12,7 +12,7 @@ vi.mock("~/auth/authentication.server", () => ({
 
 beforeEach(() => {
   isAuthenticatedMock.mockReset();
-  vi.stubEnv("FRONTEND_BACKEND_API_KEY", "injected-key");
+  vi.stubEnv("FRONTEND_BACKEND_API_KEY", "poisoned-env-key");
 });
 
 function mockReq(partial: {
@@ -30,21 +30,21 @@ function mockReq(partial: {
 describe("setApiKeyForAuthenticatedRequests", () => {
   it("ignores non-/api paths", async () => {
     const req = mockReq({ path: "/view/movie" });
-    await setApiKeyForAuthenticatedRequests(req);
+    await setApiKeyForAuthenticatedRequests(req, "injected-key");
     expect(isAuthenticatedMock).not.toHaveBeenCalled();
     expect(req.headers["x-api-key"]).toBeUndefined();
   });
 
   it("ignores /apifoo bare-prefix false positives", async () => {
     const req = mockReq({ path: "/apifoo" });
-    await setApiKeyForAuthenticatedRequests(req);
+    await setApiKeyForAuthenticatedRequests(req, "injected-key");
     expect(isAuthenticatedMock).not.toHaveBeenCalled();
   });
 
   it("injects for decoded /api paths", async () => {
     isAuthenticatedMock.mockResolvedValueOnce(true);
     const req = mockReq({ path: "/%61pi/get-config" });
-    await setApiKeyForAuthenticatedRequests(req);
+    await setApiKeyForAuthenticatedRequests(req, "injected-key");
     expect(req.headers["x-api-key"]).toBe("injected-key");
   });
 
@@ -53,7 +53,7 @@ describe("setApiKeyForAuthenticatedRequests", () => {
       path: "/api/get-config",
       headers: { "x-api-key": "client-key" },
     });
-    await setApiKeyForAuthenticatedRequests(req);
+    await setApiKeyForAuthenticatedRequests(req, "injected-key");
     expect(isAuthenticatedMock).not.toHaveBeenCalled();
     expect(req.headers["x-api-key"]).toBe("client-key");
   });
@@ -61,21 +61,21 @@ describe("setApiKeyForAuthenticatedRequests", () => {
   it("does not inject when the session is unauthenticated", async () => {
     isAuthenticatedMock.mockResolvedValueOnce(false);
     const req = mockReq({ path: "/api/get-config" });
-    await setApiKeyForAuthenticatedRequests(req);
+    await setApiKeyForAuthenticatedRequests(req, "injected-key");
     expect(req.headers["x-api-key"]).toBeUndefined();
   });
 
   it("injects FRONTEND_BACKEND_API_KEY for authenticated /api requests", async () => {
     isAuthenticatedMock.mockResolvedValueOnce(true);
     const req = mockReq({ path: "/api/get-config" });
-    await setApiKeyForAuthenticatedRequests(req);
+    await setApiKeyForAuthenticatedRequests(req, "injected-key");
     expect(req.headers["x-api-key"]).toBe("injected-key");
   });
 
   it("injects FRONTEND_BACKEND_API_KEY for authenticated API docs requests", async () => {
     isAuthenticatedMock.mockResolvedValueOnce(true);
     const req = mockReq({ path: "/openapi/admin.json" });
-    await setApiKeyForAuthenticatedRequests(req);
+    await setApiKeyForAuthenticatedRequests(req, "injected-key");
     expect(req.headers["x-api-key"]).toBe("injected-key");
   });
 
@@ -84,7 +84,7 @@ describe("setApiKeyForAuthenticatedRequests", () => {
       path: "/api",
       query: { apikey: "query-key" },
     });
-    await setApiKeyForAuthenticatedRequests(req);
+    await setApiKeyForAuthenticatedRequests(req, "injected-key");
     expect(isAuthenticatedMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/server/inject-api-key.server.ts
+++ b/frontend/server/inject-api-key.server.ts
@@ -6,7 +6,10 @@ import { isBackendApiDocsPath, isBackendApiPath, isBackendMetricsPath } from "./
  * Inject the frontend→backend API key for authenticated UI sessions that proxy
  * `/api` or `/metrics` without supplying their own key.
  */
-export async function setApiKeyForAuthenticatedRequests(req: express.Request): Promise<void> {
+export async function setApiKeyForAuthenticatedRequests(
+  req: express.Request,
+  frontendBackendApiKey: string,
+): Promise<void> {
   // if the path is not a protected backend endpoint, do nothing
   if (
     !isBackendApiPath(req.path) &&
@@ -26,5 +29,5 @@ export async function setApiKeyForAuthenticatedRequests(req: express.Request): P
   if (!authenticated) return;
 
   // otherwise, set the api key header
-  req.headers["x-api-key"] = process.env["FRONTEND_BACKEND_API_KEY"] || "";
+  req.headers["x-api-key"] = frontendBackendApiKey;
 }

--- a/frontend/server/runtime-config.startup.test.ts
+++ b/frontend/server/runtime-config.startup.test.ts
@@ -1,0 +1,191 @@
+import { spawn } from "node:child_process";
+import http from "node:http";
+import net from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { FRONTEND_BACKEND_API_KEY_ERROR } from "./runtime-config";
+
+const frontendRoot = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
+const serverEntry = path.join(frontendRoot, "server.ts");
+const CHILD_TIMEOUT_MS = 15_000;
+
+type OccupiedPort = {
+  port: number;
+  close: () => Promise<void>;
+};
+
+async function occupyLoopbackPort(): Promise<OccupiedPort> {
+  const server = net.createServer();
+  const connections: net.Socket[] = [];
+  server.on("connection", (socket) => connections.push(socket));
+  server.on("error", () => undefined);
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+    server.once("error", reject);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("occupied port has no address");
+  }
+  return {
+    port: address.port,
+    close: () =>
+      new Promise((resolve, reject) => {
+        for (const socket of connections) socket.destroy();
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      }),
+  };
+}
+
+async function listenFakeBackend(): Promise<{
+  port: number;
+  accepted: number;
+  close: () => Promise<void>;
+}> {
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end("ok");
+  });
+  server.on("upgrade", (request, socket) => {
+    socket.destroy();
+  });
+  let accepted = 0;
+  server.on("connection", () => {
+    accepted += 1;
+  });
+  server.on("error", () => undefined);
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+    server.once("error", reject);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("fake backend has no address");
+  }
+  return {
+    get accepted() {
+      return accepted;
+    },
+    port: address.port,
+    close: () =>
+      new Promise((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      }),
+  };
+}
+
+function spawnFrontend(env: NodeJS.ProcessEnv) {
+  return spawn(process.execPath, ["--import", "tsx", serverEntry], {
+    cwd: frontendRoot,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function collectOutput(
+  child: ReturnType<typeof spawn>,
+): Promise<{
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+}> {
+  let stdout = "";
+  let stderr = "";
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error("frontend child did not exit before timeout"));
+    }, CHILD_TIMEOUT_MS);
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("exit", (exitCode, signal) => {
+      clearTimeout(timer);
+      resolve({ stdout, stderr, exitCode, signal });
+    });
+  });
+}
+
+describe("frontend runtime config startup", () => {
+  const resources: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    const closers = resources.splice(0);
+    await Promise.all(closers.map((close) => close()));
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["empty", ""],
+    ["spaces", "   "],
+    ["mixed whitespace", " \t\r\n "],
+  ] as const)(
+    "exits before listen when FRONTEND_BACKEND_API_KEY is %s",
+    async (_name, fixtureValue) => {
+      const occupied = await occupyLoopbackPort();
+      resources.push(occupied.close);
+      const backend = await listenFakeBackend();
+      resources.push(backend.close);
+
+      const childEnvironment: NodeJS.ProcessEnv = {
+        ...process.env,
+        NODE_ENV: "development",
+        NO_COLOR: "1",
+        PORT: String(occupied.port),
+        BACKEND_URL: `http://127.0.0.1:${backend.port}`,
+      };
+      delete childEnvironment["FORCE_COLOR"];
+
+      if (fixtureValue === undefined) {
+        delete childEnvironment["FRONTEND_BACKEND_API_KEY"];
+      } else {
+        childEnvironment["FRONTEND_BACKEND_API_KEY"] = fixtureValue;
+      }
+
+      const child = spawnFrontend(childEnvironment);
+      resources.push(async () => {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill("SIGKILL");
+          await new Promise((resolve) => child.once("exit", resolve));
+        }
+      });
+
+      const result = await collectOutput(child);
+      const output = `${result.stdout}\n${result.stderr}`;
+      const errorMatches = output.split(FRONTEND_BACKEND_API_KEY_ERROR);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.signal).toBeNull();
+      expect(errorMatches).toHaveLength(2);
+      if (fixtureValue) {
+        expect(output).not.toContain(fixtureValue);
+      }
+      expect(output).not.toContain("ERR_INVALID_ARG_TYPE");
+      expect(output).not.toContain("EADDRINUSE");
+      expect(output).not.toContain("Starting frontend development server");
+      expect(output).not.toContain("Starting frontend production server");
+      expect(output).not.toContain("Frontend server listening");
+      expect(output).not.toContain("Backend websocket connected");
+      expect(backend.accepted).toBe(0);
+    },
+  );
+});

--- a/frontend/server/runtime-config.startup.test.ts
+++ b/frontend/server/runtime-config.startup.test.ts
@@ -116,7 +116,7 @@ function collectOutput(child: ReturnType<typeof spawn>): Promise<{
       clearTimeout(timer);
       reject(error);
     });
-    child.once("exit", (exitCode, signal) => {
+    child.once("close", (exitCode, signal) => {
       clearTimeout(timer);
       resolve({ stdout, stderr, exitCode, signal });
     });

--- a/frontend/server/runtime-config.startup.test.ts
+++ b/frontend/server/runtime-config.startup.test.ts
@@ -91,9 +91,7 @@ function spawnFrontend(env: NodeJS.ProcessEnv) {
   });
 }
 
-function collectOutput(
-  child: ReturnType<typeof spawn>,
-): Promise<{
+function collectOutput(child: ReturnType<typeof spawn>): Promise<{
   stdout: string;
   stderr: string;
   exitCode: number | null;
@@ -176,9 +174,6 @@ describe("frontend runtime config startup", () => {
       expect(result.exitCode).toBe(1);
       expect(result.signal).toBeNull();
       expect(errorMatches).toHaveLength(2);
-      if (fixtureValue) {
-        expect(output).not.toContain(fixtureValue);
-      }
       expect(output).not.toContain("ERR_INVALID_ARG_TYPE");
       expect(output).not.toContain("EADDRINUSE");
       expect(output).not.toContain("Starting frontend development server");
@@ -187,5 +182,6 @@ describe("frontend runtime config startup", () => {
       expect(output).not.toContain("Backend websocket connected");
       expect(backend.accepted).toBe(0);
     },
+    20_000,
   );
 });

--- a/frontend/server/runtime-config.test.ts
+++ b/frontend/server/runtime-config.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FRONTEND_BACKEND_API_KEY_ERROR, readFrontendRuntimeConfig } from "./runtime-config";
+
+describe("readFrontendRuntimeConfig", () => {
+  it.each([
+    ["missing", undefined],
+    ["empty", ""],
+    ["spaces", "   "],
+    ["mixed whitespace", " \t\r\n "],
+  ] as const)("rejects %s FRONTEND_BACKEND_API_KEY", (_name, value) => {
+    const environment: NodeJS.ProcessEnv = {};
+    if (value !== undefined) environment["FRONTEND_BACKEND_API_KEY"] = value;
+
+    expect(() => readFrontendRuntimeConfig(environment)).toThrowError(
+      FRONTEND_BACKEND_API_KEY_ERROR,
+    );
+  });
+
+  it("returns the valid key unchanged", () => {
+    const frontendBackendApiKey = "unit-test-shared-key";
+
+    expect(readFrontendRuntimeConfig({ FRONTEND_BACKEND_API_KEY: frontendBackendApiKey })).toEqual({
+      frontendBackendApiKey,
+    });
+  });
+
+  it("preserves leading and trailing whitespace when the trimmed value is nonblank", () => {
+    const frontendBackendApiKey = "  keep-these-bytes  ";
+
+    expect(readFrontendRuntimeConfig({ FRONTEND_BACKEND_API_KEY: frontendBackendApiKey })).toEqual({
+      frontendBackendApiKey,
+    });
+  });
+});
+
+describe("installFrontendRuntimeConfig", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("installs once and returns the same frozen config", async () => {
+    const { getFrontendRuntimeConfig: getConfig, installFrontendRuntimeConfig: install } =
+      await import("./runtime-config");
+    const config = Object.freeze({ frontendBackendApiKey: "installer-key" });
+
+    install(config);
+    expect(getConfig()).toEqual(config);
+    install(config);
+    expect(getConfig()).toBe(getConfig());
+  });
+
+  it("treats reinstalling the same key as a no-op", async () => {
+    const { getFrontendRuntimeConfig: getConfig, installFrontendRuntimeConfig: install } =
+      await import("./runtime-config");
+
+    install({ frontendBackendApiKey: "same-key" });
+    install({ frontendBackendApiKey: "same-key" });
+    expect(getConfig()).toEqual({ frontendBackendApiKey: "same-key" });
+  });
+
+  it("throws before install without including a credential", async () => {
+    const { getFrontendRuntimeConfig: getConfig } = await import("./runtime-config");
+
+    expect(() => getConfig()).toThrowError(
+      "Frontend runtime configuration has not been initialized.",
+    );
+  });
+
+  it("rejects a different installed value without including either key", async () => {
+    const { installFrontendRuntimeConfig: install } = await import("./runtime-config");
+
+    install({ frontendBackendApiKey: "first-key" });
+    expect(() => install({ frontendBackendApiKey: "second-key" })).toThrowError(
+      "Frontend runtime configuration is already initialized.",
+    );
+  });
+});

--- a/frontend/server/runtime-config.test.ts
+++ b/frontend/server/runtime-config.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { FRONTEND_BACKEND_API_KEY_ERROR, readFrontendRuntimeConfig } from "./runtime-config";
+import {
+  ALREADY_INITIALIZED_ERROR,
+  FRONTEND_BACKEND_API_KEY_ERROR,
+  NOT_INITIALIZED_ERROR,
+  readFrontendRuntimeConfig,
+} from "./runtime-config";
 
 describe("readFrontendRuntimeConfig", () => {
   it.each([
@@ -44,9 +49,11 @@ describe("installFrontendRuntimeConfig", () => {
     const config = Object.freeze({ frontendBackendApiKey: "installer-key" });
 
     install(config);
-    expect(getConfig()).toEqual(config);
+    const first = getConfig();
+    expect(first).toEqual(config);
+    expect(Object.isFrozen(first)).toBe(true);
     install(config);
-    expect(getConfig()).toBe(getConfig());
+    expect(getConfig()).toBe(first);
   });
 
   it("treats reinstalling the same key as a no-op", async () => {
@@ -61,9 +68,7 @@ describe("installFrontendRuntimeConfig", () => {
   it("throws before install without including a credential", async () => {
     const { getFrontendRuntimeConfig: getConfig } = await import("./runtime-config");
 
-    expect(() => getConfig()).toThrowError(
-      "Frontend runtime configuration has not been initialized.",
-    );
+    expect(() => getConfig()).toThrowError(NOT_INITIALIZED_ERROR);
   });
 
   it("rejects a different installed value without including either key", async () => {
@@ -71,7 +76,7 @@ describe("installFrontendRuntimeConfig", () => {
 
     install({ frontendBackendApiKey: "first-key" });
     expect(() => install({ frontendBackendApiKey: "second-key" })).toThrowError(
-      "Frontend runtime configuration is already initialized.",
+      ALREADY_INITIALIZED_ERROR,
     );
   });
 });

--- a/frontend/server/runtime-config.ts
+++ b/frontend/server/runtime-config.ts
@@ -1,0 +1,34 @@
+export type FrontendRuntimeConfig = Readonly<{
+  frontendBackendApiKey: string;
+}>;
+
+export const FRONTEND_BACKEND_API_KEY_ERROR =
+  "Invalid frontend configuration: FRONTEND_BACKEND_API_KEY must be a non-empty value shared with the backend.";
+
+const ALREADY_INITIALIZED_ERROR = "Frontend runtime configuration is already initialized.";
+const NOT_INITIALIZED_ERROR = "Frontend runtime configuration has not been initialized.";
+
+export function readFrontendRuntimeConfig(environment: NodeJS.ProcessEnv): FrontendRuntimeConfig {
+  const frontendBackendApiKey = environment["FRONTEND_BACKEND_API_KEY"];
+  if (frontendBackendApiKey === undefined || frontendBackendApiKey.trim().length === 0) {
+    throw new Error(FRONTEND_BACKEND_API_KEY_ERROR);
+  }
+
+  return Object.freeze({ frontendBackendApiKey });
+}
+
+let installedConfig: FrontendRuntimeConfig | undefined;
+
+export function installFrontendRuntimeConfig(config: FrontendRuntimeConfig): void {
+  if (installedConfig && installedConfig.frontendBackendApiKey !== config.frontendBackendApiKey) {
+    throw new Error(ALREADY_INITIALIZED_ERROR);
+  }
+  installedConfig ??= Object.freeze({ ...config });
+}
+
+export function getFrontendRuntimeConfig(): FrontendRuntimeConfig {
+  if (!installedConfig) {
+    throw new Error(NOT_INITIALIZED_ERROR);
+  }
+  return installedConfig;
+}

--- a/frontend/server/runtime-config.ts
+++ b/frontend/server/runtime-config.ts
@@ -5,8 +5,8 @@ export type FrontendRuntimeConfig = Readonly<{
 export const FRONTEND_BACKEND_API_KEY_ERROR =
   "Invalid frontend configuration: FRONTEND_BACKEND_API_KEY must be a non-empty value shared with the backend.";
 
-const ALREADY_INITIALIZED_ERROR = "Frontend runtime configuration is already initialized.";
-const NOT_INITIALIZED_ERROR = "Frontend runtime configuration has not been initialized.";
+export const ALREADY_INITIALIZED_ERROR = "Frontend runtime configuration is already initialized.";
+export const NOT_INITIALIZED_ERROR = "Frontend runtime configuration has not been initialized.";
 
 export function readFrontendRuntimeConfig(environment: NodeJS.ProcessEnv): FrontendRuntimeConfig {
   const frontendBackendApiKey = environment["FRONTEND_BACKEND_API_KEY"];

--- a/frontend/server/websocket.server.test.ts
+++ b/frontend/server/websocket.server.test.ts
@@ -1,9 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
-import WebSocket from "ws";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import WebSocket, { WebSocketServer } from "ws";
 import {
   BACKEND_RECONNECT_INITIAL_MS,
   BACKEND_RECONNECT_MAX_MS,
   cacheStateMessage,
+  initializeWebsocketClient,
   MAX_CLIENT_BUFFERED_AMOUNT,
   MAX_TOPICS_PER_SOCKET,
   nextBackendReconnectDelayMs,
@@ -234,5 +237,74 @@ describe("relay reconnect preserves browser clients", () => {
     expect(close).not.toHaveBeenCalled();
     expect(lastMessage.get("ls")).toBe(rawMessage);
     expect(send).toHaveBeenCalledWith(rawMessage);
+  });
+});
+
+describe("initializeWebsocketClient relay authentication", () => {
+  const resources: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    const closers = resources.splice(0);
+    await Promise.all(closers.map((close) => close()));
+  });
+
+  it("sends the runtime backend API key instead of reading process.env", async () => {
+    vi.stubEnv("FRONTEND_BACKEND_API_KEY", "poisoned-env-key");
+
+    const messages: string[] = [];
+    const server = http.createServer();
+    server.on("error", () => undefined);
+    const wss = new WebSocketServer({ server, path: "/ws" });
+    const firstMessage = new Promise<string>((resolve, reject) => {
+      wss.on("connection", (socket) => {
+        socket.on("message", (data) => {
+          const text = Buffer.isBuffer(data)
+            ? data.toString("utf8")
+            : Array.isArray(data)
+              ? Buffer.concat(data).toString("utf8")
+              : Buffer.from(data).toString("utf8");
+          messages.push(text);
+          if (messages.length === 1) resolve(text);
+        });
+        socket.on("error", reject);
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+      server.once("error", reject);
+    });
+    const address = server.address() as AddressInfo;
+    vi.stubEnv("BACKEND_URL", `http://127.0.0.1:${address.port}`);
+
+    const relay = initializeWebsocketClient(new Map(), new Map(), undefined, {
+      backendApiKey: "relay-test-key",
+    });
+    resources.push(() => {
+      relay.stop();
+      return Promise.resolve();
+    });
+    resources.push(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          wss.close((error) => {
+            if (error) reject(error);
+            else resolve();
+          });
+        }),
+    );
+    resources.push(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => {
+            if (error) reject(error);
+            else resolve();
+          });
+        }),
+    );
+
+    await expect(firstMessage).resolves.toBe("relay-test-key");
+    expect(messages).toHaveLength(1);
   });
 });

--- a/frontend/server/websocket.server.ts
+++ b/frontend/server/websocket.server.ts
@@ -134,7 +134,12 @@ function initializeWebsocketServer(wss: WebSocketServer, runtime: WebsocketRunti
   // aggregate changes upstream to the backend so it can skip serialization
   // for topics with zero listeners.
   const upstreamSubscriptions = new UpstreamSubscriptionForwarder(subscriptions);
-  initializeWebsocketClient(subscriptions, lastMessage, upstreamSubscriptions, runtime);
+  const backendRelay = initializeWebsocketClient(
+    subscriptions,
+    lastMessage,
+    upstreamSubscriptions,
+    runtime,
+  );
 
   const heartbeat = setInterval(() => {
     for (const client of wss.clients) {
@@ -148,7 +153,10 @@ function initializeWebsocketServer(wss: WebSocketServer, runtime: WebsocketRunti
     }
   }, WEBSOCKET_HEARTBEAT_INTERVAL_MS);
   heartbeat.unref?.();
-  wss.on("close", () => clearInterval(heartbeat));
+  wss.on("close", () => {
+    clearInterval(heartbeat);
+    backendRelay.stop();
+  });
 
   // authenticate new websocket sessions
   wss.on("connection", (ws: TrackedSocket, request: IncomingMessage) => {

--- a/frontend/server/websocket.server.ts
+++ b/frontend/server/websocket.server.ts
@@ -24,6 +24,10 @@ export const BACKEND_RECONNECT_MAX_MS = 30_000;
 
 export type TopicKind = "state" | "stream" | "event";
 
+export type WebsocketRuntimeOptions = Readonly<{
+  backendApiKey: string;
+}>;
+
 const TOPIC_KINDS = new Set<TopicKind>(["state", "stream", "event"]);
 export const KEYED_REPLAY_TOPICS = new Set(["cxs"]);
 export const KEYED_REPLAY_RESET_MESSAGE = "reset";
@@ -120,7 +124,7 @@ export function nextBackendReconnectDelayMs(
   return Math.floor(random() * (exp + 1));
 }
 
-function initializeWebsocketServer(wss: WebSocketServer) {
+function initializeWebsocketServer(wss: WebSocketServer, runtime: WebsocketRuntimeOptions) {
   // keep track of socket subscriptions
   const websockets = new Map<TrackedSocket, Record<string, TopicKind>>();
   const subscriptions = new Map<string, Set<TrackedSocket>>();
@@ -130,7 +134,7 @@ function initializeWebsocketServer(wss: WebSocketServer) {
   // aggregate changes upstream to the backend so it can skip serialization
   // for topics with zero listeners.
   const upstreamSubscriptions = new UpstreamSubscriptionForwarder(subscriptions);
-  initializeWebsocketClient(subscriptions, lastMessage, upstreamSubscriptions);
+  initializeWebsocketClient(subscriptions, lastMessage, upstreamSubscriptions, runtime);
 
   const heartbeat = setInterval(() => {
     for (const client of wss.clients) {
@@ -242,9 +246,12 @@ function initializeWebsocketServer(wss: WebSocketServer) {
 export function initializeWebsocketClient(
   subscriptions: Map<string, Set<WebSocket>>,
   lastMessage: Map<string, string>,
-  upstreamForwarder?: UpstreamSubscriptionForwarder,
-) {
+  upstreamForwarder: UpstreamSubscriptionForwarder | undefined,
+  runtime: WebsocketRuntimeOptions,
+): { stop(): void } {
   let reconnectTimeout: NodeJS.Timeout | null = null;
+  let currentSocket: WebSocket | null = null;
+  let stopped = false;
   let connected = false;
   let connectionFailures = 0;
   let lastFailureLogAt = 0;
@@ -276,7 +283,9 @@ export function initializeWebsocketClient(
   }
 
   function connect() {
+    if (stopped) return;
     const socket = new WebSocket(url);
+    currentSocket = socket;
 
     socket.on("error", (error: Error) => {
       // Failed-connect errors are logged from onclose to avoid double-counting.
@@ -296,7 +305,7 @@ export function initializeWebsocketClient(
         reconnectTimeout = null;
       }
 
-      socket.send(Buffer.from(process.env["FRONTEND_BACKEND_API_KEY"]!, "utf-8"), {
+      socket.send(Buffer.from(runtime.backendApiKey, "utf-8"), {
         binary: false,
       });
 
@@ -326,6 +335,8 @@ export function initializeWebsocketClient(
     };
 
     socket.onclose = (event: WebSocket.CloseEvent) => {
+      if (currentSocket === socket) currentSocket = null;
+      if (stopped) return;
       // Keep browser sockets open and preserve lastMessage. Overview uses
       // live-stats age for the soft stale banner; when the relay returns,
       // the backend replays state topics and fan-out resumes without a
@@ -347,6 +358,7 @@ export function initializeWebsocketClient(
   }
 
   function scheduleReconnect(delayMs: number) {
+    if (stopped) return;
     if (reconnectTimeout) clearTimeout(reconnectTimeout);
 
     reconnectTimeout = setTimeout(() => {
@@ -355,6 +367,20 @@ export function initializeWebsocketClient(
   }
 
   connect();
+  return {
+    stop() {
+      stopped = true;
+      if (reconnectTimeout) {
+        clearTimeout(reconnectTimeout);
+        reconnectTimeout = null;
+      }
+      const socket = currentSocket;
+      currentSocket = null;
+      if (socket && socket.readyState !== WebSocket.CLOSED) {
+        socket.close();
+      }
+    },
+  };
 }
 
 /**

--- a/frontend/server/websocket.server.ts
+++ b/frontend/server/websocket.server.ts
@@ -385,7 +385,7 @@ export function initializeWebsocketClient(
       const socket = currentSocket;
       currentSocket = null;
       if (socket && socket.readyState !== WebSocket.CLOSED) {
-        socket.close();
+        socket.terminate();
       }
     },
   };

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -8,6 +8,7 @@
     "server/request-log-throttle.ts",
     "server/startup-grace.ts",
     "server/websocket-upgrade-guard.ts",
+    "server/runtime-config.ts",
     "server/security-headers.ts",
     "app/utils/url-base.ts",
     "vite.config.ts",


### PR DESCRIPTION
## Summary
- Validate `FRONTEND_BACKEND_API_KEY` once at frontend process start and exit 1 with a single actionable error when it is missing, empty, or whitespace-only.
- Pass the captured key into the WebSocket relay, authenticated proxy injection, SSR backend client, and Explore download HMAC so those owners no longer read `process.env` or fall back to an empty secret.
- Invalid configuration fails before Vite, HTTP listen, or a backend WebSocket connection, so a standalone frontend cannot appear healthy and later crash with `ERR_INVALID_ARG_TYPE`.

Fixes #1244

## Test plan
- [ ] Focused Vitest: missing/empty/whitespace key, valid key preservation, child-process ordering against an occupied port, relay auth with a poisoned env, proxy injection, SSR client, and HMAC.
- [ ] Start `npm run dev` with a synced valid key and confirm the UI and backend WebSocket still connect.
- [ ] Start the frontend with the key unset and confirm one Error line plus exit code 1, with no listen/bind/backend-connect output.
- [ ] PR CI: frontend lint/typecheck/build, custom-server export smoke (`configureRuntime`), and production proxy contract with a valid key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validated frontend runtime configuration for backend connectivity.
  - Added consistent credential handling for backend requests, downloads, and WebSocket connections.
  - Added graceful WebSocket shutdown and reconnect cancellation.

- **Bug Fixes**
  - Startup now exits early with a clear error when required configuration is missing or blank.

- **Tests**
  - Expanded coverage for configuration, startup failures, authentication, downloads, and WebSocket behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->