### PR TITLE
fix(health): recover PAR2 repair after transient patch catalog load failures

### DIFF
--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -12,6 +12,7 @@ using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Logging;
 using NzbWebDAV.Models;
 using NzbWebDAV.Models.Nzb;
 using NzbWebDAV.Par2Recovery;
@@ -35,11 +36,15 @@ public class Par2RepairService : BackgroundService
 {
     private const int MaxQueueLength = 50;
     private const int MaxAttempts = 3;
+    private static readonly TimeSpan CatalogWarningInterval = TimeSpan.FromMinutes(1);
+    private static readonly TimeSpan CatalogMaxRetryDelay = TimeSpan.FromMinutes(1);
 
     private readonly ConfigManager _configManager;
     private readonly UsenetStreamingClient _usenetClient;
     private readonly RepairPatchStore _patchStore;
     private readonly IDbContextFactory<DavDatabaseContext>? _dbContextFactory;
+    private readonly LogThrottle _catalogWarningThrottle = new();
+    private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
     private readonly Channel<RepairWorkItem> _queue;
     private readonly Channel<ZeroFillEvent> _zeroFillQueue;
     private readonly ConcurrentDictionary<Guid, byte> _queuedOrRunning = new();
@@ -66,11 +71,22 @@ public class Par2RepairService : BackgroundService
         UsenetStreamingClient usenetClient,
         RepairPatchStore patchStore,
         IDbContextFactory<DavDatabaseContext>? dbContextFactory = null)
+        : this(configManager, usenetClient, patchStore, dbContextFactory, static (delay, ct) => Task.Delay(delay, ct))
+    {
+    }
+
+    internal Par2RepairService(
+        ConfigManager configManager,
+        UsenetStreamingClient usenetClient,
+        RepairPatchStore patchStore,
+        IDbContextFactory<DavDatabaseContext>? dbContextFactory,
+        Func<TimeSpan, CancellationToken, Task> delayAsync)
     {
         _configManager = configManager;
         _usenetClient = usenetClient;
         _patchStore = patchStore;
         _dbContextFactory = dbContextFactory;
+        _delayAsync = delayAsync;
         // Wait mode makes non-blocking TryWrite report full queues as false so
         // callers can undo bookkeeping; DropWrite would return true and silently
         // discard the item, leaking _queuedOrRunning/_pendingZeroFillPaths entries.
@@ -90,6 +106,8 @@ public class Par2RepairService : BackgroundService
 
     private DavDatabaseContext CreateContext() =>
         _dbContextFactory?.CreateDbContext() ?? new DavDatabaseContext();
+
+    internal Action? OnWorkersStarting { get; set; }
 
     internal int PendingZeroFillCount => _pendingZeroFillPaths.Count;
 
@@ -228,7 +246,7 @@ public class Par2RepairService : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        await _patchStore.CatalogLoadTask.ConfigureAwait(false);
+        await WaitForPatchCatalogAsync(stoppingToken).ConfigureAwait(false);
         try
         {
             await ReconcileInterruptedJobsAsync(stoppingToken).ConfigureAwait(false);
@@ -247,9 +265,116 @@ public class Par2RepairService : BackgroundService
             e.LogWarningKnownOrStack("PAR2 interrupted-job reconciliation deferred");
         }
 
-        await Task.WhenAll(
+        await RunWorkersAsync(stoppingToken).ConfigureAwait(false);
+    }
+
+    internal Task RunWorkersAsync(CancellationToken stoppingToken)
+    {
+        OnWorkersStarting?.Invoke();
+        return Task.WhenAll(
             ProcessRepairQueueAsync(stoppingToken),
-            ProcessZeroFillQueueAsync(stoppingToken)).ConfigureAwait(false);
+            ProcessZeroFillQueueAsync(stoppingToken));
+    }
+
+    private async Task WaitForPatchCatalogAsync(CancellationToken stoppingToken)
+    {
+        var failures = 0;
+
+        while (true)
+        {
+            try
+            {
+                await _patchStore
+                    .EnsureCatalogLoadedAsync(stoppingToken)
+                    .ConfigureAwait(false);
+
+                if (failures > 0)
+                {
+                    _catalogWarningThrottle.Reset("par2-patch-catalog");
+                    Log.Information(
+                        "PAR2 patch catalog recovered after {FailureCount} failed load attempt(s).",
+                        failures);
+                }
+
+                return;
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception) when (IsKnownCatalogOperationalException(exception))
+            {
+                failures++;
+                var delay = exception.IsDatabaseCorruptionException()
+                    ? BackgroundServiceErrorHandler.CorruptionDelay
+                    : GetCatalogRetryDelay(failures);
+
+                LogKnownCatalogFailure(exception, failures, delay);
+                await _delayAsync(delay, stoppingToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static TimeSpan GetCatalogRetryDelay(int failureCount)
+    {
+        var shift = Math.Min(Math.Max(failureCount - 1, 0), 6);
+        var seconds = Math.Min(
+            CatalogMaxRetryDelay.TotalSeconds,
+            1 << shift);
+        return TimeSpan.FromSeconds(seconds);
+    }
+
+    private static bool IsFatalCatalogException(Exception exception)
+    {
+        return exception.TryGetCausingException<OutOfMemoryException>(out _)
+            || exception.TryGetCausingException<StackOverflowException>(out _)
+            || exception.TryGetCausingException<AccessViolationException>(out _);
+    }
+
+    private static bool IsKnownCatalogOperationalException(Exception exception)
+    {
+        if (IsFatalCatalogException(exception))
+            return false;
+
+        return exception.TryGetCausingException<IOException>(out _)
+            || exception.TryGetCausingException<UnauthorizedAccessException>(out _)
+            || exception.IsTransientDatabaseException()
+            || exception.IsKnownSqliteDiskException()
+            || exception.IsDatabaseCorruptionException();
+    }
+
+    private void LogKnownCatalogFailure(
+        Exception exception,
+        int failureCount,
+        TimeSpan retryDelay)
+    {
+        exception.TryGetKnownErrorMessage(out var reason);
+
+        if (!_catalogWarningThrottle.ShouldLog(
+                "par2-patch-catalog",
+                CatalogWarningInterval,
+                out var suppressed))
+            return;
+
+        if (suppressed > 0)
+        {
+            Log.Warning(
+                "PAR2 patch catalog load failed on attempt {Attempt}. " +
+                "Reason: {Reason} Retrying in {RetryDelay}. " +
+                "Suppressed {Suppressed} repeated warning(s).",
+                failureCount,
+                reason,
+                retryDelay,
+                suppressed);
+            return;
+        }
+
+        Log.Warning(
+            "PAR2 patch catalog load failed on attempt {Attempt}. " +
+            "Reason: {Reason} Retrying in {RetryDelay}.",
+            failureCount,
+            reason,
+            retryDelay);
     }
 
     private async Task ReconcileInterruptedJobsAsync(CancellationToken ct)

--- a/backend/Services/Repair/RepairPatchStore.cs
+++ b/backend/Services/Repair/RepairPatchStore.cs
@@ -286,7 +286,11 @@ public sealed class RepairPatchStore
 
             if (file.EndsWith(".tmp", StringComparison.Ordinal))
             {
-                SafeDelete(file);
+                // Only reap orphans. A temp file that is still being staged by a
+                // concurrent CommitPatches call must survive the scan.
+                var temp = new FileInfo(file);
+                if (!temp.Exists || DateTime.UtcNow - temp.LastWriteTimeUtc > TimeSpan.FromHours(1))
+                    SafeDelete(file);
                 continue;
             }
 

--- a/backend/Services/Repair/RepairPatchStore.cs
+++ b/backend/Services/Repair/RepairPatchStore.cs
@@ -17,7 +17,9 @@ public sealed class RepairPatchStore
     private readonly long _maxBytes;
     private readonly ConcurrentDictionary<string, CacheEntry> _index = new();
     private readonly object _evictLock = new();
-    private readonly Func<IEnumerable<string>> _enumerateCacheFiles;
+    private readonly object _catalogLoadSync = new();
+    private readonly Func<CancellationToken, IEnumerable<string>> _enumerateCacheFiles;
+    private Task? _catalogLoadInFlight;
     private long _currentBytes;
     private int _catalogReady;
     private long _hitCount;
@@ -33,19 +35,17 @@ public sealed class RepairPatchStore
     internal RepairPatchStore(
         string cacheDir,
         long maxBytes,
-        Func<IEnumerable<string>>? enumerateCacheFiles)
+        Func<CancellationToken, IEnumerable<string>>? enumerateCacheFiles)
     {
         _dir = cacheDir;
         _maxBytes = maxBytes;
         Directory.CreateDirectory(_dir);
         _enumerateCacheFiles = enumerateCacheFiles
-                               ?? (() => Directory.EnumerateFiles(_dir, "*", SearchOption.AllDirectories));
+            ?? (_ => Directory.EnumerateFiles(_dir, "*", SearchOption.AllDirectories));
         Log.Information("PAR2 repair patch store path: {Path}", _dir);
-        CatalogLoadTask = Task.Run(LoadIndex);
     }
 
     public bool IsCatalogReady => Volatile.Read(ref _catalogReady) != 0;
-    internal Task CatalogLoadTask { get; }
     internal long CurrentBytes => Interlocked.Read(ref _currentBytes);
     internal int EntryCount => _index.Count;
     internal long HitCount => Interlocked.Read(ref _hitCount);
@@ -213,54 +213,133 @@ public sealed class RepairPatchStore
         }
     }
 
-    private void LoadIndex()
+    internal Task EnsureCatalogLoadedAsync(CancellationToken ct)
     {
-        var stopwatch = Stopwatch.StartNew();
+        if (IsCatalogReady)
+            return Task.CompletedTask;
+
+        Task load;
+        lock (_catalogLoadSync)
+        {
+            if (IsCatalogReady)
+                return Task.CompletedTask;
+
+            if (_catalogLoadInFlight is { IsCompleted: false } inflight)
+            {
+                load = inflight;
+            }
+            else
+            {
+                load = LoadCatalogOnceAsync(ct);
+                _catalogLoadInFlight = load;
+            }
+        }
+
+        return AwaitCatalogLoadAsync(load, ct);
+    }
+
+    private async Task AwaitCatalogLoadAsync(Task load, CancellationToken ct)
+    {
         try
         {
-            foreach (var file in _enumerateCacheFiles())
-            {
-                if (file.EndsWith(".tmp", StringComparison.Ordinal))
-                {
-                    SafeDelete(file);
-                    continue;
-                }
-
-                if (file.EndsWith(".h", StringComparison.Ordinal)) continue;
-                var info = new FileInfo(file);
-                if (!info.Exists) continue;
-                var entry = new CacheEntry
-                {
-                    Size = info.Length,
-                    LastAccessTicks = info.LastWriteTimeUtc.Ticks,
-                };
-
-                lock (_evictLock)
-                {
-                    if (_index.TryAdd(Path.GetFileName(file), entry))
-                        _currentBytes += info.Length;
-                }
-            }
+            await load.WaitAsync(ct).ConfigureAwait(false);
         }
-        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        catch
         {
-            Log.Warning(e, "Repair patch store: failed to scan {Dir}; starting empty.", _dir);
+            lock (_catalogLoadSync)
+            {
+                if (ReferenceEquals(_catalogLoadInFlight, load) && load.IsCompleted)
+                    _catalogLoadInFlight = null;
+            }
+
+            throw;
         }
-        finally
+    }
+
+    private async Task LoadCatalogOnceAsync(CancellationToken ct)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var snapshot = await Task.Run(
+                () => BuildCatalogSnapshot(ct),
+                CancellationToken.None)
+            .ConfigureAwait(false);
+
+        ct.ThrowIfCancellationRequested();
+        PublishCatalog(snapshot);
+
+        stopwatch.Stop();
+        Log.Information(
+            "Repair patch store catalog loaded: {Count} entries, {Size} bytes in {Elapsed}ms.",
+            _index.Count,
+            Interlocked.Read(ref _currentBytes),
+            stopwatch.ElapsedMilliseconds);
+    }
+
+    private CatalogSnapshot BuildCatalogSnapshot(CancellationToken ct)
+    {
+        var entries = new Dictionary<string, CacheEntry>(StringComparer.Ordinal);
+        long bytes = 0;
+
+        foreach (var file in _enumerateCacheFiles(ct))
         {
-            try
+            ct.ThrowIfCancellationRequested();
+
+            if (file.EndsWith(".tmp", StringComparison.Ordinal))
             {
-                EvictIfNeeded();
+                SafeDelete(file);
+                continue;
             }
-            finally
+
+            if (file.EndsWith(".h", StringComparison.Ordinal))
+                continue;
+
+            var info = new FileInfo(file);
+            if (!info.Exists)
+                continue;
+
+            var entry = new CacheEntry
             {
-                Volatile.Write(ref _catalogReady, 1);
-                stopwatch.Stop();
-                Log.Information(
-                    "Repair patch store catalog loaded: {Count} entries, {Size} bytes in {Elapsed}ms.",
-                    _index.Count, Interlocked.Read(ref _currentBytes), stopwatch.ElapsedMilliseconds);
-            }
+                Size = info.Length,
+                LastAccessTicks = info.LastWriteTimeUtc.Ticks,
+            };
+
+            if (entries.TryAdd(Path.GetFileName(file), entry))
+                bytes = checked(bytes + info.Length);
         }
+
+        return new CatalogSnapshot(entries, bytes);
+    }
+
+    private void PublishCatalog(CatalogSnapshot snapshot)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(snapshot.Bytes);
+
+        lock (_evictLock)
+        {
+            foreach (var (hash, scannedEntry) in snapshot.Entries)
+            {
+                // A live entry finalized during scanning is newer and wins.
+                if (_index.TryAdd(hash, scannedEntry))
+                    _currentBytes = checked(_currentBytes + scannedEntry.Size);
+            }
+
+            EvictIfNeeded();
+
+            // Final release write: readers that observe ready also observe the index.
+            Volatile.Write(ref _catalogReady, 1);
+        }
+    }
+
+    private sealed class CatalogSnapshot
+    {
+        public CatalogSnapshot(IReadOnlyDictionary<string, CacheEntry> entries, long bytes)
+        {
+            Entries = entries;
+            Bytes = bytes;
+        }
+
+        public IReadOnlyDictionary<string, CacheEntry> Entries { get; }
+        public long Bytes { get; }
     }
 
     private string BlobPath(string hash) => Path.Join(_dir, hash[..2], hash);

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/RepairedSegmentNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/RepairedSegmentNntpClientTests.cs
@@ -28,7 +28,7 @@ public sealed class RepairedSegmentNntpClientTests
         try
         {
             var store = new RepairPatchStore(dir, 1024 * 1024);
-            await store.CatalogLoadTask;
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
             store.CommitPatch(segmentId, content, HeaderFor(content));
 
             var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
@@ -64,7 +64,7 @@ public sealed class RepairedSegmentNntpClientTests
         try
         {
             var store = new RepairPatchStore(dir, 1024 * 1024);
-            await store.CatalogLoadTask;
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
             var inner = new FakeNntpClient(new Dictionary<string, byte[]>
             {
                 [segmentId] = content,

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
@@ -84,7 +84,7 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
         _failureTracker = new StreamingFailureTracker();
         _healthCheckConnectionGate = new HealthCheckConnectionGate(_configManager);
         _patchStore = new RepairPatchStore(Path.Join(_configRoot, "patches"), 1024 * 1024);
-        await _patchStore.CatalogLoadTask;
+        await _patchStore.EnsureCatalogLoadedAsync(CancellationToken.None);
 
         var websocketManager = new WebsocketManager();
         _usenet = new UsenetStreamingClient(

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckWorkerAdmissionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckWorkerAdmissionTests.cs
@@ -83,7 +83,7 @@ public sealed class HealthCheckWorkerAdmissionTests
                 new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "true" },
             ]);
             var patchStore = new RepairPatchStore(patchDirectory, 1024 * 1024);
-            await patchStore.CatalogLoadTask;
+            await patchStore.EnsureCatalogLoadedAsync(CancellationToken.None);
             var time = new ControllableTimeProvider();
             var healthCheckConnectionGate = new HealthCheckConnectionGate(config);
             var service = new HealthCheckService(

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairIntegrationTests.cs
@@ -216,7 +216,7 @@ public sealed class Par2RepairIntegrationTests
         try
         {
             var store = new RepairPatchStore(dir, 1024 * 1024);
-            await store.CatalogLoadTask;
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
             store.CommitPatch(segmentId, result.ReconstructedSlices[corruptIndex], new UsenetYencHeader
             {
                 FileName = "corrupt-target.bin",
@@ -353,7 +353,7 @@ public sealed class Par2RepairIntegrationTests
         {
             var config = new ConfigManager();
             var store = new RepairPatchStore(dir, 1024 * 1024);
-            await store.CatalogLoadTask;
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
             var service = new Par2RepairService(config, null!, store);
 
             service.ReportZeroFill("/view/test.mkv", "seg1@test");
@@ -378,7 +378,7 @@ public sealed class Par2RepairIntegrationTests
                 new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "true" },
             ]);
             var store = new RepairPatchStore(dir, 1024 * 1024);
-            await store.CatalogLoadTask;
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
             var service = new Par2RepairService(config, null!, store);
 
             // Repeated zero-fills for the same path collapse to one pending event.
@@ -418,7 +418,7 @@ public sealed class Par2RepairIntegrationTests
                 new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "true" },
             ]);
             var store = new RepairPatchStore(patchDir, 1024 * 1024);
-            await store.CatalogLoadTask;
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
             var service = new Par2RepairService(config, null!, store);
 
             await service.StartAsync(CancellationToken.None);
@@ -483,7 +483,7 @@ public sealed class Par2RepairIntegrationTests
         try
         {
             var store = new RepairPatchStore(dir, 1024 * 1024);
-            await store.CatalogLoadTask;
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
 
             var segmentIds = new[] { "seg0@test", "seg1@test", "seg2@test" };
             var ranges = new[]
@@ -546,7 +546,7 @@ public sealed class Par2RepairIntegrationTests
         try
         {
             var store = new RepairPatchStore(dir, 1024 * 1024);
-            await store.CatalogLoadTask;
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
 
             Assert.False(store.Contains(segmentId));
             store.CommitPatch(segmentId, content, header);
@@ -563,7 +563,7 @@ public sealed class Par2RepairIntegrationTests
             Assert.Equal(content, ms.ToArray());
 
             var reloaded = new RepairPatchStore(dir, 1024 * 1024);
-            await reloaded.CatalogLoadTask;
+            await reloaded.EnsureCatalogLoadedAsync(CancellationToken.None);
             Assert.True(reloaded.Contains(segmentId));
         }
         finally

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceCatalogLoadTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceCatalogLoadTests.cs
@@ -602,14 +602,8 @@ public sealed class Par2RepairServiceCatalogLoadTests
             finally
             {
                 allowThrow.TrySetResult();
-                try
-                {
+                if (service.ExecuteTask is not { IsFaulted: true })
                     await StopAsync(service);
-                }
-                catch (Exception)
-                {
-                    // Faulted ExecuteAsync may surface again during stop.
-                }
             }
         }
         finally

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceCatalogLoadTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceCatalogLoadTests.cs
@@ -1,0 +1,930 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Repair;
+using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Tests.TestUtils;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace NzbWebDAV.Tests.Services.Repair;
+
+public sealed class Par2RepairServiceCatalogLoadTests
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
+    [Fact]
+    public async Task KnownFailureThenSuccess_StartsWorkersOnce()
+    {
+        var dir = NewTempDir("known-then-success");
+        var attempts = 0;
+        var workerStarts = 0;
+        var delays = new List<TimeSpan>();
+        var delayEntered = NewTcs();
+        var allowRetry = NewTcs();
+        var workersStarted = NewTcs();
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024, _ =>
+            {
+                if (Interlocked.Increment(ref attempts) == 1)
+                    throw new IOException("catalog temporarily unavailable");
+                return [];
+            });
+            var service = CreateService(store, Delay, () =>
+            {
+                Interlocked.Increment(ref workerStarts);
+                workersStarted.TrySetResult();
+            });
+
+            await service.StartAsync(CancellationToken.None);
+            try
+            {
+                await delayEntered.Task.WaitAsync(Timeout);
+                Assert.False(store.IsCatalogReady);
+                Assert.Equal(1, Volatile.Read(ref attempts));
+                Assert.Equal(0, Volatile.Read(ref workerStarts));
+
+                allowRetry.TrySetResult();
+                await workersStarted.Task.WaitAsync(Timeout);
+
+                Assert.True(store.IsCatalogReady);
+                Assert.Equal(2, Volatile.Read(ref attempts));
+                Assert.Equal(1, Volatile.Read(ref workerStarts));
+                Assert.Equal(TimeSpan.FromSeconds(1), Assert.Single(delays));
+            }
+            finally
+            {
+                allowRetry.TrySetResult();
+                await StopAsync(service);
+            }
+        }
+        finally
+        {
+            DeleteDir(dir);
+        }
+
+        Task Delay(TimeSpan delay, CancellationToken ct)
+        {
+            delays.Add(delay);
+            delayEntered.TrySetResult();
+            return allowRetry.Task.WaitAsync(ct);
+        }
+    }
+
+    [Fact]
+    public async Task RepeatedKnownFailures_UseExponentialBackoff_AndStartWorkersOnce()
+    {
+        var dir = NewTempDir("backoff");
+        var attempts = 0;
+        var workerStarts = 0;
+        var delays = new List<TimeSpan>();
+        var workersStarted = NewTcs();
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024, _ =>
+            {
+                if (Interlocked.Increment(ref attempts) <= 2)
+                    throw new IOException("catalog temporarily unavailable");
+                return [];
+            });
+            var service = CreateService(store, ImmediateDelay, () =>
+            {
+                Interlocked.Increment(ref workerStarts);
+                workersStarted.TrySetResult();
+            });
+
+            await service.StartAsync(CancellationToken.None);
+            try
+            {
+                await workersStarted.Task.WaitAsync(Timeout);
+                Assert.Equal(new[] { TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2) }, delays);
+                Assert.True(store.IsCatalogReady);
+                Assert.Equal(3, Volatile.Read(ref attempts));
+                Assert.Equal(1, Volatile.Read(ref workerStarts));
+            }
+            finally
+            {
+                await StopAsync(service);
+            }
+        }
+        finally
+        {
+            DeleteDir(dir);
+        }
+
+        Task ImmediateDelay(TimeSpan delay, CancellationToken ct)
+        {
+            delays.Add(delay);
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task UnauthorizedAccess_IsRetriedLikeKnownIo()
+    {
+        await AssertRetriedThenSucceeds(
+            "unauthorized",
+            () => new UnauthorizedAccessException("catalog access denied"));
+    }
+
+    [Fact]
+    public async Task SqliteBusy_IsRetriedLikeKnownIo()
+    {
+        await AssertRetriedThenSucceeds(
+            "sqlite-busy",
+            () => new SqliteException("SQLite Error 5: 'database is locked'.", 5));
+    }
+
+    [Fact]
+    public async Task SqliteCorruption_UsesCorruptionDelay()
+    {
+        var dir = NewTempDir("sqlite-corrupt");
+        var attempts = 0;
+        var workerStarts = 0;
+        var delays = new List<TimeSpan>();
+        var workersStarted = NewTcs();
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024, _ =>
+            {
+                if (Interlocked.Increment(ref attempts) == 1)
+                    throw new SqliteException("SQLite Error 11: 'database disk image is malformed'.", 11);
+                return [];
+            });
+            var service = CreateService(store, ImmediateDelay, () =>
+            {
+                Interlocked.Increment(ref workerStarts);
+                workersStarted.TrySetResult();
+            });
+
+            await service.StartAsync(CancellationToken.None);
+            try
+            {
+                await workersStarted.Task.WaitAsync(Timeout);
+                Assert.Equal(BackgroundServiceErrorHandler.CorruptionDelay, Assert.Single(delays));
+                Assert.Equal(1, Volatile.Read(ref workerStarts));
+            }
+            finally
+            {
+                await StopAsync(service);
+            }
+        }
+        finally
+        {
+            DeleteDir(dir);
+        }
+
+        Task ImmediateDelay(TimeSpan delay, CancellationToken ct)
+        {
+            delays.Add(delay);
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task UnexpectedFailure_DoesNotRetryOrStartWorkers()
+    {
+        var dir = NewTempDir("unexpected");
+        var failure = new InvalidOperationException("catalog iterator poisoned");
+        var attempts = 0;
+        var workerStarts = 0;
+        var delays = new List<TimeSpan>();
+        var scanEntered = NewTcs();
+        var allowThrow = NewTcs();
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024, ct =>
+            {
+                Interlocked.Increment(ref attempts);
+                scanEntered.TrySetResult();
+                allowThrow.Task.Wait(ct);
+                throw failure;
+            });
+            var service = CreateService(store, RecordDelay, () => Interlocked.Increment(ref workerStarts));
+            using var host = BuildHost(service);
+            var stopping = NewTcs();
+            host.Services.GetRequiredService<IHostApplicationLifetime>()
+                .ApplicationStopping.Register(() => stopping.TrySetResult());
+
+            var startTask = Task.Run(() => host.StartAsync(CancellationToken.None));
+            try
+            {
+                await scanEntered.Task.WaitAsync(Timeout);
+                await startTask.WaitAsync(Timeout);
+                allowThrow.TrySetResult();
+                await stopping.Task.WaitAsync(Timeout);
+
+                Assert.True(host.Services.GetRequiredService<IHostApplicationLifetime>()
+                    .ApplicationStopping.IsCancellationRequested);
+                Assert.True(service.ExecuteTask!.IsFaulted);
+                Assert.Same(failure, service.ExecuteTask.Exception!.GetBaseException());
+                Assert.Empty(delays);
+                Assert.Equal(0, Volatile.Read(ref workerStarts));
+                Assert.False(store.IsCatalogReady);
+            }
+            finally
+            {
+                allowThrow.TrySetResult();
+                await host.StopAsync(CancellationToken.None).WaitAsync(Timeout);
+            }
+        }
+        finally
+        {
+            allowThrow.TrySetResult();
+            DeleteDir(dir);
+        }
+
+        Task RecordDelay(TimeSpan delay, CancellationToken ct)
+        {
+            delays.Add(delay);
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task ShutdownDuringBlockedScan_DoesNotRetryOrStartWorkers()
+    {
+        var dir = NewTempDir("shutdown-scan");
+        var attempts = 0;
+        var workerStarts = 0;
+        var delays = new List<TimeSpan>();
+        var scanEntered = NewTcs();
+        using var releaseScan = new ManualResetEventSlim(false);
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024, ct =>
+            {
+                Interlocked.Increment(ref attempts);
+                scanEntered.TrySetResult();
+                releaseScan.Wait(ct);
+                return [];
+            });
+            var service = CreateService(store, RecordDelay, () => Interlocked.Increment(ref workerStarts));
+            using var host = BuildHost(service);
+
+            var startTask = Task.Run(() => host.StartAsync(CancellationToken.None));
+            try
+            {
+                await scanEntered.Task.WaitAsync(Timeout);
+                await startTask.WaitAsync(Timeout);
+                await host.StopAsync(CancellationToken.None).WaitAsync(Timeout);
+
+                Assert.Equal(1, Volatile.Read(ref attempts));
+                Assert.Empty(delays);
+                Assert.Equal(0, Volatile.Read(ref workerStarts));
+                Assert.False(store.IsCatalogReady);
+            }
+            finally
+            {
+                releaseScan.Set();
+            }
+        }
+        finally
+        {
+            releaseScan.Set();
+            DeleteDir(dir);
+        }
+
+        Task RecordDelay(TimeSpan delay, CancellationToken ct)
+        {
+            delays.Add(delay);
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task ShutdownDuringRetryDelay_DoesNotStartSecondScan()
+    {
+        var dir = NewTempDir("shutdown-delay");
+        var attempts = 0;
+        var workerStarts = 0;
+        var delays = new List<TimeSpan>();
+        var delayEntered = NewTcs();
+        var blockDelay = NewTcs();
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024, _ =>
+            {
+                Interlocked.Increment(ref attempts);
+                throw new IOException("catalog temporarily unavailable");
+            });
+            var service = CreateService(store, Delay, () => Interlocked.Increment(ref workerStarts));
+            using var host = BuildHost(service);
+
+            await host.StartAsync(CancellationToken.None).WaitAsync(Timeout);
+            try
+            {
+                await delayEntered.Task.WaitAsync(Timeout);
+                await host.StopAsync(CancellationToken.None).WaitAsync(Timeout);
+
+                Assert.Equal(1, Volatile.Read(ref attempts));
+                Assert.Equal(TimeSpan.FromSeconds(1), Assert.Single(delays));
+                Assert.Equal(0, Volatile.Read(ref workerStarts));
+                Assert.False(store.IsCatalogReady);
+            }
+            finally
+            {
+                blockDelay.TrySetCanceled();
+            }
+        }
+        finally
+        {
+            blockDelay.TrySetCanceled();
+            DeleteDir(dir);
+        }
+
+        Task Delay(TimeSpan delay, CancellationToken ct)
+        {
+            delays.Add(delay);
+            delayEntered.TrySetResult();
+            return blockDelay.Task.WaitAsync(ct);
+        }
+    }
+
+    [Fact]
+    public async Task NonShutdownCancellation_DoesNotRetryOrStartWorkers()
+    {
+        var dir = NewTempDir("non-shutdown-cancel");
+        var attempts = 0;
+        var workerStarts = 0;
+        var delays = new List<TimeSpan>();
+        var scanEntered = NewTcs();
+        var allowThrow = NewTcs();
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024, ct =>
+            {
+                Interlocked.Increment(ref attempts);
+                scanEntered.TrySetResult();
+                allowThrow.Task.Wait(ct);
+                throw new OperationCanceledException();
+            });
+            var service = CreateService(store, RecordDelay, () => Interlocked.Increment(ref workerStarts));
+            using var host = BuildHost(service);
+            var stopping = NewTcs();
+            host.Services.GetRequiredService<IHostApplicationLifetime>()
+                .ApplicationStopping.Register(() => stopping.TrySetResult());
+
+            var startTask = Task.Run(() => host.StartAsync(CancellationToken.None));
+            try
+            {
+                await scanEntered.Task.WaitAsync(Timeout);
+                await startTask.WaitAsync(Timeout);
+                allowThrow.TrySetResult();
+                await stopping.Task.WaitAsync(Timeout);
+
+                Assert.True(service.ExecuteTask!.IsCompleted);
+                Assert.False(service.ExecuteTask.IsCompletedSuccessfully);
+                Assert.Empty(delays);
+                Assert.Equal(0, Volatile.Read(ref workerStarts));
+                Assert.False(store.IsCatalogReady);
+            }
+            finally
+            {
+                allowThrow.TrySetResult();
+                await host.StopAsync(CancellationToken.None).WaitAsync(Timeout);
+            }
+        }
+        finally
+        {
+            allowThrow.TrySetResult();
+            DeleteDir(dir);
+        }
+
+        Task RecordDelay(TimeSpan delay, CancellationToken ct)
+        {
+            delays.Add(delay);
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task OutOfMemory_DoesNotRetryOrStartWorkers()
+    {
+        await AssertFatalDoesNotRetry(new OutOfMemoryException("scripted"));
+    }
+
+    [Fact]
+    public async Task NestedFatal_TakesPrecedenceOverKnownIo()
+    {
+        await AssertFatalDoesNotRetry(new AggregateException(
+            new OutOfMemoryException("scripted"),
+            new IOException("disk")));
+    }
+
+    [Fact]
+    public async Task HostStartAsync_ReturnsWhileCatalogScanBlocks()
+    {
+        var dir = NewTempDir("host-start");
+        var scanEntered = NewTcs();
+        using var releaseScan = new ManualResetEventSlim(false);
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024, ct =>
+            {
+                scanEntered.TrySetResult();
+                releaseScan.Wait(ct);
+                return [];
+            });
+            var service = CreateService(store, (_, _) => Task.CompletedTask);
+            using var host = BuildHost(service);
+
+            var startTask = Task.Run(() => host.StartAsync(CancellationToken.None));
+            try
+            {
+                await scanEntered.Task.WaitAsync(Timeout);
+                var startCompleted = await Task.WhenAny(startTask, Task.Delay(Timeout)) == startTask;
+                Assert.True(startCompleted, "Host startup must not wait for the patch catalog scan to finish.");
+            }
+            finally
+            {
+                releaseScan.Set();
+            }
+
+            await startTask.WaitAsync(Timeout);
+            await host.StopAsync(CancellationToken.None).WaitAsync(Timeout);
+        }
+        finally
+        {
+            releaseScan.Set();
+            DeleteDir(dir);
+        }
+    }
+
+    [Fact]
+    public async Task PersistentKnownFailures_StayInRetryUntilShutdown()
+    {
+        var dir = NewTempDir("persistent");
+        var attempts = 0;
+        var workerStarts = 0;
+        var delays = new List<TimeSpan>();
+        var delayCount = 0;
+        var fourthDelay = NewTcs();
+        var blockFourth = NewTcs();
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024, _ =>
+            {
+                Interlocked.Increment(ref attempts);
+                throw new IOException("catalog persistently unavailable");
+            });
+            var service = CreateService(store, Delay, () => Interlocked.Increment(ref workerStarts));
+
+            await service.StartAsync(CancellationToken.None);
+            try
+            {
+                await fourthDelay.Task.WaitAsync(Timeout);
+                Assert.False(store.IsCatalogReady);
+                Assert.Equal(4, Volatile.Read(ref attempts));
+                Assert.Equal(0, Volatile.Read(ref workerStarts));
+                Assert.Equal(4, delays.Count);
+
+                await StopAsync(service);
+
+                Assert.Equal(4, Volatile.Read(ref attempts));
+                Assert.Equal(0, Volatile.Read(ref workerStarts));
+                Assert.False(store.IsCatalogReady);
+            }
+            finally
+            {
+                blockFourth.TrySetCanceled();
+            }
+        }
+        finally
+        {
+            blockFourth.TrySetCanceled();
+            DeleteDir(dir);
+        }
+
+        Task Delay(TimeSpan delay, CancellationToken ct)
+        {
+            delays.Add(delay);
+            if (Interlocked.Increment(ref delayCount) < 4)
+                return Task.CompletedTask;
+            fourthDelay.TrySetResult();
+            return blockFourth.Task.WaitAsync(ct);
+        }
+    }
+
+    private static async Task AssertRetriedThenSucceeds(string prefix, Func<Exception> createFailure)
+    {
+        var dir = NewTempDir(prefix);
+        var attempts = 0;
+        var workerStarts = 0;
+        var delays = new List<TimeSpan>();
+        var workersStarted = NewTcs();
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024, _ =>
+            {
+                if (Interlocked.Increment(ref attempts) == 1)
+                    throw createFailure();
+                return [];
+            });
+            var service = CreateService(store, ImmediateDelay, () =>
+            {
+                Interlocked.Increment(ref workerStarts);
+                workersStarted.TrySetResult();
+            });
+
+            await service.StartAsync(CancellationToken.None);
+            try
+            {
+                await workersStarted.Task.WaitAsync(Timeout);
+                Assert.Equal(TimeSpan.FromSeconds(1), Assert.Single(delays));
+                Assert.True(store.IsCatalogReady);
+                Assert.Equal(1, Volatile.Read(ref workerStarts));
+            }
+            finally
+            {
+                await StopAsync(service);
+            }
+        }
+        finally
+        {
+            DeleteDir(dir);
+        }
+
+        Task ImmediateDelay(TimeSpan delay, CancellationToken ct)
+        {
+            delays.Add(delay);
+            return Task.CompletedTask;
+        }
+    }
+
+    private static async Task AssertFatalDoesNotRetry(Exception failure)
+    {
+        var dir = NewTempDir("fatal");
+        var workerStarts = 0;
+        var delays = new List<TimeSpan>();
+        var scanEntered = NewTcs();
+        var allowThrow = NewTcs();
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024, ct =>
+            {
+                scanEntered.TrySetResult();
+                allowThrow.Task.Wait(ct);
+                throw failure;
+            });
+            var service = CreateService(store, RecordDelay, () => Interlocked.Increment(ref workerStarts));
+
+            await service.StartAsync(CancellationToken.None);
+            try
+            {
+                await scanEntered.Task.WaitAsync(Timeout);
+                allowThrow.TrySetResult();
+                await Assert.ThrowsAnyAsync<Exception>(() => service.ExecuteTask!.WaitAsync(Timeout));
+
+                Assert.True(service.ExecuteTask!.IsFaulted);
+                Assert.Empty(delays);
+                Assert.Equal(0, Volatile.Read(ref workerStarts));
+                Assert.False(store.IsCatalogReady);
+            }
+            finally
+            {
+                allowThrow.TrySetResult();
+                try
+                {
+                    await StopAsync(service);
+                }
+                catch (Exception)
+                {
+                    // Faulted ExecuteAsync may surface again during stop.
+                }
+            }
+        }
+        finally
+        {
+            allowThrow.TrySetResult();
+            DeleteDir(dir);
+        }
+
+        Task RecordDelay(TimeSpan delay, CancellationToken ct)
+        {
+            delays.Add(delay);
+            return Task.CompletedTask;
+        }
+    }
+
+    private static Par2RepairService CreateService(
+        RepairPatchStore store,
+        Func<TimeSpan, CancellationToken, Task> delay,
+        Action? onWorkers = null,
+        IDbContextFactory<DavDatabaseContext>? dbFactory = null,
+        ConfigManager? config = null)
+    {
+        var service = new Par2RepairService(
+            config ?? new ConfigManager(),
+            null!,
+            store,
+            dbFactory ?? new ThrowingDbContextFactory(),
+            delay);
+        if (onWorkers != null)
+            service.OnWorkersStarting = onWorkers;
+        return service;
+    }
+
+    private static IHost BuildHost(Par2RepairService service) =>
+        new HostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton(service);
+                services.AddHostedService(_ => service);
+            })
+            .Build();
+
+    private static async Task StopAsync(Par2RepairService service)
+    {
+        using var cts = new CancellationTokenSource(Timeout);
+        await service.StopAsync(cts.Token);
+    }
+
+    private static TaskCompletionSource NewTcs() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private static string NewTempDir(string prefix) =>
+        Path.Join(Path.GetTempPath(), $"nzbdav-par2-catalog-{prefix}-" + Guid.NewGuid().ToString("N"));
+
+    private static void DeleteDir(string dir)
+    {
+        if (Directory.Exists(dir))
+            Directory.Delete(dir, recursive: true);
+    }
+
+    private sealed class ThrowingDbContextFactory : IDbContextFactory<DavDatabaseContext>
+    {
+        public DavDatabaseContext CreateDbContext() =>
+            throw new InvalidOperationException("catalog-load tests do not open SQLite.");
+    }
+}
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class Par2RepairServiceCatalogRetentionTests
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public async Task ZeroFillReports_StayDeduplicatedWhileCatalogRetryBlocksWorkers()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), $"nzbdav-catalog-zf-{Guid.NewGuid():N}");
+        var patchDir = Path.Join(tempDir, "patches");
+        Directory.CreateDirectory(tempDir);
+        var prevConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        var attempts = 0;
+        var workerStarts = 0;
+        var delayEntered = NewTcs();
+        var allowRetry = NewTcs();
+        var workersStarted = NewTcs();
+
+        try
+        {
+            Environment.SetEnvironmentVariable("CONFIG_PATH", tempDir);
+            DavDatabaseContext.ResetOptionsForTests();
+            await using (var ctx = new DavDatabaseContext())
+                await ctx.Database.EnsureCreatedAsync();
+
+            var config = new ConfigManager();
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "true" },
+            ]);
+            var store = new RepairPatchStore(patchDir, 1024 * 1024, _ =>
+            {
+                if (Interlocked.Increment(ref attempts) == 1)
+                    throw new IOException("catalog temporarily unavailable");
+                return Directory.EnumerateFiles(patchDir, "*", SearchOption.AllDirectories);
+            });
+            var service = new Par2RepairService(config, null!, store, dbContextFactory: null, Delay);
+            service.OnWorkersStarting = () =>
+            {
+                Interlocked.Increment(ref workerStarts);
+                workersStarted.TrySetResult();
+            };
+
+            await service.StartAsync(CancellationToken.None);
+            try
+            {
+                await delayEntered.Task.WaitAsync(Timeout);
+                for (var i = 0; i < 1_000; i++)
+                    service.ReportZeroFill("/view/same.mkv", $"seg{i}@test");
+
+                Assert.Equal(1, service.PendingZeroFillCount);
+                Assert.Equal(0, Volatile.Read(ref workerStarts));
+
+                allowRetry.TrySetResult();
+                await workersStarted.Task.WaitAsync(Timeout);
+
+                var deadline = DateTime.UtcNow + Timeout;
+                while (service.PendingZeroFillCount > 0 && DateTime.UtcNow < deadline)
+                    await Task.Delay(25);
+
+                Assert.Equal(0, service.PendingZeroFillCount);
+                Assert.Equal(1, Volatile.Read(ref workerStarts));
+            }
+            finally
+            {
+                allowRetry.TrySetResult();
+                using var stopCts = new CancellationTokenSource(Timeout);
+                await service.StopAsync(stopCts.Token);
+            }
+        }
+        finally
+        {
+            allowRetry.TrySetResult();
+            Environment.SetEnvironmentVariable("CONFIG_PATH", prevConfigPath);
+            DavDatabaseContext.ResetOptionsForTests();
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+
+        Task Delay(TimeSpan delay, CancellationToken ct)
+        {
+            delayEntered.TrySetResult();
+            return allowRetry.Task.WaitAsync(ct);
+        }
+    }
+
+    private static TaskCompletionSource NewTcs() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+}
+
+[Collection(nameof(GlobalLoggerCollection))]
+public sealed class Par2RepairServiceCatalogLoadLoggingTests
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
+    [Fact]
+    public async Task KnownWarning_IsSingleLineAndThrottled_ThenRecoveryLogsInformation()
+    {
+        var dir = NewTempDir("log-throttle");
+        var attempts = 0;
+        var workersStarted = NewTcs();
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024, _ =>
+            {
+                if (Interlocked.Increment(ref attempts) <= 3)
+                    throw new IOException("catalog temporarily unavailable");
+                return [];
+            });
+            var service = new Par2RepairService(
+                new ConfigManager(),
+                null!,
+                store,
+                new ThrowingDbContextFactory(),
+                (_, _) => Task.CompletedTask);
+            service.OnWorkersStarting = () => workersStarted.TrySetResult();
+
+            await service.StartAsync(CancellationToken.None);
+            try
+            {
+                await workersStarted.Task.WaitAsync(Timeout);
+
+                var warning = Assert.Single(sink.Events, IsCatalogWarning);
+                Assert.Null(warning.Exception);
+                var rendered = warning.RenderMessage();
+                Assert.Contains("catalog temporarily unavailable", rendered, StringComparison.Ordinal);
+                Assert.Contains("attempt 1", rendered, StringComparison.OrdinalIgnoreCase);
+                Assert.DoesNotContain("   at ", rendered, StringComparison.Ordinal);
+
+                var recovered = Assert.Single(
+                    sink.Events,
+                    e => e.Level == LogEventLevel.Information
+                        && e.RenderMessage().Contains("PAR2 patch catalog recovered", StringComparison.Ordinal));
+                Assert.Contains("3 failed load attempt", recovered.RenderMessage(), StringComparison.Ordinal);
+            }
+            finally
+            {
+                using var cts = new CancellationTokenSource(Timeout);
+                await service.StopAsync(cts.Token);
+            }
+        }
+        finally
+        {
+            Log.Logger = previous;
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ShutdownCancellation_DoesNotLogCatalogFailure()
+    {
+        var dir = NewTempDir("log-shutdown");
+        var scanEntered = NewTcs();
+        using var releaseScan = new ManualResetEventSlim(false);
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024, ct =>
+            {
+                scanEntered.TrySetResult();
+                releaseScan.Wait(ct);
+                return [];
+            });
+            var service = new Par2RepairService(
+                new ConfigManager(),
+                null!,
+                store,
+                new ThrowingDbContextFactory(),
+                (_, _) => Task.CompletedTask);
+            using var host = new HostBuilder()
+                .ConfigureServices(services =>
+                {
+                    services.AddSingleton(service);
+                    services.AddHostedService(_ => service);
+                })
+                .Build();
+
+            var startTask = Task.Run(() => host.StartAsync(CancellationToken.None));
+            try
+            {
+                await scanEntered.Task.WaitAsync(Timeout);
+                await startTask.WaitAsync(Timeout);
+                await host.StopAsync(CancellationToken.None).WaitAsync(Timeout);
+
+                Assert.DoesNotContain(sink.Events, e =>
+                    e.Level >= LogEventLevel.Warning && IsCatalogMessage(e));
+            }
+            finally
+            {
+                releaseScan.Set();
+            }
+        }
+        finally
+        {
+            releaseScan.Set();
+            Log.Logger = previous;
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    private static bool IsCatalogWarning(LogEvent logEvent) =>
+        logEvent.Level == LogEventLevel.Warning && IsCatalogMessage(logEvent);
+
+    private static bool IsCatalogMessage(LogEvent logEvent) =>
+        logEvent.RenderMessage().Contains("PAR2 patch catalog", StringComparison.Ordinal);
+
+    private static TaskCompletionSource NewTcs() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private static string NewTempDir(string prefix) =>
+        Path.Join(Path.GetTempPath(), $"nzbdav-par2-catalog-{prefix}-" + Guid.NewGuid().ToString("N"));
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events) return _events.ToList();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events) _events.Add(logEvent);
+        }
+    }
+
+    private sealed class ThrowingDbContextFactory : IDbContextFactory<DavDatabaseContext>
+    {
+        public DavDatabaseContext CreateDbContext() =>
+            throw new InvalidOperationException("catalog-load tests do not open SQLite.");
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceCorruptSourceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceCorruptSourceTests.cs
@@ -53,7 +53,7 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
     {
         var patchDir = Path.Join(_configRoot, "reconcile-patches");
         var store = new RepairPatchStore(patchDir, 1024 * 1024);
-        await store.CatalogLoadTask;
+        await store.EnsureCatalogLoadedAsync(CancellationToken.None);
         var service = new Par2RepairService(_config, null!, store);
         var runningId = Guid.NewGuid();
         var queuedId = Guid.NewGuid();
@@ -582,7 +582,7 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
 
         var patchDir = Path.Join(_configRoot, "patches", token);
         var store = new RepairPatchStore(patchDir, 32 * 1024 * 1024);
-        await store.CatalogLoadTask;
+        await store.EnsureCatalogLoadedAsync(CancellationToken.None);
         var usenet = new UsenetStreamingClient(fake, store);
         var service = new Par2RepairService(_config, usenet, store);
         return new SeededRelease(item, contentIds, fake, store, service, usenet);

--- a/tests/NzbWebDAV.Tests/Services/Repair/RepairPatchStoreTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/RepairPatchStoreTests.cs
@@ -135,9 +135,15 @@ public sealed class RepairPatchStoreTests
     {
         var dir = NewTempDir("catalog-cancel");
         var scanEntered = NewTcs();
+        var scanExited = NewTcs();
         using var releaseScan = new ManualResetEventSlim(false);
         Func<CancellationToken, IEnumerable<string>> enumerate = ct =>
-            YieldOneThenWait(WriteBlob(dir, "cancel-retry@test", "blob-bytes"u8.ToArray()), scanEntered, releaseScan, ct);
+            YieldOneThenWait(
+                WriteBlob(dir, "cancel-retry@test", "blob-bytes"u8.ToArray()),
+                scanEntered,
+                releaseScan,
+                scanExited,
+                ct);
 
         try
         {
@@ -148,6 +154,7 @@ public sealed class RepairPatchStoreTests
             cts.Cancel();
 
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => load);
+            await scanExited.Task.WaitAsync(Timeout);
             AssertUnpublished(store);
 
             enumerate = ct => Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories);
@@ -320,6 +327,53 @@ public sealed class RepairPatchStoreTests
         }
     }
 
+    [Fact]
+    public async Task CatalogScan_PreservesLiveTempFile()
+    {
+        var dir = NewTempDir("live-tmp");
+        try
+        {
+            var liveTmp = Path.Join(dir, "live.tmp");
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(liveTmp, "staging");
+            var store = new RepairPatchStore(dir, 1024 * 1024, _ => [liveTmp]);
+
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
+
+            Assert.True(File.Exists(liveTmp));
+            Assert.True(store.IsCatalogReady);
+            Assert.Equal(0, store.EntryCount);
+        }
+        finally
+        {
+            DeleteDir(dir);
+        }
+    }
+
+    [Fact]
+    public async Task CatalogScan_DeletesStaleTempFile()
+    {
+        var dir = NewTempDir("stale-tmp");
+        try
+        {
+            var staleTmp = Path.Join(dir, "stale.tmp");
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(staleTmp, "orphan");
+            File.SetLastWriteTimeUtc(staleTmp, DateTime.UtcNow - TimeSpan.FromHours(2));
+            var store = new RepairPatchStore(dir, 1024 * 1024, _ => [staleTmp]);
+
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
+
+            Assert.False(File.Exists(staleTmp));
+            Assert.True(store.IsCatalogReady);
+            Assert.Equal(0, store.EntryCount);
+        }
+        finally
+        {
+            DeleteDir(dir);
+        }
+    }
+
     private static void AssertUnpublished(RepairPatchStore store)
     {
         Assert.False(store.IsCatalogReady);
@@ -362,12 +416,20 @@ public sealed class RepairPatchStoreTests
         string file,
         TaskCompletionSource scanEntered,
         ManualResetEventSlim releaseScan,
+        TaskCompletionSource scanExited,
         CancellationToken ct)
     {
-        ct.ThrowIfCancellationRequested();
-        yield return file;
-        scanEntered.TrySetResult();
-        releaseScan.Wait(ct);
+        try
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return file;
+            scanEntered.TrySetResult();
+            releaseScan.Wait(ct);
+        }
+        finally
+        {
+            scanExited.TrySetResult();
+        }
     }
 
     private static IEnumerable<string> YieldThenWait(

--- a/tests/NzbWebDAV.Tests/Services/Repair/RepairPatchStoreTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/RepairPatchStoreTests.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using NzbWebDAV.Services.Repair;
 using UsenetSharp.Models;
 
@@ -5,6 +7,8 @@ namespace NzbWebDAV.Tests.Services.Repair;
 
 public sealed class RepairPatchStoreTests
 {
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
     private static UsenetYencHeader Header(int size) => new()
     {
         FileName = "test.bin",
@@ -26,7 +30,7 @@ public sealed class RepairPatchStoreTests
         try
         {
             var store = new RepairPatchStore(dir, 1024 * 1024);
-            await store.CatalogLoadTask;
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
 
             store.CommitPatch(segmentId, content, Header(content.Length));
 
@@ -46,7 +50,7 @@ public sealed class RepairPatchStoreTests
             }
 
             var reloaded = new RepairPatchStore(dir, 1024 * 1024);
-            await reloaded.CatalogLoadTask;
+            await reloaded.EnsureCatalogLoadedAsync(CancellationToken.None);
             Assert.True(reloaded.IsRepaired(segmentId, replacement.Length));
         }
         finally
@@ -64,7 +68,7 @@ public sealed class RepairPatchStoreTests
         {
             var maxBytes = 50;
             var store = new RepairPatchStore(dir, maxBytes);
-            await store.CatalogLoadTask;
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
 
             store.CommitPatch("a@test", new byte[30], Header(30));
             store.CommitPatch("b@test", new byte[30], Header(30));
@@ -77,5 +81,313 @@ public sealed class RepairPatchStoreTests
             if (Directory.Exists(dir))
                 Directory.Delete(dir, recursive: true);
         }
+    }
+
+    [Fact]
+    public async Task PartialKnownFailure_PublishesNothing()
+    {
+        var dir = NewTempDir("catalog-io");
+        try
+        {
+            var blob = WriteBlob(dir, "partial-io@test", "blob-bytes"u8.ToArray());
+            var store = new RepairPatchStore(
+                dir,
+                1024 * 1024,
+                ct => YieldOneThenThrow(blob, new IOException("catalog scan failed"), ct));
+
+            await Assert.ThrowsAsync<IOException>(
+                () => store.EnsureCatalogLoadedAsync(CancellationToken.None));
+
+            AssertUnpublished(store);
+        }
+        finally
+        {
+            DeleteDir(dir);
+        }
+    }
+
+    [Fact]
+    public async Task PartialUnexpectedFailure_PublishesNothing()
+    {
+        var dir = NewTempDir("catalog-unexpected");
+        try
+        {
+            var blob = WriteBlob(dir, "partial-unexpected@test", "blob-bytes"u8.ToArray());
+            var failure = new InvalidOperationException("catalog iterator poisoned");
+            var store = new RepairPatchStore(
+                dir,
+                1024 * 1024,
+                ct => YieldOneThenThrow(blob, failure, ct));
+
+            var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => store.EnsureCatalogLoadedAsync(CancellationToken.None));
+            Assert.Same(failure, thrown);
+            AssertUnpublished(store);
+        }
+        finally
+        {
+            DeleteDir(dir);
+        }
+    }
+
+    [Fact]
+    public async Task Cancellation_DoesNotPoisonRetry()
+    {
+        var dir = NewTempDir("catalog-cancel");
+        var scanEntered = NewTcs();
+        using var releaseScan = new ManualResetEventSlim(false);
+        Func<CancellationToken, IEnumerable<string>> enumerate = ct =>
+            YieldOneThenWait(WriteBlob(dir, "cancel-retry@test", "blob-bytes"u8.ToArray()), scanEntered, releaseScan, ct);
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024, ct => enumerate(ct));
+            using var cts = new CancellationTokenSource();
+            var load = store.EnsureCatalogLoadedAsync(cts.Token);
+            await scanEntered.Task.WaitAsync(Timeout);
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => load);
+            AssertUnpublished(store);
+
+            enumerate = ct => Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories);
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
+
+            Assert.True(store.IsCatalogReady);
+            Assert.Equal(1, store.EntryCount);
+            Assert.Equal("blob-bytes"u8.ToArray().Length, store.CurrentBytes);
+        }
+        finally
+        {
+            releaseScan.Set();
+            DeleteDir(dir);
+        }
+    }
+
+    [Fact]
+    public async Task OutOfMemory_PublishesNothing()
+    {
+        var dir = NewTempDir("catalog-oom");
+        try
+        {
+            var blob = WriteBlob(dir, "partial-oom@test", "blob-bytes"u8.ToArray());
+            var oom = new OutOfMemoryException("scripted");
+            var store = new RepairPatchStore(
+                dir,
+                1024 * 1024,
+                ct => YieldOneThenThrow(blob, oom, ct));
+
+            var thrown = await Assert.ThrowsAsync<OutOfMemoryException>(
+                () => store.EnsureCatalogLoadedAsync(CancellationToken.None));
+            Assert.Same(oom, thrown);
+            AssertUnpublished(store);
+        }
+        finally
+        {
+            DeleteDir(dir);
+        }
+    }
+
+    [Fact]
+    public async Task ConcurrentEnsure_RunsOneScan()
+    {
+        var dir = NewTempDir("catalog-concurrent");
+        var scanEntered = NewTcs();
+        var allowScan = NewTcs();
+        var starts = 0;
+        var active = 0;
+        var maxActive = 0;
+        var maxLock = new object();
+        var content = "concurrent-blob"u8.ToArray();
+        var blob = WriteBlob(dir, "concurrent@test", content);
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024, ct =>
+            {
+                Interlocked.Increment(ref starts);
+                var now = Interlocked.Increment(ref active);
+                lock (maxLock)
+                {
+                    if (now > maxActive)
+                        maxActive = now;
+                }
+
+                try
+                {
+                    scanEntered.TrySetResult();
+                    allowScan.Task.Wait(ct);
+                    return new[] { blob };
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref active);
+                }
+            });
+
+            var first = store.EnsureCatalogLoadedAsync(CancellationToken.None);
+            await scanEntered.Task.WaitAsync(Timeout);
+            var second = store.EnsureCatalogLoadedAsync(CancellationToken.None);
+
+            Assert.Equal(1, Volatile.Read(ref starts));
+            Assert.Equal(1, maxActive);
+            Assert.False(store.IsCatalogReady);
+            Assert.False(first.IsCompleted);
+            Assert.False(second.IsCompleted);
+
+            allowScan.TrySetResult();
+            await Task.WhenAll(first, second).WaitAsync(Timeout);
+
+            Assert.Equal(1, Volatile.Read(ref starts));
+            Assert.Equal(1, maxActive);
+            Assert.True(store.IsCatalogReady);
+            Assert.Equal(1, store.EntryCount);
+            Assert.Equal(content.Length, store.CurrentBytes);
+        }
+        finally
+        {
+            allowScan.TrySetResult();
+            DeleteDir(dir);
+        }
+    }
+
+    [Fact]
+    public async Task ConcurrentCommit_NewHashSurvivesPublication()
+    {
+        var dir = NewTempDir("catalog-live-unique");
+        var captured = NewTcs();
+        var allowPublish = NewTcs();
+        var live = "live-unique"u8.ToArray();
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024, ct =>
+                WaitThenComplete(captured, allowPublish, ct));
+
+            var load = store.EnsureCatalogLoadedAsync(CancellationToken.None);
+            await captured.Task.WaitAsync(Timeout);
+            Assert.False(store.IsCatalogReady);
+
+            store.CommitPatch("live-unique@test", live, Header(live.Length));
+            allowPublish.TrySetResult();
+            await load.WaitAsync(Timeout);
+
+            Assert.True(store.IsCatalogReady);
+            Assert.True(store.Contains("live-unique@test"));
+            Assert.Equal(1, store.EntryCount);
+            Assert.Equal(live.Length, store.CurrentBytes);
+        }
+        finally
+        {
+            allowPublish.TrySetResult();
+            DeleteDir(dir);
+        }
+    }
+
+    [Fact]
+    public async Task ConcurrentCommit_SameHashLiveSizeWins()
+    {
+        var dir = NewTempDir("catalog-live-same");
+        var captured = NewTcs();
+        var allowPublish = NewTcs();
+        var scanned = new byte[10];
+        var live = new byte[20];
+        var blob = WriteBlob(dir, "same-hash@test", scanned);
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024, ct =>
+                YieldThenWait(blob, captured, allowPublish, ct));
+
+            var load = store.EnsureCatalogLoadedAsync(CancellationToken.None);
+            await captured.Task.WaitAsync(Timeout);
+            Assert.False(store.IsCatalogReady);
+
+            store.CommitPatch("same-hash@test", live, Header(live.Length));
+            allowPublish.TrySetResult();
+            await load.WaitAsync(Timeout);
+
+            Assert.True(store.IsCatalogReady);
+            Assert.True(store.Contains("same-hash@test"));
+            Assert.True(store.IsRepaired("same-hash@test", live.Length));
+            Assert.Equal(1, store.EntryCount);
+            Assert.Equal(live.Length, store.CurrentBytes);
+        }
+        finally
+        {
+            allowPublish.TrySetResult();
+            DeleteDir(dir);
+        }
+    }
+
+    private static void AssertUnpublished(RepairPatchStore store)
+    {
+        Assert.False(store.IsCatalogReady);
+        Assert.Equal(0, store.EntryCount);
+        Assert.Equal(0, store.CurrentBytes);
+    }
+
+    private static string NewTempDir(string prefix) =>
+        Path.Join(Path.GetTempPath(), $"nzbdav-repair-{prefix}-" + Guid.NewGuid().ToString("N"));
+
+    private static void DeleteDir(string dir)
+    {
+        if (Directory.Exists(dir))
+            Directory.Delete(dir, recursive: true);
+    }
+
+    private static TaskCompletionSource NewTcs() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private static string WriteBlob(string dir, string segmentId, byte[] content)
+    {
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(segmentId)));
+        var path = Path.Join(dir, hash[..2], hash);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllBytes(path, content);
+        return path;
+    }
+
+    private static IEnumerable<string> YieldOneThenThrow(
+        string file,
+        Exception failure,
+        CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        yield return file;
+        throw failure;
+    }
+
+    private static IEnumerable<string> YieldOneThenWait(
+        string file,
+        TaskCompletionSource scanEntered,
+        ManualResetEventSlim releaseScan,
+        CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        yield return file;
+        scanEntered.TrySetResult();
+        releaseScan.Wait(ct);
+    }
+
+    private static IEnumerable<string> YieldThenWait(
+        string file,
+        TaskCompletionSource captured,
+        TaskCompletionSource allowPublish,
+        CancellationToken ct)
+    {
+        yield return file;
+        captured.TrySetResult();
+        allowPublish.Task.Wait(ct);
+    }
+
+    private static IEnumerable<string> WaitThenComplete(
+        TaskCompletionSource captured,
+        TaskCompletionSource allowPublish,
+        CancellationToken ct)
+    {
+        captured.TrySetResult();
+        allowPublish.Task.Wait(ct);
+        yield break;
     }
 }

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -797,7 +797,7 @@ public sealed class SupportPackContentsTests : IDisposable
         using var gcDiagnosticsStore = new GcDiagnosticsStore();
         var repairDir = Path.Join(Path.GetTempPath(), "nzbdav-support-test-" + Guid.NewGuid().ToString("N"));
         var repairPatchStore = new RepairPatchStore(repairDir, 1024 * 1024);
-        await repairPatchStore.CatalogLoadTask;
+        await repairPatchStore.EnsureCatalogLoadedAsync(CancellationToken.None);
         var par2RepairService = new Par2RepairService(configManager, usenet, repairPatchStore);
         using var healthCheckConnectionGate = new HealthCheckConnectionGate(configManager);
         var service = new SupportPackService(

--- a/tests/NzbWebDAV.Tests/Streams/KnownCorruptFastPathTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/KnownCorruptFastPathTests.cs
@@ -75,7 +75,7 @@ public class KnownCorruptFastPathTests
         try
         {
             var store = new RepairPatchStore(dir, 1024 * 1024);
-            await store.CatalogLoadTask;
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
             store.CommitPatch(segmentId, patched, new UsenetYencHeader
             {
                 FileName = "movie.mkv",
@@ -212,7 +212,7 @@ public class KnownCorruptFastPathTests
                 new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "true" },
             ]);
             var store = new RepairPatchStore(dir, 1024 * 1024);
-            await store.CatalogLoadTask;
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
             var service = new Par2RepairService(config, null!, store);
             Par2RepairTriggerSink.Current = new Par2RepairTriggerSink(service);
 


### PR DESCRIPTION
Fixes #1250

## Summary
- PAR2 patch catalog loading is now a supervised, retryable startup barrier: known I/O and authorization failures no longer publish a partial catalog or start repair workers against empty/incomplete state.
- A complete successful scan is required before readiness is published; patches committed during the scan survive merge (`TryAdd`, live metadata wins) and workers start exactly once afterward.
- Unexpected exceptions, non-shutdown cancellation, and OOM/fatal failures still escape to the host’s default stop-host policy with their original stacks.

## Persistent known-failure policy
**Option 1 — retry known catalog-operational failures for the lifetime of the process** (recorded on [#1250](https://github.com/infinidysk/infinidysk/issues/1250#issuecomment-5466351101)).

- Catalog readiness stays false until a complete successful scan.
- PAR2’s two workers stay stopped until that success (or host shutdown). The worker pair starts once.
- Queued repair/zero-fill signals are preserved within existing channel and dedup bounds; retry does not re-enqueue.
- Retry uses capped exponential backoff (1s, doubling, 60s cap). SQLite corruption, if it ever appears on this boundary, uses the existing 5-minute corruption delay.
- `/health` and `/ready` are unchanged. The catalog is not a liveness or readiness dependency (`/ready` remains healthy while repair is unavailable).
- `UnauthorizedAccessException` is treated as potentially recoverable at runtime and retried like other known I/O.
- No degraded-empty operation and no host stop for persistent known I/O.
- Shutdown cancellation: no warning, no retry, no readiness, no worker start.

The previous empty-on-I/O path could publish a partial catalog and run repair against a lie. Indefinite retry without starting workers avoids both a container boot-loop and that false catalog.

## Behavior
- **Known operational failures** (`IOException`, `UnauthorizedAccessException`, classified SQLite busy/disk/corruption): throttled single-line Warning with `{Reason}` / attempt / next delay; no exception/stack; retry until success or shutdown.
- **Unexpected / fatal**: original exception retained; not classified as retryable even when nested with I/O; host default `StopHost`.
- **Atomic publication**: scan builds a local snapshot; `_catalogReady` is written only after merge and cap enforcement.

## Health / readiness
None. `/health` and `/ready` are not tied to this optional repair-sidecar catalog.

## Test plan
- [x] Focused local run of `RepairPatchStoreTests` and `Par2RepairServiceCatalogLoadTests` (including retention and logging classes): 25 passed
- [ ] PR CI (`ci.yml`) runs the full frontend/backend gate

Normal build/tests are delegated to PR CI per repository guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved repair-catalog startup reliability with automatic retries and increasing delays.
  - Added cancellation support so shutdowns and interrupted loads complete cleanly.
  - Prevented incomplete or failed catalog scans from publishing invalid data.
  - Preserved valid repair entries when new catalog files are discovered.
  - Improved warnings and recovery logs for catalog-loading issues.

- **Tests**
  - Added comprehensive coverage for retries, failures, cancellation, concurrent loading, retention, logging, and startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->