### PR TITLE
fix(ui): show a clear error and exit when the frontend port is already in use

### DIFF
--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -3,6 +3,10 @@ import express from "express";
 import http from "http";
 import { WebSocketServer } from "ws";
 import { shouldCompressResponse } from "./server/compression-filter.js";
+import {
+  attachHttpServerLifecycle,
+  attachWebsocketServerErrorListener,
+} from "./server/http-server-lifecycle.js";
 import { logger, requestLogger } from "./server/logger.js";
 import { securityHeadersMiddleware } from "./server/security-headers.js";
 import { websocketUpgradeGuard } from "./server/websocket-upgrade-guard.js";
@@ -138,6 +142,7 @@ const setServerModule = (serverModule: ServerBuildModule) => {
 };
 
 // Handle development vs production
+let closeDevelopmentServer: (() => Promise<void>) | null = null;
 if (DEVELOPMENT) {
   logger.info("Starting frontend development server");
   const viteDevServer = await import("vite").then((vite) =>
@@ -145,6 +150,7 @@ if (DEVELOPMENT) {
       server: { middlewareMode: true },
     }),
   );
+  closeDevelopmentServer = () => Promise.resolve(viteDevServer.close());
   // Vite's dev middlewares handle their own `base` prefix, so they stay on the
   // root app; only the SSR module goes on the URL_BASE-mounted router.
   app.use(viteDevServer.middlewares);
@@ -186,14 +192,69 @@ if (URL_BASE) {
 
 // Create both the http and websocket servers
 const server = http.createServer(app);
+let websocketServer: WebSocketServer | null = null;
+
+const disposeStartupResources = async () => {
+  const operations: Promise<unknown>[] = [];
+  const closingWebsocket = websocketServer;
+  if (closingWebsocket) {
+    operations.push(
+      new Promise<void>((resolve) => {
+        closingWebsocket.close(() => resolve());
+      }),
+    );
+  }
+  if (closeDevelopmentServer) operations.push(closeDevelopmentServer());
+  await Promise.allSettled(operations);
+};
+
+const httpLifecycle = attachHttpServerLifecycle(server, {
+  configuredPort: PORT,
+  logError: (message, detail) => {
+    if (detail) logger.error(message, detail);
+    else logger.error(message);
+  },
+  onListening: () => {
+    if (websocketServer == null) return;
+    setWebsocketServer(websocketServer);
+    logger.info(`Frontend server listening on http://localhost:${PORT}${URL_BASE}`);
+  },
+  disposeStartupResources: async () => {
+    await disposeStartupResources();
+    // Vite close leaves watcher handles in middleware mode, so drain alone
+    // cannot terminate. Exit after cleanup so supervisors see status 1.
+    process.exit(1);
+  },
+  markFatal: (exitCode, fatalPhase) => {
+    process.exitCode = exitCode;
+    if (fatalPhase === "runtime") {
+      process.exit(exitCode);
+    }
+  },
+});
+
 // Allow long-lived proxied API calls (Usenet speed tests can run for many
 // minutes on large data budgets). Node defaults are 5 minutes / 60s headers.
 const LONG_RUNNING_REQUEST_TIMEOUT_MS = 3 * 60 * 60 * 1000; // 3 hours
 server.requestTimeout = LONG_RUNNING_REQUEST_TIMEOUT_MS;
 server.headersTimeout = LONG_RUNNING_REQUEST_TIMEOUT_MS + 1000;
-setWebsocketServer(new WebSocketServer({ server, path: `${URL_BASE}/ws`, maxPayload: 64 * 1024 }));
 
-// Begin listening for connections
-server.listen(PORT, () => {
-  logger.info(`Frontend server listening on http://localhost:${PORT}${URL_BASE}`);
+websocketServer = new WebSocketServer({
+  server,
+  path: `${URL_BASE}/ws`,
+  maxPayload: 64 * 1024,
 });
+// Issue 1234 owns general browser WebSocketServer error handling. This listener
+// only suppresses HTTP errors already owned by attachHttpServerLifecycle; `ws`
+// forwards the same Error object on bind failure. Rebase 1234 onto this listener
+// rather than adding a second one.
+attachWebsocketServerErrorListener(websocketServer, {
+  isOwned: httpLifecycle.owns,
+  onUnexpectedError: (error) => {
+    logger.error("Unexpected frontend WebSocket server error", error);
+    process.exitCode = 1;
+    process.exit(1);
+  },
+});
+
+server.listen(PORT);

--- a/frontend/server/http-server-lifecycle.test.ts
+++ b/frontend/server/http-server-lifecycle.test.ts
@@ -14,7 +14,7 @@ import {
   formatStartupListenError,
   isHttpServerErrorOwned,
   markHttpServerErrorOwned,
-  type HttpServerLifecycleOptions,
+  type FatalPhase,
 } from "./http-server-lifecycle";
 
 const FRONTEND_ROOT = fileURLToPath(new URL("..", import.meta.url));
@@ -28,20 +28,21 @@ function systemError(
   return Object.assign(new Error(message), fields);
 }
 
-function lifecycleOptions(
-  overrides: Partial<HttpServerLifecycleOptions> = {},
-): HttpServerLifecycleOptions & {
-  logError: ReturnType<typeof vi.fn>;
-  onListening: ReturnType<typeof vi.fn>;
-  disposeStartupResources: ReturnType<typeof vi.fn>;
-  markFatal: ReturnType<typeof vi.fn>;
-} {
+type LifecycleTestOptions = {
+  configuredPort: number;
+  logError: ReturnType<typeof vi.fn<(message: string, detail?: Error) => void>>;
+  onListening: ReturnType<typeof vi.fn<() => void>>;
+  disposeStartupResources: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  markFatal: ReturnType<typeof vi.fn<(exitCode: number, phase: FatalPhase) => void>>;
+};
+
+function lifecycleOptions(overrides: Partial<LifecycleTestOptions> = {}): LifecycleTestOptions {
   return {
     configuredPort: 3000,
-    logError: vi.fn(),
-    onListening: vi.fn(),
-    disposeStartupResources: vi.fn(() => Promise.resolve()),
-    markFatal: vi.fn(),
+    logError: vi.fn<(message: string, detail?: Error) => void>(),
+    onListening: vi.fn<() => void>(),
+    disposeStartupResources: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    markFatal: vi.fn<(exitCode: number, phase: FatalPhase) => void>(),
     ...overrides,
   };
 }
@@ -140,7 +141,7 @@ describe("formatStartupListenError", () => {
     expect(message).toContain("Frontend server could not start");
     expect(message).toContain("EACCES");
     expect(message).toContain("0.0.0.0");
-    expect(message).toContain("80");
+    expect(message).toContain("port 80");
     expect(message).toContain(
       "Use an unprivileged PORT or grant the runtime permission to bind it",
     );
@@ -402,7 +403,7 @@ describe("attachWebsocketServerErrorListener", () => {
     expect(options.logError).toHaveBeenCalledOnce();
   });
 
-  it("exports identity mark helpers for issue 1234", () => {
+  it("marks and detects HTTP-owned errors by identity", () => {
     const error = new Error("owned-elsewhere");
     expect(isHttpServerErrorOwned(error)).toBe(false);
     markHttpServerErrorOwned(error);

--- a/frontend/server/http-server-lifecycle.test.ts
+++ b/frontend/server/http-server-lifecycle.test.ts
@@ -1,0 +1,496 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  attachHttpServerLifecycle,
+  attachWebsocketServerErrorListener,
+  formatStartupListenError,
+  isHttpServerErrorOwned,
+  markHttpServerErrorOwned,
+  type HttpServerLifecycleOptions,
+} from "./http-server-lifecycle";
+
+const FRONTEND_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const SECRET_MARKER = "DO_NOT_LOG_SECRET_MARKER";
+const DUMMY_API_KEY = "1246-dummy-frontend-backend-api-key";
+
+function systemError(
+  message: string,
+  fields: { code?: unknown; address?: unknown; port?: unknown; syscall?: unknown },
+): Error {
+  return Object.assign(new Error(message), fields);
+}
+
+function lifecycleOptions(
+  overrides: Partial<HttpServerLifecycleOptions> = {},
+): HttpServerLifecycleOptions & {
+  logError: ReturnType<typeof vi.fn>;
+  onListening: ReturnType<typeof vi.fn>;
+  disposeStartupResources: ReturnType<typeof vi.fn>;
+  markFatal: ReturnType<typeof vi.fn>;
+} {
+  return {
+    configuredPort: 3000,
+    logError: vi.fn(),
+    onListening: vi.fn(),
+    disposeStartupResources: vi.fn(() => Promise.resolve()),
+    markFatal: vi.fn(),
+    ...overrides,
+  };
+}
+
+function listen(server: http.Server | net.Server): Promise<AddressInfo> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("server has no address"));
+        return;
+      }
+      resolve(address);
+    });
+  });
+}
+
+function listenOnLoopback(server: http.Server | net.Server): Promise<AddressInfo> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("server has no address"));
+        return;
+      }
+      resolve(address);
+    });
+  });
+}
+
+function closeServer(server: http.Server | net.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+function waitForExit(
+  child: ChildProcess,
+  timeoutMs: number,
+  output: () => string,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(
+        new Error(
+          `frontend child did not exit within ${timeoutMs}ms\n--- child output ---\n${output()}`,
+        ),
+      );
+    }, timeoutMs);
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal });
+    });
+  });
+}
+
+describe("formatStartupListenError", () => {
+  it("formats EADDRINUSE with address, port, and a corrective action", () => {
+    const error = systemError(SECRET_MARKER, {
+      code: "EADDRINUSE",
+      address: "127.0.0.1",
+      port: 45678,
+      syscall: "listen",
+    });
+
+    const message = formatStartupListenError(error, 3000);
+
+    expect(message).toContain("Frontend server could not start");
+    expect(message).toContain("EADDRINUSE");
+    expect(message).toContain("127.0.0.1");
+    expect(message).toContain("45678");
+    expect(message).toContain("Stop the other listener or set PORT to an available port");
+    expect(message).not.toContain(SECRET_MARKER);
+    expect(message).not.toContain("\n");
+  });
+
+  it("formats EACCES without attempting a privileged bind", () => {
+    const error = systemError(SECRET_MARKER, {
+      code: "EACCES",
+      address: "0.0.0.0",
+      port: 80,
+      syscall: "listen",
+    });
+
+    const message = formatStartupListenError(error, 3000);
+
+    expect(message).toContain("Frontend server could not start");
+    expect(message).toContain("EACCES");
+    expect(message).toContain("0.0.0.0");
+    expect(message).toContain("80");
+    expect(message).toContain(
+      "Use an unprivileged PORT or grant the runtime permission to bind it",
+    );
+    expect(message).not.toContain(SECRET_MARKER);
+  });
+
+  it("formats unknown codes without interpolating the raw Error message", () => {
+    const error = systemError(SECRET_MARKER, {
+      code: "EFOO",
+      address: "127.0.0.1",
+      port: 3000,
+    });
+
+    const message = formatStartupListenError(error, 3000);
+
+    expect(message).toContain("code EFOO");
+    expect(message).toContain(
+      "Check the bind configuration and operating-system limits, then restart",
+    );
+    expect(message).not.toContain(SECRET_MARKER);
+  });
+
+  it("formats EADDRNOTAVAIL and descriptor-limit codes", () => {
+    expect(
+      formatStartupListenError(
+        systemError(SECRET_MARKER, { code: "EADDRNOTAVAIL", address: "192.0.2.1", port: 3000 }),
+        3000,
+      ),
+    ).toContain("the local address is unavailable");
+    expect(
+      formatStartupListenError(
+        systemError(SECRET_MARKER, { code: "EMFILE", address: "127.0.0.1", port: 3000 }),
+        3000,
+      ),
+    ).toContain("the file-descriptor limit was reached");
+    expect(
+      formatStartupListenError(
+        systemError(SECRET_MARKER, { code: "ENFILE", address: "127.0.0.1", port: 3000 }),
+        3000,
+      ),
+    ).toContain("the file-descriptor limit was reached");
+  });
+
+  it("falls back when metadata is absent, malformed, or injects control characters", () => {
+    const error = systemError(SECRET_MARKER, {
+      code: 123,
+      address: "127.0.0.1\ninjected",
+      port: 1.5,
+    });
+
+    const message = formatStartupListenError(error, 3000);
+
+    expect(message).toContain("address default interface");
+    expect(message).toContain("port 3000");
+    expect(message).toContain("code UNKNOWN");
+    expect(message).not.toContain("injected");
+    expect(message).not.toContain(SECRET_MARKER);
+    expect(message).not.toContain("\n");
+  });
+
+  it("rejects overlong tokens and out-of-range ports", () => {
+    const error = systemError(SECRET_MARKER, {
+      code: `EADDRINUSE${"x".repeat(200)}`,
+      address: "a".repeat(200),
+      port: 70000,
+    });
+
+    const message = formatStartupListenError(error, 4123);
+
+    expect(message).toContain("address default interface");
+    expect(message).toContain("port 4123");
+    expect(message).toContain("code UNKNOWN");
+    expect(message).not.toContain("EADDRINUSE");
+    expect(() => formatStartupListenError(error, 4123)).not.toThrow();
+  });
+
+  it("accepts the legal TCP port range and rejects negatives", () => {
+    expect(
+      formatStartupListenError(
+        systemError("x", { code: "EADDRINUSE", address: "127.0.0.1", port: 0 }),
+        3000,
+      ),
+    ).toContain("port 0");
+    expect(
+      formatStartupListenError(
+        systemError("x", { code: "EADDRINUSE", address: "127.0.0.1", port: 65535 }),
+        3000,
+      ),
+    ).toContain("port 65535");
+    expect(
+      formatStartupListenError(
+        systemError(SECRET_MARKER, { code: "EADDRINUSE", address: "127.0.0.1", port: -1 }),
+        3000,
+      ),
+    ).toContain("port 3000");
+  });
+});
+
+describe("attachHttpServerLifecycle", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers an error listener immediately and never touches process.exit", () => {
+    const server = http.createServer();
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as typeof process.exit);
+    const previousExitCode = process.exitCode;
+    const options = lifecycleOptions();
+
+    expect(server.listenerCount("error")).toBe(0);
+    const listeningBefore = server.listenerCount("listening");
+    attachHttpServerLifecycle(server, options);
+    expect(server.listenerCount("error")).toBe(1);
+    expect(server.listenerCount("listening")).toBe(listeningBefore + 1);
+
+    const error = systemError(SECRET_MARKER, {
+      code: "EADDRINUSE",
+      address: "127.0.0.1",
+      port: 3000,
+    });
+    server.emit("error", error);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(previousExitCode);
+  });
+
+  it("treats a pre-listening error as an exactly-once startup failure", async () => {
+    const server = http.createServer();
+    let resolveDispose: (() => void) | undefined;
+    const options = lifecycleOptions({
+      disposeStartupResources: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveDispose = resolve;
+          }),
+      ),
+    });
+    const lifecycle = attachHttpServerLifecycle(server, options);
+    const first = systemError(SECRET_MARKER, {
+      code: "EADDRINUSE",
+      address: "127.0.0.1",
+      port: 45678,
+    });
+    const second = systemError("another", { code: "EACCES", address: "127.0.0.1", port: 3000 });
+
+    server.emit("error", first);
+    expect(lifecycle.owns(first)).toBe(true);
+
+    server.emit("error", first);
+    server.emit("error", second);
+
+    expect(options.logError).toHaveBeenCalledOnce();
+    expect(options.logError.mock.calls[0]).toEqual([
+      expect.stringContaining("Frontend server could not start"),
+    ]);
+    expect(options.markFatal).toHaveBeenCalledOnce();
+    expect(options.markFatal).toHaveBeenCalledWith(1, "startup");
+    expect(options.disposeStartupResources).toHaveBeenCalledOnce();
+    expect(options.onListening).not.toHaveBeenCalled();
+    expect(lifecycle.owns(second)).toBe(true);
+
+    resolveDispose?.();
+    await lifecycle.failure();
+  });
+
+  it("invokes onListening exactly once and ignores a later startup callback", async () => {
+    const server = http.createServer();
+    const options = lifecycleOptions();
+    attachHttpServerLifecycle(server, options);
+
+    const address = await listenOnLoopback(server);
+    expect(address.port).toBeGreaterThan(0);
+    expect(options.onListening).toHaveBeenCalledOnce();
+    expect(options.markFatal).not.toHaveBeenCalled();
+    expect(options.disposeStartupResources).not.toHaveBeenCalled();
+    expect(options.logError).not.toHaveBeenCalled();
+
+    server.emit("listening");
+    expect(options.onListening).toHaveBeenCalledOnce();
+
+    await closeServer(server);
+  });
+
+  it("does not initialize after a late listening event that follows failure", () => {
+    const server = http.createServer();
+    const options = lifecycleOptions();
+    attachHttpServerLifecycle(server, options);
+
+    server.emit(
+      "error",
+      systemError(SECRET_MARKER, { code: "EADDRINUSE", address: "127.0.0.1", port: 3000 }),
+    );
+    server.emit("listening");
+
+    expect(options.onListening).not.toHaveBeenCalled();
+    expect(options.markFatal).toHaveBeenCalledWith(1, "startup");
+  });
+
+  it("describes a post-listening error as a runtime failure", async () => {
+    const server = http.createServer();
+    const options = lifecycleOptions();
+    const lifecycle = attachHttpServerLifecycle(server, options);
+    const error = systemError(SECRET_MARKER, {
+      code: "ECONNRESET",
+      address: "127.0.0.1",
+      port: 3000,
+    });
+
+    server.emit("listening");
+    server.emit("error", error);
+
+    expect(options.onListening).toHaveBeenCalledOnce();
+    expect(options.logError).toHaveBeenCalledOnce();
+    expect(options.logError).toHaveBeenCalledWith(
+      "Unexpected frontend HTTP server error after startup",
+      error,
+    );
+    expect(options.markFatal).toHaveBeenCalledWith(1, "runtime");
+    expect(options.disposeStartupResources).toHaveBeenCalledOnce();
+    expect(lifecycle.owns(error)).toBe(true);
+    await lifecycle.failure();
+  });
+});
+
+describe("attachWebsocketServerErrorListener", () => {
+  it("suppresses the exact HTTP-owned Error and forwards any other WSS error", () => {
+    const server = http.createServer();
+    const options = lifecycleOptions();
+    const lifecycle = attachHttpServerLifecycle(server, options);
+    const onUnexpectedError = vi.fn();
+    const websocketServer = new EventEmitter();
+    attachWebsocketServerErrorListener(websocketServer, {
+      isOwned: lifecycle.owns,
+      onUnexpectedError,
+    });
+
+    const forwarded = systemError(SECRET_MARKER, {
+      code: "EADDRINUSE",
+      address: "127.0.0.1",
+      port: 3000,
+    });
+    server.emit("error", forwarded);
+    websocketServer.emit("error", forwarded);
+
+    expect(options.logError).toHaveBeenCalledOnce();
+    expect(onUnexpectedError).not.toHaveBeenCalled();
+
+    const independent = systemError("wss-only", {
+      code: "EADDRINUSE",
+      address: "127.0.0.1",
+      port: 3000,
+    });
+    websocketServer.emit("error", independent);
+
+    expect(onUnexpectedError).toHaveBeenCalledOnce();
+    expect(onUnexpectedError).toHaveBeenCalledWith(independent);
+    expect(options.logError).toHaveBeenCalledOnce();
+  });
+
+  it("exports identity mark helpers for issue 1234", () => {
+    const error = new Error("owned-elsewhere");
+    expect(isHttpServerErrorOwned(error)).toBe(false);
+    markHttpServerErrorOwned(error);
+    expect(isHttpServerErrorOwned(error)).toBe(true);
+  });
+});
+
+describe("occupied ephemeral port child process", () => {
+  it("exits 1 with one controlled EADDRINUSE line and no backend connection", async () => {
+    const reservation = net.createServer();
+    const fakeBackend = net.createServer();
+    let child: ChildProcess | undefined;
+    let configPath: string | undefined;
+    let killedByHarness = false;
+    let stdout = "";
+    let stderr = "";
+    let backendConnections = 0;
+
+    const output = () => `${stdout}\n${stderr}`;
+
+    try {
+      const reserved = await listen(reservation);
+      fakeBackend.on("connection", () => {
+        backendConnections += 1;
+      });
+      const backendAddress = await listenOnLoopback(fakeBackend);
+      configPath = await mkdtemp(path.join(tmpdir(), "nzbdav-1246-"));
+
+      const childEnv: NodeJS.ProcessEnv = {
+        ...process.env,
+        NODE_ENV: "development",
+        PORT: String(reserved.port),
+        NO_COLOR: "1",
+        FRONTEND_BACKEND_API_KEY: DUMMY_API_KEY,
+        BACKEND_URL: `http://127.0.0.1:${backendAddress.port}`,
+        CONFIG_PATH: configPath,
+      };
+      delete childEnv["NODE_OPTIONS"];
+
+      child = spawn(process.execPath, ["--import", "tsx", "server.ts"], {
+        cwd: FRONTEND_ROOT,
+        env: childEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      child.stdout?.setEncoding("utf8");
+      child.stderr?.setEncoding("utf8");
+      child.stdout?.on("data", (chunk: string) => {
+        stdout += chunk;
+      });
+      child.stderr?.on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+
+      const result = await waitForExit(child, 45_000, output);
+
+      expect(killedByHarness).toBe(false);
+      expect(result.code).toBe(1);
+      expect(result.signal).toBeNull();
+
+      const combined = output();
+      expect(combined.match(/Frontend server could not start/g)).toHaveLength(1);
+      expect(combined).toContain("EADDRINUSE");
+      expect(combined).toContain(String(reserved.port));
+      expect(combined).toContain("address ");
+      expect(combined).toContain("Stop the other listener or set PORT to an available port");
+      expect(combined).not.toContain("Unhandled 'error' event");
+      expect(combined).not.toContain("at Server.setupListenHandle");
+      expect(combined).not.toContain(SECRET_MARKER);
+      expect(combined).not.toContain(DUMMY_API_KEY);
+      expect(combined).not.toContain("Frontend server listening");
+      expect(combined).not.toContain("Backend websocket connected");
+      expect(combined).not.toContain("Backend websocket reconnected");
+      expect(combined).not.toContain("Waiting for backend to start");
+      expect(combined).not.toContain("Could not connect to backend websocket");
+      expect(backendConnections).toBe(0);
+    } finally {
+      if (child && child.exitCode === null && child.signalCode === null) {
+        killedByHarness = true;
+        child.kill("SIGKILL");
+        await waitForExit(child, 5_000, output).catch(() => undefined);
+      }
+      child?.stdout?.destroy();
+      child?.stderr?.destroy();
+      await Promise.allSettled([closeServer(reservation), closeServer(fakeBackend)]);
+      if (configPath) {
+        await rm(configPath, { recursive: true, force: true });
+      }
+    }
+    expect(killedByHarness).toBe(false);
+  }, 60_000);
+});

--- a/frontend/server/http-server-lifecycle.ts
+++ b/frontend/server/http-server-lifecycle.ts
@@ -1,0 +1,160 @@
+import type { Server as HttpServer } from "node:http";
+
+type ListenSystemError = Error & {
+  code?: unknown;
+  address?: unknown;
+  port?: unknown;
+  syscall?: unknown;
+};
+
+type ListenErrorContext = Readonly<{
+  code: string;
+  address: string;
+  port: number;
+}>;
+
+export type FatalPhase = "startup" | "runtime";
+
+export type HttpServerLifecycleOptions = Readonly<{
+  configuredPort: number;
+  logError: (message: string, detail?: Error) => void;
+  onListening: () => void;
+  disposeStartupResources: () => Promise<void>;
+  markFatal: (exitCode: number, phase: FatalPhase) => void;
+}>;
+
+export type HttpServerLifecycle = Readonly<{
+  owns: (error: Error) => boolean;
+  failure: () => Promise<void> | null;
+}>;
+
+export type WebsocketServerErrorTarget = {
+  on(event: "error", listener: (error: Error) => void): unknown;
+};
+
+export type WebsocketServerErrorListenerOptions = Readonly<{
+  isOwned: (error: Error) => boolean;
+  onUnexpectedError: (error: Error) => void;
+}>;
+
+const ownedHttpServerErrors = new WeakSet<Error>();
+
+export function markHttpServerErrorOwned(error: Error): void {
+  ownedHttpServerErrors.add(error);
+}
+
+export function isHttpServerErrorOwned(error: Error): boolean {
+  return ownedHttpServerErrors.has(error);
+}
+
+function safeToken(value: unknown, fallback: string): string {
+  if (typeof value !== "string") return fallback;
+  if (value.length === 0 || value.length > 128 || /[\r\n\0]/.test(value)) return fallback;
+  return value;
+}
+
+function listenPort(value: unknown, configuredPort: number): number {
+  if (typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 65535) {
+    return value;
+  }
+  return configuredPort;
+}
+
+function listenErrorContext(error: Error, configuredPort: number): ListenErrorContext {
+  const systemError = error as ListenSystemError;
+  return {
+    code: safeToken(systemError.code, "UNKNOWN"),
+    address: safeToken(systemError.address, "default interface"),
+    port: listenPort(systemError.port, configuredPort),
+  };
+}
+
+export function formatStartupListenError(error: Error, configuredPort: number): string {
+  const { code, address, port } = listenErrorContext(error, configuredPort);
+  const endpoint = `address ${address}, port ${port}, code ${code}`;
+
+  switch (code) {
+    case "EADDRINUSE":
+      return (
+        `Frontend server could not start (${endpoint}): the address is already in use. ` +
+        "Stop the other listener or set PORT to an available port."
+      );
+    case "EACCES":
+      return (
+        `Frontend server could not start (${endpoint}): permission to bind was denied. ` +
+        "Use an unprivileged PORT or grant the runtime permission to bind it."
+      );
+    case "EADDRNOTAVAIL":
+      return (
+        `Frontend server could not start (${endpoint}): the local address is unavailable. ` +
+        "Correct the bind configuration and restart the frontend."
+      );
+    case "EMFILE":
+    case "ENFILE":
+      return (
+        `Frontend server could not start (${endpoint}): the file-descriptor limit was reached. ` +
+        "Close leaked descriptors or raise the limit before restarting."
+      );
+    default:
+      return (
+        `Frontend server could not start (${endpoint}). ` +
+        "Check the bind configuration and operating-system limits, then restart."
+      );
+  }
+}
+
+export function attachHttpServerLifecycle(
+  server: HttpServer,
+  options: HttpServerLifecycleOptions,
+): HttpServerLifecycle {
+  let phase: "starting" | "listening" | "failing" = "starting";
+  let failure: Promise<void> | null = null;
+
+  server.on("error", (error: Error) => {
+    if (error instanceof Error) {
+      markHttpServerErrorOwned(error);
+    }
+    if (phase === "failing") return;
+
+    const fatalPhase: FatalPhase = phase === "starting" ? "startup" : "runtime";
+    phase = "failing";
+
+    if (fatalPhase === "startup") {
+      options.logError(formatStartupListenError(error, options.configuredPort));
+    } else {
+      options.logError("Unexpected frontend HTTP server error after startup", error);
+    }
+
+    options.markFatal(1, fatalPhase);
+    if (failure === null) {
+      try {
+        failure = Promise.resolve(options.disposeStartupResources()).catch(() => {
+          return;
+        });
+      } catch {
+        failure = Promise.resolve();
+      }
+    }
+  });
+
+  server.once("listening", () => {
+    if (phase !== "starting") return;
+    phase = "listening";
+    options.onListening();
+  });
+
+  return {
+    owns: isHttpServerErrorOwned,
+    failure: () => failure,
+  };
+}
+
+export function attachWebsocketServerErrorListener(
+  websocketServer: WebsocketServerErrorTarget,
+  options: WebsocketServerErrorListenerOptions,
+): void {
+  websocketServer.on("error", (error: Error) => {
+    if (error instanceof Error && options.isOwned(error)) return;
+    options.onUnexpectedError(error);
+  });
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "include": [
     "server.ts",
+    "server/http-server-lifecycle.ts",
     "server/logger.ts",
     "server/proxy-path.ts",
     "server/compression-filter.ts",


### PR DESCRIPTION
## Summary
- When the frontend cannot bind its port (`EADDRINUSE`, `EACCES`, and similar listen errors), it now logs one actionable Error-level line with safe address/port/code context and exits with status 1.
- The HTTP server `error` listener is registered before the browser WebSocket server is created, and the same `Error` object forwarded by `ws` is suppressed by identity so the failure is reported once.
- Backend WebSocket/heartbeat work starts only after a successful bind. Development bind failures close the middleware-mode Vite server, then exit so supervisors still see a nonzero status.

## Test plan
- [x] `npx vitest run http-server-lifecycle` (formatter, lifecycle, WSS identity suppression, occupied-ephemeral-port child process)
- [ ] PR CI frontend lint/typecheck/build/Vitest
- [ ] Confirm a local `PORT` collision prints the new line and does not print `Frontend server listening`
- [ ] Confirm a free port still logs `Frontend server listening on http://localhost:${PORT}${URL_BASE}` and serves as before

Fixes #1246

Issues 1234 (browser WSS/accepted-socket listeners), 1244 (`FRONTEND_BACKEND_API_KEY` validation), and 1245 (process-wide rejection/exception policy) remain separate. This PR installs one WSS `error` listener that only suppresses HTTP-owned bind errors; 1234 should retain that listener rather than add a second one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved development-server startup and shutdown handling.
  - Added clearer, sanitized errors when the configured port cannot be used.
  - Prevented duplicate failure handling and ensured resources are cleaned up safely.
  - Improved handling of runtime HTTP and WebSocket errors, including controlled termination for unexpected failures.

- **Tests**
  - Added comprehensive coverage for startup failures, runtime errors, WebSocket behavior, event ordering, and occupied-port scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->