### PR TITLE
fix(api): reject invalid Warden source uploads with 400 and count UTF-8 bytes

### DIFF
--- a/backend/Api/Controllers/BaseApiController.cs
+++ b/backend/Api/Controllers/BaseApiController.cs
@@ -14,6 +14,9 @@ public abstract class BaseApiController : ControllerBase
     protected virtual bool RequiresAuthentication => true;
     protected abstract Task<IActionResult> HandleRequest();
 
+    protected virtual void AuthenticateRequest(ConfigManager configManager)
+        => ApiKeyValidator.Validate(HttpContext, configManager);
+
     [HttpGet]
     [HttpPost]
     public virtual Task<IActionResult> HandleApiRequest() => ExecuteApiRequest();
@@ -25,7 +28,7 @@ public abstract class BaseApiController : ControllerBase
             if (RequiresAuthentication)
             {
                 var configManager = HttpContext.RequestServices.GetRequiredService<ConfigManager>();
-                ApiKeyValidator.Validate(HttpContext, configManager);
+                AuthenticateRequest(configManager);
             }
 
             return await HandleRequest().ConfigureAwait(false);

--- a/backend/Api/Controllers/Warden/WardenSourcesBundleController.cs
+++ b/backend/Api/Controllers/Warden/WardenSourcesBundleController.cs
@@ -3,6 +3,8 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Auth;
+using NzbWebDAV.Config;
 using NzbWebDAV.Services;
 using Serilog;
 
@@ -15,6 +17,9 @@ public class WardenSourcesImportController(WardenStore warden, WardenRemoteSourc
     private const int MaxItems = 1000;
     private const long MaxUploadBytes = 5L * 1024 * 1024;
     private const string InvalidFormDetail = "Invalid form data.";
+
+    protected override void AuthenticateRequest(ConfigManager configManager)
+        => ApiKeyValidator.ValidateWithoutFormParse(HttpContext, configManager);
 
     protected override async Task<IActionResult> HandleRequest()
     {

--- a/backend/Api/Controllers/Warden/WardenSourcesBundleController.cs
+++ b/backend/Api/Controllers/Warden/WardenSourcesBundleController.cs
@@ -14,14 +14,25 @@ public class WardenSourcesImportController(WardenStore warden, WardenRemoteSourc
 {
     private const int MaxItems = 1000;
     private const long MaxUploadBytes = 5L * 1024 * 1024;
+    private const string InvalidFormDetail = "Invalid form data.";
 
     protected override async Task<IActionResult> HandleRequest()
     {
-        if (!HttpContext.Request.HasFormContentType)
+        var request = HttpContext.Request;
+        if (!request.HasFormContentType)
             throw new BadHttpRequestException("Missing form body.");
 
         var ct = HttpContext.RequestAborted;
-        var form = HttpContext.Request.Form;
+        IFormCollection form;
+        try
+        {
+            form = await request.ReadFormAsync(ct).ConfigureAwait(false);
+        }
+        catch (InvalidDataException e)
+        {
+            throw new BadHttpRequestException(InvalidFormDetail, e);
+        }
+
         var defaultTrust = form["trust"].ToString();
         if (string.IsNullOrWhiteSpace(defaultTrust)) defaultTrust = WardenStore.TrustCorroborate;
         var defaultRefresh = int.TryParse(form["refreshHours"].ToString(), out var drh) ? drh : 24;
@@ -42,7 +53,7 @@ public class WardenSourcesImportController(WardenStore warden, WardenRemoteSourc
 
         if (string.IsNullOrWhiteSpace(content))
             throw new BadHttpRequestException("Paste some entries or choose a file.");
-        if (content.Length > MaxUploadBytes)
+        if (Encoding.UTF8.GetByteCount(content) > MaxUploadBytes)
             throw new BadHttpRequestException("Input is too large.");
 
         var specs = Parse(content, defaultTrust, defaultRefresh, out var invalid);

--- a/backend/Auth/ApiKeyValidator.cs
+++ b/backend/Auth/ApiKeyValidator.cs
@@ -15,8 +15,13 @@ namespace NzbWebDAV.Auth;
 public static class ApiKeyValidator
 {
     public static void Validate(HttpContext httpContext, ConfigManager configManager)
+        => ValidateKey(httpContext.GetRequestApiKey(), configManager);
+
+    public static void ValidateWithoutFormParse(HttpContext httpContext, ConfigManager configManager)
+        => ValidateKey(httpContext.GetRequestApiKeyWithoutFormParse(), configManager);
+
+    private static void ValidateKey(string? apiKey, ConfigManager configManager)
     {
-        var apiKey = httpContext.GetRequestApiKey();
         if (apiKey == null)
             throw new UnauthorizedAccessException("API Key Required");
 

--- a/backend/Extensions/HttpContextExtensions.cs
+++ b/backend/Extensions/HttpContextExtensions.cs
@@ -34,13 +34,19 @@ public static class HttpContextExtensions
     public static string? GetRequestApiKey(this HttpContext httpContext)
     {
         return httpContext.Request.Headers["x-api-key"].FirstOrDefault()
+            ?? httpContext.GetRequestParam("apikey");
+    }
+
+    // Header, query, and already-buffered form only. Does not touch Request.Form,
+    // which parses lazily and can throw InvalidDataException. Warden source import
+    // uses this so unauthenticated malformed multipart stays 401.
+    public static string? GetRequestApiKeyWithoutFormParse(this HttpContext httpContext)
+    {
+        return httpContext.Request.Headers["x-api-key"].FirstOrDefault()
             ?? httpContext.GetQueryParam("apikey")
             ?? GetBufferedFormParam(httpContext, "apikey");
     }
 
-    // Request.Form parses lazily and can throw InvalidDataException. API-key lookup
-    // must not trigger that parse, or unauthenticated malformed bodies become HTTP 500
-    // before ApiKeyValidator can return 401.
     private static string? GetBufferedFormParam(HttpContext httpContext, string name)
     {
         var form = httpContext.Features.Get<IFormFeature>()?.Form;

--- a/backend/Extensions/HttpContextExtensions.cs
+++ b/backend/Extensions/HttpContextExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Extensions;
@@ -33,7 +34,19 @@ public static class HttpContextExtensions
     public static string? GetRequestApiKey(this HttpContext httpContext)
     {
         return httpContext.Request.Headers["x-api-key"].FirstOrDefault()
-            ?? httpContext.GetRequestParam("apikey");
+            ?? httpContext.GetQueryParam("apikey")
+            ?? GetBufferedFormParam(httpContext, "apikey");
+    }
+
+    // Request.Form parses lazily and can throw InvalidDataException. API-key lookup
+    // must not trigger that parse, or unauthenticated malformed bodies become HTTP 500
+    // before ApiKeyValidator can return 401.
+    private static string? GetBufferedFormParam(HttpContext httpContext, string name)
+    {
+        var form = httpContext.Features.Get<IFormFeature>()?.Form;
+        if (form is null)
+            return null;
+        return StringUtil.EmptyToNull(form[name].FirstOrDefault());
     }
 
     public static string GetPublicBaseUrl(this HttpContext httpContext, string configuredBaseUrl)

--- a/tests/NzbWebDAV.Tests/Api/HttpPipelineIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/HttpPipelineIntegrationTests.cs
@@ -28,6 +28,23 @@ public sealed class HttpPipelineIntegrationTests(NzbDavWebApplicationFactory fac
     }
 
     [Fact]
+    public async Task AdminApi_AcceptsFormFieldApiKey()
+    {
+        using var client = factory.CreateClient();
+        using var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["apikey"] = NzbDavWebApplicationFactory.ApiKey,
+        });
+
+        using var response = await client.PostAsync("/api/is-onboarding", form);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var json = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+        Assert.True(json.RootElement.GetProperty("status").GetBoolean());
+        Assert.True(json.RootElement.GetProperty("isOnboarding").GetBoolean());
+    }
+
+    [Fact]
     public async Task ProwlarrSyncStatus_RequiresApiKey()
     {
         using var client = factory.CreateClient();

--- a/tests/NzbWebDAV.Tests/Api/SabHttpContractTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabHttpContractTests.cs
@@ -123,6 +123,15 @@ public sealed class SabHttpContractTests
             $"/api?mode=queue&output=json&apikey={NzbDavWebApplicationFactory.ApiKey}");
         await SabContractAssertions.AssertSuccessAsync(queryKey);
 
+        using var formKey = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["mode"] = "queue",
+            ["output"] = "json",
+            ["apikey"] = NzbDavWebApplicationFactory.ApiKey,
+        });
+        using var formKeyResponse = await anonymous.PostAsync("/api", formKey);
+        await SabContractAssertions.AssertSuccessAsync(formKeyResponse);
+
         using var invalidMode = await client.GetAsync("/api?mode=not-a-mode&output=json");
         await SabContractAssertions.AssertFailureAsync(
             invalidMode, HttpStatusCode.BadRequest, "Invalid mode");

--- a/tests/NzbWebDAV.Tests/Api/WardenSourcesImportControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/WardenSourcesImportControllerTests.cs
@@ -1,0 +1,420 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
+using NzbWebDAV.Api.Controllers;
+using NzbWebDAV.Api.Controllers.Warden;
+using NzbWebDAV.Logging;
+using NzbWebDAV.Services;
+using NzbWebDAV.Tests.TestUtils;
+
+namespace NzbWebDAV.Tests.Api;
+
+[Collection(nameof(HttpIntegrationCollection))]
+public sealed class WardenSourcesImportControllerTests(
+    NzbDavWebApplicationFactory factory)
+{
+    private const int MaxUploadBytes = 5 * 1024 * 1024;
+
+    [Fact]
+    public async Task Import_MultipartWithoutBoundary_ReturnsBadRequestProblem()
+    {
+        using var client = factory.CreateAuthenticatedClient();
+        using var content = MalformedMultipartWithoutBoundary();
+
+        using var response = await client.PostAsync("/api/warden-sources-import", content);
+        using var problem = await AdminProblemAssertions.AssertProblemAsync(
+            response,
+            HttpStatusCode.BadRequest,
+            "Invalid form data.");
+
+        Assert.Equal(
+            "https://www.infinidysk.com/problems/bad-request",
+            problem.RootElement.GetProperty("type").GetString());
+        Assert.DoesNotContain(
+            "boundary",
+            problem.RootElement.GetProperty("detail").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+
+        var traceId = problem.RootElement.GetProperty("traceId").GetString();
+        var sink = factory.Services.GetRequiredService<LogBufferSink>();
+        Assert.DoesNotContain(
+            sink.Snapshot(50, ["Error"], source: null, search: null, beforeSequence: null).Entries,
+            entry => entry.TraceId == traceId
+                && entry.Message.Contains("Unhandled admin API request failure", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Import_MalformedMultipartWithoutApiKey_IsRejectedBeforeFormParsing()
+    {
+        using var client = factory.CreateClient();
+        using var content = MalformedMultipartWithoutBoundary();
+
+        using var response = await client.PostAsync("/api/warden-sources-import", content);
+
+        await AdminProblemAssertions.AssertProblemAsync(
+            response,
+            HttpStatusCode.Unauthorized,
+            "API Key");
+    }
+
+    [Fact]
+    public async Task Import_AsciiTextAtExactlyFiveMiB_IsAccepted()
+    {
+        var url = $"https://example.invalid/exact-{Guid.NewGuid():N}";
+        SeedRemoteSource(url);
+        var content = BuildAsciiContent(url, MaxUploadBytes);
+        using var form = BuildTextForm(content);
+        using var client = factory.CreateAuthenticatedClient();
+
+        using var response = await client.PostAsync("/api/warden-sources-import", form);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var json = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+        Assert.True(json.RootElement.GetProperty("status").GetBoolean());
+        Assert.Equal(0, json.RootElement.GetProperty("added").GetInt32());
+        Assert.Equal(1, json.RootElement.GetProperty("skipped").GetInt32());
+        Assert.Equal(0, json.RootElement.GetProperty("invalid").GetInt32());
+    }
+
+    [Fact]
+    public async Task Import_AsciiTextOneByteOverFiveMiB_ReturnsBadRequest()
+    {
+        var url = $"https://example.invalid/over-{Guid.NewGuid():N}";
+        var content = BuildAsciiContent(url, MaxUploadBytes + 1);
+        using var form = BuildTextForm(content);
+        using var client = factory.CreateAuthenticatedClient();
+
+        using var response = await client.PostAsync("/api/warden-sources-import", form);
+
+        await AdminProblemAssertions.AssertProblemAsync(
+            response,
+            HttpStatusCode.BadRequest,
+            "Input is too large.");
+        AssertSourceUrlNotImported(url);
+    }
+
+    [Fact]
+    public async Task Import_MultibyteTextOneUtf8ByteOverLimit_ReturnsBadRequest()
+    {
+        var url = $"https://example.invalid/unicode-{Guid.NewGuid():N}";
+        var content = BuildMultibyteContent(url, MaxUploadBytes + 1);
+        Assert.True(content.Length < MaxUploadBytes);
+        Assert.Equal(MaxUploadBytes + 1, Encoding.UTF8.GetByteCount(content));
+
+        using var form = BuildTextForm(content);
+        using var client = factory.CreateAuthenticatedClient();
+        using var response = await client.PostAsync("/api/warden-sources-import", form);
+
+        await AdminProblemAssertions.AssertProblemAsync(
+            response,
+            HttpStatusCode.BadRequest,
+            "Input is too large.");
+        AssertSourceUrlNotImported(url);
+    }
+
+    [Fact]
+    public async Task Import_Utf16FileUnderRawLimitButOverUtf8Limit_ReturnsBadRequest()
+    {
+        var url = $"https://example.invalid/utf16-{Guid.NewGuid():N}";
+        var content = BuildMultibyteContent(url, MaxUploadBytes + 1);
+        var fileBytes = Encoding.Unicode.GetPreamble()
+            .Concat(Encoding.Unicode.GetBytes(content))
+            .ToArray();
+
+        Assert.True(fileBytes.Length <= MaxUploadBytes);
+        Assert.True(content.Length < MaxUploadBytes);
+        Assert.Equal(MaxUploadBytes + 1, Encoding.UTF8.GetByteCount(content));
+
+        using var form = new MultipartFormDataContent();
+        var file = new ByteArrayContent(fileBytes);
+        file.Headers.ContentType = new MediaTypeHeaderValue("text/plain")
+        {
+            CharSet = "utf-16",
+        };
+        form.Add(file, "file", "sources.txt");
+        using var client = factory.CreateAuthenticatedClient();
+
+        using var response = await client.PostAsync("/api/warden-sources-import", form);
+
+        await AdminProblemAssertions.AssertProblemAsync(
+            response,
+            HttpStatusCode.BadRequest,
+            "Input is too large.");
+        AssertSourceUrlNotImported(url);
+    }
+
+    [Fact]
+    public async Task Import_AsciiFileAtExactlyFiveMiB_IsAccepted()
+    {
+        var url = $"https://example.invalid/file-exact-{Guid.NewGuid():N}";
+        SeedRemoteSource(url);
+        var content = BuildAsciiContent(url, MaxUploadBytes);
+        var fileBytes = Encoding.UTF8.GetBytes(content);
+        Assert.Equal(MaxUploadBytes, fileBytes.Length);
+
+        using var form = BuildFileForm(fileBytes);
+        using var client = factory.CreateAuthenticatedClient();
+
+        using var response = await client.PostAsync("/api/warden-sources-import", form);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var json = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+        Assert.True(json.RootElement.GetProperty("status").GetBoolean());
+        Assert.Equal(0, json.RootElement.GetProperty("added").GetInt32());
+        Assert.Equal(1, json.RootElement.GetProperty("skipped").GetInt32());
+        Assert.Equal(0, json.RootElement.GetProperty("invalid").GetInt32());
+    }
+
+    [Fact]
+    public async Task Import_AsciiFileOneByteOverFiveMiB_ReturnsFileTooLarge()
+    {
+        var url = $"https://example.invalid/file-over-{Guid.NewGuid():N}";
+        var content = BuildAsciiContent(url, MaxUploadBytes + 1);
+        var fileBytes = Encoding.UTF8.GetBytes(content);
+        Assert.Equal(MaxUploadBytes + 1, fileBytes.Length);
+
+        using var form = BuildFileForm(fileBytes);
+        using var client = factory.CreateAuthenticatedClient();
+
+        using var response = await client.PostAsync("/api/warden-sources-import", form);
+
+        await AdminProblemAssertions.AssertProblemAsync(
+            response,
+            HttpStatusCode.BadRequest,
+            "File is too large.");
+        AssertSourceUrlNotImported(url);
+    }
+
+    [Fact]
+    public async Task Import_FormReadCancellation_RemainsCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var context = new DefaultHttpContext
+        {
+            RequestAborted = cancellation.Token,
+        };
+        context.Request.ContentType = "multipart/form-data; boundary=test";
+        context.Features.Set<IFormFeature>(
+            new FaultingFormFeature(ct => Task.FromCanceled<IFormCollection>(ct)));
+
+        var controller = new TestController
+        {
+            ControllerContext = new ControllerContext { HttpContext = context },
+        };
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => controller.HandleApiRequest());
+    }
+
+    [Fact]
+    public async Task Import_FileReadCancellation_RemainsCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var context = new DefaultHttpContext
+        {
+            RequestAborted = cancellation.Token,
+        };
+        context.Request.ContentType = "multipart/form-data; boundary=test";
+
+        using var stream = new MemoryStream("x"u8.ToArray());
+        var file = new FormFile(stream, 0, stream.Length, "file", "sources.txt")
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = "text/plain",
+        };
+        context.Request.Form = new FormCollection(
+            new Dictionary<string, StringValues>(),
+            new FormFileCollection { file });
+
+        var controller = new TestController
+        {
+            ControllerContext = new ControllerContext { HttpContext = context },
+        };
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => controller.HandleApiRequest());
+    }
+
+    [Theory]
+    [InlineData(typeof(IOException))]
+    [InlineData(typeof(InvalidDataException))]
+    [InlineData(typeof(InvalidOperationException))]
+    public async Task Import_FileReadFailure_RemainsInternalServerError(Type exceptionType)
+    {
+        var sink = factory.Services.GetRequiredService<LogBufferSink>();
+        var exception = (Exception)Activator.CreateInstance(exceptionType, "synthetic test failure")!;
+        using var stream = new ThrowingReadStream(exception);
+        var file = new FormFile(stream, 0, 1, "file", "sources.txt")
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = "text/plain",
+        };
+
+        var context = new DefaultHttpContext();
+        context.Request.ContentType = "multipart/form-data; boundary=test";
+        context.Request.Form = new FormCollection(
+            new Dictionary<string, StringValues>(),
+            new FormFileCollection { file });
+
+        var controller = new TestController
+        {
+            ControllerContext = new ControllerContext { HttpContext = context },
+        };
+
+        var result = await controller.HandleApiRequest();
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status500InternalServerError, objectResult.StatusCode);
+        var body = Assert.IsType<BaseApiResponse>(objectResult.Value);
+        Assert.False(body.Status);
+        Assert.Equal("An internal server error occurred.", body.Error);
+        Assert.DoesNotContain("synthetic test failure", body.Error, StringComparison.Ordinal);
+
+        Assert.Contains(
+            sink.Snapshot(50, ["Error"], source: null, search: "Unhandled admin API request failure", beforeSequence: null)
+                .Entries,
+            entry => entry.Exception is { Length: > 0 } ex
+                && ex.Contains(exceptionType.Name, StringComparison.Ordinal)
+                && ex.Contains("synthetic test failure", StringComparison.Ordinal));
+    }
+
+    private void SeedRemoteSource(string url)
+    {
+        var warden = factory.Services.GetRequiredService<WardenStore>();
+        var id = warden.AddSource(
+            "remote",
+            "Boundary fixture",
+            url,
+            WardenStore.TrustCorroborate,
+            24);
+        warden.UpdateSource(id, enabled: false, trust: null, refreshHours: null, name: null);
+    }
+
+    private void AssertSourceUrlNotImported(string url)
+    {
+        var warden = factory.Services.GetRequiredService<WardenStore>();
+        Assert.DoesNotContain(
+            warden.GetSources(),
+            source => string.Equals(source.Url, url, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static HttpContent MalformedMultipartWithoutBoundary()
+    {
+        var content = new ByteArrayContent("malformed"u8.ToArray());
+        content.Headers.ContentType = new MediaTypeHeaderValue("multipart/form-data");
+        return content;
+    }
+
+    private static string BuildAsciiContent(string url, int utf8Bytes)
+    {
+        var prefix = url + "\n#";
+        var prefixBytes = Encoding.UTF8.GetByteCount(prefix);
+        Assert.True(prefixBytes <= utf8Bytes);
+
+        var content = prefix + new string('a', utf8Bytes - prefixBytes);
+        Assert.Equal(utf8Bytes, content.Length);
+        Assert.Equal(utf8Bytes, Encoding.UTF8.GetByteCount(content));
+        return content;
+    }
+
+    private static string BuildMultibyteContent(string url, int utf8Bytes)
+    {
+        var prefix = url + "\n#";
+        var remainingBytes = utf8Bytes - Encoding.UTF8.GetByteCount(prefix);
+        Assert.True(remainingBytes > 0);
+
+        var threeByteCharacters = remainingBytes / 3;
+        var asciiTailBytes = remainingBytes % 3;
+        var content = prefix
+            + new string('界', threeByteCharacters)
+            + new string('a', asciiTailBytes);
+
+        Assert.Equal(utf8Bytes, Encoding.UTF8.GetByteCount(content));
+        return content;
+    }
+
+    private static MultipartFormDataContent BuildTextForm(string content)
+    {
+        var form = new MultipartFormDataContent();
+        form.Add(new StringContent(content, Encoding.UTF8), "text");
+        form.Add(new StringContent(WardenStore.TrustCorroborate), "trust");
+        form.Add(new StringContent("24"), "refreshHours");
+        return form;
+    }
+
+    private static MultipartFormDataContent BuildFileForm(byte[] fileBytes)
+    {
+        var form = new MultipartFormDataContent();
+        var file = new ByteArrayContent(fileBytes);
+        file.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+        form.Add(file, "file", "sources.txt");
+        form.Add(new StringContent(WardenStore.TrustCorroborate), "trust");
+        form.Add(new StringContent("24"), "refreshHours");
+        return form;
+    }
+
+    private sealed class TestController()
+        : WardenSourcesImportController(null!, null!)
+    {
+        protected override bool RequiresAuthentication => false;
+    }
+
+    private sealed class FaultingFormFeature(Func<CancellationToken, Task<IFormCollection>> readAsync) : IFormFeature
+    {
+        public bool HasFormContentType => true;
+
+        public IFormCollection? Form { get; set; }
+
+        public IFormCollection ReadForm() => throw new NotSupportedException();
+
+        public Task<IFormCollection> ReadFormAsync(CancellationToken cancellationToken)
+            => readAsync(cancellationToken);
+    }
+
+    private sealed class ThrowingReadStream(Exception exception) : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => 1;
+        public override long Position { get; set; }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw exception;
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => throw exception;
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => throw exception;
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            var next = origin switch
+            {
+                SeekOrigin.Begin => offset,
+                SeekOrigin.Current => Position + offset,
+                SeekOrigin.End => Length + offset,
+                _ => throw new ArgumentOutOfRangeException(nameof(origin)),
+            };
+            ArgumentOutOfRangeException.ThrowIfNegative(next);
+            Position = next;
+            return Position;
+        }
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
## Summary
- Malformed Warden source-list form data at `POST /api/warden-sources-import` now returns HTTP 400 (`Invalid form data.`) instead of a logged 500. Only `InvalidDataException` from the explicit `ReadFormAsync` call is translated; request cancellation and later I/O or programming failures keep their prior identities.
- The 5 MiB content ceiling is inclusive and measured as canonical UTF-8 bytes (`Encoding.UTF8.GetByteCount`). Exactly 5,242,880 bytes is valid; 5,242,881 is rejected. Raw uploaded file bytes still use the existing independent `IFormFile.Length` check. Parser messages, payload, filenames, and secrets are not echoed.
- API-key lookup no longer triggers lazy `Request.Form` parsing, so an unauthenticated malformed body is still 401. Header and query `apikey` are unchanged; a form-field `apikey` is used only if the form was already buffered.

Fixes #1249

The Warden settings UI still shows its generic `Request failed.` fallback for this 400 because it does not read RFC 7807 `detail`. That helper change is out of scope. The endpoint remains excluded from generated admin OpenAPI.

## Test plan
- [x] Focused: `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter 'FullyQualifiedName~NzbWebDAV.Tests.Api.WardenSourcesImportControllerTests'` (13 passed)
- [x] Malformed multipart without boundary → 400 bad-request ProblemDetails, no Error stack
- [x] Unauthenticated malformed multipart → 401 before form parsing
- [x] ASCII text at exactly 5,242,880 UTF-8 bytes accepted (pre-seeded skip); one byte over → `Input is too large.`
- [x] Multibyte `界` payload with UTF-16 length below the limit and UTF-8 size 5,242,881 → 400
- [x] BOM UTF-16 file under the raw limit but over normalized UTF-8 → 400; raw ASCII file over limit → `File is too large.`
- [x] Form-read and file-read cancellation remain `OperationCanceledException`; post-form `IOException` / `InvalidDataException` / `InvalidOperationException` remain logged 500
- [ ] Full frontend and backend gates: PR CI per AGENTS.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed form and multipart upload requests with clearer invalid-request responses.
  * Authentication remains reliable when request form data is malformed.
  * API keys supplied through supported form fields now authenticate correctly.
  * Upload size validation accurately accounts for UTF-8 encoded data.
  * Improved cancellation and error handling during source imports, including file-read failures.
* **Tests**
  * Added coverage for upload limits, malformed requests, authentication methods, cancellation, and import failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->