### PR TITLE
fix(nntp): keep streaming when an article-completion observer throws

### DIFF
--- a/backend/Clients/Usenet/ArticleBodyCompletion.cs
+++ b/backend/Clients/Usenet/ArticleBodyCompletion.cs
@@ -1,0 +1,36 @@
+using Serilog;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Clients.Usenet;
+
+/// <summary>
+/// Invokes an <see cref="ArticleBodyCompletionHandler"/> with non-fatal exception
+/// containment so observer failures cannot escape into cache, repair, admission, or
+/// NNTP transport control flow.
+/// </summary>
+/// <remarks>
+/// Addresses https://github.com/infinidysk/infinidysk/issues/1239 (#1128 F10).
+/// Adjacent callback hardening found while validating
+/// https://github.com/infinidysk/infinidysk/issues/1185; that issue's
+/// queue-stage/provider-pool admission deadlines remain separate work.
+/// </remarks>
+internal static class ArticleBodyCompletion
+{
+    public static void InvokeContained(
+        ArticleBodyCompletionHandler? callback,
+        ArticleBodyResult result,
+        string? failureReason = null)
+    {
+        try
+        {
+            callback?.Invoke(result, failureReason);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            Log.Warning(
+                exception,
+                "NNTP completion callback failed for {Result}",
+                result);
+        }
+    }
+}

--- a/backend/Clients/Usenet/ArticleCachingNntpClient.cs
+++ b/backend/Clients/Usenet/ArticleCachingNntpClient.cs
@@ -74,7 +74,7 @@ public class ArticleCachingNntpClient(
         }
         catch
         {
-            onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved);
+            ArticleBodyCompletion.InvokeContained(onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
             throw;
         }
 
@@ -83,7 +83,7 @@ public class ArticleCachingNntpClient(
             // Check if already cached
             if (_cachedSegments.TryGetValue(segmentId, out var existingEntry))
             {
-                onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+                ArticleBodyCompletion.InvokeContained(onConnectionReadyAgain, ArticleBodyResult.Retrieved);
                 return ReadCachedBodyAsync(segmentId, existingEntry.YencHeaders);
             }
 
@@ -123,7 +123,7 @@ public class ArticleCachingNntpClient(
         var partition = PartitionBatch(segmentIds);
         if (partition.Missing.Count == 0)
         {
-            InvokeCompletionCallback(
+            ArticleBodyCompletion.InvokeContained(
                 onConnectionReadyAgain, ArticleBodyResult.Retrieved);
             return MergeBatchForCaching(
                 segmentIds.Count, partition, null, cancellationToken);
@@ -147,7 +147,7 @@ public class ArticleCachingNntpClient(
         }
         catch
         {
-            onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved);
+            ArticleBodyCompletion.InvokeContained(onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
             throw;
         }
 
@@ -159,7 +159,7 @@ public class ArticleCachingNntpClient(
                 if (cacheEntry.HasArticleHeaders)
                 {
                     // Full article is cached, read from cache
-                    onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+                    ArticleBodyCompletion.InvokeContained(onConnectionReadyAgain, ArticleBodyResult.Retrieved);
                     return ReadCachedArticleAsync(segmentId, cacheEntry.YencHeaders, cacheEntry.ArticleHeaders!);
                 }
                 else
@@ -172,7 +172,7 @@ public class ArticleCachingNntpClient(
                     }
                     finally
                     {
-                        onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+                        ArticleBodyCompletion.InvokeContained(onConnectionReadyAgain, ArticleBodyResult.Retrieved);
                     }
 
                     // Update cache entry to include article headers
@@ -276,7 +276,7 @@ public class ArticleCachingNntpClient(
         var partition = PartitionBatch(segmentIds);
         if (partition.Missing.Count == 0)
         {
-            InvokeCompletionCallback(
+            ArticleBodyCompletion.InvokeContained(
                 exclusiveConnection.OnConnectionReadyAgain, ArticleBodyResult.Retrieved);
             return MergeBatchForCaching(
                 segmentIds.Count, partition, null, cancellationToken);
@@ -393,21 +393,6 @@ public class ArticleCachingNntpClient(
         }
 
         return new BatchCachePartition(cached, missing);
-    }
-
-    private static void InvokeCompletionCallback(
-        ArticleBodyCompletionHandler? callback,
-        ArticleBodyResult result,
-        string? failureReason = null)
-    {
-        try
-        {
-            callback?.Invoke(result, failureReason);
-        }
-        catch
-        {
-            // Callback exceptions must not fault transport tasks (streaming lifecycle invariant).
-        }
     }
 
     private async Task<UsenetDecodedBodyResponse> CacheBatchResponseAsync(

--- a/backend/Clients/Usenet/DeferredArticleBodyCallback.cs
+++ b/backend/Clients/Usenet/DeferredArticleBodyCallback.cs
@@ -25,7 +25,7 @@ internal sealed class DeferredArticleBodyCallback
             }
         }
 
-        InvokeSafely(target, result, failureReason);
+        ArticleBodyCompletion.InvokeContained(target, result, failureReason);
     }
 
     public void Activate(ArticleBodyCompletionHandler target)
@@ -41,7 +41,7 @@ internal sealed class DeferredArticleBodyCallback
 
         if (deferred.HasValue)
         {
-            InvokeSafely(target, deferred.Value.Result, deferred.Value.FailureReason);
+            ArticleBodyCompletion.InvokeContained(target, deferred.Value.Result, deferred.Value.FailureReason);
         }
     }
 
@@ -52,21 +52,6 @@ internal sealed class DeferredArticleBodyCallback
             _discarded = true;
             _target = null;
             _deferred = null;
-        }
-    }
-
-    private static void InvokeSafely(
-        ArticleBodyCompletionHandler target,
-        ArticleBodyResult result,
-        string? failureReason)
-    {
-        try
-        {
-            target(result, failureReason);
-        }
-        catch
-        {
-            // Completion callbacks must not fault NNTP transfer tasks.
         }
     }
 }

--- a/backend/Clients/Usenet/DownloadingNntpClient.cs
+++ b/backend/Clients/Usenet/DownloadingNntpClient.cs
@@ -103,13 +103,8 @@ public class DownloadingNntpClient : WrappingNntpClient
         ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken cancellationToken)
     {
         var semaphore = await AcquireExclusiveConnectionAsync(onConnectionReadyAgain, cancellationToken).ConfigureAwait(false);
-        return await base.DecodedBodyAsync(segmentId, OnConnectionReadyAgain, cancellationToken).ConfigureAwait(false);
-
-        void OnConnectionReadyAgain(ArticleBodyResult articleBodyResult, string? failureReason)
-        {
-            semaphore.Release();
-            onConnectionReadyAgain?.Invoke(articleBodyResult, failureReason);
-        }
+        return await base.DecodedBodyAsync(
+            segmentId, CreatePermitCompletion(semaphore, onConnectionReadyAgain), cancellationToken).ConfigureAwait(false);
     }
 
     public override async Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
@@ -119,27 +114,16 @@ public class DownloadingNntpClient : WrappingNntpClient
     {
         var semaphore = await AcquireExclusiveConnectionAsync(onConnectionReadyAgain, cancellationToken).ConfigureAwait(false);
         return await base.DecodedBodiesAsync(
-            segmentIds, OnConnectionReadyAgain, cancellationToken).ConfigureAwait(false);
-
-        void OnConnectionReadyAgain(ArticleBodyResult articleBodyResult, string? failureReason)
-        {
-            semaphore.Release();
-            onConnectionReadyAgain?.Invoke(articleBodyResult, failureReason);
-        }
+            segmentIds, CreatePermitCompletion(semaphore, onConnectionReadyAgain), cancellationToken).ConfigureAwait(false);
     }
 
     public override async Task<UsenetDecodedArticleResponse> DecodedArticleAsync(SegmentId segmentId,
         ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken cancellationToken)
     {
         var semaphore = await AcquireExclusiveConnectionAsync(onConnectionReadyAgain, cancellationToken).ConfigureAwait(false);
-        return await base.DecodedArticleAsync(segmentId, OnConnectionReadyAgain, cancellationToken)
+        return await base.DecodedArticleAsync(
+            segmentId, CreatePermitCompletion(semaphore, onConnectionReadyAgain), cancellationToken)
             .ConfigureAwait(false);
-
-        void OnConnectionReadyAgain(ArticleBodyResult articleBodyResult, string? failureReason)
-        {
-            semaphore.Release();
-            onConnectionReadyAgain?.Invoke(articleBodyResult, failureReason);
-        }
     }
 
     private async Task<PrioritizedSemaphore> AcquireExclusiveConnectionAsync(ArticleBodyCompletionHandler? onConnectionReadyAgain,
@@ -151,9 +135,27 @@ public class DownloadingNntpClient : WrappingNntpClient
         }
         catch
         {
-            onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved);
+            ArticleBodyCompletion.InvokeContained(onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
             throw;
         }
+    }
+
+    // First terminal event wins: a duplicate inner completion must not release the
+    // queue/streaming permit twice (see #1239; adjacent to #1185 callback hardening).
+    private static ArticleBodyCompletionHandler CreatePermitCompletion(
+        PrioritizedSemaphore semaphore,
+        ArticleBodyCompletionHandler? next)
+    {
+        var completionState = 0;
+
+        return (result, failureReason) =>
+        {
+            if (Interlocked.CompareExchange(ref completionState, 1, 0) != 0)
+                return;
+
+            semaphore.Release();
+            ArticleBodyCompletion.InvokeContained(next, result, failureReason);
+        };
     }
 
     // Picks the semaphore (and its priority) a download should acquire from.
@@ -217,7 +219,7 @@ public class DownloadingNntpClient : WrappingNntpClient
     )
     {
         var semaphore = await AcquireExclusiveConnectionAsync(cancellationToken).ConfigureAwait(false);
-        return new UsenetExclusiveConnection((_, _) => semaphore.Release());
+        return new UsenetExclusiveConnection(CreatePermitCompletion(semaphore, next: null));
     }
 
     public override async Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync
@@ -233,7 +235,7 @@ public class DownloadingNntpClient : WrappingNntpClient
         }
 
         var semaphore = await AcquireExclusiveConnectionAsync(cancellationToken).ConfigureAwait(false);
-        return new UsenetExclusiveConnection((_, _) => semaphore.Release());
+        return new UsenetExclusiveConnection(CreatePermitCompletion(semaphore, next: null));
     }
 
     public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(SegmentId segmentId,

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -328,7 +328,7 @@ public class MultiProviderNntpClient(
                 {
                     try
                     {
-                        InvokeCompletionCallback(onConnectionReadyAgain, result, failureReason);
+                        ArticleBodyCompletion.InvokeContained(onConnectionReadyAgain, result, failureReason);
                     }
                     finally
                     {
@@ -360,7 +360,7 @@ public class MultiProviderNntpClient(
         {
             try
             {
-                InvokeCompletionCallback(onConnectionReadyAgain, result, failureReason);
+                ArticleBodyCompletion.InvokeContained(onConnectionReadyAgain, result, failureReason);
             }
             finally
             {
@@ -432,7 +432,7 @@ public class MultiProviderNntpClient(
                     // Every provider in this client belongs to the same retired generation.
                     // Do not walk the remaining disposed pools or record network failures.
                     deferredCallback.Discard();
-                    InvokeCompletionCallback(
+                    ArticleBodyCompletion.InvokeContained(
                         CompleteBatchFetches, ArticleBodyResult.NotRetrieved);
                     throw;
                 }
@@ -440,7 +440,7 @@ public class MultiProviderNntpClient(
                 {
                     // Invalid / permanently missing segment ids are invalid on every provider.
                     deferredCallback.Discard();
-                    InvokeCompletionCallback(
+                    ArticleBodyCompletion.InvokeContained(
                         CompleteBatchFetches, ArticleBodyResult.NotRetrieved);
                     throw;
                 }
@@ -452,13 +452,13 @@ public class MultiProviderNntpClient(
                 catch
                 {
                     deferredCallback.Discard();
-                    InvokeCompletionCallback(
+                    ArticleBodyCompletion.InvokeContained(
                         CompleteBatchFetches, ArticleBodyResult.NotRetrieved);
                     throw;
                 }
             }
 
-            InvokeCompletionCallback(CompleteBatchFetches, ArticleBodyResult.NotRetrieved);
+            ArticleBodyCompletion.InvokeContained(CompleteBatchFetches, ArticleBodyResult.NotRetrieved);
             lastException?.Throw();
             throw new InvalidOperationException("There are no usenet providers configured.");
         }
@@ -786,7 +786,7 @@ public class MultiProviderNntpClient(
 
             var failed = Volatile.Read(ref _transportFailed) != 0 ||
                          Volatile.Read(ref _resolutionFailed) != 0;
-            InvokeCompletionCallback(
+            ArticleBodyCompletion.InvokeContained(
                 callback,
                 failed ? ArticleBodyResult.NotRetrieved : ArticleBodyResult.Retrieved,
                 failed ? Volatile.Read(ref _firstFailureReason) : null);
@@ -895,7 +895,7 @@ public class MultiProviderNntpClient(
                 walk.UnexpectedResponses++;
                 RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing,
                     stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
-                InvokeCompletionCallback(
+                ArticleBodyCompletion.InvokeContained(
                     onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
                 return result;
             }
@@ -903,7 +903,7 @@ public class MultiProviderNntpClient(
             {
                 walk.Retired = true;
                 deferredCallback.Discard();
-                InvokeCompletionCallback(
+                ArticleBodyCompletion.InvokeContained(
                     onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
                 throw;
             }
@@ -925,14 +925,14 @@ public class MultiProviderNntpClient(
             {
                 walk.Cancelled = cancellationToken.IsCancellationRequested;
                 deferredCallback.Discard();
-                InvokeCompletionCallback(
+                ArticleBodyCompletion.InvokeContained(
                     onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
                 throw;
             }
         }
 
         // Terminal 430 after skips/exhaustion must fire the completion callback exactly once.
-        InvokeCompletionCallback(onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
+        ArticleBodyCompletion.InvokeContained(onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
         walk.LastOutcomeWasException = lastOutcomeWasException;
         LogProviderWalkOutcome(
             walk, segmentId, operation, lastAttemptedProvider?.Host, lastException?.SourceException);
@@ -1665,21 +1665,6 @@ public class MultiProviderNntpClient(
                            segmentIds, effectiveDepth, cancellationToken)
                            .WithCancellation(cancellationToken).ConfigureAwait(false))
             yield return result;
-    }
-
-    private static void InvokeCompletionCallback(
-        ArticleBodyCompletionHandler? callback,
-        ArticleBodyResult result,
-        string? failureReason = null)
-    {
-        try
-        {
-            callback?.Invoke(result, failureReason);
-        }
-        catch (Exception e) when (e is not OutOfMemoryException)
-        {
-            Log.Warning(e, "NNTP completion callback failed");
-        }
     }
 
     public override void Dispose()

--- a/backend/Clients/Usenet/RepairedSegmentNntpClient.cs
+++ b/backend/Clients/Usenet/RepairedSegmentNntpClient.cs
@@ -27,7 +27,7 @@ public sealed class RepairedSegmentNntpClient : WrappingNntpClient
 
         if (TryGetPatchedResponse(segmentId, out var patched))
         {
-            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            ArticleBodyCompletion.InvokeContained(onConnectionReadyAgain, ArticleBodyResult.Retrieved);
             PrometheusMetrics.Current?.RecordPar2PatchHit();
             return patched!;
         }
@@ -67,7 +67,8 @@ public sealed class RepairedSegmentNntpClient : WrappingNntpClient
 
         if (TryGetPatchedResponse(segmentId, out var patched))
         {
-            exclusiveConnection.OnConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            ArticleBodyCompletion.InvokeContained(
+                exclusiveConnection.OnConnectionReadyAgain, ArticleBodyResult.Retrieved);
             PrometheusMetrics.Current?.RecordPar2PatchHit();
             return patched!;
         }

--- a/backend/Clients/Usenet/SegmentCacheNntpClient.cs
+++ b/backend/Clients/Usenet/SegmentCacheNntpClient.cs
@@ -78,7 +78,7 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         if (TryServeFromCache(id, out var cached))
         {
             RecordCacheHit();
-            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            ArticleBodyCompletion.InvokeContained(onConnectionReadyAgain, ArticleBodyResult.Retrieved);
             return cached!;
         }
 
@@ -119,7 +119,8 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         if (TryServeFromCache(id, out var cached))
         {
             RecordCacheHit();
-            exclusiveConnection.OnConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            ArticleBodyCompletion.InvokeContained(
+                exclusiveConnection.OnConnectionReadyAgain, ArticleBodyResult.Retrieved);
             return cached!;
         }
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleBodyCompletionTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleBodyCompletionTests.cs
@@ -1,0 +1,116 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Tests.TestUtils;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+[Collection(nameof(GlobalLoggerCollection))]
+public sealed class ArticleBodyCompletionTests
+{
+    [Theory]
+    [InlineData(ArticleBodyResult.Retrieved)]
+    [InlineData(ArticleBodyResult.Cancelled)]
+    [InlineData(ArticleBodyResult.NotFound)]
+    [InlineData(ArticleBodyResult.NotRetrieved)]
+    public void InvokeContained_NullCallback_DoesNothing(ArticleBodyResult result)
+    {
+        var exception = Record.Exception(() =>
+            ArticleBodyCompletion.InvokeContained(null, result, "SocketException"));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void InvokeContained_ThrowingCallback_DoesNotEscape()
+    {
+        var count = 0;
+        ArticleBodyCompletionHandler callback = (_, _) =>
+        {
+            count++;
+            throw new InvalidOperationException("callback failure");
+        };
+
+        var exception = Record.Exception(() =>
+            ArticleBodyCompletion.InvokeContained(callback, ArticleBodyResult.Retrieved));
+
+        Assert.Null(exception);
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public void InvokeContained_PreservesResultAndFailureReason()
+    {
+        ArticleBodyResult? observedResult = null;
+        string? observedReason = null;
+        ArticleBodyCompletion.InvokeContained(
+            (result, reason) =>
+            {
+                observedResult = result;
+                observedReason = reason;
+            },
+            ArticleBodyResult.NotRetrieved,
+            "SocketException");
+
+        Assert.Equal(ArticleBodyResult.NotRetrieved, observedResult);
+        Assert.Equal("SocketException", observedReason);
+    }
+
+    [Fact]
+    public void InvokeContained_ThrowingCallback_LogsOneWarning()
+    {
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        var callbackException = new InvalidOperationException("callback failure");
+        try
+        {
+            ArticleBodyCompletion.InvokeContained(
+                (_, _) => throw callbackException,
+                ArticleBodyResult.Retrieved);
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+
+        var warning = Assert.Single(sink.Events, e => e.Level == LogEventLevel.Warning);
+        Assert.Equal("NNTP completion callback failed for {Result}", warning.MessageTemplate.Text);
+        Assert.Same(callbackException, warning.Exception);
+        Assert.True(warning.Properties.TryGetValue("Result", out var resultValue));
+        var scalar = Assert.IsType<ScalarValue>(resultValue);
+        Assert.Equal(ArticleBodyResult.Retrieved.ToString(), scalar.Value?.ToString());
+    }
+
+    [Fact]
+    public void InvokeContained_OutOfMemoryException_IsNotContained()
+    {
+        Assert.Throws<OutOfMemoryException>(() =>
+            ArticleBodyCompletion.InvokeContained(
+                (_, _) => throw new OutOfMemoryException("fatal"),
+                ArticleBodyResult.Retrieved));
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events) return _events.ToArray();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events) _events.Add(logEvent);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleCachingNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleCachingNntpClientTests.cs
@@ -76,7 +76,7 @@ public class ArticleCachingNntpClientTests
         var primed = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
         await ReadAllAsync(primed.Stream!);
 
-        var recorder = new ThrowingRecorder();
+        var recorder = new ArticleBodyCompletionRecorder(throwOnInvoke: true);
         var response = await client.DecodedBodyAsync(segmentId, recorder.Invoke, CancellationToken.None);
         var bytes = await ReadAllAsync(response.Stream!);
 
@@ -101,7 +101,7 @@ public class ArticleCachingNntpClientTests
         await ReadAllAsync((await client.DecodedBodyAsync("one", CancellationToken.None)).Stream!);
         await ReadAllAsync((await client.DecodedBodyAsync("two", CancellationToken.None)).Stream!);
 
-        var recorder = new ThrowingRecorder();
+        var recorder = new ArticleBodyCompletionRecorder(throwOnInvoke: true);
         var batch = await client.DecodedBodiesAsync(
             ["one", "two"], recorder.Invoke, CancellationToken.None);
         var responses = await Task.WhenAll(batch.Responses);
@@ -128,7 +128,7 @@ public class ArticleCachingNntpClientTests
         var primedBytes = await ReadAllAsync(primed.Stream);
         Assert.Equal(FixedArticleHeaders.Headers, primed.ArticleHeaders.Headers);
 
-        var recorder = new ThrowingRecorder();
+        var recorder = new ArticleBodyCompletionRecorder(throwOnInvoke: true);
         var response = await client.DecodedArticleAsync(segmentId, recorder.Invoke, CancellationToken.None);
         var bytes = await ReadAllAsync(response.Stream);
 
@@ -156,9 +156,8 @@ public class ArticleCachingNntpClientTests
         await inner.BodyEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         using var cts = new CancellationTokenSource();
-        var recorder = new ThrowingRecorder();
+        var recorder = new ArticleBodyCompletionRecorder(throwOnInvoke: true);
         var waiting = client.DecodedBodyAsync(segmentId, recorder.Invoke, cts.Token);
-        await WaitUntilAsync(() => !waiting.IsCompleted, TimeSpan.FromSeconds(5));
         await cts.CancelAsync();
 
         var cancelled = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiting);
@@ -187,7 +186,7 @@ public class ArticleCachingNntpClientTests
         var sentinel = new InvalidOperationException("sentinel-head");
         inner.HeadException = sentinel;
 
-        var recorder = new ThrowingRecorder();
+        var recorder = new ArticleBodyCompletionRecorder(throwOnInvoke: true);
         var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() =>
             client.DecodedArticleAsync(segmentId, recorder.Invoke, CancellationToken.None));
 
@@ -197,18 +196,6 @@ public class ArticleCachingNntpClientTests
         Assert.Equal(0, inner.ArticleRequestCount);
     }
 
-    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        while (DateTime.UtcNow < deadline)
-        {
-            if (condition()) return;
-            await Task.Delay(10);
-        }
-
-        Assert.Fail($"Condition not met within {timeout.TotalSeconds:0.#}s");
-    }
-
     private static async Task<byte[]> ReadAllAsync(Stream stream)
     {
         await using (stream)
@@ -216,21 +203,6 @@ public class ArticleCachingNntpClientTests
             using var destination = new MemoryStream();
             await stream.CopyToAsync(destination);
             return destination.ToArray();
-        }
-    }
-
-    private sealed class ThrowingRecorder
-    {
-        public int Count;
-        public ArticleBodyResult? Result;
-        public string? FailureReason;
-
-        public void Invoke(ArticleBodyResult result, string? failureReason)
-        {
-            Count++;
-            Result = result;
-            FailureReason = failureReason;
-            throw new InvalidOperationException("callback failure");
         }
     }
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleCachingNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleCachingNntpClientTests.cs
@@ -1,12 +1,24 @@
 using System.Text;
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Streams;
 using NzbWebDAV.Tests.Fakes;
 using NzbWebDAV.Tests.TestUtils;
+using UsenetSharp.Models;
 
 namespace NzbWebDAV.Tests.Clients.Usenet;
 
 public class ArticleCachingNntpClientTests
 {
+    private static readonly UsenetArticleHeader FixedArticleHeaders = new()
+    {
+        Headers = new Dictionary<string, string>
+        {
+            ["Subject"] = "cache-test",
+            ["Message-ID"] = "<segment@test>",
+        },
+    };
+
     [SkippableFact]
     public async Task DecodedBodyAsync_CachesDecodedBytesAfterFirstRead()
     {
@@ -51,6 +63,152 @@ public class ArticleCachingNntpClientTests
         Assert.Equal(1, inner.BatchRequestCount);
     }
 
+    [Fact]
+    public async Task DecodedBodyAsync_CacheHit_ThrowingCallbackReturnsCachedBody()
+    {
+        const string segmentId = "segment";
+        byte[] payload = "cached payload"u8.ToArray();
+        var inner = new FakeNntpClient(
+            new Dictionary<string, byte[]> { [segmentId] = payload },
+            useCachedYencStreams: true);
+        using var client = new ArticleCachingNntpClient(inner);
+
+        var primed = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+        await ReadAllAsync(primed.Stream!);
+
+        var recorder = new ThrowingRecorder();
+        var response = await client.DecodedBodyAsync(segmentId, recorder.Invoke, CancellationToken.None);
+        var bytes = await ReadAllAsync(response.Stream!);
+
+        Assert.Equal((int)UsenetResponseType.ArticleRetrievedBodyFollows, response.ResponseCode);
+        Assert.Equal(payload, bytes);
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
+        Assert.Equal(1, inner.BodyRequestCount);
+    }
+
+    [Fact]
+    public async Task DecodedBodiesAsync_AllCached_ThrowingCallbackReturnsOrderedBodies()
+    {
+        var inner = new FakeNntpClient(
+            new Dictionary<string, byte[]>
+            {
+                ["one"] = "one"u8.ToArray(),
+                ["two"] = "two"u8.ToArray(),
+            },
+            useCachedYencStreams: true);
+        using var client = new ArticleCachingNntpClient(inner);
+        await ReadAllAsync((await client.DecodedBodyAsync("one", CancellationToken.None)).Stream!);
+        await ReadAllAsync((await client.DecodedBodyAsync("two", CancellationToken.None)).Stream!);
+
+        var recorder = new ThrowingRecorder();
+        var batch = await client.DecodedBodiesAsync(
+            ["one", "two"], recorder.Invoke, CancellationToken.None);
+        var responses = await Task.WhenAll(batch.Responses);
+        var bodies = new List<string>();
+        foreach (var response in responses)
+            bodies.Add(Encoding.ASCII.GetString(await ReadAllAsync(response.Stream!)));
+
+        Assert.Equal(["one", "two"], bodies);
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
+        Assert.Equal(2, inner.BodyRequestCount);
+        Assert.Equal(0, inner.BatchRequestCount);
+    }
+
+    [Fact]
+    public async Task DecodedArticleAsync_FullCacheHit_ThrowingCallbackReturnsCachedArticle()
+    {
+        const string segmentId = "article-segment";
+        byte[] payload = "article-bytes"u8.ToArray();
+        var inner = new CacheProbeNntpClient { Segments = { [segmentId] = payload } };
+        using var client = new ArticleCachingNntpClient(inner);
+
+        var primed = await client.DecodedArticleAsync(segmentId, CancellationToken.None);
+        var primedBytes = await ReadAllAsync(primed.Stream);
+        Assert.Equal(FixedArticleHeaders.Headers, primed.ArticleHeaders.Headers);
+
+        var recorder = new ThrowingRecorder();
+        var response = await client.DecodedArticleAsync(segmentId, recorder.Invoke, CancellationToken.None);
+        var bytes = await ReadAllAsync(response.Stream);
+
+        Assert.Equal(payload, primedBytes);
+        Assert.Equal(payload, bytes);
+        Assert.Equal(FixedArticleHeaders.Headers, response.ArticleHeaders.Headers);
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
+        Assert.Equal(1, inner.ArticleRequestCount);
+    }
+
+    [Fact]
+    public async Task DecodedBodyAsync_CancelledWhileWaiting_ThrowingCallbackPreservesCancellation()
+    {
+        const string segmentId = "held-segment";
+        byte[] payload = "held-bytes"u8.ToArray();
+        var inner = new CacheProbeNntpClient
+        {
+            Segments = { [segmentId] = payload },
+            GateFirstBody = true,
+        };
+        using var client = new ArticleCachingNntpClient(inner);
+
+        var first = client.DecodedBodyAsync(segmentId, CancellationToken.None);
+        await inner.BodyEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        using var cts = new CancellationTokenSource();
+        var recorder = new ThrowingRecorder();
+        var waiting = client.DecodedBodyAsync(segmentId, recorder.Invoke, cts.Token);
+        await WaitUntilAsync(() => !waiting.IsCompleted, TimeSpan.FromSeconds(5));
+        await cts.CancelAsync();
+
+        var cancelled = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiting);
+        Assert.True(cancelled.CancellationToken == cts.Token || cancelled is TaskCanceledException);
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, recorder.Result);
+        Assert.Equal(1, inner.BodyRequestCount);
+
+        inner.BodyContinue.TrySetResult();
+        await ReadAllAsync((await first).Stream!);
+
+        var after = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+        await ReadAllAsync(after.Stream!);
+        Assert.Equal(1, inner.BodyRequestCount);
+    }
+
+    [Fact]
+    public async Task DecodedArticleAsync_BodyCachedHeadThrows_ThrowingCallbackPreservesHeadException()
+    {
+        const string segmentId = "head-segment";
+        byte[] payload = "body-only"u8.ToArray();
+        var inner = new CacheProbeNntpClient { Segments = { [segmentId] = payload } };
+        using var client = new ArticleCachingNntpClient(inner);
+
+        await ReadAllAsync((await client.DecodedBodyAsync(segmentId, CancellationToken.None)).Stream!);
+        var sentinel = new InvalidOperationException("sentinel-head");
+        inner.HeadException = sentinel;
+
+        var recorder = new ThrowingRecorder();
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            client.DecodedArticleAsync(segmentId, recorder.Invoke, CancellationToken.None));
+
+        Assert.Same(sentinel, thrown);
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
+        Assert.Equal(0, inner.ArticleRequestCount);
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return;
+            await Task.Delay(10);
+        }
+
+        Assert.Fail($"Condition not met within {timeout.TotalSeconds:0.#}s");
+    }
+
     private static async Task<byte[]> ReadAllAsync(Stream stream)
     {
         await using (stream)
@@ -59,5 +217,145 @@ public class ArticleCachingNntpClientTests
             await stream.CopyToAsync(destination);
             return destination.ToArray();
         }
+    }
+
+    private sealed class ThrowingRecorder
+    {
+        public int Count;
+        public ArticleBodyResult? Result;
+        public string? FailureReason;
+
+        public void Invoke(ArticleBodyResult result, string? failureReason)
+        {
+            Count++;
+            Result = result;
+            FailureReason = failureReason;
+            throw new InvalidOperationException("callback failure");
+        }
+    }
+
+    private sealed class CacheProbeNntpClient : NntpClient
+    {
+        public Dictionary<string, byte[]> Segments { get; } = new(StringComparer.Ordinal);
+        public int BodyRequestCount { get; private set; }
+        public int ArticleRequestCount { get; private set; }
+        public bool GateFirstBody { get; set; }
+        public Exception? HeadException { get; set; }
+        public TaskCompletionSource BodyEntered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource BodyContinue { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override Task ConnectAsync(string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken)
+        {
+            if (HeadException != null)
+                throw HeadException;
+
+            return Task.FromResult(new UsenetHeadResponse
+            {
+                SegmentId = segmentId.ToString(),
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedHeadFollows,
+                ResponseMessage = "221",
+                ArticleHeaders = FixedArticleHeaders,
+            });
+        }
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, null, cancellationToken);
+
+        public override async Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            BodyRequestCount++;
+            if (GateFirstBody && BodyRequestCount == 1)
+            {
+                BodyEntered.TrySetResult();
+                await BodyContinue.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            var response = CreateBody(segmentId);
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return response;
+        }
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            var responses = segmentIds
+                .Select(id => DecodedBodyAsync(id, cancellationToken))
+                .ToArray();
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
+        }
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedArticleAsync(segmentId, null, cancellationToken);
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            ArticleRequestCount++;
+            var bytes = Segments[segmentId.ToString()];
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedArticleResponse
+            {
+                SegmentId = segmentId.ToString(),
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedHeadAndBodyFollow,
+                ResponseMessage = "220",
+                ArticleHeaders = FixedArticleHeaders,
+                Stream = CreateStream(bytes),
+            });
+        }
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+
+        private UsenetDecodedBodyResponse CreateBody(SegmentId segmentId)
+        {
+            var bytes = Segments[segmentId.ToString()];
+            return new UsenetDecodedBodyResponse
+            {
+                SegmentId = segmentId.ToString(),
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                ResponseMessage = "222",
+                Stream = CreateStream(bytes),
+            };
+        }
+
+        private static CachedYencStream CreateStream(byte[] bytes) =>
+            new(
+                new UsenetYencHeader
+                {
+                    FileName = "fake.bin",
+                    FileSize = bytes.Length,
+                    LineLength = 128,
+                    PartNumber = 1,
+                    TotalParts = 1,
+                    PartOffset = 0,
+                    PartSize = bytes.Length,
+                },
+                new MemoryStream(bytes, writable: false));
     }
 }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadingNntpClientStatGateTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadingNntpClientStatGateTests.cs
@@ -8,6 +8,7 @@ using NzbWebDAV.Database.Models;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.TestUtils;
 using UsenetSharp.Models;
 
 namespace NzbWebDAV.Tests.Clients.Usenet;
@@ -247,7 +248,7 @@ public class DownloadingNntpClientStatGateTests
         var inner = new ManualCompletionNntpClient();
         var config = CreateConfig(maxQueueConnections: 1, maxDownloadConnections: 10);
         using var client = new DownloadingNntpClient(inner, config);
-        var outerA = new CompletionRecorder();
+        var outerA = new ArticleBodyCompletionRecorder();
 
         var aTask = StartApi(client, api, "a", outerA.Invoke, CancellationToken.None);
         var aOp = await WaitForOpAsync(inner, 1);
@@ -291,7 +292,7 @@ public class DownloadingNntpClientStatGateTests
         var inner = new ManualCompletionNntpClient();
         var config = CreateConfig(maxQueueConnections: 1, maxDownloadConnections: 10);
         using var client = new DownloadingNntpClient(inner, config);
-        var outerA = new CompletionRecorder();
+        var outerA = new ArticleBodyCompletionRecorder();
 
         var aTask = StartApi(client, api, "a", outerA.Invoke, CancellationToken.None);
         var aOp = await WaitForOpAsync(inner, 1);
@@ -302,7 +303,7 @@ public class DownloadingNntpClientStatGateTests
 
         var first = (Result: ArticleBodyResult.Retrieved, Reason: (string?)null);
         var second = (Result: ArticleBodyResult.NotRetrieved, Reason: "SocketException");
-        var barrier = new Barrier(2);
+        using var barrier = new Barrier(2);
         var fire1 = Task.Run(() =>
         {
             barrier.SignalAndWait();
@@ -336,7 +337,7 @@ public class DownloadingNntpClientStatGateTests
         var inner = new ManualCompletionNntpClient();
         var config = CreateConfig(maxQueueConnections: 1, maxDownloadConnections: 10);
         using var client = new DownloadingNntpClient(inner, config);
-        var outerA = new CompletionRecorder { ThrowOnInvoke = true };
+        var outerA = new ArticleBodyCompletionRecorder(throwOnInvoke: true);
 
         var aTask = StartApi(client, api, "a", outerA.Invoke, CancellationToken.None);
         var aOp = await WaitForOpAsync(inner, 1);
@@ -372,7 +373,7 @@ public class DownloadingNntpClientStatGateTests
         var inner = new ManualCompletionNntpClient();
         var config = CreateConfig(maxQueueConnections: 1, maxDownloadConnections: 10);
         using var client = new DownloadingNntpClient(inner, config);
-        var outer = new CompletionRecorder();
+        var outer = new ArticleBodyCompletionRecorder();
 
         var aTask = StartApi(client, api, "a", outer.Invoke, CancellationToken.None);
         var aOp = await WaitForOpAsync(inner, 1);
@@ -400,7 +401,7 @@ public class DownloadingNntpClientStatGateTests
         var aOp = await WaitForOpAsync(inner, 1);
 
         using var cts = new CancellationTokenSource();
-        var outerB = new CompletionRecorder { ThrowOnInvoke = true };
+        var outerB = new ArticleBodyCompletionRecorder(throwOnInvoke: true);
         var bTask = client.DecodedBodyAsync(new SegmentId("b"), outerB.Invoke, cts.Token);
         await WaitUntilAsync(() => !bTask.IsCompleted && inner.Ops.Count == 1, TimeSpan.FromSeconds(5));
         await cts.CancelAsync();
@@ -431,7 +432,7 @@ public class DownloadingNntpClientStatGateTests
         };
         var config = CreateConfig(maxQueueConnections: 1, maxDownloadConnections: 10);
         using var client = new DownloadingNntpClient(inner, config);
-        var outer = new CompletionRecorder();
+        var outer = new ArticleBodyCompletionRecorder();
 
         var miss = await client.DecodedBodyAsync(new SegmentId("missing"), outer.Invoke, CancellationToken.None);
         Assert.Equal((int)UsenetResponseType.NoArticleWithThatMessageId, miss.ResponseCode);
@@ -497,7 +498,7 @@ public class DownloadingNntpClientStatGateTests
         var bTask = client.DecodedBodyAsync(new SegmentId("b"), null, CancellationToken.None);
         await WaitUntilAsync(() => !bTask.IsCompleted && inner.Ops.Count == 0, TimeSpan.FromSeconds(5));
 
-        var barrier = new Barrier(2);
+        using var barrier = new Barrier(2);
         await Task.WhenAll(
             Task.Run(() =>
             {
@@ -676,23 +677,6 @@ public class DownloadingNntpClientStatGateTests
             new ConfigItem { ConfigName = ConfigKeys.UsenetMaxDownloadConnections, ConfigValue = "10" },
         ]);
         return config;
-    }
-
-    private sealed class CompletionRecorder
-    {
-        public int Count;
-        public ArticleBodyResult? Result;
-        public string? FailureReason;
-        public bool ThrowOnInvoke;
-
-        public void Invoke(ArticleBodyResult result, string? failureReason)
-        {
-            Interlocked.Increment(ref Count);
-            Result = result;
-            FailureReason = failureReason;
-            if (ThrowOnInvoke)
-                throw new InvalidOperationException("callback failure");
-        }
     }
 
     private sealed class PendingOp

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadingNntpClientStatGateTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadingNntpClientStatGateTests.cs
@@ -7,6 +7,7 @@ using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
+using NzbWebDAV.Streams;
 using UsenetSharp.Models;
 
 namespace NzbWebDAV.Tests.Clients.Usenet;
@@ -235,6 +236,369 @@ public class DownloadingNntpClientStatGateTests
             $"Expected pipelined wait to record semaphore contention, got {waitingCtx.SemaphoreWaitMilliseconds}ms");
     }
 
+    public enum CompletionApi { Body, Batch, Article }
+
+    [Theory]
+    [InlineData(CompletionApi.Body)]
+    [InlineData(CompletionApi.Batch)]
+    [InlineData(CompletionApi.Article)]
+    public async Task DuplicateInnerCompletion_ReleasesPermitAndForwardsOnlyOnce(CompletionApi api)
+    {
+        var inner = new ManualCompletionNntpClient();
+        var config = CreateConfig(maxQueueConnections: 1, maxDownloadConnections: 10);
+        using var client = new DownloadingNntpClient(inner, config);
+        var outerA = new CompletionRecorder();
+
+        var aTask = StartApi(client, api, "a", outerA.Invoke, CancellationToken.None);
+        var aOp = await WaitForOpAsync(inner, 1);
+        await DrainAsync(api, aTask);
+
+        var bTask = StartApi(client, api, "b", null, CancellationToken.None);
+        var cTask = StartApi(client, api, "c", null, CancellationToken.None);
+        await WaitUntilAsync(() => !bTask.IsCompleted && !cTask.IsCompleted && inner.Ops.Count == 1, TimeSpan.FromSeconds(5));
+
+        aOp.Callback!(ArticleBodyResult.Retrieved, null);
+        aOp.Callback!(ArticleBodyResult.NotRetrieved, "SocketException");
+
+        var bOp = await WaitForOpAsync(inner, 2);
+        Assert.Equal(2, inner.Ops.Count);
+        Assert.False(cTask.IsCompleted);
+        Assert.Equal(1, outerA.Count);
+        Assert.Equal(ArticleBodyResult.Retrieved, outerA.Result);
+        Assert.Null(outerA.FailureReason);
+        Assert.Equal(1, inner.MaxEntries);
+
+        bOp.Callback!(ArticleBodyResult.Retrieved, null);
+        var cOp = await WaitForOpAsync(inner, 3);
+        cOp.Callback!(ArticleBodyResult.Retrieved, null);
+
+        await DrainAsync(api, bTask);
+        await DrainAsync(api, cTask);
+
+        var dTask = StartApi(client, api, "d", null, CancellationToken.None);
+        var dOp = await WaitForOpAsync(inner, 4);
+        dOp.Callback!(ArticleBodyResult.Retrieved, null);
+        await DrainAsync(api, dTask);
+        Assert.Equal(1, inner.MaxEntries);
+    }
+
+    [Theory]
+    [InlineData(CompletionApi.Body)]
+    [InlineData(CompletionApi.Batch)]
+    [InlineData(CompletionApi.Article)]
+    public async Task DuplicateInnerCompletion_ConcurrentFire_ForwardsOneCompletePair(CompletionApi api)
+    {
+        var inner = new ManualCompletionNntpClient();
+        var config = CreateConfig(maxQueueConnections: 1, maxDownloadConnections: 10);
+        using var client = new DownloadingNntpClient(inner, config);
+        var outerA = new CompletionRecorder();
+
+        var aTask = StartApi(client, api, "a", outerA.Invoke, CancellationToken.None);
+        var aOp = await WaitForOpAsync(inner, 1);
+        await DrainAsync(api, aTask);
+
+        var bTask = StartApi(client, api, "b", null, CancellationToken.None);
+        await WaitUntilAsync(() => !bTask.IsCompleted && inner.Ops.Count == 1, TimeSpan.FromSeconds(5));
+
+        var first = (Result: ArticleBodyResult.Retrieved, Reason: (string?)null);
+        var second = (Result: ArticleBodyResult.NotRetrieved, Reason: "SocketException");
+        var barrier = new Barrier(2);
+        var fire1 = Task.Run(() =>
+        {
+            barrier.SignalAndWait();
+            aOp.Callback!(first.Result, first.Reason);
+        });
+        var fire2 = Task.Run(() =>
+        {
+            barrier.SignalAndWait();
+            aOp.Callback!(second.Result, second.Reason);
+        });
+        await Task.WhenAll(fire1, fire2);
+
+        Assert.Equal(1, outerA.Count);
+        Assert.True(
+            (outerA.Result == first.Result && outerA.FailureReason == first.Reason)
+            || (outerA.Result == second.Result && outerA.FailureReason == second.Reason),
+            $"Mixed completion pair: {outerA.Result}, {outerA.FailureReason}");
+
+        var bOp = await WaitForOpAsync(inner, 2);
+        bOp.Callback!(ArticleBodyResult.Retrieved, null);
+        await DrainAsync(api, bTask);
+        Assert.Equal(1, inner.MaxEntries);
+    }
+
+    [Theory]
+    [InlineData(CompletionApi.Body)]
+    [InlineData(CompletionApi.Batch)]
+    [InlineData(CompletionApi.Article)]
+    public async Task ThrowingOuterCallback_DoesNotFaultSuccessfulTransport_AndPermitRecovers(CompletionApi api)
+    {
+        var inner = new ManualCompletionNntpClient();
+        var config = CreateConfig(maxQueueConnections: 1, maxDownloadConnections: 10);
+        using var client = new DownloadingNntpClient(inner, config);
+        var outerA = new CompletionRecorder { ThrowOnInvoke = true };
+
+        var aTask = StartApi(client, api, "a", outerA.Invoke, CancellationToken.None);
+        var aOp = await WaitForOpAsync(inner, 1);
+        var bTask = StartApi(client, api, "b", null, CancellationToken.None);
+        await WaitUntilAsync(() => !bTask.IsCompleted && inner.Ops.Count == 1, TimeSpan.FromSeconds(5));
+
+        aOp.Callback!(ArticleBodyResult.Retrieved, null);
+        await DrainAsync(api, aTask);
+        Assert.Equal(1, outerA.Count);
+        Assert.Equal(ArticleBodyResult.Retrieved, outerA.Result);
+
+        var bOp = await WaitForOpAsync(inner, 2);
+        bOp.Callback!(ArticleBodyResult.Retrieved, null);
+        await DrainAsync(api, bTask);
+    }
+
+    [Theory]
+    [InlineData(CompletionApi.Body, ArticleBodyResult.Retrieved, null)]
+    [InlineData(CompletionApi.Body, ArticleBodyResult.Cancelled, null)]
+    [InlineData(CompletionApi.Body, ArticleBodyResult.NotFound, null)]
+    [InlineData(CompletionApi.Body, ArticleBodyResult.NotRetrieved, "SocketException")]
+    [InlineData(CompletionApi.Batch, ArticleBodyResult.Retrieved, null)]
+    [InlineData(CompletionApi.Batch, ArticleBodyResult.Cancelled, null)]
+    [InlineData(CompletionApi.Batch, ArticleBodyResult.NotFound, null)]
+    [InlineData(CompletionApi.Batch, ArticleBodyResult.NotRetrieved, "SocketException")]
+    [InlineData(CompletionApi.Article, ArticleBodyResult.Retrieved, null)]
+    [InlineData(CompletionApi.Article, ArticleBodyResult.Cancelled, null)]
+    [InlineData(CompletionApi.Article, ArticleBodyResult.NotFound, null)]
+    [InlineData(CompletionApi.Article, ArticleBodyResult.NotRetrieved, "SocketException")]
+    public async Task TerminalStatus_IsForwardedOnceAndReleasesPermit(
+        CompletionApi api, ArticleBodyResult result, string? failureReason)
+    {
+        var inner = new ManualCompletionNntpClient();
+        var config = CreateConfig(maxQueueConnections: 1, maxDownloadConnections: 10);
+        using var client = new DownloadingNntpClient(inner, config);
+        var outer = new CompletionRecorder();
+
+        var aTask = StartApi(client, api, "a", outer.Invoke, CancellationToken.None);
+        var aOp = await WaitForOpAsync(inner, 1);
+        aOp.Callback!(result, failureReason);
+        await DrainAsync(api, aTask);
+
+        Assert.Equal(1, outer.Count);
+        Assert.Equal(result, outer.Result);
+        Assert.Equal(failureReason, outer.FailureReason);
+
+        var bTask = StartApi(client, api, "b", null, CancellationToken.None);
+        var bOp = await WaitForOpAsync(inner, 2);
+        bOp.Callback!(ArticleBodyResult.Retrieved, null);
+        await DrainAsync(api, bTask);
+    }
+
+    [Fact]
+    public async Task CancellationWhileWaiting_ThrowingCallbackPreservesOperationCanceledException()
+    {
+        var inner = new ManualCompletionNntpClient();
+        var config = CreateConfig(maxQueueConnections: 1, maxDownloadConnections: 10);
+        using var client = new DownloadingNntpClient(inner, config);
+
+        var aTask = client.DecodedBodyAsync(new SegmentId("a"), null, CancellationToken.None);
+        var aOp = await WaitForOpAsync(inner, 1);
+
+        using var cts = new CancellationTokenSource();
+        var outerB = new CompletionRecorder { ThrowOnInvoke = true };
+        var bTask = client.DecodedBodyAsync(new SegmentId("b"), outerB.Invoke, cts.Token);
+        await WaitUntilAsync(() => !bTask.IsCompleted && inner.Ops.Count == 1, TimeSpan.FromSeconds(5));
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => bTask);
+        Assert.Equal(1, outerB.Count);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, outerB.Result);
+        Assert.Single(inner.Ops);
+
+        aOp.Callback!(ArticleBodyResult.Retrieved, null);
+        await DrainAsync(CompletionApi.Body, aTask);
+
+        var cTask = client.DecodedBodyAsync(new SegmentId("c"), null, CancellationToken.None);
+        var cOp = await WaitForOpAsync(inner, 2);
+        cOp.Callback!(ArticleBodyResult.Retrieved, null);
+        await DrainAsync(CompletionApi.Body, cTask);
+    }
+
+    [Fact]
+    public async Task CleanMiss_ForwardsNotFoundOnceAndPermitRecovers()
+    {
+        var inner = new ManualCompletionNntpClient
+        {
+            AutoComplete = true,
+            AutoResult = ArticleBodyResult.NotFound,
+            AutoReason = null,
+            Success = false,
+        };
+        var config = CreateConfig(maxQueueConnections: 1, maxDownloadConnections: 10);
+        using var client = new DownloadingNntpClient(inner, config);
+        var outer = new CompletionRecorder();
+
+        var miss = await client.DecodedBodyAsync(new SegmentId("missing"), outer.Invoke, CancellationToken.None);
+        Assert.Equal((int)UsenetResponseType.NoArticleWithThatMessageId, miss.ResponseCode);
+        Assert.Equal(1, outer.Count);
+        Assert.Equal(ArticleBodyResult.NotFound, outer.Result);
+        Assert.Null(outer.FailureReason);
+        Assert.Single(inner.Ops);
+
+        inner.AutoComplete = false;
+        inner.Success = true;
+        var recovered = client.DecodedBodyAsync(new SegmentId("recovered"), null, CancellationToken.None);
+        var recoveredOp = await WaitForOpAsync(inner, 2);
+        recoveredOp.Callback!(ArticleBodyResult.Retrieved, null);
+        await DrainAsync(CompletionApi.Body, recovered);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task AcquireExclusiveConnectionAsync_DuplicateInvoke_ReleasesPermitOnce(bool useListOverload)
+    {
+        var inner = new ManualCompletionNntpClient();
+        var config = CreateConfig(maxQueueConnections: 1, maxDownloadConnections: 10);
+        using var client = new DownloadingNntpClient(inner, config);
+
+        var exclusive = useListOverload
+            ? await client.AcquireExclusiveConnectionAsync(
+                (IReadOnlyList<SegmentId>)[new SegmentId("held")], CancellationToken.None)
+            : await client.AcquireExclusiveConnectionAsync("held", CancellationToken.None);
+
+        var bTask = client.DecodedBodyAsync(new SegmentId("b"), null, CancellationToken.None);
+        var cTask = client.DecodedBodyAsync(new SegmentId("c"), null, CancellationToken.None);
+        await WaitUntilAsync(() => !bTask.IsCompleted && !cTask.IsCompleted && inner.Ops.Count == 0, TimeSpan.FromSeconds(5));
+
+        exclusive.OnConnectionReadyAgain!(ArticleBodyResult.Retrieved, null);
+        exclusive.OnConnectionReadyAgain!(ArticleBodyResult.NotRetrieved, "SocketException");
+
+        var bOp = await WaitForOpAsync(inner, 1);
+        Assert.Single(inner.Ops);
+        Assert.False(cTask.IsCompleted);
+
+        bOp.Callback!(ArticleBodyResult.Retrieved, null);
+        var cOp = await WaitForOpAsync(inner, 2);
+        cOp.Callback!(ArticleBodyResult.Retrieved, null);
+        await DrainAsync(CompletionApi.Body, bTask);
+        await DrainAsync(CompletionApi.Body, cTask);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task AcquireExclusiveConnectionAsync_ConcurrentInvoke_ReleasesPermitOnce(bool useListOverload)
+    {
+        var inner = new ManualCompletionNntpClient();
+        var config = CreateConfig(maxQueueConnections: 1, maxDownloadConnections: 10);
+        using var client = new DownloadingNntpClient(inner, config);
+
+        var exclusive = useListOverload
+            ? await client.AcquireExclusiveConnectionAsync(
+                (IReadOnlyList<SegmentId>)[new SegmentId("held")], CancellationToken.None)
+            : await client.AcquireExclusiveConnectionAsync("held", CancellationToken.None);
+
+        var bTask = client.DecodedBodyAsync(new SegmentId("b"), null, CancellationToken.None);
+        await WaitUntilAsync(() => !bTask.IsCompleted && inner.Ops.Count == 0, TimeSpan.FromSeconds(5));
+
+        var barrier = new Barrier(2);
+        await Task.WhenAll(
+            Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                exclusive.OnConnectionReadyAgain!(ArticleBodyResult.Retrieved, null);
+            }),
+            Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                exclusive.OnConnectionReadyAgain!(ArticleBodyResult.NotRetrieved, "SocketException");
+            }));
+
+        var bOp = await WaitForOpAsync(inner, 1);
+        Assert.Single(inner.Ops);
+        bOp.Callback!(ArticleBodyResult.Retrieved, null);
+        await DrainAsync(CompletionApi.Body, bTask);
+    }
+
+    [Fact]
+    public async Task DuplicateInnerCompletion_NullOuterCallback_StillReleasesPermitOnce()
+    {
+        var inner = new ManualCompletionNntpClient();
+        var config = CreateConfig(maxQueueConnections: 1, maxDownloadConnections: 10);
+        using var client = new DownloadingNntpClient(inner, config);
+
+        var aTask = client.DecodedBodyAsync(new SegmentId("a"), null, CancellationToken.None);
+        var aOp = await WaitForOpAsync(inner, 1);
+        var bTask = client.DecodedBodyAsync(new SegmentId("b"), null, CancellationToken.None);
+        await WaitUntilAsync(() => !bTask.IsCompleted && inner.Ops.Count == 1, TimeSpan.FromSeconds(5));
+
+        aOp.Callback!(ArticleBodyResult.Retrieved, null);
+        aOp.Callback!(ArticleBodyResult.NotRetrieved, "SocketException");
+        await DrainAsync(CompletionApi.Body, aTask);
+
+        var bOp = await WaitForOpAsync(inner, 2);
+        Assert.Equal(2, inner.Ops.Count);
+        bOp.Callback!(ArticleBodyResult.Retrieved, null);
+        await DrainAsync(CompletionApi.Body, bTask);
+    }
+
+    private static Task StartApi(
+        DownloadingNntpClient client,
+        CompletionApi api,
+        string segmentId,
+        ArticleBodyCompletionHandler? callback,
+        CancellationToken cancellationToken) => api switch
+    {
+        CompletionApi.Body => client.DecodedBodyAsync(new SegmentId(segmentId), callback, cancellationToken),
+        CompletionApi.Batch => client.DecodedBodiesAsync([new SegmentId(segmentId)], callback, cancellationToken),
+        CompletionApi.Article => client.DecodedArticleAsync(new SegmentId(segmentId), callback, cancellationToken),
+        _ => throw new ArgumentOutOfRangeException(nameof(api)),
+    };
+
+    private static async Task DrainAsync(CompletionApi api, Task task)
+    {
+        switch (api)
+        {
+            case CompletionApi.Body:
+            {
+                var body = await (Task<UsenetDecodedBodyResponse>)task;
+                if (body.Stream != null)
+                {
+                    await using (body.Stream)
+                        await body.Stream.CopyToAsync(Stream.Null);
+                }
+
+                break;
+            }
+            case CompletionApi.Batch:
+            {
+                var batch = await (Task<UsenetDecodedBodyBatch>)task;
+                foreach (var responseTask in batch.Responses)
+                {
+                    var response = await responseTask;
+                    if (response.Stream != null)
+                    {
+                        await using (response.Stream)
+                            await response.Stream.CopyToAsync(Stream.Null);
+                    }
+                }
+
+                break;
+            }
+            case CompletionApi.Article:
+            {
+                var article = await (Task<UsenetDecodedArticleResponse>)task;
+                await using (article.Stream)
+                    await article.Stream.CopyToAsync(Stream.Null);
+                break;
+            }
+        }
+    }
+
+    private static async Task<PendingOp> WaitForOpAsync(ManualCompletionNntpClient inner, int count)
+    {
+        await WaitUntilAsync(() => inner.Ops.Count >= count, TimeSpan.FromSeconds(5));
+        var op = inner.Ops[count - 1];
+        await op.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        return op;
+    }
+
     private static async Task<List<PipelinedBodyResult>> CollectPipelinedBodiesAsync(
         DownloadingNntpClient client,
         IReadOnlyList<string> segmentIds,
@@ -312,6 +676,191 @@ public class DownloadingNntpClientStatGateTests
             new ConfigItem { ConfigName = ConfigKeys.UsenetMaxDownloadConnections, ConfigValue = "10" },
         ]);
         return config;
+    }
+
+    private sealed class CompletionRecorder
+    {
+        public int Count;
+        public ArticleBodyResult? Result;
+        public string? FailureReason;
+        public bool ThrowOnInvoke;
+
+        public void Invoke(ArticleBodyResult result, string? failureReason)
+        {
+            Interlocked.Increment(ref Count);
+            Result = result;
+            FailureReason = failureReason;
+            if (ThrowOnInvoke)
+                throw new InvalidOperationException("callback failure");
+        }
+    }
+
+    private sealed class PendingOp
+    {
+        public required ArticleBodyCompletionHandler? Callback { get; init; }
+        public TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    private sealed class ManualCompletionNntpClient : MinimalNntpClient
+    {
+        private readonly List<PendingOp> _ops = [];
+        private int _currentEntries;
+        private int _maxEntries;
+
+        public bool AutoComplete { get; set; }
+        public ArticleBodyResult AutoResult { get; set; } = ArticleBodyResult.Retrieved;
+        public string? AutoReason { get; set; }
+        public bool Success { get; set; } = true;
+
+        public IReadOnlyList<PendingOp> Ops
+        {
+            get
+            {
+                lock (_ops) return _ops.ToArray();
+            }
+        }
+
+        public int MaxEntries => Volatile.Read(ref _maxEntries);
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            var op = Enter(onConnectionReadyAgain);
+            try
+            {
+                MaybeComplete(op);
+                return Task.FromResult(CreateBody(segmentId));
+            }
+            finally
+            {
+                Exit();
+            }
+        }
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            var op = Enter(onConnectionReadyAgain);
+            try
+            {
+                MaybeComplete(op);
+                var responses = segmentIds
+                    .Select(id => Task.FromResult(CreateBody(id)))
+                    .ToArray();
+                return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
+            }
+            finally
+            {
+                Exit();
+            }
+        }
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            var op = Enter(onConnectionReadyAgain);
+            try
+            {
+                MaybeComplete(op);
+                return Task.FromResult(CreateArticle(segmentId));
+            }
+            finally
+            {
+                Exit();
+            }
+        }
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, exclusiveConnection.OnConnectionReadyAgain, cancellationToken);
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            DecodedBodiesAsync(segmentIds, exclusiveConnection.OnConnectionReadyAgain, cancellationToken);
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            UsenetExclusiveConnection exclusiveConnection,
+            CancellationToken cancellationToken) =>
+            DecodedArticleAsync(segmentId, exclusiveConnection.OnConnectionReadyAgain, cancellationToken);
+
+        private PendingOp Enter(ArticleBodyCompletionHandler? callback)
+        {
+            var current = Interlocked.Increment(ref _currentEntries);
+            int snapshot;
+            while (current > (snapshot = Volatile.Read(ref _maxEntries)))
+            {
+                if (Interlocked.CompareExchange(ref _maxEntries, current, snapshot) == snapshot)
+                    break;
+            }
+
+            var op = new PendingOp { Callback = callback };
+            lock (_ops) _ops.Add(op);
+            op.Entered.TrySetResult();
+            return op;
+        }
+
+        private void Exit() => Interlocked.Decrement(ref _currentEntries);
+
+        private void MaybeComplete(PendingOp op)
+        {
+            if (AutoComplete)
+                op.Callback?.Invoke(AutoResult, AutoReason);
+        }
+
+        private UsenetDecodedBodyResponse CreateBody(SegmentId segmentId)
+        {
+            var bytes = "body"u8.ToArray();
+            return new UsenetDecodedBodyResponse
+            {
+                SegmentId = segmentId.ToString(),
+                ResponseCode = Success
+                    ? (int)UsenetResponseType.ArticleRetrievedBodyFollows
+                    : (int)UsenetResponseType.NoArticleWithThatMessageId,
+                ResponseMessage = Success ? "222" : "430",
+                Stream = Success ? CreateStream(bytes) : null,
+            };
+        }
+
+        private static UsenetDecodedArticleResponse CreateArticle(SegmentId segmentId)
+        {
+            var bytes = "article"u8.ToArray();
+            return new UsenetDecodedArticleResponse
+            {
+                SegmentId = segmentId.ToString(),
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedHeadAndBodyFollow,
+                ResponseMessage = "220",
+                ArticleHeaders = new UsenetArticleHeader
+                {
+                    Headers = new Dictionary<string, string> { ["Subject"] = "test" },
+                },
+                Stream = CreateStream(bytes),
+            };
+        }
+
+        private static CachedYencStream CreateStream(byte[] bytes) =>
+            new(
+                new UsenetYencHeader
+                {
+                    FileName = "fake.bin",
+                    FileSize = bytes.Length,
+                    LineLength = 128,
+                    PartNumber = 1,
+                    TotalParts = 1,
+                    PartOffset = 0,
+                    PartSize = bytes.Length,
+                },
+                new MemoryStream(bytes, writable: false));
     }
 
     private abstract class MinimalNntpClient : NntpClient

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/RepairedSegmentNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/RepairedSegmentNntpClientTests.cs
@@ -1,5 +1,7 @@
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Services.Repair;
+using NzbWebDAV.Streams;
 using NzbWebDAV.Tests.Fakes;
 using UsenetSharp.Models;
 
@@ -82,5 +84,208 @@ public sealed class RepairedSegmentNntpClientTests
             if (Directory.Exists(dir))
                 Directory.Delete(dir, recursive: true);
         }
+    }
+
+    [Fact]
+    public async Task PatchedSegment_ThrowingCallbackStillReturnsPatch()
+    {
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-repair-patch-" + Guid.NewGuid().ToString("N"));
+        const string segmentId = "patched-throw@test";
+        byte[] content = "repaired-bytes"u8.ToArray();
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024);
+            await store.CatalogLoadTask;
+            store.CommitPatch(segmentId, content, HeaderFor(content));
+
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
+            using var client = new RepairedSegmentNntpClient(inner, store);
+
+            var recorder = new CompletionRecorder { ThrowOnInvoke = true };
+            var response = await client.DecodedBodyAsync(segmentId, recorder.Invoke, CancellationToken.None);
+            Assert.NotNull(response.Stream);
+            await using var output = new MemoryStream();
+            await response.Stream.CopyToAsync(output);
+
+            Assert.Equal(1, recorder.Count);
+            Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
+            Assert.Equal(0, inner.BodyRequestCount);
+            Assert.Equal(content, output.ToArray());
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PatchedSegment_ExclusiveThrowingCallbackStillReturnsPatch()
+    {
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-repair-patch-" + Guid.NewGuid().ToString("N"));
+        const string segmentId = "patched-exclusive@test";
+        byte[] content = "exclusive-repaired"u8.ToArray();
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024);
+            await store.CatalogLoadTask;
+            store.CommitPatch(segmentId, content, HeaderFor(content));
+
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
+            using var client = new RepairedSegmentNntpClient(inner, store);
+
+            var recorder = new CompletionRecorder { ThrowOnInvoke = true };
+            var exclusive = new UsenetExclusiveConnection(recorder.Invoke);
+            var response = await client.DecodedBodyAsync(segmentId, exclusive, CancellationToken.None);
+            Assert.NotNull(response.Stream);
+            await using var output = new MemoryStream();
+            await response.Stream.CopyToAsync(output);
+
+            Assert.Equal(1, recorder.Count);
+            Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
+            Assert.Equal(0, inner.BodyRequestCount);
+            Assert.Equal(content, output.ToArray());
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(ArticleBodyResult.Retrieved, null)]
+    [InlineData(ArticleBodyResult.Cancelled, null)]
+    [InlineData(ArticleBodyResult.NotFound, null)]
+    [InlineData(ArticleBodyResult.NotRetrieved, "SocketException")]
+    public async Task UnpatchedSegment_ForwardsTerminalStatusOnce(
+        ArticleBodyResult result, string? failureReason)
+    {
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-repair-patch-" + Guid.NewGuid().ToString("N"));
+        const string segmentId = "unpatched@test";
+        byte[] content = "provider-bytes"u8.ToArray();
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024);
+            await store.CatalogLoadTask;
+            var inner = new ScriptedStatusNntpClient(result, failureReason, content);
+            using var client = new RepairedSegmentNntpClient(inner, store);
+
+            var recorder = new CompletionRecorder();
+            var response = await client.DecodedBodyAsync(segmentId, recorder.Invoke, CancellationToken.None);
+            if (response.Stream != null)
+            {
+                await using (response.Stream)
+                    await response.Stream.CopyToAsync(Stream.Null);
+            }
+
+            Assert.Equal(1, recorder.Count);
+            Assert.Equal(result, recorder.Result);
+            Assert.Equal(failureReason, recorder.FailureReason);
+            Assert.Equal(1, inner.BodyRequestCount);
+            Assert.Equal(1, inner.CompletionCount);
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    private sealed class CompletionRecorder
+    {
+        public int Count;
+        public ArticleBodyResult? Result;
+        public string? FailureReason;
+        public bool ThrowOnInvoke;
+
+        public void Invoke(ArticleBodyResult result, string? failureReason)
+        {
+            Count++;
+            Result = result;
+            FailureReason = failureReason;
+            if (ThrowOnInvoke)
+                throw new InvalidOperationException("callback failure");
+        }
+    }
+
+    private sealed class ScriptedStatusNntpClient(
+        ArticleBodyResult result,
+        string? failureReason,
+        byte[] content) : NntpClient
+    {
+        public int BodyRequestCount { get; private set; }
+        public int CompletionCount { get; private set; }
+
+        public override Task ConnectAsync(string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, null, cancellationToken);
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            BodyRequestCount++;
+            var success = result == ArticleBodyResult.Retrieved;
+            var response = new UsenetDecodedBodyResponse
+            {
+                SegmentId = segmentId.ToString(),
+                ResponseCode = success
+                    ? (int)UsenetResponseType.ArticleRetrievedBodyFollows
+                    : (int)UsenetResponseType.NoArticleWithThatMessageId,
+                ResponseMessage = success ? "222" : "430",
+                Stream = success ? CreateStream(content) : null,
+            };
+            onConnectionReadyAgain?.Invoke(result, failureReason);
+            CompletionCount++;
+            return Task.FromResult(response);
+        }
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+
+        private static CachedYencStream CreateStream(byte[] bytes) =>
+            new(
+                HeaderFor(bytes),
+                new MemoryStream(bytes, writable: false));
     }
 }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/RepairedSegmentNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/RepairedSegmentNntpClientTests.cs
@@ -3,6 +3,7 @@ using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Services.Repair;
 using NzbWebDAV.Streams;
 using NzbWebDAV.Tests.Fakes;
+using NzbWebDAV.Tests.TestUtils;
 using UsenetSharp.Models;
 
 namespace NzbWebDAV.Tests.Clients.Usenet;
@@ -102,7 +103,7 @@ public sealed class RepairedSegmentNntpClientTests
             var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
             using var client = new RepairedSegmentNntpClient(inner, store);
 
-            var recorder = new CompletionRecorder { ThrowOnInvoke = true };
+            var recorder = new ArticleBodyCompletionRecorder(throwOnInvoke: true);
             var response = await client.DecodedBodyAsync(segmentId, recorder.Invoke, CancellationToken.None);
             Assert.NotNull(response.Stream);
             await using var output = new MemoryStream();
@@ -136,7 +137,7 @@ public sealed class RepairedSegmentNntpClientTests
             var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
             using var client = new RepairedSegmentNntpClient(inner, store);
 
-            var recorder = new CompletionRecorder { ThrowOnInvoke = true };
+            var recorder = new ArticleBodyCompletionRecorder(throwOnInvoke: true);
             var exclusive = new UsenetExclusiveConnection(recorder.Invoke);
             var response = await client.DecodedBodyAsync(segmentId, exclusive, CancellationToken.None);
             Assert.NotNull(response.Stream);
@@ -174,7 +175,7 @@ public sealed class RepairedSegmentNntpClientTests
             var inner = new ScriptedStatusNntpClient(result, failureReason, content);
             using var client = new RepairedSegmentNntpClient(inner, store);
 
-            var recorder = new CompletionRecorder();
+            var recorder = new ArticleBodyCompletionRecorder();
             var response = await client.DecodedBodyAsync(segmentId, recorder.Invoke, CancellationToken.None);
             if (response.Stream != null)
             {
@@ -192,23 +193,6 @@ public sealed class RepairedSegmentNntpClientTests
         {
             if (Directory.Exists(dir))
                 Directory.Delete(dir, recursive: true);
-        }
-    }
-
-    private sealed class CompletionRecorder
-    {
-        public int Count;
-        public ArticleBodyResult? Result;
-        public string? FailureReason;
-        public bool ThrowOnInvoke;
-
-        public void Invoke(ArticleBodyResult result, string? failureReason)
-        {
-            Count++;
-            Result = result;
-            FailureReason = failureReason;
-            if (ThrowOnInvoke)
-                throw new InvalidOperationException("callback failure");
         }
     }
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
@@ -2,6 +2,8 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Streams;
 using NzbWebDAV.Tests.Fakes;
 using UsenetSharp.Models;
 
@@ -119,6 +121,117 @@ public sealed class SegmentCacheNntpClientTests
         }
     }
 
+    [Fact]
+    public async Task DecodedBodyAsync_CacheHit_ThrowingCallbackReturnsCachedBody()
+    {
+        var cacheDir = Path.Join(
+            Path.GetTempPath(), "nzbdav-segment-cache-" + Guid.NewGuid().ToString("N"));
+        const string segmentId = "cached-hit";
+        byte[] content = "cached-hit-bytes"u8.ToArray();
+
+        try
+        {
+            WriteCacheEntry(cacheDir, segmentId, content);
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
+            using var client = new SegmentCacheNntpClient(inner, cacheDir, maxBytes: 1024 * 1024);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var recorder = new CompletionRecorder { ThrowOnInvoke = true };
+            var response = await client.DecodedBodyAsync(segmentId, recorder.Invoke, CancellationToken.None);
+            Assert.NotNull(response.Stream);
+            await using var output = new MemoryStream();
+            await response.Stream.CopyToAsync(output);
+
+            Assert.Equal(content, output.ToArray());
+            Assert.Equal(1, recorder.Count);
+            Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
+            Assert.Equal(0, inner.BodyRequestCount);
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+                Directory.Delete(cacheDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task DecodedBodyAsync_ExclusiveCacheHit_ThrowingCallbackReturnsCachedBody()
+    {
+        var cacheDir = Path.Join(
+            Path.GetTempPath(), "nzbdav-segment-cache-" + Guid.NewGuid().ToString("N"));
+        const string segmentId = "exclusive-hit";
+        byte[] content = "exclusive-hit-bytes"u8.ToArray();
+
+        try
+        {
+            WriteCacheEntry(cacheDir, segmentId, content);
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
+            using var client = new SegmentCacheNntpClient(inner, cacheDir, maxBytes: 1024 * 1024);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var recorder = new CompletionRecorder { ThrowOnInvoke = true };
+            var exclusive = new UsenetExclusiveConnection(recorder.Invoke);
+            var response = await client.DecodedBodyAsync(segmentId, exclusive, CancellationToken.None);
+            Assert.NotNull(response.Stream);
+            await using var output = new MemoryStream();
+            await response.Stream.CopyToAsync(output);
+
+            Assert.Equal(content, output.ToArray());
+            Assert.Equal(1, recorder.Count);
+            Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
+            Assert.Equal(0, inner.BodyRequestCount);
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+                Directory.Delete(cacheDir, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(ArticleBodyResult.Retrieved, null)]
+    [InlineData(ArticleBodyResult.Cancelled, null)]
+    [InlineData(ArticleBodyResult.NotFound, null)]
+    [InlineData(ArticleBodyResult.NotRetrieved, "SocketException")]
+    public async Task DecodedBodyAsync_CacheMiss_ForwardsTerminalStatusOnce(
+        ArticleBodyResult result, string? failureReason)
+    {
+        var cacheDir = Path.Join(
+            Path.GetTempPath(), "nzbdav-segment-cache-" + Guid.NewGuid().ToString("N"));
+        const string segmentId = "cache-miss";
+        byte[] content = "provider-bytes"u8.ToArray();
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            var inner = new ScriptedStatusNntpClient(result, failureReason, content);
+            using var client = new SegmentCacheNntpClient(inner, cacheDir, maxBytes: 1024 * 1024);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var recorder = new CompletionRecorder();
+            var response = await client.DecodedBodyAsync(segmentId, recorder.Invoke, CancellationToken.None);
+            if (response.Stream != null)
+                await ReadAndDisposeAsync(response.Stream);
+
+            Assert.Equal(1, recorder.Count);
+            Assert.Equal(result, recorder.Result);
+            Assert.Equal(failureReason, recorder.FailureReason);
+            Assert.Equal(1, inner.BodyRequestCount);
+            Assert.Equal(1, inner.CompletionCount);
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+                Directory.Delete(cacheDir, recursive: true);
+        }
+    }
+
+    private static async Task ReadAndDisposeAsync(Stream stream)
+    {
+        await using (stream)
+            await stream.CopyToAsync(Stream.Null);
+    }
+
     private static void WriteCacheEntry(string cacheDir, string segmentId, byte[] content)
     {
         var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(segmentId)));
@@ -139,5 +252,108 @@ public sealed class SegmentCacheNntpClientTests
         File.WriteAllText(
             Path.Join(directory, hash) + ".h",
             JsonSerializer.Serialize(header, new JsonSerializerOptions { IncludeFields = true }));
+    }
+
+    private sealed class CompletionRecorder
+    {
+        public int Count;
+        public ArticleBodyResult? Result;
+        public string? FailureReason;
+        public bool ThrowOnInvoke;
+
+        public void Invoke(ArticleBodyResult result, string? failureReason)
+        {
+            Count++;
+            Result = result;
+            FailureReason = failureReason;
+            if (ThrowOnInvoke)
+                throw new InvalidOperationException("callback failure");
+        }
+    }
+
+    private sealed class ScriptedStatusNntpClient(
+        ArticleBodyResult result,
+        string? failureReason,
+        byte[] content) : NntpClient
+    {
+        public int BodyRequestCount { get; private set; }
+        public int CompletionCount { get; private set; }
+
+        public override Task ConnectAsync(string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            DecodedBodyAsync(segmentId, null, cancellationToken);
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            BodyRequestCount++;
+            var success = result == ArticleBodyResult.Retrieved;
+            var response = new UsenetDecodedBodyResponse
+            {
+                SegmentId = segmentId.ToString(),
+                ResponseCode = success
+                    ? (int)UsenetResponseType.ArticleRetrievedBodyFollows
+                    : (int)UsenetResponseType.NoArticleWithThatMessageId,
+                ResponseMessage = success ? "222" : "430",
+                Stream = success ? CreateStream(content) : null,
+            };
+            onConnectionReadyAgain?.Invoke(result, failureReason);
+            CompletionCount++;
+            return Task.FromResult(response);
+        }
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+
+        private static CachedYencStream CreateStream(byte[] bytes) =>
+            new(
+                new UsenetYencHeader
+                {
+                    FileName = "fake.bin",
+                    FileSize = bytes.Length,
+                    LineLength = 128,
+                    PartNumber = 1,
+                    TotalParts = 1,
+                    PartOffset = 0,
+                    PartSize = bytes.Length,
+                },
+                new MemoryStream(bytes, writable: false));
     }
 }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
@@ -5,6 +5,7 @@ using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Streams;
 using NzbWebDAV.Tests.Fakes;
+using NzbWebDAV.Tests.TestUtils;
 using UsenetSharp.Models;
 
 namespace NzbWebDAV.Tests.Clients.Usenet;
@@ -136,7 +137,7 @@ public sealed class SegmentCacheNntpClientTests
             using var client = new SegmentCacheNntpClient(inner, cacheDir, maxBytes: 1024 * 1024);
             await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
 
-            var recorder = new CompletionRecorder { ThrowOnInvoke = true };
+            var recorder = new ArticleBodyCompletionRecorder(throwOnInvoke: true);
             var response = await client.DecodedBodyAsync(segmentId, recorder.Invoke, CancellationToken.None);
             Assert.NotNull(response.Stream);
             await using var output = new MemoryStream();
@@ -169,7 +170,7 @@ public sealed class SegmentCacheNntpClientTests
             using var client = new SegmentCacheNntpClient(inner, cacheDir, maxBytes: 1024 * 1024);
             await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
 
-            var recorder = new CompletionRecorder { ThrowOnInvoke = true };
+            var recorder = new ArticleBodyCompletionRecorder(throwOnInvoke: true);
             var exclusive = new UsenetExclusiveConnection(recorder.Invoke);
             var response = await client.DecodedBodyAsync(segmentId, exclusive, CancellationToken.None);
             Assert.NotNull(response.Stream);
@@ -208,7 +209,7 @@ public sealed class SegmentCacheNntpClientTests
             using var client = new SegmentCacheNntpClient(inner, cacheDir, maxBytes: 1024 * 1024);
             await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
 
-            var recorder = new CompletionRecorder();
+            var recorder = new ArticleBodyCompletionRecorder();
             var response = await client.DecodedBodyAsync(segmentId, recorder.Invoke, CancellationToken.None);
             if (response.Stream != null)
                 await ReadAndDisposeAsync(response.Stream);
@@ -252,23 +253,6 @@ public sealed class SegmentCacheNntpClientTests
         File.WriteAllText(
             Path.Join(directory, hash) + ".h",
             JsonSerializer.Serialize(header, new JsonSerializerOptions { IncludeFields = true }));
-    }
-
-    private sealed class CompletionRecorder
-    {
-        public int Count;
-        public ArticleBodyResult? Result;
-        public string? FailureReason;
-        public bool ThrowOnInvoke;
-
-        public void Invoke(ArticleBodyResult result, string? failureReason)
-        {
-            Count++;
-            Result = result;
-            FailureReason = failureReason;
-            if (ThrowOnInvoke)
-                throw new InvalidOperationException("callback failure");
-        }
     }
 
     private sealed class ScriptedStatusNntpClient(

--- a/tests/NzbWebDAV.Tests/TestUtils/ArticleBodyCompletionRecorder.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/ArticleBodyCompletionRecorder.cs
@@ -1,0 +1,22 @@
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.TestUtils;
+
+internal sealed class ArticleBodyCompletionRecorder(bool throwOnInvoke = false)
+{
+    private int _count;
+
+    public bool ThrowOnInvoke { get; set; } = throwOnInvoke;
+    public int Count => Volatile.Read(ref _count);
+    public ArticleBodyResult? Result { get; private set; }
+    public string? FailureReason { get; private set; }
+
+    public void Invoke(ArticleBodyResult result, string? failureReason)
+    {
+        Interlocked.Increment(ref _count);
+        Result = result;
+        FailureReason = failureReason;
+        if (ThrowOnInvoke)
+            throw new InvalidOperationException("callback failure");
+    }
+}


### PR DESCRIPTION
## Summary
- Contain non-fatal `ArticleBodyCompletionHandler` exceptions in one backend helper so a throwing observer cannot fault a successful cache hit, PAR2 patch hit, BODY/batch/ARTICLE transfer, or replace the original cancellation/miss/setup failure.
- Release each `DownloadingNntpClient` queue/streaming permit at most once (including exclusive-connection acquisition), even when a lower layer invokes completion twice.
- Addresses https://github.com/infinidysk/infinidysk/issues/1239 and the F10 callback item on https://github.com/infinidysk/infinidysk/issues/1128. This also hardens the adjacent callback defect noted while validating https://github.com/infinidysk/infinidysk/issues/1185; it does **not** implement #1185 queue-stage or provider-pool admission deadlines.

Fixes #1239

## Test plan
- [x] Focused xUnit filter for new/changed NNTP callback tests (`ArticleBodyCompletionTests`, `ArticleCachingNntpClientTests`, `SegmentCacheNntpClientTests`, `RepairedSegmentNntpClientTests`, `DownloadingNntpClientStatGateTests`, `DeferredArticleBodyCallbackTests`): 72 passed
- [ ] PR CI backend build/tests (`ci.yml`)
- [ ] Confirm CI logs do not show `PrioritizedSemaphore over-released` for these paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of article downloads when completion callbacks fail.
  * Callback errors are contained and logged without disrupting article retrieval.
  * Completion status is reported consistently and only once across cached, repaired, batch, and multi-provider downloads.
  * Queue and connection limits recover correctly after cancellations, failures, or duplicate completion events.

* **Tests**
  * Added comprehensive coverage for callback failures, cancellation, caching, download limits, status forwarding, and connection recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->