### PR TITLE
fix(usenet): keep pooling and config updates running if a telemetry observer throws

### DIFF
--- a/backend/Clients/Usenet/Connections/ConnectionPool.cs
+++ b/backend/Clients/Usenet/Connections/ConnectionPool.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using NzbWebDAV.Clients.Usenet.Concurrency;
 using NzbWebDAV.Clients.Usenet.Contexts;
+using NzbWebDAV.Logging;
 using Serilog;
 
 namespace NzbWebDAV.Clients.Usenet.Connections;
@@ -59,6 +60,11 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
     public int AvailableConnections => Math.Max(0, EffectiveMaxConnections - ActiveConnections);
     internal bool IsDisposed => Volatile.Read(ref _disposed) == 1;
 
+    /// <summary>
+    /// Raised after live/idle/effective-max counts change. This is post-state telemetry:
+    /// handlers cannot vote on admission or replacement. Subscriber failures are isolated
+    /// and logged. Dispatch snapshots the invocation list at the start of each notification.
+    /// </summary>
     public event EventHandler<ConnectionPoolStats.ConnectionPoolChangedEventArgs>? OnConnectionPoolChanged;
 
     private readonly Func<CancellationToken, ValueTask<T>> _factory;
@@ -194,6 +200,7 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
         // it is active and disposal leaves it for the borrower to return or destroy.
         T? reused = default;
         var reusedConnection = false;
+        var staleEvicted = false;
         lock (_lifecycleLock)
         {
             if (_disposed == 1)
@@ -201,16 +208,15 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
 
             if (preferIdle)
             {
-                reusedConnection = TryTakeIdleConnection(out reused!);
+                reusedConnection = TryTakeIdleConnection(out reused!, out staleEvicted);
                 if (reusedConnection)
                     Interlocked.Increment(ref _connectionsReused);
             }
         }
-        if (reusedConnection)
-        {
+        if (reusedConnection || staleEvicted)
             TriggerConnectionPoolChangedEvent();
+        if (reusedConnection)
             return BuildLock(reused!, wasReused: true);
-        }
 
         // Need a fresh connection. Pace handshakes so a cold burst of borrowers
         // does not open dozens of TLS sessions in parallel. While waiting, other
@@ -231,6 +237,7 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
         {
             reused = default;
             reusedConnection = false;
+            staleEvicted = false;
             lock (_lifecycleLock)
             {
                 if (_disposed == 1)
@@ -238,16 +245,15 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
 
                 if (preferIdle)
                 {
-                    reusedConnection = TryTakeIdleConnection(out reused!);
+                    reusedConnection = TryTakeIdleConnection(out reused!, out staleEvicted);
                     if (reusedConnection)
                         Interlocked.Increment(ref _connectionsReused);
                 }
             }
-            if (reusedConnection)
-            {
+            if (reusedConnection || staleEvicted)
                 TriggerConnectionPoolChangedEvent();
+            if (reusedConnection)
                 return BuildLock(reused!, wasReused: true);
-            }
 
             T conn;
             ReplacementPacingReservation? pacingReservation = null;
@@ -354,21 +360,25 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
         {
             T? reused = default;
             var reusedConnection = false;
+            var staleEvicted = false;
             lock (_lifecycleLock)
             {
                 ObjectDisposedException.ThrowIf(_disposed == 1, this);
                 reusedConnection = TryTakeIdleConnection(
                     out reused!,
+                    out staleEvicted,
                     excludedConnections);
                 if (reusedConnection)
                     Interlocked.Increment(ref _connectionsReused);
             }
 
+            if (reusedConnection || staleEvicted)
+                TriggerConnectionPoolChangedEvent();
+
             if (!reusedConnection)
                 return null;
 
             releaseGate = false;
-            TriggerConnectionPoolChangedEvent();
             return new ConnectionLock<T>(
                 reused!,
                 Return,
@@ -393,8 +403,10 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
 
     private bool TryTakeIdleConnection(
         out T connection,
+        out bool staleEvicted,
         ISet<object>? excludedConnections = null)
     {
+        staleEvicted = false;
         List<Pooled>? excluded = null;
         try
         {
@@ -402,11 +414,12 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
             {
                 if (item.IsExpired(IdleTimeout))
                 {
-                    // Stale – destroy and continue looking.
+                    // Stale – destroy and continue looking. Notify after the caller
+                    // leaves _lifecycleLock so observer code never runs under it.
                     DisposeConnection(item.Connection);
                     Interlocked.Decrement(ref _live);
                     Interlocked.Increment(ref _staleEvictions);
-                    TriggerConnectionPoolChangedEvent();
+                    staleEvicted = true;
                     continue;
                 }
 
@@ -645,14 +658,26 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
 
     private void TriggerConnectionPoolChangedEvent()
     {
-        if (Volatile.Read(ref _disposed) == 1)
-            return;
+        EventHandler<ConnectionPoolStats.ConnectionPoolChangedEventArgs>? subscribers;
+        int live;
+        int idle;
+        int max;
+        lock (_lifecycleLock)
+        {
+            if (_disposed == 1)
+                return;
 
-        OnConnectionPoolChanged?.Invoke(this, new ConnectionPoolStats.ConnectionPoolChangedEventArgs(
-            _live,
-            _idleConnections.Count,
-            EffectiveMaxConnections
-        ));
+            subscribers = OnConnectionPoolChanged;
+            live = _live;
+            idle = _idleConnections.Count;
+            max = EffectiveMaxConnections;
+        }
+
+        SynchronousObserverInvoker.Invoke(
+            subscribers,
+            this,
+            new ConnectionPoolStats.ConnectionPoolChangedEventArgs(live, idle, max),
+            SynchronousObserverSource.ConnectionPoolChanged);
     }
 
     /// <summary>
@@ -688,7 +713,11 @@ public sealed class ConnectionPool<T> : IDisposable, IAsyncDisposable
 
         _gate.UpdateMaxAllowed(newEffective);
         TriggerConnectionPoolChangedEvent();
-        _onConnectionLimitLearned?.Invoke(learned, newEffective);
+        SynchronousObserverInvoker.Invoke(
+            _onConnectionLimitLearned,
+            learned,
+            newEffective,
+            SynchronousObserverSource.ConnectionLimitLearned);
     }
 
     /* =================== idle sweeper (background) ================================= */

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -6,6 +6,7 @@ using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Logging;
 using NzbWebDAV.Models;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Metrics;
@@ -422,7 +423,11 @@ public class UsenetStreamingClient : WrappingNntpClient
             keepAliveAdmission: keepAliveAdmission);
         connectionPool.OnConnectionPoolChanged += onConnectionPoolChanged;
         var args = new ConnectionPoolStats.ConnectionPoolChangedEventArgs(0, 0, maxConnections);
-        onConnectionPoolChanged(connectionPool, args);
+        SynchronousObserverInvoker.Invoke(
+            onConnectionPoolChanged,
+            connectionPool,
+            args,
+            SynchronousObserverSource.ConnectionPoolChanged);
         return connectionPool;
     }
 

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -8,6 +8,7 @@ using NzbWebDAV.Clients.Usenet.Concurrency;
 using NzbWebDAV.Config.Scheduling;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Logging;
 using NzbWebDAV.Models;
 using NzbWebDAV.Streams;
 using NzbWebDAV.Utils;
@@ -44,6 +45,13 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
     private readonly object _excludeLock = new();
     private IReadOnlyList<Regex>? _compiledExcludeCache;
     private ConfigEnvironmentOverlay _environmentOverlay = ConfigEnvironmentOverlay.Empty;
+    /// <summary>
+    /// Raised after configuration values have been committed in memory. Notification is
+    /// synchronous, in registration order, and does not run while config locks are held.
+    /// Subscriber failures are isolated and logged; they cannot roll back the commit or
+    /// skip later subscribers. Dispatch snapshots the invocation list, so a handler
+    /// removed during publication may still run once for that in-flight event.
+    /// </summary>
     public event EventHandler<ConfigEventArgs>? OnConfigChanged;
 
     public IDisposable Subscribe(EventHandler<ConfigEventArgs> handler)
@@ -312,7 +320,14 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
 
         if (changedConfig.ContainsKey(ConfigKeys.WebdavWindowsSafePaths))
             SyncPathSanitizer();
-        OnConfigChanged?.Invoke(this, new ConfigEventArgs { ChangedConfig = changedConfig });
+
+        var args = new ConfigEventArgs { ChangedConfig = changedConfig };
+        var subscribers = OnConfigChanged;
+        SynchronousObserverInvoker.Invoke(
+            subscribers,
+            this,
+            args,
+            SynchronousObserverSource.ConfigChanged);
     }
 
     private void SyncPathSanitizer() =>

--- a/backend/Config/IConfigChangeSource.cs
+++ b/backend/Config/IConfigChangeSource.cs
@@ -1,8 +1,12 @@
 namespace NzbWebDAV.Config;
 
 /// <summary>
-/// Config change notifications. Subscribers must dispose the returned
-/// subscription so hosted services do not leak handlers after shutdown.
+/// Config change notifications. This is post-commit synchronous fan-out: values are
+/// already committed before handlers run. Subscriber failures are isolated and logged
+/// and do not skip later subscribers. Dispatch snapshots the invocation list, so a
+/// handler removed during publication may still run once for that in-flight event.
+/// Subscribers must dispose the returned subscription so hosted services do not leak
+/// handlers after shutdown.
 /// </summary>
 public interface IConfigChangeSource
 {

--- a/backend/Logging/SynchronousObserverInvoker.cs
+++ b/backend/Logging/SynchronousObserverInvoker.cs
@@ -1,0 +1,148 @@
+using NzbWebDAV.Extensions;
+using Serilog;
+
+namespace NzbWebDAV.Logging;
+
+internal enum SynchronousObserverSource
+{
+    ConnectionPoolChanged,
+    ConnectionLimitLearned,
+    ConfigChanged,
+    SharedStreamRingRetainedBytes,
+    SharedStreamForceEvictions,
+}
+
+/// <summary>
+/// Invokes multicast telemetry observers one subscriber at a time. A non-fatal
+/// exception from one subscriber is logged and cannot skip later subscribers or
+/// fault the owner. <see cref="OutOfMemoryException"/> is never contained.
+/// </summary>
+internal static class SynchronousObserverInvoker
+{
+    private static readonly TimeSpan FailureLogInterval = TimeSpan.FromMinutes(1);
+    private static readonly LogThrottle FailureLogThrottle = new();
+
+    internal static void ResetFailureLogThrottleForTests()
+        => FailureLogThrottle.Clear();
+
+    public static void Invoke<TEventArgs>(
+        EventHandler<TEventArgs>? subscribers,
+        object sender,
+        TEventArgs args,
+        SynchronousObserverSource source)
+        where TEventArgs : EventArgs
+    {
+        if (subscribers is null)
+            return;
+
+        var snapshot = subscribers.GetInvocationList();
+        foreach (var candidate in snapshot)
+        {
+            var subscriber = (EventHandler<TEventArgs>)candidate;
+            try
+            {
+                subscriber(sender, args);
+            }
+            catch (Exception exception) when (exception is not OutOfMemoryException)
+            {
+                LogFailure(source, subscriber, exception);
+            }
+        }
+    }
+
+    public static void Invoke<T>(
+        Action<T>? subscribers,
+        T argument,
+        SynchronousObserverSource source)
+    {
+        if (subscribers is null)
+            return;
+
+        var snapshot = subscribers.GetInvocationList();
+        foreach (var candidate in snapshot)
+        {
+            var subscriber = (Action<T>)candidate;
+            try
+            {
+                subscriber(argument);
+            }
+            catch (Exception exception) when (exception is not OutOfMemoryException)
+            {
+                LogFailure(source, subscriber, exception);
+            }
+        }
+    }
+
+    public static void Invoke<T1, T2>(
+        Action<T1, T2>? subscribers,
+        T1 first,
+        T2 second,
+        SynchronousObserverSource source)
+    {
+        if (subscribers is null)
+            return;
+
+        var snapshot = subscribers.GetInvocationList();
+        foreach (var candidate in snapshot)
+        {
+            var subscriber = (Action<T1, T2>)candidate;
+            try
+            {
+                subscriber(first, second);
+            }
+            catch (Exception exception) when (exception is not OutOfMemoryException)
+            {
+                LogFailure(source, subscriber, exception);
+            }
+        }
+    }
+
+    private static void LogFailure(
+        SynchronousObserverSource source,
+        Delegate subscriber,
+        Exception exception)
+    {
+        if (!FailureLogThrottle.ShouldLog(
+                source.ToString(),
+                FailureLogInterval,
+                out var suppressed))
+        {
+            return;
+        }
+
+        var subscriberType = subscriber.Method.DeclaringType?.FullName ?? "unknown";
+        var subscriberMethod = subscriber.Method.Name;
+
+        if (exception.TryGetKnownErrorMessage(out _))
+        {
+            Log.Warning(
+                "Synchronous observer failed. Source: {ObserverSource} " +
+                "Subscriber: {SubscriberType}.{SubscriberMethod} " +
+                "ExceptionType: {ExceptionType} Suppressed: {SuppressedCount} " +
+                "Reason: subscriber dependency reported a known failure",
+                source,
+                subscriberType,
+                subscriberMethod,
+                exception.GetType().FullName,
+                suppressed);
+            Log.Debug(
+                "Synchronous observer known failure stack. Source: {ObserverSource} " +
+                "StackTrace: {ObserverStackTrace}",
+                source,
+                exception.StackTrace);
+            return;
+        }
+
+        Log.Error(
+            "Unexpected synchronous observer failure. Source: {ObserverSource} " +
+            "Subscriber: {SubscriberType}.{SubscriberMethod} " +
+            "ExceptionType: {ExceptionType} Suppressed: {SuppressedCount} " +
+            "StackTrace: {ObserverStackTrace}",
+            source,
+            subscriberType,
+            subscriberMethod,
+            exception.GetType().FullName,
+            suppressed,
+            exception.StackTrace);
+    }
+}

--- a/backend/Logging/SynchronousObserverInvoker.cs
+++ b/backend/Logging/SynchronousObserverInvoker.cs
@@ -35,10 +35,9 @@ internal static class SynchronousObserverInvoker
         if (subscribers is null)
             return;
 
-        var snapshot = subscribers.GetInvocationList();
-        foreach (var candidate in snapshot)
+        var snapshot = subscribers.GetInvocationList().Cast<EventHandler<TEventArgs>>();
+        foreach (var subscriber in snapshot)
         {
-            var subscriber = (EventHandler<TEventArgs>)candidate;
             try
             {
                 subscriber(sender, args);
@@ -58,10 +57,9 @@ internal static class SynchronousObserverInvoker
         if (subscribers is null)
             return;
 
-        var snapshot = subscribers.GetInvocationList();
-        foreach (var candidate in snapshot)
+        var snapshot = subscribers.GetInvocationList().Cast<Action<T>>();
+        foreach (var subscriber in snapshot)
         {
-            var subscriber = (Action<T>)candidate;
             try
             {
                 subscriber(argument);
@@ -82,10 +80,9 @@ internal static class SynchronousObserverInvoker
         if (subscribers is null)
             return;
 
-        var snapshot = subscribers.GetInvocationList();
-        foreach (var candidate in snapshot)
+        var snapshot = subscribers.GetInvocationList().Cast<Action<T1, T2>>();
+        foreach (var subscriber in snapshot)
         {
-            var subscriber = (Action<T1, T2>)candidate;
             try
             {
                 subscriber(first, second);

--- a/backend/Streams/SharedStreamEntry.cs
+++ b/backend/Streams/SharedStreamEntry.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Logging;
 using NzbWebDAV.WebDav.Base;
 using Serilog;
 
@@ -276,7 +277,10 @@ internal sealed class SharedStreamEntry : IAsyncDisposable
 
                 _ring.Append(scratch.AsSpan(0, read));
                 Interlocked.Add(ref _bytesPumped, read);
-                OnRingRetainedBytes?.Invoke(_ring.RetainedBytes);
+                SynchronousObserverInvoker.Invoke(
+                    OnRingRetainedBytes,
+                    _ring.RetainedBytes,
+                    SynchronousObserverSource.SharedStreamRingRetainedBytes);
                 MaybeEvict();
             }
         }
@@ -352,7 +356,10 @@ internal sealed class SharedStreamEntry : IAsyncDisposable
         if (min is { } minCursor)
             _ring.EvictThrough(minCursor);
 
-        OnRingRetainedBytes?.Invoke(_ring.RetainedBytes);
+        SynchronousObserverInvoker.Invoke(
+            OnRingRetainedBytes,
+            _ring.RetainedBytes,
+            SynchronousObserverSource.SharedStreamRingRetainedBytes);
 
         min = _ring.GetMinCursor();
         if (min is not { } pinning)
@@ -366,9 +373,17 @@ internal sealed class SharedStreamEntry : IAsyncDisposable
             newTail = Anchor;
         var evicted = _ring.ForceEvictBelow(newTail);
         if (evicted.Count > 0)
-            OnForceEvictions?.Invoke(evicted.Count);
+        {
+            SynchronousObserverInvoker.Invoke(
+                OnForceEvictions,
+                evicted.Count,
+                SynchronousObserverSource.SharedStreamForceEvictions);
+        }
 
-        OnRingRetainedBytes?.Invoke(_ring.RetainedBytes);
+        SynchronousObserverInvoker.Invoke(
+            OnRingRetainedBytes,
+            _ring.RetainedBytes,
+            SynchronousObserverSource.SharedStreamRingRetainedBytes);
     }
 
     private void StartGraceLocked()

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolConnectionLimitTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolConnectionLimitTests.cs
@@ -2,12 +2,21 @@ using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Concurrency;
 using NzbWebDAV.Clients.Usenet.Connections;
 using NzbWebDAV.Exceptions;
+using NzbWebDAV.Logging;
+using NzbWebDAV.Tests.TestUtils;
 
 namespace NzbWebDAV.Tests.Clients.Usenet;
 
-public class ConnectionPoolConnectionLimitTests
+[Collection(nameof(GlobalLoggerCollection))]
+public class ConnectionPoolConnectionLimitTests : IDisposable
 {
     private static readonly TimeSpan WaitBudget = TimeSpan.FromSeconds(10);
+
+    public ConnectionPoolConnectionLimitTests()
+        => SynchronousObserverInvoker.ResetFailureLogThrottleForTests();
+
+    public void Dispose()
+        => SynchronousObserverInvoker.ResetFailureLogThrottleForTests();
 
     private static ConnectionPool<object> CreatePool(
         int maxConnections,
@@ -232,5 +241,62 @@ public class ConnectionPoolConnectionLimitTests
             () => pool.GetConnectionLockAsync(SemaphorePriority.High, cts.Token).WaitAsync(WaitBudget));
 
         foreach (var l in locks) l.Dispose();
+    }
+
+    [Fact]
+    public async Task ConnectionLimitObservers_ThrowingFirstSubscribers_PreserveFactoryErrorAndGate()
+    {
+        var factoryError = new CouldNotLoginToUsenetException(
+            "Could not login to usenet host: 502 connection limit (2) reached",
+            responseCode: 502);
+        var factoryCalls = 0;
+        var poolOrder = new List<string>();
+        var learnedOrder = new List<string>();
+        var learnedValues = new List<(int learned, int effective)>();
+        var throwStats = true;
+        Action<int, int> onLearned = (_, _) =>
+        {
+            learnedOrder.Add("first");
+            throw new InvalidOperationException("learned observer");
+        };
+        onLearned += (learned, effective) =>
+        {
+            learnedOrder.Add("second");
+            learnedValues.Add((learned, effective));
+        };
+
+        await using var pool = CreatePool(
+            maxConnections: 2,
+            detector: Detector502(2),
+            onLearned: onLearned,
+            factory: _ =>
+            {
+                if (Interlocked.Increment(ref factoryCalls) == 1)
+                    throw factoryError;
+                return ValueTask.FromResult(new object());
+            });
+
+        pool.OnConnectionPoolChanged += (_, _) =>
+        {
+            poolOrder.Add("first");
+            if (throwStats)
+                throw new InvalidOperationException("stats observer");
+        };
+        pool.OnConnectionPoolChanged += (_, _) => poolOrder.Add("second");
+
+        var thrown = await Assert.ThrowsAsync<CouldNotLoginToUsenetException>(
+            () => pool.GetConnectionLockAsync(SemaphorePriority.High, CancellationToken.None)
+                .WaitAsync(WaitBudget));
+        Assert.Same(factoryError, thrown);
+        Assert.Equal(1, pool.EffectiveMaxConnections);
+        Assert.Equal(2, pool.LearnedConnectionLimit);
+        Assert.Equal(["first", "second"], poolOrder);
+        Assert.Equal(["first", "second"], learnedOrder);
+        Assert.Equal([(2, 1)], learnedValues);
+
+        throwStats = false;
+        var recovered = await pool.GetConnectionLockAsync(SemaphorePriority.High, CancellationToken.None)
+            .WaitAsync(WaitBudget);
+        recovered.Dispose();
     }
 }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolObserverTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ConnectionPoolObserverTests.cs
@@ -1,0 +1,122 @@
+using NzbWebDAV.Clients.Usenet.Concurrency;
+using NzbWebDAV.Clients.Usenet.Connections;
+using NzbWebDAV.Logging;
+using NzbWebDAV.Tests.TestUtils;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+[Collection(nameof(GlobalLoggerCollection))]
+public sealed class ConnectionPoolObserverTests : IDisposable
+{
+    private static readonly TimeSpan WaitBudget = TimeSpan.FromSeconds(10);
+
+    public ConnectionPoolObserverTests()
+        => SynchronousObserverInvoker.ResetFailureLogThrottleForTests();
+
+    public void Dispose()
+        => SynchronousObserverInvoker.ResetFailureLogThrottleForTests();
+
+    [Fact]
+    public async Task Borrow_ThrowingFirstStatsSubscriber_ReturnsLockAndInvokesLaterSubscriber()
+    {
+        await using var pool = CreatePool();
+        var order = new List<string>();
+        AttachThrowingThenCounting(pool, order, throwEnabled: () => true);
+
+        var borrowed = await pool.GetConnectionLockAsync(SemaphorePriority.High)
+            .WaitAsync(WaitBudget);
+        Assert.Equal(["first", "second"], order);
+        Assert.NotNull(borrowed.Connection);
+
+        borrowed.Dispose();
+        var again = await pool.GetConnectionLockAsync(SemaphorePriority.High)
+            .WaitAsync(WaitBudget);
+        again.Dispose();
+    }
+
+    [Fact]
+    public async Task Return_ThrowingFirstStatsSubscriber_DoesNotFaultLockDispose()
+    {
+        await using var pool = CreatePool();
+        var order = new List<string>();
+        var throwEnabled = false;
+        AttachThrowingThenCounting(pool, order, () => throwEnabled);
+
+        var borrowed = await pool.GetConnectionLockAsync(SemaphorePriority.High)
+            .WaitAsync(WaitBudget);
+        order.Clear();
+        throwEnabled = true;
+
+        borrowed.Dispose();
+
+        Assert.Equal(["first", "second"], order);
+        Assert.Equal(1, pool.IdleConnections);
+    }
+
+    [Fact]
+    public async Task Destroy_ThrowingFirstStatsSubscriber_DoesNotFaultLockDispose()
+    {
+        await using var pool = CreatePool();
+        var order = new List<string>();
+        var throwEnabled = false;
+        AttachThrowingThenCounting(pool, order, () => throwEnabled);
+
+        var borrowed = await pool.GetConnectionLockAsync(SemaphorePriority.High)
+            .WaitAsync(WaitBudget);
+        borrowed.Replace("test replacement");
+        order.Clear();
+        throwEnabled = true;
+
+        borrowed.Dispose();
+
+        Assert.Equal(["first", "second"], order);
+        Assert.Equal(1, pool.GetChurn().ConnectionsDestroyed);
+
+        var replacement = await pool.GetConnectionLockAsync(SemaphorePriority.High)
+            .WaitAsync(WaitBudget);
+        replacement.Dispose();
+        Assert.Equal(2, pool.GetChurn().ConnectionsOpened);
+    }
+
+    [Fact]
+    public async Task Sweeper_ThrowingStatsSubscriber_CompletesAndCanSweepAgain()
+    {
+        await using var pool = CreatePool();
+        var order = new List<string>();
+        AttachThrowingThenCounting(pool, order, throwEnabled: () => true);
+
+        var borrowed = await pool.GetConnectionLockAsync(SemaphorePriority.High)
+            .WaitAsync(WaitBudget);
+        borrowed.Dispose();
+        order.Clear();
+
+        await pool.SweepOnceForTestsAsync(
+            nowMillis: Environment.TickCount64 + (long)pool.IdleTimeout.TotalMilliseconds + 1)
+            .WaitAsync(WaitBudget);
+        Assert.Equal(["first", "second"], order);
+
+        await pool.SweepOnceForTestsAsync(
+            nowMillis: Environment.TickCount64 + (long)pool.IdleTimeout.TotalMilliseconds + 1)
+            .WaitAsync(WaitBudget);
+    }
+
+    private static ConnectionPool<object> CreatePool() =>
+        new(
+            maxConnections: 1,
+            _ => ValueTask.FromResult(new object()),
+            TimeSpan.FromMinutes(5));
+
+    private static void AttachThrowingThenCounting(
+        ConnectionPool<object> pool,
+        List<string> order,
+        Func<bool> throwEnabled)
+    {
+        pool.OnConnectionPoolChanged += (_, _) =>
+        {
+            order.Add("first");
+            if (throwEnabled())
+                throw new InvalidOperationException("stats observer");
+        };
+        pool.OnConnectionPoolChanged += (_, _) => order.Add("second");
+    }
+}

--- a/tests/NzbWebDAV.Tests/Config/ConfigChangeSourceTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/ConfigChangeSourceTests.cs
@@ -1,10 +1,19 @@
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Logging;
+using NzbWebDAV.Tests.TestUtils;
 
 namespace NzbWebDAV.Tests.Config;
 
-public class ConfigChangeSourceTests
+[Collection(nameof(GlobalLoggerCollection))]
+public sealed class ConfigChangeSourceTests : IDisposable
 {
+    public ConfigChangeSourceTests()
+        => SynchronousObserverInvoker.ResetFailureLogThrottleForTests();
+
+    public void Dispose()
+        => SynchronousObserverInvoker.ResetFailureLogThrottleForTests();
+
     [Fact]
     public void Subscribe_DeliversUpdatesUntilDisposed()
     {
@@ -18,5 +27,117 @@ public class ConfigChangeSourceTests
 
         config.UpdateValues([new ConfigItem { ConfigName = ConfigKeys.RcloneHost, ConfigValue = "http://b" }]);
         Assert.Equal(1, hits);
+    }
+
+    [Fact]
+    public void UpdateValues_ThrowingFirstSubscriber_CommitsAndInvokesLaterSubscriber()
+    {
+        var config = new ConfigManager();
+        var order = new List<string>();
+        ConfigManager.ConfigEventArgs? firstArgs = null;
+        ConfigManager.ConfigEventArgs? secondArgs = null;
+        const string host = "http://observer-test.example";
+
+        config.OnConfigChanged += (_, args) =>
+        {
+            order.Add("first");
+            firstArgs = args;
+            throw new InvalidOperationException("config observer");
+        };
+        config.OnConfigChanged += (_, args) =>
+        {
+            order.Add("second");
+            secondArgs = args;
+        };
+
+        config.UpdateValues([new ConfigItem { ConfigName = ConfigKeys.RcloneHost, ConfigValue = host }]);
+
+        Assert.Equal(["first", "second"], order);
+        Assert.Same(firstArgs, secondArgs);
+        Assert.Equal(host, secondArgs!.ChangedConfig[ConfigKeys.RcloneHost]);
+        Assert.Equal(host, config.GetRcloneHost());
+    }
+
+    [Fact]
+    public void UpdateValues_DisposedDuringSnapshot_CurrentDeliveryFinishesThenStops()
+    {
+        var config = new ConfigManager();
+        var firstCount = 0;
+        var secondCount = 0;
+        IDisposable? secondSub = null;
+        using var firstSub = config.Subscribe((_, _) =>
+        {
+            firstCount++;
+            secondSub!.Dispose();
+            throw new InvalidOperationException("config observer");
+        });
+        secondSub = config.Subscribe((_, _) => secondCount++);
+
+        config.UpdateValues([new ConfigItem { ConfigName = ConfigKeys.RcloneHost, ConfigValue = "http://one" }]);
+        Assert.Equal(1, firstCount);
+        Assert.Equal(1, secondCount);
+
+        config.UpdateValues([new ConfigItem { ConfigName = ConfigKeys.RcloneHost, ConfigValue = "http://two" }]);
+        Assert.Equal(2, firstCount);
+        Assert.Equal(1, secondCount);
+
+        firstSub.Dispose();
+        secondSub.Dispose();
+    }
+
+    [Fact]
+    public void UpdateValues_SubscriberAddedDuringDispatch_StartsNextUpdate()
+    {
+        var config = new ConfigManager();
+        var order = new List<string>();
+        var added = false;
+        void Third(object? _, ConfigManager.ConfigEventArgs __) => order.Add("third");
+        config.OnConfigChanged += (_, _) =>
+        {
+            order.Add("first");
+            if (added)
+                return;
+            added = true;
+            config.OnConfigChanged += Third;
+        };
+        config.OnConfigChanged += (_, _) => order.Add("second");
+
+        config.UpdateValues([new ConfigItem { ConfigName = ConfigKeys.RcloneHost, ConfigValue = "http://one" }]);
+        Assert.Equal(["first", "second"], order);
+
+        order.Clear();
+        config.UpdateValues([new ConfigItem { ConfigName = ConfigKeys.RcloneHost, ConfigValue = "http://two" }]);
+        Assert.Equal(["first", "second", "third"], order);
+    }
+
+    [Fact]
+    public void UpdateValues_ReentrantSubscriber_PublishesNestedChangeWithoutDeadlock()
+    {
+        var config = new ConfigManager();
+        var publications = new List<string>();
+        var nested = false;
+        config.OnConfigChanged += (_, args) =>
+        {
+            publications.Add("first:" + string.Join(",", args.ChangedConfig.Keys));
+            if (nested || !args.ChangedConfig.ContainsKey(ConfigKeys.RcloneHost))
+                return;
+            nested = true;
+            config.UpdateValues([new ConfigItem { ConfigName = ConfigKeys.RcloneUser, ConfigValue = "alice" }]);
+        };
+        config.OnConfigChanged += (_, args) =>
+            publications.Add("second:" + string.Join(",", args.ChangedConfig.Keys));
+
+        config.UpdateValues([new ConfigItem { ConfigName = ConfigKeys.RcloneHost, ConfigValue = "http://nested" }]);
+
+        Assert.Equal("http://nested", config.GetRcloneHost());
+        Assert.Equal("alice", config.GetRcloneUser());
+        Assert.Equal(
+            [
+                "first:rclone.host",
+                "first:rclone.user",
+                "second:rclone.user",
+                "second:rclone.host",
+            ],
+            publications);
     }
 }

--- a/tests/NzbWebDAV.Tests/Logging/SynchronousObserverInvokerTests.cs
+++ b/tests/NzbWebDAV.Tests/Logging/SynchronousObserverInvokerTests.cs
@@ -1,0 +1,279 @@
+using NzbWebDAV.Logging;
+using NzbWebDAV.Tests.TestUtils;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace NzbWebDAV.Tests.Logging;
+
+[Collection(nameof(GlobalLoggerCollection))]
+public sealed class SynchronousObserverInvokerTests : IDisposable
+{
+    private const string SentinelSecret = "sentinel-secret-value-do-not-log";
+    private const string CallbackArgument = "callback-argument-must-not-appear";
+    private static readonly object Sender = new();
+
+    public SynchronousObserverInvokerTests()
+        => SynchronousObserverInvoker.ResetFailureLogThrottleForTests();
+
+    public void Dispose()
+        => SynchronousObserverInvoker.ResetFailureLogThrottleForTests();
+
+    [Fact]
+    public void EventHandlers_ThrowingFirstSubscriber_InvokesLaterSubscriberInOrder()
+    {
+        var order = new List<string>();
+        EventHandler<EventArgs> subscribers = (_, _) =>
+        {
+            order.Add("first");
+            throw new InvalidOperationException("first");
+        };
+        subscribers += (_, _) => order.Add("second");
+
+        SynchronousObserverInvoker.Invoke(
+            subscribers, Sender, EventArgs.Empty, SynchronousObserverSource.ConfigChanged);
+
+        Assert.Equal(["first", "second"], order);
+    }
+
+    [Fact]
+    public void Action_ThrowingFirstSubscriber_InvokesLaterSubscriberInOrder()
+    {
+        var order = new List<string>();
+        Action<int> subscribers = _ =>
+        {
+            order.Add("first");
+            throw new InvalidOperationException("first");
+        };
+        subscribers += _ => order.Add("second");
+
+        SynchronousObserverInvoker.Invoke(
+            subscribers, 1, SynchronousObserverSource.SharedStreamRingRetainedBytes);
+
+        Assert.Equal(["first", "second"], order);
+    }
+
+    [Fact]
+    public void TwoArgumentAction_ThrowingFirstSubscriber_InvokesLaterSubscriberInOrder()
+    {
+        var order = new List<string>();
+        Action<int, int> subscribers = (_, _) =>
+        {
+            order.Add("first");
+            throw new InvalidOperationException("first");
+        };
+        subscribers += (_, _) => order.Add("second");
+
+        SynchronousObserverInvoker.Invoke(
+            subscribers, 1, 2, SynchronousObserverSource.ConnectionLimitLearned);
+
+        Assert.Equal(["first", "second"], order);
+    }
+
+    [Fact]
+    public void Snapshot_RemovedSubscriberRunsCurrentPublicationOnly()
+    {
+        var order = new List<string>();
+        EventHandler<EventArgs>? source = null;
+        void First(object? _, EventArgs __)
+        {
+            order.Add("first");
+            source -= Second;
+        }
+
+        void Second(object? _, EventArgs __) => order.Add("second");
+
+        source += First;
+        source += Second;
+
+        SynchronousObserverInvoker.Invoke(
+            source, Sender, EventArgs.Empty, SynchronousObserverSource.ConfigChanged);
+        Assert.Equal(["first", "second"], order);
+
+        order.Clear();
+        SynchronousObserverInvoker.Invoke(
+            source, Sender, EventArgs.Empty, SynchronousObserverSource.ConfigChanged);
+        Assert.Equal(["first"], order);
+    }
+
+    [Fact]
+    public void Snapshot_AddedSubscriberStartsWithNextPublication()
+    {
+        var order = new List<string>();
+        EventHandler<EventArgs>? source = null;
+        void Third(object? _, EventArgs __) => order.Add("third");
+        void First(object? _, EventArgs __)
+        {
+            order.Add("first");
+            source += Third;
+        }
+
+        source += First;
+        source += (_, _) => order.Add("second");
+
+        SynchronousObserverInvoker.Invoke(
+            source, Sender, EventArgs.Empty, SynchronousObserverSource.ConfigChanged);
+        Assert.Equal(["first", "second"], order);
+
+        order.Clear();
+        SynchronousObserverInvoker.Invoke(
+            source, Sender, EventArgs.Empty, SynchronousObserverSource.ConfigChanged);
+        Assert.Equal(["first", "second", "third"], order);
+    }
+
+    [Fact]
+    public void DuplicateRegistration_InvokesEachInvocationListEntry()
+    {
+        var calls = 0;
+        Action<int> handler = _ => calls++;
+        var subscribers = handler + handler;
+
+        SynchronousObserverInvoker.Invoke(
+            subscribers, 0, SynchronousObserverSource.SharedStreamForceEvictions);
+
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
+    public void NullSubscriber_IsANoOp_EventHandler()
+    {
+        SynchronousObserverInvoker.Invoke<EventArgs>(
+            null, Sender, EventArgs.Empty, SynchronousObserverSource.ConfigChanged);
+    }
+
+    [Fact]
+    public void NullSubscriber_IsANoOp_Action()
+    {
+        SynchronousObserverInvoker.Invoke<int>(
+            null, 0, SynchronousObserverSource.SharedStreamRingRetainedBytes);
+    }
+
+    [Fact]
+    public void NullSubscriber_IsANoOp_TwoArgumentAction()
+    {
+        SynchronousObserverInvoker.Invoke<int, int>(
+            null, 0, 0, SynchronousObserverSource.ConnectionLimitLearned);
+    }
+
+    [Fact]
+    public void OutOfMemoryException_PropagatesAndIsNotLoggedAsContained()
+    {
+        var oom = new OutOfMemoryException("fatal");
+        var laterCalled = false;
+        EventHandler<EventArgs> subscribers = (_, _) => throw oom;
+        subscribers += (_, _) => laterCalled = true;
+
+        var events = CaptureLogs(() =>
+        {
+            var thrown = Assert.Throws<OutOfMemoryException>(() =>
+                SynchronousObserverInvoker.Invoke(
+                    subscribers, Sender, EventArgs.Empty, SynchronousObserverSource.ConfigChanged));
+            Assert.Same(oom, thrown);
+        });
+
+        Assert.False(laterCalled);
+        Assert.DoesNotContain(events, IsObserverFailureLog);
+    }
+
+    [Fact]
+    public void KnownFailureBurst_LogsOneOperatorFacingWarning()
+    {
+        Action<int> subscribers = _ => throw new TimeoutException("known");
+        var events = CaptureLogs(() =>
+        {
+            for (var i = 0; i < 8; i++)
+            {
+                SynchronousObserverInvoker.Invoke(
+                    subscribers, i, SynchronousObserverSource.ConnectionPoolChanged);
+            }
+        });
+
+        Assert.Equal(1, events.Count(e => e.Level == LogEventLevel.Warning && IsObserverFailureLog(e)));
+    }
+
+    [Fact]
+    public void UnexpectedFailure_LogsStackWithoutExceptionMessageOrCallbackArgument()
+    {
+        Action<string> subscribers = _ => throw new InvalidOperationException(SentinelSecret);
+        var events = CaptureLogs(() =>
+            SynchronousObserverInvoker.Invoke(
+                subscribers, CallbackArgument, SynchronousObserverSource.ConfigChanged));
+
+        var error = Assert.Single(events, e => e.Level == LogEventLevel.Error);
+        Assert.True(error.Properties.ContainsKey("ObserverStackTrace"));
+        var rendered = Render(error);
+        Assert.DoesNotContain(SentinelSecret, rendered);
+        Assert.DoesNotContain(CallbackArgument, rendered);
+    }
+
+    [Fact]
+    public void ResetFailureLogThrottleForTests_AllowsSameSourceToLogAgain()
+    {
+        Action<int> subscribers = _ => throw new InvalidOperationException("burst");
+        var events = CaptureLogs(() =>
+        {
+            for (var i = 0; i < 3; i++)
+            {
+                SynchronousObserverInvoker.Invoke(
+                    subscribers, i, SynchronousObserverSource.ConnectionLimitLearned);
+            }
+
+            SynchronousObserverInvoker.ResetFailureLogThrottleForTests();
+            SynchronousObserverInvoker.Invoke(
+                subscribers, 0, SynchronousObserverSource.ConnectionLimitLearned);
+        });
+
+        Assert.Equal(2, events.Count(e => e.Level == LogEventLevel.Error && IsObserverFailureLog(e)));
+    }
+
+    private static bool IsObserverFailureLog(LogEvent logEvent) =>
+        logEvent.MessageTemplate.Text.Contains("synchronous observer", StringComparison.OrdinalIgnoreCase);
+
+    private static string Render(LogEvent logEvent)
+    {
+        var rendered = logEvent.RenderMessage();
+        foreach (var property in logEvent.Properties)
+            rendered += $" {property.Key}={property.Value}";
+        if (logEvent.Exception is not null)
+            rendered += logEvent.Exception.ToString();
+        return rendered;
+    }
+
+    private static IReadOnlyList<LogEvent> CaptureLogs(Action act)
+    {
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        try
+        {
+            act();
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+
+        return sink.Events;
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events) return _events.ToArray();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events) _events.Add(logEvent);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Logging/SynchronousObserverInvokerTests.cs
+++ b/tests/NzbWebDAV.Tests/Logging/SynchronousObserverInvokerTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using NzbWebDAV.Logging;
 using NzbWebDAV.Tests.TestUtils;
 using Serilog;
@@ -231,12 +232,12 @@ public sealed class SynchronousObserverInvokerTests : IDisposable
 
     private static string Render(LogEvent logEvent)
     {
-        var rendered = logEvent.RenderMessage();
+        var rendered = new StringBuilder(logEvent.RenderMessage());
         foreach (var property in logEvent.Properties)
-            rendered += $" {property.Key}={property.Value}";
+            rendered.Append(' ').Append(property.Key).Append('=').Append(property.Value);
         if (logEvent.Exception is not null)
-            rendered += logEvent.Exception.ToString();
-        return rendered;
+            rendered.Append(logEvent.Exception);
+        return rendered.ToString();
     }
 
     private static IReadOnlyList<LogEvent> CaptureLogs(Action act)

--- a/tests/NzbWebDAV.Tests/Streams/SharedStreamEntryTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SharedStreamEntryTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using NzbWebDAV.Logging;
 using NzbWebDAV.Models;
 using NzbWebDAV.Streams;
 using NzbWebDAV.Tests.Fakes;
@@ -8,8 +9,14 @@ using NzbWebDAV.WebDav.Base;
 namespace NzbWebDAV.Tests.Streams;
 
 [Collection(nameof(GlobalLoggerCollection))]
-public class SharedStreamEntryTests
+public class SharedStreamEntryTests : IDisposable
 {
+    public SharedStreamEntryTests()
+        => SynchronousObserverInvoker.ResetFailureLogThrottleForTests();
+
+    public void Dispose()
+        => SynchronousObserverInvoker.ResetFailureLogThrottleForTests();
+
     [Fact]
     public async Task TwoReaders_AreByteExact_AndFetchEachSegmentOnce()
     {
@@ -306,6 +313,86 @@ public class SharedStreamEntryTests
     }
 
     [Fact]
+    public async Task RetainedBytes_ThrowingFirstSubscriber_DoesNotFailPumpOrSkipLaterSubscriber()
+    {
+        var payload = Encoding.ASCII.GetBytes("hello shared stream payload!!!!");
+        var upstream = new MemoryStream(payload, writable: false);
+        var firstCount = 0;
+        var secondCount = 0;
+        var retained = new List<long>();
+        await using var entry = StartEntry(upstream, payload.Length, configure: e =>
+        {
+            Action<long> first = _ =>
+            {
+                Interlocked.Increment(ref firstCount);
+                throw new InvalidOperationException("retained-bytes observer");
+            };
+            Action<long> second = value =>
+            {
+                Interlocked.Increment(ref secondCount);
+                lock (retained) retained.Add(value);
+            };
+            e.OnRingRetainedBytes = first + second;
+        });
+        await using var reader = Attach(entry, 0);
+
+        Assert.Equal(payload, await ReadAllAsync(reader));
+        Assert.True(firstCount > 0);
+        Assert.Equal(firstCount, secondCount);
+        lock (retained)
+            Assert.All(retained, value => Assert.True(value >= 0));
+        Assert.True(entry.Ring.IsComplete);
+        Assert.NotEqual(SharedStreamReapReason.Failure, entry.ReapReason);
+    }
+
+    [Fact]
+    public async Task ForceEvictions_ThrowingFirstSubscriber_DoesNotFailPumpOrSkipLaterSubscriber()
+    {
+        var (upstream, _, payload) = CreateUpstream(segmentCount: 8, segmentSize: 16);
+        var firstCount = 0;
+        var secondCount = 0;
+        var evictionCounts = new List<int>();
+        await using var entry = StartEntry(
+            upstream, payload.Length, ringSize: 16, chunkSize: 8, leadBytes: 8, configure: e =>
+            {
+                Action<int> first = _ =>
+                {
+                    Interlocked.Increment(ref firstCount);
+                    throw new InvalidOperationException("force-eviction observer");
+                };
+                Action<int> second = count =>
+                {
+                    Interlocked.Increment(ref secondCount);
+                    lock (evictionCounts) evictionCounts.Add(count);
+                };
+                e.OnForceEvictions = first + second;
+            });
+        await using var slow = Attach(entry, 0, (offset, _) =>
+        {
+            var (privateStream, _, _) = CreateUpstream(segmentCount: 8, segmentSize: 16);
+            privateStream.Seek(offset, SeekOrigin.Begin);
+            return Task.FromResult<Stream>(privateStream);
+        });
+        await using var fast = Attach(entry, 0);
+
+        var head = new byte[4];
+        Assert.Equal(4, await ReadExactAsync(slow, head));
+        Assert.Equal(payload.AsSpan(0, 4).ToArray(), head);
+
+        var fastBytes = await ReadAllAsync(fast);
+        Assert.Equal(payload, fastBytes);
+        await WaitUntil(() => slow.IsDetached || entry.Ring.TailStart > 4, TimeSpan.FromSeconds(5));
+
+        var remainder = await ReadAllAsync(slow);
+        Assert.Equal(payload[4..], remainder);
+        Assert.True(firstCount > 0);
+        Assert.Equal(firstCount, secondCount);
+        lock (evictionCounts)
+            Assert.All(evictionCounts, count => Assert.True(count > 0));
+        Assert.NotEqual(SharedStreamReapReason.Failure, entry.ReapReason);
+    }
+
+    [Fact]
     public void OpeningEntry_IsNotAttachable()
     {
         var entry = new SharedStreamEntry(
@@ -336,7 +423,8 @@ public class SharedStreamEntryTests
         TimeProvider? clock = null,
         int chunkSize = 8,
         int leadBytes = 16,
-        long anchor = 0)
+        long anchor = 0,
+        Action<SharedStreamEntry>? configure = null)
     {
         var entry = new SharedStreamEntry(
             "/content/movie.mkv",
@@ -348,6 +436,7 @@ public class SharedStreamEntryTests
             clock,
             chunkSize,
             leadBytes);
+        configure?.Invoke(entry);
         entry.BindAndStart(new DetachedStreamLease
         {
             Stream = upstream,


### PR DESCRIPTION
## Summary
- Isolate non-fatal exceptions from synchronous telemetry observers so one throwing subscriber cannot skip later subscribers, leak pool capacity, report a failed config save after commit, or turn a healthy shared-stream pump into a failure.
- Connection pool stats, learned-limit notifications, and the initial connection-count seed now snapshot the invocation list and catch per subscriber. Stale-eviction notifications run after `_lifecycleLock` is released.
- Config `OnConfigChanged` stays post-commit, ordered, and synchronous, with isolated subscriber failures. Shared-stream retained-byte and force-eviction telemetry is isolated without changing `OnReaped` or other functional callbacks (factories, keep-alive, limit detector, return/destroy).

Fixes #1240

## Test plan
- [x] Focused xUnit run: `SynchronousObserverInvokerTests`, `ConnectionPoolObserverTests`, `ConnectionPoolConnectionLimitTests`, `ConfigChangeSourceTests`, `SharedStreamEntryTests` (50 passed)
- [ ] PR CI (`ci.yml`) backend build and xUnit gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Improved notification handling for connection pools, configuration changes, and shared streams.
  - A failing callback no longer prevents other callbacks from running or disrupts ongoing operations.
  - Callback failures are logged while critical failures continue to surface appropriately.
  - Notifications now behave consistently during subscriber changes and nested updates.

- **Bug Fixes**
  - Prevented observer errors from leaving connection pools, stream processing, or configuration updates in an unusable state.

- **Tests**
  - Added comprehensive coverage for callback failures, ordering, subscription changes, logging, and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->