### PR TITLE
fix(health): keep prune and unlinked-file cleanup running if progress reporting fails

### DIFF
--- a/backend/Tasks/ProgressHeartbeat.cs
+++ b/backend/Tasks/ProgressHeartbeat.cs
@@ -1,0 +1,150 @@
+using Serilog;
+
+namespace NzbWebDAV.Tasks;
+
+internal enum ProgressHeartbeatOperation
+{
+    PruneCompletedHistory,
+    RemoveUnlinkedFiles,
+    RemoveMissingPayloads,
+}
+
+internal sealed class ProgressHeartbeat : IAsyncDisposable
+{
+    private enum ProgressReportSource
+    {
+        StartPhase,
+        UpdatePhase,
+        ScheduledHeartbeat,
+        Complete,
+    }
+
+    private readonly object _sync = new();
+    private readonly Action<string> _report;
+    private readonly TimeSpan _interval;
+    private readonly ProgressHeartbeatOperation _operation;
+    private readonly TimeProvider _timeProvider;
+    private readonly ITimer _timer;
+    private string? _message;
+    private long _runStartedAt;
+    private bool _hasStarted;
+    private bool _completed;
+    private bool _disposed;
+    private bool _reportFailureLogged;
+
+    internal ProgressHeartbeat(
+        Action<string> report,
+        TimeSpan interval,
+        ProgressHeartbeatOperation operation,
+        TimeProvider? timeProvider = null)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(interval, TimeSpan.Zero);
+
+        _report = report;
+        _interval = interval;
+        _operation = operation;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _timer = _timeProvider.CreateTimer(
+            static state => ((ProgressHeartbeat)state!).ReportHeartbeat(),
+            this,
+            Timeout.InfiniteTimeSpan,
+            Timeout.InfiniteTimeSpan);
+    }
+
+    internal void StartPhase(string message)
+    {
+        lock (_sync)
+        {
+            if (_disposed || _completed) return;
+            if (!_hasStarted)
+            {
+                _runStartedAt = _timeProvider.GetTimestamp();
+                _hasStarted = true;
+            }
+            _message = message;
+            ReportWithElapsed(ProgressReportSource.StartPhase);
+            _timer.Change(_interval, _interval);
+        }
+    }
+
+    internal void UpdatePhase(string message)
+    {
+        lock (_sync)
+        {
+            if (_disposed || _completed) return;
+            _message = message;
+            ReportWithElapsed(ProgressReportSource.UpdatePhase);
+        }
+    }
+
+    internal void Complete(string message)
+    {
+        lock (_sync)
+        {
+            if (_disposed || _completed) return;
+            _completed = true;
+            _message = null;
+            _timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            ReportSafely(message, ProgressReportSource.Complete);
+        }
+    }
+
+    private void ReportHeartbeat()
+    {
+        lock (_sync)
+        {
+            if (_disposed || _message is null) return;
+            ReportWithElapsed(ProgressReportSource.ScheduledHeartbeat);
+        }
+    }
+
+    private void ReportWithElapsed(ProgressReportSource source)
+    {
+        if (_message is null) return;
+        if (!_hasStarted)
+        {
+            _runStartedAt = _timeProvider.GetTimestamp();
+            _hasStarted = true;
+        }
+        var elapsed = _timeProvider.GetElapsedTime(_runStartedAt);
+        ReportSafely($"{_message}\nElapsed: {FormatElapsed(elapsed)}", source);
+    }
+
+    private void ReportSafely(string message, ProgressReportSource source)
+    {
+        try
+        {
+            _report(message);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            if (_reportFailureLogged) return;
+            _reportFailureLogged = true;
+            Log.Warning(
+                "Progress reporting failed; maintenance continues. " +
+                "Operation={Operation} Source={ReportSource} ExceptionType={ExceptionType}",
+                _operation,
+                source,
+                exception.GetType().FullName ?? exception.GetType().Name);
+        }
+    }
+
+    private static string FormatElapsed(TimeSpan elapsed) =>
+        elapsed.TotalMinutes >= 1
+            ? $"{(int)elapsed.TotalMinutes}m {elapsed.Seconds}s"
+            : $"{Math.Max(1, (int)elapsed.TotalSeconds)}s";
+
+    public async ValueTask DisposeAsync()
+    {
+        lock (_sync)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _message = null;
+            _timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        }
+
+        await _timer.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/backend/Tasks/PruneCompletedHistoryTask.cs
+++ b/backend/Tasks/PruneCompletedHistoryTask.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
@@ -44,7 +43,10 @@ public class PruneCompletedHistoryTask : BaseTask
 
     protected override async Task ExecuteInternal()
     {
-        await using var progressHeartbeat = new ProgressHeartbeat(Report, _progressHeartbeatInterval);
+        await using var progressHeartbeat = new ProgressHeartbeat(
+            Report,
+            _progressHeartbeatInterval,
+            ProgressHeartbeatOperation.PruneCompletedHistory);
         _progressHeartbeat = progressHeartbeat;
         try { await PruneCompletedHistory().ConfigureAwait(false); }
         catch (Exception e) when (e is not OutOfMemoryException)
@@ -152,19 +154,4 @@ public class PruneCompletedHistoryTask : BaseTask
     private void UpdatePhase(string message) => _progressHeartbeat?.UpdatePhase(message);
     private void Complete(string message) { if (_progressHeartbeat is not null) _progressHeartbeat.Complete(message); else Report(message); }
     private void Report(string message) { var progress = $"{(_isDryRun ? "Dry Run - " : string.Empty)}{message}"; _progressObserver?.Invoke(progress); _ = _websocketManager.SendMessage(WebsocketTopic.PruneCompletedHistoryTaskProgress, progress); }
-
-    internal sealed class ProgressHeartbeat : IAsyncDisposable
-    {
-        private readonly object _sync = new(); private readonly Action<string> _report; private readonly TimeSpan _interval; private readonly Timer _timer;
-        private string? _message; private long _runStartedAt; private bool _completed; private bool _disposed;
-        public ProgressHeartbeat(Action<string> report, TimeSpan interval)
-        { _report = report; _interval = interval; _timer = new Timer(static s => ((ProgressHeartbeat)s!).ReportHeartbeat(), this, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan); }
-        public void StartPhase(string message) { lock (_sync) { if (_disposed || _completed) return; if (_runStartedAt == 0) _runStartedAt = Stopwatch.GetTimestamp(); _message = message; ReportWithElapsed(); _timer.Change(_interval, _interval); } }
-        public void UpdatePhase(string message) { lock (_sync) { if (_disposed || _completed) return; _message = message; ReportWithElapsed(); } }
-        public void Complete(string message) { lock (_sync) { if (_disposed || _completed) return; _completed = true; _message = null; _timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan); _report(message); } }
-        private void ReportHeartbeat() { lock (_sync) { if (_disposed || _message is null) return; ReportWithElapsed(); } }
-        private void ReportWithElapsed() { if (_message is null) return; if (_runStartedAt == 0) _runStartedAt = Stopwatch.GetTimestamp(); _report($"{_message}\nElapsed: {FormatElapsed(Stopwatch.GetElapsedTime(_runStartedAt))}"); }
-        private static string FormatElapsed(TimeSpan elapsed) => elapsed.TotalMinutes >= 1 ? $"{(int)elapsed.TotalMinutes}m {elapsed.Seconds}s" : $"{Math.Max(1, (int)elapsed.TotalSeconds)}s";
-        public async ValueTask DisposeAsync() { lock (_sync) { if (_disposed) return; _disposed = true; _message = null; _timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan); } await _timer.DisposeAsync().ConfigureAwait(false); }
-    }
 }

--- a/backend/Tasks/RemoveMissingPayloadsTask.cs
+++ b/backend/Tasks/RemoveMissingPayloadsTask.cs
@@ -37,7 +37,7 @@ public sealed class RemoveMissingPayloadsTask : BaseTask
     private readonly TimeSpan _progressHeartbeatInterval;
     private readonly Action<string>? _progressObserver;
     private readonly CleanupStats _stats = new();
-    private RemoveUnlinkedFilesTask.ProgressHeartbeat? _progressHeartbeat;
+    private ProgressHeartbeat? _progressHeartbeat;
 
     public RemoveMissingPayloadsTask(
         ConfigManager configManager,
@@ -92,8 +92,10 @@ public sealed class RemoveMissingPayloadsTask : BaseTask
 
     protected override async Task ExecuteInternal()
     {
-        await using var progressHeartbeat =
-            new RemoveUnlinkedFilesTask.ProgressHeartbeat(Report, _progressHeartbeatInterval);
+        await using var progressHeartbeat = new ProgressHeartbeat(
+            Report,
+            _progressHeartbeatInterval,
+            ProgressHeartbeatOperation.RemoveMissingPayloads);
         _progressHeartbeat = progressHeartbeat;
         try
         {

--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -83,7 +83,10 @@ public class RemoveUnlinkedFilesTask : BaseTask
 
     protected override async Task ExecuteInternal()
     {
-        await using var progressHeartbeat = new ProgressHeartbeat(Report, _progressHeartbeatInterval);
+        await using var progressHeartbeat = new ProgressHeartbeat(
+            Report,
+            _progressHeartbeatInterval,
+            ProgressHeartbeatOperation.RemoveUnlinkedFiles);
         _progressHeartbeat = progressHeartbeat;
         try
         {
@@ -770,101 +773,6 @@ public class RemoveUnlinkedFilesTask : BaseTask
         var progress = $"{dryRun}{message}";
         _progressObserver?.Invoke(progress);
         _ = _websocketManager.SendMessage(WebsocketTopic.CleanupTaskProgress, progress);
-    }
-
-    internal sealed class ProgressHeartbeat : IAsyncDisposable
-    {
-        private readonly object _sync = new();
-        private readonly Action<string> _report;
-        private readonly TimeSpan _interval;
-        private readonly Timer _timer;
-        private string? _message;
-        private long _runStartedAt;
-        private bool _completed;
-        private bool _disposed;
-
-        public ProgressHeartbeat(Action<string> report, TimeSpan interval)
-        {
-            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(interval, TimeSpan.Zero);
-            _report = report;
-            _interval = interval;
-            _timer = new Timer(
-                static state => ((ProgressHeartbeat)state!).ReportHeartbeat(),
-                this,
-                Timeout.InfiniteTimeSpan,
-                Timeout.InfiniteTimeSpan);
-        }
-
-        public void StartPhase(string message)
-        {
-            lock (_sync)
-            {
-                if (_disposed || _completed) return;
-                if (_runStartedAt == 0)
-                    _runStartedAt = Stopwatch.GetTimestamp();
-                _message = message;
-                ReportWithElapsed();
-                _timer.Change(_interval, _interval);
-            }
-        }
-
-        public void UpdatePhase(string message)
-        {
-            lock (_sync)
-            {
-                if (_disposed || _completed) return;
-                _message = message;
-                ReportWithElapsed();
-            }
-        }
-
-        public void Complete(string message)
-        {
-            lock (_sync)
-            {
-                if (_disposed || _completed) return;
-                _completed = true;
-                _message = null;
-                _timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
-                _report(message);
-            }
-        }
-
-        private void ReportHeartbeat()
-        {
-            lock (_sync)
-            {
-                if (_disposed || _message is null) return;
-                ReportWithElapsed();
-            }
-        }
-
-        private void ReportWithElapsed()
-        {
-            if (_message is null) return;
-            if (_runStartedAt == 0)
-                _runStartedAt = Stopwatch.GetTimestamp();
-            var elapsed = Stopwatch.GetElapsedTime(_runStartedAt);
-            _report($"{_message}\nElapsed: {FormatElapsed(elapsed)}");
-        }
-
-        private static string FormatElapsed(TimeSpan elapsed) =>
-            elapsed.TotalMinutes >= 1
-                ? $"{(int)elapsed.TotalMinutes}m {elapsed.Seconds}s"
-                : $"{Math.Max(1, (int)elapsed.TotalSeconds)}s";
-
-        public async ValueTask DisposeAsync()
-        {
-            lock (_sync)
-            {
-                if (_disposed) return;
-                _disposed = true;
-                _message = null;
-                _timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
-            }
-
-            await _timer.DisposeAsync().ConfigureAwait(false);
-        }
     }
 
     public static string GetAuditReport()

--- a/tests/NzbWebDAV.Tests/Tasks/ProgressHeartbeatTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/ProgressHeartbeatTests.cs
@@ -563,7 +563,7 @@ public class ProgressHeartbeatTests
     {
         var sink = new CollectingSink();
         var previous = Log.Logger;
-        var logger = new LoggerConfiguration()
+        using var logger = new LoggerConfiguration()
             .MinimumLevel.Verbose()
             .WriteTo.Sink(sink)
             .CreateLogger();
@@ -575,7 +575,6 @@ public class ProgressHeartbeatTests
         finally
         {
             Log.Logger = previous;
-            logger.Dispose();
         }
 
         return sink.Events;

--- a/tests/NzbWebDAV.Tests/Tasks/ProgressHeartbeatTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/ProgressHeartbeatTests.cs
@@ -1,0 +1,603 @@
+using System.Collections.Concurrent;
+using NzbWebDAV.Tasks;
+using NzbWebDAV.Tests.TestUtils;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace NzbWebDAV.Tests.Tasks;
+
+[Collection(nameof(GlobalLoggerCollection))]
+public class ProgressHeartbeatTests
+{
+    private static readonly TimeSpan Interval = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan DeadlockGuard = TimeSpan.FromSeconds(1);
+
+    private const string PayloadSecret = "nzbdav-sentinel-payload-9f3a";
+    private const string MessageSecret = "nzbdav-sentinel-message-c21b";
+    private const string InnerSecret = "nzbdav-sentinel-inner-a44e";
+    private const string DataKeySecret = "nzbdav-sentinel-datakey-7d0c";
+    private const string DataValueSecret = "nzbdav-sentinel-datavalue-b8e1";
+    private const string PosixPath = "/var/secret-nzbdav/heartbeat-leak.sqlite";
+    private const string WindowsPath = @"C:\Users\secret-nzbdav\heartbeat-leak.sqlite";
+
+    private static readonly string[] Sentinels =
+    [
+        PayloadSecret,
+        MessageSecret,
+        InnerSecret,
+        DataKeySecret,
+        DataValueSecret,
+        PosixPath,
+        WindowsPath,
+    ];
+
+    [Fact]
+    public async Task ReportsElapsedUntilCompleted_UsingControllableTime()
+    {
+        var messages = new ConcurrentQueue<string>();
+        var clock = new ControllableTimeProvider();
+        await using var heartbeat = new ProgressHeartbeat(
+            messages.Enqueue,
+            Interval,
+            ProgressHeartbeatOperation.RemoveUnlinkedFiles,
+            clock);
+
+        heartbeat.StartPhase("Scanning all linked files...\nFound 79976...");
+
+        Assert.True(messages.TryPeek(out var startMessage));
+        Assert.StartsWith("Scanning all linked files...\nFound 79976...", startMessage);
+        Assert.Contains("Elapsed: 1s", startMessage, StringComparison.Ordinal);
+
+        clock.Advance(Interval);
+        var afterHeartbeat = messages.ToArray();
+        Assert.Equal(2, afterHeartbeat.Length);
+        Assert.Contains("Elapsed: 2s", afterHeartbeat[1], StringComparison.Ordinal);
+        Assert.StartsWith("Scanning all linked files...\nFound 79976...", afterHeartbeat[1]);
+
+        heartbeat.UpdatePhase("Scanning all linked files...\nFound 79977...");
+        var afterUpdate = messages.ToArray();
+        Assert.Equal(3, afterUpdate.Length);
+        Assert.StartsWith("Scanning all linked files...\nFound 79977...", afterUpdate[^1]);
+        Assert.Contains("Elapsed: 2s", afterUpdate[^1], StringComparison.Ordinal);
+
+        heartbeat.Complete("Done.");
+        clock.Advance(TimeSpan.FromSeconds(10));
+        heartbeat.UpdatePhase("Scanning all linked files...\nFound 79978...");
+
+        var snapshot = messages.ToArray();
+        Assert.Equal("Done.", snapshot[^1]);
+        Assert.Equal(1, snapshot.Count(message => message == "Done."));
+        Assert.DoesNotContain("Elapsed:", snapshot[^1]);
+        Assert.Equal(4, snapshot.Length);
+    }
+
+    [Fact]
+    public async Task ScheduledReporterFailure_IsContained_AndLaterReportsContinue()
+    {
+        var invocation = 0;
+        var messages = new ConcurrentQueue<string>();
+        void Report(string message)
+        {
+            if (Interlocked.Increment(ref invocation) == 2)
+                throw new InvalidOperationException("scheduled reporter failure");
+            messages.Enqueue(message);
+        }
+
+        var clock = new ControllableTimeProvider();
+        await using var heartbeat = new ProgressHeartbeat(
+            Report,
+            Interval,
+            ProgressHeartbeatOperation.RemoveUnlinkedFiles,
+            clock);
+
+        heartbeat.StartPhase("Scanning all linked files...\nFound 79976...");
+        Assert.Null(Record.Exception(() => clock.Advance(Interval)));
+
+        heartbeat.UpdatePhase("Scanning all linked files...\nFound 79977...");
+        heartbeat.Complete("Done.");
+
+        var snapshot = messages.ToArray();
+        Assert.StartsWith("Scanning all linked files...\nFound 79977...", snapshot[^2]);
+        Assert.Equal("Done.", snapshot[^1]);
+        Assert.DoesNotContain("Elapsed:", snapshot[^1]);
+
+        var invocationsAfterComplete = invocation;
+        clock.Advance(TimeSpan.FromSeconds(10));
+        Assert.Equal(invocationsAfterComplete, invocation);
+    }
+
+    [Fact]
+    public async Task ImmediateAndTerminalReporterFailures_DoNotEscape()
+    {
+        var invocation = 0;
+        void Report(string _)
+        {
+            Interlocked.Increment(ref invocation);
+            throw new InvalidOperationException("always-throw reporter");
+        }
+
+        var clock = new ControllableTimeProvider();
+        await using var heartbeat = new ProgressHeartbeat(
+            Report,
+            Interval,
+            ProgressHeartbeatOperation.PruneCompletedHistory,
+            clock);
+
+        Assert.Null(Record.Exception(() => heartbeat.StartPhase("Counting completed history items...")));
+        Assert.Null(Record.Exception(() => heartbeat.UpdatePhase("Counting completed history items...\nFound 1...")));
+        Assert.Null(Record.Exception(() => heartbeat.Complete("Done.")));
+        Assert.Equal(3, invocation);
+
+        Assert.Null(Record.Exception(() => heartbeat.UpdatePhase("later")));
+        Assert.Null(Record.Exception(() => clock.Advance(TimeSpan.FromSeconds(10))));
+        Assert.Equal(3, invocation);
+
+        var armedInvocations = 0;
+        void ArmedReport(string _)
+        {
+            Interlocked.Increment(ref armedInvocations);
+            throw new InvalidOperationException("always-throw reporter");
+        }
+
+        var armedClock = new ControllableTimeProvider();
+        await using var armed = new ProgressHeartbeat(
+            ArmedReport,
+            Interval,
+            ProgressHeartbeatOperation.PruneCompletedHistory,
+            armedClock);
+
+        Assert.Null(Record.Exception(() => armed.StartPhase("Counting completed history items...")));
+        Assert.Equal(1, armedInvocations);
+        Assert.Null(Record.Exception(() => armedClock.Advance(Interval)));
+        Assert.Equal(2, armedInvocations);
+        Assert.Null(Record.Exception(() => armed.Complete("Done.")));
+        Assert.Equal(3, armedInvocations);
+    }
+
+    [Fact]
+    public async Task CompleteRacingWithHeartbeat_ReportsTerminalOnceWithoutOverlap()
+    {
+        var heartbeatEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseHeartbeat = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var messages = new ConcurrentQueue<string>();
+        var invocation = 0;
+        var activeReporters = 0;
+        var maxActiveReporters = 0;
+        var overlap = 0;
+
+        void Report(string message)
+        {
+            var current = Interlocked.Increment(ref activeReporters);
+            if (current > 1)
+                Interlocked.Exchange(ref overlap, 1);
+            int snapshot;
+            do
+            {
+                snapshot = maxActiveReporters;
+                if (current <= snapshot) break;
+            } while (Interlocked.CompareExchange(ref maxActiveReporters, current, snapshot) != snapshot);
+
+            try
+            {
+                var n = Interlocked.Increment(ref invocation);
+                messages.Enqueue(message);
+                if (n != 2) return;
+                heartbeatEntered.TrySetResult();
+                releaseHeartbeat.Task.GetAwaiter().GetResult();
+            }
+            finally
+            {
+                Interlocked.Decrement(ref activeReporters);
+            }
+        }
+
+        var clock = new ControllableTimeProvider();
+        await using var heartbeat = new ProgressHeartbeat(
+            Report,
+            Interval,
+            ProgressHeartbeatOperation.RemoveUnlinkedFiles,
+            clock);
+
+        heartbeat.StartPhase("Scanning all linked files...\nFound 79976...");
+
+        var advanceTask = Task.Run(() => clock.Advance(Interval));
+        try
+        {
+            await heartbeatEntered.Task.WaitAsync(DeadlockGuard);
+            var completeTask = Task.Run(() =>
+                heartbeat.Complete("Failed: nzbdav is shutting down"));
+            Assert.False(completeTask.IsCompleted);
+            releaseHeartbeat.TrySetResult();
+            await advanceTask.WaitAsync(DeadlockGuard);
+            await completeTask.WaitAsync(DeadlockGuard);
+
+            Assert.Equal(0, overlap);
+            Assert.Equal(1, maxActiveReporters);
+
+            var snapshot = messages.ToArray();
+            Assert.Equal(1, snapshot.Count(message => message == "Failed: nzbdav is shutting down"));
+            Assert.Equal("Failed: nzbdav is shutting down", snapshot[^1]);
+            var scheduledIndex = Array.FindLastIndex(
+                snapshot,
+                message => message.Contains("Elapsed:", StringComparison.Ordinal));
+            var terminalIndex = Array.FindIndex(
+                snapshot,
+                message => message == "Failed: nzbdav is shutting down");
+            Assert.True(scheduledIndex >= 0 && scheduledIndex < terminalIndex);
+
+            var count = snapshot.Length;
+            clock.Advance(TimeSpan.FromSeconds(10));
+            heartbeat.UpdatePhase("should not report");
+            Assert.Equal(count, messages.Count);
+        }
+        finally
+        {
+            releaseHeartbeat.TrySetResult();
+            await advanceTask.WaitAsync(DeadlockGuard);
+        }
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WaitsForInFlightHeartbeat_AndPreventsStaleReports()
+    {
+        var heartbeatEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseHeartbeat = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var messages = new ConcurrentQueue<string>();
+        var invocation = 0;
+        var activeReporters = 0;
+        var maxActiveReporters = 0;
+        var overlap = 0;
+
+        void Report(string message)
+        {
+            var current = Interlocked.Increment(ref activeReporters);
+            if (current > 1)
+                Interlocked.Exchange(ref overlap, 1);
+            int snapshot;
+            do
+            {
+                snapshot = maxActiveReporters;
+                if (current <= snapshot) break;
+            } while (Interlocked.CompareExchange(ref maxActiveReporters, current, snapshot) != snapshot);
+
+            try
+            {
+                var n = Interlocked.Increment(ref invocation);
+                messages.Enqueue(message);
+                if (n != 2) return;
+                heartbeatEntered.TrySetResult();
+                releaseHeartbeat.Task.GetAwaiter().GetResult();
+            }
+            finally
+            {
+                Interlocked.Decrement(ref activeReporters);
+            }
+        }
+
+        var clock = new ControllableTimeProvider();
+        var heartbeat = new ProgressHeartbeat(
+            Report,
+            Interval,
+            ProgressHeartbeatOperation.RemoveUnlinkedFiles,
+            clock);
+
+        heartbeat.StartPhase("Scanning all linked files...\nFound 79976...");
+
+        var advanceTask = Task.Run(() => clock.Advance(Interval));
+        Task? disposeTask = null;
+        try
+        {
+            await heartbeatEntered.Task.WaitAsync(DeadlockGuard);
+            disposeTask = Task.Run(async () =>
+                await heartbeat.DisposeAsync().ConfigureAwait(false));
+            Assert.False(disposeTask.IsCompleted);
+            releaseHeartbeat.TrySetResult();
+            await advanceTask.WaitAsync(DeadlockGuard);
+            await disposeTask.WaitAsync(DeadlockGuard);
+
+            Assert.Equal(0, overlap);
+            Assert.Equal(1, maxActiveReporters);
+
+            var count = messages.Count;
+            clock.Advance(TimeSpan.FromSeconds(10));
+            heartbeat.UpdatePhase("stale");
+            heartbeat.Complete("Done.");
+            Assert.Equal(count, messages.Count);
+        }
+        finally
+        {
+            releaseHeartbeat.TrySetResult();
+            await advanceTask.WaitAsync(DeadlockGuard);
+            if (disposeTask is not null)
+                await disposeTask.WaitAsync(DeadlockGuard);
+            else
+                await heartbeat.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task KnownReporterFailure_LogsTypeOnlyWithoutSentinels()
+    {
+        var exception = CreateSecretException(
+            (message, inner) => new IOException(message, inner));
+        var events = await CaptureLogsAsync(async () =>
+        {
+            var clock = new ControllableTimeProvider();
+            await using var heartbeat = new ProgressHeartbeat(
+                _ => throw exception,
+                Interval,
+                ProgressHeartbeatOperation.PruneCompletedHistory,
+                clock);
+
+            heartbeat.StartPhase($"Scanning {PayloadSecret}\n{PosixPath}\n{WindowsPath}");
+            clock.Advance(Interval);
+            heartbeat.UpdatePhase($"Updating {PayloadSecret}\n{PosixPath}\n{WindowsPath}");
+            heartbeat.Complete($"Done. {PayloadSecret}");
+        });
+
+        var warning = Assert.Single(
+            events,
+            logEvent => IsReporterFailureWarning(logEvent)
+                && PropertyText(logEvent, "Operation") == nameof(ProgressHeartbeatOperation.PruneCompletedHistory)
+                && PropertyText(logEvent, "ReportSource") == "StartPhase"
+                && PropertyText(logEvent, "ExceptionType") == typeof(IOException).FullName);
+        AssertReporterFailureEvent(
+            warning,
+            expectedOperation: nameof(ProgressHeartbeatOperation.PruneCompletedHistory),
+            expectedSource: "StartPhase",
+            expectedExceptionType: typeof(IOException).FullName!);
+    }
+
+    [Fact]
+    public async Task UnexpectedReporterFailure_LogsTypeOnlyWithoutSentinels()
+    {
+        var exception = CreateSecretException(
+            (message, inner) => new InvalidOperationException(message, inner));
+        var invocation = 0;
+        var events = await CaptureLogsAsync(async () =>
+        {
+            var clock = new ControllableTimeProvider();
+            await using var heartbeat = new ProgressHeartbeat(
+                _ =>
+                {
+                    if (Interlocked.Increment(ref invocation) == 1)
+                        return;
+                    throw exception;
+                },
+                Interval,
+                ProgressHeartbeatOperation.RemoveUnlinkedFiles,
+                clock);
+
+            heartbeat.StartPhase($"Scanning {PayloadSecret}\n{PosixPath}\n{WindowsPath}");
+            clock.Advance(Interval);
+            heartbeat.UpdatePhase($"Updating {PayloadSecret}\n{PosixPath}\n{WindowsPath}");
+            heartbeat.Complete($"Done. {PayloadSecret}");
+        });
+
+        var warning = Assert.Single(
+            events,
+            logEvent => IsReporterFailureWarning(logEvent)
+                && PropertyText(logEvent, "Operation") == nameof(ProgressHeartbeatOperation.RemoveUnlinkedFiles)
+                && PropertyText(logEvent, "ReportSource") == "ScheduledHeartbeat"
+                && PropertyText(logEvent, "ExceptionType") == typeof(InvalidOperationException).FullName);
+        AssertReporterFailureEvent(
+            warning,
+            expectedOperation: nameof(ProgressHeartbeatOperation.RemoveUnlinkedFiles),
+            expectedSource: "ScheduledHeartbeat",
+            expectedExceptionType: typeof(InvalidOperationException).FullName!);
+    }
+
+    [Fact]
+    public async Task ReporterFailureThrottle_IsPerInstance_AndNeedsNoGlobalReset()
+    {
+        var events = await CaptureLogsAsync(async () =>
+        {
+            var clock = new ControllableTimeProvider();
+            await using var first = new ProgressHeartbeat(
+                _ => throw new PerInstanceThrottleException(),
+                Interval,
+                ProgressHeartbeatOperation.PruneCompletedHistory,
+                clock);
+            first.StartPhase("first-a");
+            first.UpdatePhase("first-b");
+            first.Complete("first-done");
+
+            await using var second = new ProgressHeartbeat(
+                _ => throw new PerInstanceThrottleException(),
+                Interval,
+                ProgressHeartbeatOperation.RemoveMissingPayloads,
+                clock);
+            second.StartPhase("second-a");
+            second.UpdatePhase("second-b");
+            second.Complete("second-done");
+        });
+
+        var warnings = events
+            .Where(logEvent =>
+                IsReporterFailureWarning(logEvent)
+                && PropertyText(logEvent, "ExceptionType") == typeof(PerInstanceThrottleException).FullName)
+            .ToArray();
+        Assert.Equal(2, warnings.Length);
+        AssertReporterFailureEvent(
+            warnings[0],
+            expectedOperation: nameof(ProgressHeartbeatOperation.PruneCompletedHistory),
+            expectedSource: "StartPhase",
+            expectedExceptionType: typeof(PerInstanceThrottleException).FullName!,
+            sentinels: []);
+        AssertReporterFailureEvent(
+            warnings[1],
+            expectedOperation: nameof(ProgressHeartbeatOperation.RemoveMissingPayloads),
+            expectedSource: "StartPhase",
+            expectedExceptionType: typeof(PerInstanceThrottleException).FullName!,
+            sentinels: []);
+    }
+
+    [Fact]
+    public async Task OutOfMemoryException_IsNotContained()
+    {
+        var oom = new OutOfMemoryException("pre-created");
+        var heartbeat = new ProgressHeartbeat(
+            _ => throw oom,
+            Interval,
+            ProgressHeartbeatOperation.PruneCompletedHistory);
+        try
+        {
+            var thrown = Assert.Throws<OutOfMemoryException>(
+                () => heartbeat.StartPhase("Counting completed history items..."));
+            Assert.Same(oom, thrown);
+        }
+        finally
+        {
+            await heartbeat.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public void Constructor_RejectsNonPositiveInterval()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new ProgressHeartbeat(_ => { }, TimeSpan.Zero, ProgressHeartbeatOperation.PruneCompletedHistory));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new ProgressHeartbeat(
+                _ => { },
+                Timeout.InfiniteTimeSpan,
+                ProgressHeartbeatOperation.RemoveUnlinkedFiles));
+    }
+
+    private static TException CreateSecretException<TException>(
+        Func<string, Exception, TException> factory)
+        where TException : Exception
+    {
+        var inner = new IOException($"{InnerSecret} {PosixPath} {WindowsPath}");
+        var exception = factory($"{MessageSecret} {PosixPath} {WindowsPath}", inner);
+        exception.Data[DataKeySecret] = DataValueSecret;
+        return exception;
+    }
+
+    private static bool IsReporterFailureWarning(LogEvent logEvent) =>
+        logEvent.Level == LogEventLevel.Warning
+        && logEvent.MessageTemplate.Text.Contains(
+            "Progress reporting failed; maintenance continues.",
+            StringComparison.Ordinal);
+
+    private static void AssertReporterFailureEvent(
+        LogEvent logEvent,
+        string expectedOperation,
+        string expectedSource,
+        string expectedExceptionType,
+        string[]? sentinels = null)
+    {
+        Assert.Equal(LogEventLevel.Warning, logEvent.Level);
+        Assert.Null(logEvent.Exception);
+        Assert.Contains(
+            "Progress reporting failed; maintenance continues.",
+            logEvent.MessageTemplate.Text,
+            StringComparison.Ordinal);
+
+        Assert.Equal(
+            new HashSet<string>(StringComparer.Ordinal)
+            {
+                "Operation",
+                "ReportSource",
+                "ExceptionType",
+            },
+            logEvent.Properties.Keys.ToHashSet(StringComparer.Ordinal));
+        Assert.False(logEvent.Properties.ContainsKey("Reason"));
+        Assert.False(logEvent.Properties.ContainsKey("Stack"));
+        Assert.False(logEvent.Properties.ContainsKey("Payload"));
+        Assert.False(logEvent.Properties.ContainsKey("Exception"));
+
+        Assert.Equal(expectedOperation, PropertyText(logEvent, "Operation"));
+        Assert.Equal(expectedSource, PropertyText(logEvent, "ReportSource"));
+        Assert.Equal(expectedExceptionType, PropertyText(logEvent, "ExceptionType"));
+
+        foreach (var sentinel in sentinels ?? Sentinels)
+            AssertEventHasNoSentinel(logEvent, sentinel);
+    }
+
+    private static void AssertEventHasNoSentinel(LogEvent logEvent, string sentinel)
+    {
+        Assert.DoesNotContain(sentinel, logEvent.MessageTemplate.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain(sentinel, logEvent.RenderMessage(), StringComparison.Ordinal);
+        foreach (var (name, value) in logEvent.Properties)
+        {
+            Assert.DoesNotContain(sentinel, name, StringComparison.Ordinal);
+            Assert.DoesNotContain(sentinel, FormatPropertyValue(value), StringComparison.Ordinal);
+        }
+
+        if (logEvent.Exception is { } exception)
+        {
+            Assert.DoesNotContain(sentinel, exception.ToString(), StringComparison.Ordinal);
+            Assert.DoesNotContain(sentinel, exception.Message, StringComparison.Ordinal);
+            Assert.DoesNotContain(sentinel, exception.GetType().FullName ?? "", StringComparison.Ordinal);
+        }
+    }
+
+    private static string PropertyText(LogEvent logEvent, string name)
+    {
+        if (!logEvent.Properties.TryGetValue(name, out var value))
+            return "";
+        return value is ScalarValue { Value: { } raw }
+            ? raw.ToString() ?? ""
+            : value.ToString();
+    }
+
+    private static string FormatPropertyValue(LogEventPropertyValue value) => value switch
+    {
+        ScalarValue { Value: { } raw } => raw.ToString() ?? "",
+        ScalarValue => "",
+        SequenceValue sequence => string.Join(",", sequence.Elements.Select(FormatPropertyValue)),
+        DictionaryValue dictionary => string.Join(
+            ",",
+            dictionary.Elements.Select(pair =>
+                $"{FormatPropertyValue(pair.Key)}={FormatPropertyValue(pair.Value)}")),
+        StructureValue structure => string.Join(
+            ",",
+            structure.Properties.Select(property =>
+                $"{property.Name}={FormatPropertyValue(property.Value)}")),
+        _ => value.ToString(),
+    };
+
+    private static async Task<IReadOnlyList<LogEvent>> CaptureLogsAsync(Func<Task> action)
+    {
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        var logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        Log.Logger = logger;
+        try
+        {
+            await action().ConfigureAwait(false);
+        }
+        finally
+        {
+            Log.Logger = previous;
+            logger.Dispose();
+        }
+
+        return sink.Events;
+    }
+
+    private sealed class PerInstanceThrottleException : Exception;
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events) return _events.ToArray();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events) _events.Add(logEvent);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Tasks/PruneCompletedHistoryTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/PruneCompletedHistoryTaskTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
 using NzbWebDAV.Database;
@@ -86,6 +87,48 @@ public class PruneCompletedHistoryTaskTests
             Assert.True(await new PruneCompletedHistoryTask(new WebsocketManager(), false, "movies", 90, () => harness.CreateContext()).Execute());
             Assert.Equal(0, await ctx.HistoryItems.CountAsync());
             Assert.Equal(150, await ctx.HistoryCleanupItems.CountAsync());
+        }
+        finally { await BaseTask.ResetRunningTaskForTestsAsync(); }
+    }
+
+    [Fact]
+    public async Task Execute_PrunesAndReportsDone_WhenProgressObserverThrowsOnce()
+    {
+        await BaseTask.ResetRunningTaskForTestsAsync();
+        await using var harness = await TempDb.CreateAsync();
+        try
+        {
+            var ctx = harness.Context;
+            var id = Guid.NewGuid();
+            ctx.HistoryItems.Add(CreateHistory(id, "old-movies.nzb", "movies", DateTime.UtcNow.AddDays(-120)));
+            await ctx.SaveChangesAsync();
+            ctx.ChangeTracker.Clear();
+
+            var invocation = 0;
+            var messages = new ConcurrentQueue<string>();
+            void Observer(string message)
+            {
+                if (Interlocked.Increment(ref invocation) == 1)
+                    throw new InvalidOperationException("progress observer failure");
+                messages.Enqueue(message);
+            }
+
+            Assert.True(await new PruneCompletedHistoryTask(
+                new WebsocketManager(),
+                false,
+                "movies",
+                90,
+                () => harness.CreateContext(),
+                progressObserver: Observer).Execute());
+
+            Assert.Null(await ctx.HistoryItems.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id));
+            Assert.Equal(1, await ctx.HistoryCleanupItems.CountAsync());
+            Assert.Contains(
+                messages,
+                message => message.StartsWith("Done. Pruned 1", StringComparison.Ordinal));
+            Assert.DoesNotContain(
+                messages,
+                message => message.StartsWith("Failed:", StringComparison.Ordinal));
         }
         finally { await BaseTask.ResetRunningTaskForTestsAsync(); }
     }

--- a/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
@@ -51,46 +51,6 @@ public class RemoveUnlinkedFilesTaskTests
     }
 
     [Fact]
-    public async Task ProgressHeartbeat_ReportsElapsedUntilCompleted()
-    {
-        var messages = new ConcurrentQueue<string>();
-        var heartbeatReported = new TaskCompletionSource<string>(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-        var heartbeat = new RemoveUnlinkedFilesTask.ProgressHeartbeat(message =>
-        {
-            messages.Enqueue(message);
-            if (messages.Count > 1 && message.Contains("Elapsed:", StringComparison.Ordinal))
-                heartbeatReported.TrySetResult(message);
-        }, TimeSpan.FromMilliseconds(10));
-
-        try
-        {
-            heartbeat.StartPhase("Scanning all linked files...\nFound 79976...");
-
-            Assert.True(messages.TryPeek(out var startMessage));
-            Assert.StartsWith("Scanning all linked files...\nFound 79976...", startMessage);
-            Assert.Contains("Elapsed:", startMessage);
-
-            heartbeat.UpdatePhase("Scanning all linked files...\nFound 79977...");
-            Assert.Contains("Elapsed:", messages.Last());
-            Assert.StartsWith("Scanning all linked files...\nFound 79977...", messages.Last());
-
-            var elapsedMessage = await heartbeatReported.Task.WaitAsync(TimeSpan.FromSeconds(1));
-            Assert.Contains("Elapsed:", elapsedMessage);
-
-            heartbeat.Complete("Done.");
-            heartbeat.UpdatePhase("Scanning all linked files...\nFound 79978...");
-
-            Assert.Equal("Done.", messages.Last());
-            Assert.DoesNotContain("Elapsed:", messages.Last());
-        }
-        finally
-        {
-            await heartbeat.DisposeAsync();
-        }
-    }
-
-    [Fact]
     public async Task RemoveEmptyDirectoriesAsync_RemovesNestedEmptyDirsAndTerminates()
     {
         await using var harness = await TempDb.CreateAsync();
@@ -424,6 +384,91 @@ public class RemoveUnlinkedFilesTaskTests
                 "Searching for unlinked webdav items",
                 "Identifying unlinked files",
                 "Done. Identified 1 unlinked files");
+        }
+        finally
+        {
+            await BaseTask.ResetRunningTaskForTestsAsync();
+            RemoveUnlinkedFilesTask.ClearAuditPathsForTests();
+            try { Directory.Delete(libraryDir, recursive: true); } catch (IOException) { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task DryRun_Completes_WhenProgressObserverThrowsOnce()
+    {
+        await BaseTask.ResetRunningTaskForTestsAsync();
+        var libraryDir = Path.Join(Path.GetTempPath(), $"nzbdav-lib-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(libraryDir);
+        await using var harness = await TempDb.CreateAsync();
+        try
+        {
+            var ctx = harness.Context;
+            await SeedRootsAsync(ctx);
+
+            var linkedIds = Enumerable.Range(0, 5).Select(_ => Guid.NewGuid()).ToList();
+            var orphanId = Guid.NewGuid();
+            foreach (var id in linkedIds.Append(orphanId))
+            {
+                ctx.Items.Add(DavItem.New(
+                    id,
+                    DavItem.ContentFolder,
+                    $"{id:N}.mkv",
+                    10,
+                    DavItem.ItemType.UsenetFile,
+                    DavItem.ItemSubType.NzbFile,
+                    null,
+                    null,
+                    null,
+                    null));
+            }
+
+            await ctx.SaveChangesAsync();
+
+            foreach (var id in linkedIds)
+            {
+                await File.WriteAllTextAsync(
+                    Path.Join(libraryDir, $"{id:N}.strm"),
+                    $"http://localhost/view/.ids/{id}.mkv");
+            }
+
+            var config = new ConfigManager();
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.MediaLibraryDir, ConfigValue = libraryDir },
+            ]);
+
+            var websocket = new WebsocketManager();
+            var invocation = 0;
+            var messages = new ConcurrentQueue<string>();
+            void Observer(string message)
+            {
+                if (Interlocked.Increment(ref invocation) == 1)
+                    throw new InvalidOperationException("progress observer failure");
+                messages.Enqueue(message);
+            }
+
+            var task = new RemoveUnlinkedFilesTask(
+                config,
+                websocket,
+                isDryRun: true,
+                createContext: () => harness.CreateContext(),
+                progressObserver: Observer);
+
+            Assert.True(await task.Execute());
+
+            Assert.True(await ctx.Items.AnyAsync(x => x.Id == orphanId));
+            foreach (var id in linkedIds)
+                Assert.True(await ctx.Items.AnyAsync(x => x.Id == id));
+
+            var progress = websocket.PeekLastMessage(WebsocketTopic.CleanupTaskProgress);
+            Assert.Equal("Dry Run - Done. Identified 1 unlinked files.", progress);
+            Assert.Contains(
+                messages,
+                message => message == "Dry Run - Done. Identified 1 unlinked files.");
+            Assert.DoesNotContain(
+                messages,
+                message => message.StartsWith("Dry Run - Failed:", StringComparison.Ordinal)
+                    || message.StartsWith("Failed:", StringComparison.Ordinal));
         }
         finally
         {


### PR DESCRIPTION
## Summary
- Shared `ProgressHeartbeat` now contains non-fatal progress-reporter exceptions (immediate, scheduled, and terminal) so timer callbacks and maintenance tasks keep running.
- Prune and remove-unlinked results stay authoritative: a throw-once observer still prunes history / dry-run identifies orphans, with a later `Done.` status and no synthetic `Failed:` progress.
- Reporter-failure logs are one type-only warning per heartbeat (`Operation`, `ReportSource`, `ExceptionType` only). `OutOfMemoryException` is not caught.

Fixes #1241

## Test plan
- [x] `ProgressHeartbeatTests` with `ControllableTimeProvider` (elapsed/timer semantics, scheduled containment, complete/dispose races, sentinel-secret logs, OOM filter, interval validation)
- [x] `Execute_PrunesAndReportsDone_WhenProgressObserverThrowsOnce`
- [x] `DryRun_Completes_WhenProgressObserverThrowsOnce`
- [ ] PR CI backend build and xUnit suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent progress reporting for maintenance tasks, including elapsed time, updates, scheduled heartbeats, and completion status.

* **Bug Fixes**
  * Maintenance operations now continue and complete successfully when a progress update fails.
  * Improved handling prevents stale progress reports after completion or disposal.
  * Added safer logging for progress-reporting failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->