### PR TITLE
fix(hosting): backend exits nonzero after a hosted background service crashes

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -572,6 +572,8 @@ public sealed partial class Program
         {
             await host.StartAsync(cancellationToken).ConfigureAwait(false);
 
+            // Only BackgroundService, matching HostOptions.BackgroundServiceExceptionBehavior —
+            // raw IHostedService implementations are not monitored for ExecuteTask faults.
             var backgroundServices = host.Services
                 .GetRequiredService<IEnumerable<IHostedService>>()
                 .OfType<BackgroundService>()

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -46,7 +46,7 @@ using Serilog.Templates.Themes;
 
 namespace NzbWebDAV;
 
-public partial class Program
+public sealed partial class Program
 {
     static async Task Main(string[] args)
     {
@@ -226,7 +226,11 @@ public partial class Program
             builder.WebHost.ConfigureKestrel(options => options.Limits.MaxRequestBodySize = maxRequestBodySize);
             builder.Host.UseSerilog();
             builder.Services.Configure<HostOptions>(options =>
-                options.ShutdownTimeout = TimeSpan.FromSeconds(5));
+            {
+                options.ShutdownTimeout = TimeSpan.FromSeconds(5);
+                options.BackgroundServiceExceptionBehavior =
+                    BackgroundServiceExceptionBehavior.StopHost;
+            });
             builder.Services.AddControllers(options =>
                 options.Filters.Add<ApiErrorContractFilter>());
             builder.Services.AddHttpContextAccessor();
@@ -369,6 +373,7 @@ public partial class Program
                 .AddSingleton<NzbWebDAV.UsenetMigration.UsenetMigrationStore>()
                 .AddSingleton<NzbWebDAV.UsenetMigration.Runner.UsenetMigrationRunner>()
                 .AddHostedService(sp => sp.GetRequiredService<NzbWebDAV.UsenetMigration.Runner.UsenetMigrationRunner>())
+                .AddSingleton<ProcessExitCoordinator>()
                 .AddSingleton<RestartService>()
                 .AddHostedService<DatabaseBackupSchedulerService>()
                 .AddSingleton<IndexerConfigWriteLock>()
@@ -530,7 +535,7 @@ public partial class Program
             // before the first BODY decode (which can crash on a bad native lib).
             app.Lifetime.ApplicationStarted.Register(() =>
                 app.Services.GetRequiredService<QueueManager>().StartProcessing());
-            await app.RunAsync().ConfigureAwait(false);
+            await RunHostAndSetExitCodeAsync(app).ConfigureAwait(false);
         }
         catch (ConfigPathAccessException exception)
         {
@@ -556,6 +561,48 @@ public partial class Program
         finally
         {
             await Log.CloseAndFlushAsync().ConfigureAwait(false);
+        }
+    }
+
+    internal static async Task RunHostAndSetExitCodeAsync(
+        IHost host,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await host.StartAsync(cancellationToken).ConfigureAwait(false);
+
+            var backgroundServices = host.Services
+                .GetRequiredService<IEnumerable<IHostedService>>()
+                .OfType<BackgroundService>()
+                .ToArray();
+            var exitCoordinator = host.Services
+                .GetRequiredService<ProcessExitCoordinator>();
+
+            await host.WaitForShutdownAsync(cancellationToken).ConfigureAwait(false);
+
+            var faultedServiceNames = backgroundServices
+                .Where(service => service.ExecuteTask?.IsFaulted == true)
+                .Select(service => service.GetType().FullName ?? service.GetType().Name)
+                .Order(StringComparer.Ordinal)
+                .ToArray();
+
+            if (faultedServiceNames.Length == 0)
+                return;
+
+            var exitCode = exitCoordinator.ReportBackgroundServiceFault();
+            Log.Fatal(
+                "Backend stopped because background services faulted: {BackgroundServices}. " +
+                "Exiting with code {ExitCode}",
+                string.Join(", ", faultedServiceNames),
+                exitCode);
+        }
+        finally
+        {
+            if (host is IAsyncDisposable asyncDisposable)
+                await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+            else
+                host.Dispose();
         }
     }
 

--- a/backend/Services/ProcessExitCoordinator.cs
+++ b/backend/Services/ProcessExitCoordinator.cs
@@ -1,0 +1,48 @@
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Serializes process-exit reasons so a background-service fault cannot be
+/// overwritten by a later staged-restore request, and vice versa cannot hide
+/// a fault that arrives after restore was already requested.
+/// </summary>
+public sealed class ProcessExitCoordinator
+{
+    private readonly object _gate = new();
+    private ProcessExitReason _reason;
+
+    internal int RequestRestoreRestart() =>
+        Promote(ProcessExitReason.RestoreRestart);
+
+    internal int ReportBackgroundServiceFault() =>
+        Promote(ProcessExitReason.BackgroundServiceFault);
+
+    private int Promote(ProcessExitReason requested)
+    {
+        lock (_gate)
+        {
+            if ((int)requested > (int)_reason)
+                _reason = requested;
+
+            var exitCode = _reason switch
+            {
+                ProcessExitReason.RestoreRestart =>
+                    RestartUtil.RestartForRestoreExitCode,
+                ProcessExitReason.BackgroundServiceFault => 1,
+                _ => throw new InvalidOperationException(
+                    "An exit reason must be selected before promotion."),
+            };
+
+            Environment.ExitCode = exitCode;
+            return exitCode;
+        }
+    }
+
+    private enum ProcessExitReason
+    {
+        None = 0,
+        RestoreRestart = 1,
+        BackgroundServiceFault = 2,
+    }
+}

--- a/backend/Services/RestartService.cs
+++ b/backend/Services/RestartService.cs
@@ -8,7 +8,9 @@ namespace NzbWebDAV.Services;
 /// Schedules a graceful process exit after a restore has been staged so the
 /// Docker/local restart loop can re-enter the maintenance phase.
 /// </summary>
-public sealed class RestartService(IHostApplicationLifetime lifetime)
+public sealed class RestartService(
+    IHostApplicationLifetime lifetime,
+    ProcessExitCoordinator exitCoordinator)
 {
     public void RequestRestartForRestore()
     {
@@ -17,16 +19,32 @@ public sealed class RestartService(IHostApplicationLifetime lifetime)
             try
             {
                 await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
-                Environment.ExitCode = RestartUtil.RestartForRestoreExitCode;
-                Log.Information(
-                    "Exiting with code {ExitCode} to apply staged database restore",
-                    RestartUtil.RestartForRestoreExitCode);
-                lifetime.StopApplication();
+                StopForStagedRestore();
             }
             catch (Exception ex) when (ex is not OutOfMemoryException)
             {
                 Log.Error(ex, "Failed to request restart for database restore");
             }
         });
+    }
+
+    internal int StopForStagedRestore()
+    {
+        var exitCode = exitCoordinator.RequestRestoreRestart();
+        if (exitCode == RestartUtil.RestartForRestoreExitCode)
+        {
+            Log.Information(
+                "Exiting with code {ExitCode} to apply staged database restore",
+                exitCode);
+        }
+        else
+        {
+            Log.Information(
+                "Preserving exit code {ExitCode} instead of staged restore restart",
+                exitCode);
+        }
+
+        lifetime.StopApplication();
+        return exitCode;
     }
 }

--- a/tests/NzbWebDAV.Tests/Hosting/HostShutdownConventionTests.cs
+++ b/tests/NzbWebDAV.Tests/Hosting/HostShutdownConventionTests.cs
@@ -348,6 +348,8 @@ public sealed class HostShutdownConventionTests(NzbDavWebApplicationFactory fact
         await started.Task.WaitAsync(GateTimeout);
     }
 
+    // TimeoutException is not swallowed: RunHostAndSetExitCodeAsync has not
+    // reached its dispose finally while shutdown is still in flight.
     private static async Task StopIfRunningAsync(Task runTask, IHostApplicationLifetime lifetime)
     {
         if (!runTask.IsCompleted)
@@ -356,9 +358,6 @@ public sealed class HostShutdownConventionTests(NzbDavWebApplicationFactory fact
         try
         {
             await runTask.WaitAsync(GateTimeout);
-        }
-        catch (TimeoutException)
-        {
         }
         catch (OperationCanceledException)
         {

--- a/tests/NzbWebDAV.Tests/Hosting/HostShutdownConventionTests.cs
+++ b/tests/NzbWebDAV.Tests/Hosting/HostShutdownConventionTests.cs
@@ -1,17 +1,417 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using NzbWebDAV;
+using NzbWebDAV.Services;
 using NzbWebDAV.Tests.TestUtils;
+using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Tests.Hosting;
 
 [Collection(nameof(HttpIntegrationCollection))]
 public sealed class HostShutdownConventionTests(NzbDavWebApplicationFactory factory)
 {
+    private static readonly TimeSpan GateTimeout = TimeSpan.FromSeconds(5);
+
     [Fact]
     public void HostShutdownTimeout_IsFiveSeconds()
     {
         var options = factory.Services.GetRequiredService<IOptions<HostOptions>>();
         Assert.Equal(TimeSpan.FromSeconds(5), options.Value.ShutdownTimeout);
+    }
+
+    [Fact]
+    public void BackgroundServiceExceptionBehavior_IsStopHost()
+    {
+        var options = factory.Services.GetRequiredService<IOptions<HostOptions>>();
+        Assert.Equal(
+            BackgroundServiceExceptionBehavior.StopHost,
+            options.Value.BackgroundServiceExceptionBehavior);
+    }
+
+    [Fact]
+    public async Task FrameworkRunAsync_StopHostFault_CompletesNormallyAndLeavesExitCodeZero()
+    {
+        var priorExitCode = Environment.ExitCode;
+        IHostApplicationLifetime? lifetime = null;
+        Task? runTask = null;
+        try
+        {
+            Environment.ExitCode = 0;
+
+            var builder = Host.CreateApplicationBuilder();
+            builder.Logging.ClearProviders();
+            builder.Services.Configure<HostOptions>(options =>
+                options.BackgroundServiceExceptionBehavior =
+                    BackgroundServiceExceptionBehavior.StopHost);
+            builder.Services.AddSingleton<ControlledBackgroundService>();
+            builder.Services.AddHostedService(sp =>
+                sp.GetRequiredService<ControlledBackgroundService>());
+
+            var host = builder.Build();
+            var service = host.Services.GetRequiredService<ControlledBackgroundService>();
+            lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+
+            runTask = host.RunAsync();
+            await service.Started.Task.WaitAsync(GateTimeout);
+            service.Fail();
+
+            var thrown = await Record.ExceptionAsync(() => runTask.WaitAsync(GateTimeout));
+            Assert.Null(thrown);
+            Assert.True(lifetime.ApplicationStopping.IsCancellationRequested);
+            Assert.True(service.ExecuteTask?.IsFaulted);
+            Assert.Equal(0, Environment.ExitCode);
+        }
+        finally
+        {
+            if (runTask is not null && lifetime is not null)
+                await StopIfRunningAsync(runTask, lifetime);
+            Environment.ExitCode = priorExitCode;
+        }
+    }
+
+    [Fact]
+    public async Task RunHostAndSetExitCodeAsync_RuntimeFault_SetsExitCodeOne()
+    {
+        var priorExitCode = Environment.ExitCode;
+        IHostApplicationLifetime? lifetime = null;
+        Task? runTask = null;
+        try
+        {
+            Environment.ExitCode = 0;
+            var host = CreateControlledHost(out var service, out lifetime, out _);
+
+            runTask = Program.RunHostAndSetExitCodeAsync(host);
+            await service.Started.Task.WaitAsync(GateTimeout);
+            service.Fail();
+
+            var thrown = await Record.ExceptionAsync(() => runTask.WaitAsync(GateTimeout));
+            Assert.Null(thrown);
+            Assert.True(lifetime.ApplicationStopping.IsCancellationRequested);
+            Assert.True(service.ExecuteTask?.IsFaulted);
+            Assert.Equal(1, Environment.ExitCode);
+        }
+        finally
+        {
+            if (runTask is not null && lifetime is not null)
+                await StopIfRunningAsync(runTask, lifetime);
+            Environment.ExitCode = priorExitCode;
+        }
+    }
+
+    [Fact]
+    public async Task RunHostAndSetExitCodeAsync_GracefulStop_LeavesExitCodeZero()
+    {
+        var priorExitCode = Environment.ExitCode;
+        IHostApplicationLifetime? lifetime = null;
+        Task? runTask = null;
+        try
+        {
+            Environment.ExitCode = 0;
+            var host = CreateControlledHost(out var service, out lifetime, out _);
+
+            runTask = Program.RunHostAndSetExitCodeAsync(host);
+            await service.Started.Task.WaitAsync(GateTimeout);
+            lifetime.StopApplication();
+
+            var thrown = await Record.ExceptionAsync(() => runTask.WaitAsync(GateTimeout));
+            Assert.Null(thrown);
+            Assert.Equal(0, Environment.ExitCode);
+            Assert.True(service.ExecuteTask?.IsCanceled);
+            Assert.False(service.ExecuteTask?.IsFaulted);
+        }
+        finally
+        {
+            if (runTask is not null && lifetime is not null)
+                await StopIfRunningAsync(runTask, lifetime);
+            Environment.ExitCode = priorExitCode;
+        }
+    }
+
+    [Fact]
+    public async Task RunHostAndSetExitCodeAsync_RestoreRestart_PreservesCode86()
+    {
+        var priorExitCode = Environment.ExitCode;
+        IHostApplicationLifetime? lifetime = null;
+        Task? runTask = null;
+        try
+        {
+            Environment.ExitCode = 0;
+            var host = CreateControlledHost(out var service, out lifetime, out var restart);
+
+            runTask = Program.RunHostAndSetExitCodeAsync(host);
+            await service.Started.Task.WaitAsync(GateTimeout);
+            Assert.Equal(RestartUtil.RestartForRestoreExitCode, restart.StopForStagedRestore());
+
+            var thrown = await Record.ExceptionAsync(() => runTask.WaitAsync(GateTimeout));
+            Assert.Null(thrown);
+            Assert.Equal(RestartUtil.RestartForRestoreExitCode, Environment.ExitCode);
+            Assert.False(service.ExecuteTask?.IsFaulted);
+        }
+        finally
+        {
+            if (runTask is not null && lifetime is not null)
+                await StopIfRunningAsync(runTask, lifetime);
+            Environment.ExitCode = priorExitCode;
+        }
+    }
+
+    [Fact]
+    public void ProcessExitCoordinator_RestoreThenRuntimeFault_EndsAtOne()
+    {
+        var priorExitCode = Environment.ExitCode;
+        try
+        {
+            Environment.ExitCode = 0;
+            var coordinator = new ProcessExitCoordinator();
+            var restart = new RestartService(new NoopHostApplicationLifetime(), coordinator);
+
+            Assert.Equal(RestartUtil.RestartForRestoreExitCode, restart.StopForStagedRestore());
+            Assert.Equal(RestartUtil.RestartForRestoreExitCode, Environment.ExitCode);
+
+            Assert.Equal(1, coordinator.ReportBackgroundServiceFault());
+            Assert.Equal(1, Environment.ExitCode);
+        }
+        finally
+        {
+            Environment.ExitCode = priorExitCode;
+        }
+    }
+
+    [Fact]
+    public void ProcessExitCoordinator_RuntimeFaultThenRestore_StaysAtOne()
+    {
+        var priorExitCode = Environment.ExitCode;
+        try
+        {
+            Environment.ExitCode = 0;
+            var coordinator = new ProcessExitCoordinator();
+            var restart = new RestartService(new NoopHostApplicationLifetime(), coordinator);
+
+            Assert.Equal(1, coordinator.ReportBackgroundServiceFault());
+            Assert.Equal(1, Environment.ExitCode);
+
+            Assert.Equal(1, restart.StopForStagedRestore());
+            Assert.Equal(1, Environment.ExitCode);
+        }
+        finally
+        {
+            Environment.ExitCode = priorExitCode;
+        }
+    }
+
+    [Fact]
+    public async Task RunHostAndSetExitCodeAsync_StartupFailure_StillPropagates()
+    {
+        var priorExitCode = Environment.ExitCode;
+        try
+        {
+            Environment.ExitCode = 0;
+            var expected = new InvalidOperationException("deterministic startup failure");
+
+            var builder = CreateMinimalHostBuilder();
+            builder.Services.AddSingleton<ProcessExitCoordinator>();
+            builder.Services.AddSingleton<IHostedService>(_ => new StartFailingHostedService(expected));
+            var host = builder.Build();
+
+            var thrown = await Record.ExceptionAsync(
+                () => Program.RunHostAndSetExitCodeAsync(host).WaitAsync(GateTimeout));
+
+            Assert.Same(expected, thrown);
+            Assert.Equal(0, Environment.ExitCode);
+        }
+        finally
+        {
+            Environment.ExitCode = priorExitCode;
+        }
+    }
+
+    [Fact]
+    public async Task RunHostAndSetExitCodeAsync_HostedServiceFactoryFailure_DisposesAndPropagates()
+    {
+        var priorExitCode = Environment.ExitCode;
+        try
+        {
+            Environment.ExitCode = 0;
+            DisposableSentinel? sentinel = null;
+            var expected = new InvalidOperationException(
+                "deterministic hosted-service factory failure");
+
+            var builder = CreateMinimalHostBuilder();
+            builder.Services.AddSingleton<ProcessExitCoordinator>();
+            builder.Services.AddSingleton<DisposableSentinel>(
+                _ => sentinel = new DisposableSentinel());
+            builder.Services.AddSingleton<IHostedService>(serviceProvider =>
+            {
+                _ = serviceProvider.GetRequiredService<DisposableSentinel>();
+                throw expected;
+            });
+
+            var host = builder.Build();
+            var thrown = await Record.ExceptionAsync(
+                () => Program.RunHostAndSetExitCodeAsync(host).WaitAsync(GateTimeout));
+
+            Assert.Same(expected, thrown);
+            Assert.NotNull(sentinel);
+            Assert.True(sentinel.IsDisposed);
+        }
+        finally
+        {
+            Environment.ExitCode = priorExitCode;
+        }
+    }
+
+    [Fact]
+    public async Task RunHostAndSetExitCodeAsync_ShutdownFailure_DisposesAndPropagates()
+    {
+        var priorExitCode = Environment.ExitCode;
+        IHostApplicationLifetime? lifetime = null;
+        Task? runTask = null;
+        try
+        {
+            Environment.ExitCode = 0;
+            DisposableSentinel? sentinel = null;
+            var expected = new InvalidOperationException("deterministic shutdown failure");
+
+            var builder = CreateMinimalHostBuilder();
+            builder.Services.AddSingleton<ProcessExitCoordinator>();
+            builder.Services.AddSingleton<DisposableSentinel>(
+                _ => sentinel = new DisposableSentinel());
+            builder.Services.AddSingleton<IHostedService>(serviceProvider =>
+            {
+                _ = serviceProvider.GetRequiredService<DisposableSentinel>();
+                return new StopFailingHostedService(expected);
+            });
+
+            var host = builder.Build();
+            lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+            runTask = Program.RunHostAndSetExitCodeAsync(host);
+            await WaitUntilStartedAsync(lifetime);
+            lifetime.StopApplication();
+
+            var thrown = await Record.ExceptionAsync(() => runTask.WaitAsync(GateTimeout));
+            Assert.Same(expected, thrown);
+            Assert.NotNull(sentinel);
+            Assert.True(sentinel.IsDisposed);
+        }
+        finally
+        {
+            if (runTask is not null && lifetime is not null)
+                await StopIfRunningAsync(runTask, lifetime);
+            Environment.ExitCode = priorExitCode;
+        }
+    }
+
+    private static IHost CreateControlledHost(
+        out ControlledBackgroundService service,
+        out IHostApplicationLifetime lifetime,
+        out RestartService restart)
+    {
+        var builder = CreateMinimalHostBuilder();
+        builder.Services.AddSingleton<ProcessExitCoordinator>();
+        builder.Services.AddSingleton<RestartService>();
+        builder.Services.AddSingleton<ControlledBackgroundService>();
+        builder.Services.AddHostedService(sp =>
+            sp.GetRequiredService<ControlledBackgroundService>());
+
+        var host = builder.Build();
+        service = host.Services.GetRequiredService<ControlledBackgroundService>();
+        lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+        restart = host.Services.GetRequiredService<RestartService>();
+        return host;
+    }
+
+    private static HostApplicationBuilder CreateMinimalHostBuilder()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.Logging.ClearProviders();
+        builder.Services.Configure<HostOptions>(options =>
+        {
+            options.ShutdownTimeout = TimeSpan.FromSeconds(5);
+            options.BackgroundServiceExceptionBehavior =
+                BackgroundServiceExceptionBehavior.StopHost;
+        });
+        return builder;
+    }
+
+    private static async Task WaitUntilStartedAsync(IHostApplicationLifetime lifetime)
+    {
+        if (lifetime.ApplicationStarted.IsCancellationRequested)
+            return;
+
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        lifetime.ApplicationStarted.Register(() => started.TrySetResult());
+        if (lifetime.ApplicationStarted.IsCancellationRequested)
+            started.TrySetResult();
+
+        await started.Task.WaitAsync(GateTimeout);
+    }
+
+    private static async Task StopIfRunningAsync(Task runTask, IHostApplicationLifetime lifetime)
+    {
+        if (!runTask.IsCompleted)
+            lifetime.StopApplication();
+
+        try
+        {
+            await runTask.WaitAsync(GateTimeout);
+        }
+        catch (Exception)
+        {
+            // Tear-down only: the test body already observed success or failure.
+        }
+    }
+
+    private sealed class ControlledBackgroundService : BackgroundService
+    {
+        private readonly TaskCompletionSource<bool> _release =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<bool> Started { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Fail() => _release.TrySetResult(true);
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            Started.TrySetResult(true);
+            await _release.Task.WaitAsync(stoppingToken);
+            throw new InvalidOperationException("deterministic hosted-service fault");
+        }
+    }
+
+    private sealed class StartFailingHostedService(Exception startException) : IHostedService
+    {
+        public Task StartAsync(CancellationToken cancellationToken) =>
+            Task.FromException(startException);
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
+    private sealed class StopFailingHostedService(Exception stopException) : IHostedService
+    {
+        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task StopAsync(CancellationToken cancellationToken) =>
+            Task.FromException(stopException);
+    }
+
+    private sealed class DisposableSentinel : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public void Dispose() => IsDisposed = true;
+    }
+
+    private sealed class NoopHostApplicationLifetime : IHostApplicationLifetime
+    {
+        private readonly CancellationTokenSource _stopping = new();
+
+        public CancellationToken ApplicationStarted => CancellationToken.None;
+        public CancellationToken ApplicationStopping => _stopping.Token;
+        public CancellationToken ApplicationStopped => CancellationToken.None;
+
+        public void StopApplication() => _stopping.Cancel();
     }
 }

--- a/tests/NzbWebDAV.Tests/Hosting/HostShutdownConventionTests.cs
+++ b/tests/NzbWebDAV.Tests/Hosting/HostShutdownConventionTests.cs
@@ -357,10 +357,13 @@ public sealed class HostShutdownConventionTests(NzbDavWebApplicationFactory fact
         {
             await runTask.WaitAsync(GateTimeout);
         }
-        catch (Exception exception) when (
-            exception is TimeoutException
-            or exception is OperationCanceledException
-            or exception is InvalidOperationException)
+        catch (TimeoutException)
+        {
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (InvalidOperationException)
         {
             // Tear-down only: the test body already observed success or failure.
         }

--- a/tests/NzbWebDAV.Tests/Hosting/HostShutdownConventionTests.cs
+++ b/tests/NzbWebDAV.Tests/Hosting/HostShutdownConventionTests.cs
@@ -49,7 +49,7 @@ public sealed class HostShutdownConventionTests(NzbDavWebApplicationFactory fact
             builder.Services.AddHostedService(sp =>
                 sp.GetRequiredService<ControlledBackgroundService>());
 
-            var host = builder.Build();
+            using var host = builder.Build();
             var service = host.Services.GetRequiredService<ControlledBackgroundService>();
             lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
 
@@ -357,7 +357,10 @@ public sealed class HostShutdownConventionTests(NzbDavWebApplicationFactory fact
         {
             await runTask.WaitAsync(GateTimeout);
         }
-        catch (Exception)
+        catch (Exception exception) when (
+            exception is TimeoutException
+            or exception is OperationCanceledException
+            or exception is InvalidOperationException)
         {
             // Tear-down only: the test body already observed success or failure.
         }


### PR DESCRIPTION
Fixes #1231

## Summary
- Static-audit hardening, not a confirmed production incident: .NET `StopHost` still stops the host after an unhandled `BackgroundService` exception, but `RunAsync()` completes normally and previously left `Environment.ExitCode` at 0.
- After graceful shutdown, the backend now reports exit code **1** when a hosted background service faulted, so the existing entrypoint/`wait_either` path already propagates failure to the container.
- Graceful SIGTERM/`StopApplication()` still exits **0**. Staged restore still uses **86**, unless a background-service fault wins in either ordering (restore-then-fault or fault-then-restore → **1**).
- `entrypoint.sh` is unchanged; it already forwards the backend process status, including the code-86 maintenance loop.

## Test plan
- [x] Characterization: `FrameworkRunAsync_StopHostFault_CompletesNormallyAndLeavesExitCodeZero` (framework `RunAsync` returns normally, execute task faulted, exit code stays 0)
- [x] Runtime fault → exit 1 without rethrowing the service exception
- [x] Graceful stop → exit 0 and canceled (not faulted) execute task
- [x] Restore restart → exit 86 when no fault occurred
- [x] Restore-then-fault and fault-then-restore both end at 1
- [x] Startup and hosted-service factory failures still propagate; factory failure disposes a container-created sentinel
- [x] Shutdown `StopAsync` failure still propagates and disposes the sentinel
- [ ] PR CI backend tests (`.github/workflows/ci.yml`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application shutdown handling when background services fail.
  * Added reliable process exit codes for runtime failures and staged restore restarts.
  * Ensured startup, shutdown, and hosted-service failures are reported and propagated correctly.
  * Preserved the highest-priority exit reason when multiple shutdown events occur.

* **Tests**
  * Expanded lifecycle coverage for graceful shutdown, failures, restart scenarios, exit codes, and resource disposal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->