### PR TITLE
fix(arr): prevent overlapping Watchtower cycles after a timeout

### DIFF
--- a/backend/Services/Watchtower/WatchtowerService.CycleLifetime.cs
+++ b/backend/Services/Watchtower/WatchtowerService.CycleLifetime.cs
@@ -472,26 +472,24 @@ public partial class WatchtowerService
 
     private static OutOfMemoryException? SelectOutOfMemory(params ExceptionDispatchInfo?[] sources)
     {
-        foreach (var source in sources)
-        {
-            if (source?.SourceException.TryGetCausingException<OutOfMemoryException>(out var oom) == true)
-                return oom;
-        }
-
-        return null;
+        return sources
+            .Select(TryGetOutOfMemory)
+            .FirstOrDefault(oom => oom is not null);
     }
+
+    private static OutOfMemoryException? TryGetOutOfMemory(ExceptionDispatchInfo? source) =>
+        source?.SourceException.TryGetCausingException<OutOfMemoryException>(out var oom) == true
+            ? oom
+            : null;
 
     private static ExceptionDispatchInfo? CombineNonfatalFailures(params ExceptionDispatchInfo?[] sources)
     {
         List<Exception>? leaves = null;
-        foreach (var source in sources)
+        foreach (var source in sources.Where(source =>
+                     source is not null
+                     && !source.SourceException.TryGetCausingException<OutOfMemoryException>(out _)))
         {
-            if (source is null)
-                continue;
-            if (source.SourceException.TryGetCausingException<OutOfMemoryException>(out _))
-                continue;
-
-            foreach (var leaf in EnumerateLeaves(source.SourceException))
+            foreach (var leaf in EnumerateLeaves(source!.SourceException))
             {
                 leaves ??= [];
                 if (!leaves.Exists(existing => ReferenceEquals(existing, leaf)))

--- a/backend/Services/Watchtower/WatchtowerService.CycleLifetime.cs
+++ b/backend/Services/Watchtower/WatchtowerService.CycleLifetime.cs
@@ -1,0 +1,544 @@
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+using NzbWebDAV.Extensions;
+using Serilog;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Hosted-loop ownership for a single Watchtower cycle.
+/// </summary>
+/// <remarks>
+/// Permanent noncooperation policy (issue #1243): after cancellation is requested,
+/// await the exact <c>RunCycleAsync</c> task indefinitely. Never detach it and never
+/// start a replacement while that task or its memoized <c>CancelAsync</c> task is
+/// incomplete. A stuck cycle can delay graceful Watchtower shutdown past
+/// <c>HostOptions.ShutdownTimeout</c>; the host may then abort the process. Operators
+/// see one watchdog warning and no further cycle starts. Streaming readiness is
+/// unaffected. Independently owned work in <c>NzbFetchCoalescer</c>,
+/// <c>PlaybackFastVerifier</c> probe cores, and best-effort <c>IndexerHitTracker</c>
+/// records is not claimed to be drained by the cycle task.
+/// <para>
+/// Multiple <see cref="OutOfMemoryException"/> instances: propagate the
+/// cancellation-task OOM first, then the cycle-task OOM. Do not log secondary OOMs
+/// and do not wrap the selected OOM in a new aggregate.
+/// </para>
+/// </remarks>
+public partial class WatchtowerService
+{
+    internal enum CycleStopReason
+    {
+        None = 0,
+        CycleFinished = 1,
+        Watchdog = 2,
+        Disabled = 3,
+        HostStopping = 4,
+    }
+
+    private enum TaskObservationStatus
+    {
+        RanToCompletion,
+        Canceled,
+        Faulted,
+    }
+
+    private readonly record struct TaskObservation(
+        TaskObservationStatus Status,
+        ExceptionDispatchInfo? Exception);
+
+    private sealed class CycleObservation
+    {
+        public required CycleStopReason StopReason { get; init; }
+        public required bool WatchdogWarningEmitted { get; init; }
+        public ExceptionDispatchInfo? Failure { get; init; }
+        public TimeSpan DrainElapsed { get; init; }
+        public bool ExpectedCycleCancellation { get; init; }
+        public bool CancellationFailed { get; init; }
+        public bool RegistrationFailed { get; init; }
+    }
+
+    internal sealed class ActiveCycle : IDisposable
+    {
+        private readonly object _gate = new();
+        private readonly CancellationTokenSource _cancellationSource = new();
+        private readonly TaskCompletionSource _stopRequested =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _bothTasksObservedSignal =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _ownerClearedSignal =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TimeProvider _timeProvider;
+
+        private CycleStopReason _stopReason;
+        private Task? _cancellationTask;
+        private Task? _cycleTask;
+        private bool _cancellationStartedWhileCycleActive;
+        private bool _bothTasksObserved;
+        private bool _hostRegistrationDisposed;
+        private DateTimeOffset? _drainStartedAt;
+
+        private bool _disposed;
+
+        internal ActiveCycle() : this(0, TimeProvider.System)
+        {
+        }
+
+        internal ActiveCycle(int cycleId, TimeProvider timeProvider)
+        {
+            CycleId = cycleId;
+            _timeProvider = timeProvider;
+        }
+
+        internal int CycleId { get; }
+
+        internal CancellationToken Token => _cancellationSource.Token;
+
+        internal Task StopRequested => _stopRequested.Task;
+
+        internal Task WhenBothTasksObserved => _bothTasksObservedSignal.Task;
+
+        internal Task WhenOwnerCleared => _ownerClearedSignal.Task;
+
+        internal CycleStopReason StopReason
+        {
+            get
+            {
+                lock (_gate)
+                    return _stopReason;
+            }
+        }
+
+        internal Task? CycleTask
+        {
+            get
+            {
+                lock (_gate)
+                    return _cycleTask;
+            }
+        }
+
+        internal Task? CancellationTask
+        {
+            get
+            {
+                lock (_gate)
+                    return _cancellationTask;
+            }
+        }
+
+        internal bool BothTasksObserved
+        {
+            get
+            {
+                lock (_gate)
+                    return _bothTasksObserved;
+            }
+        }
+
+        internal bool HostRegistrationDisposed
+        {
+            get
+            {
+                lock (_gate)
+                    return _hostRegistrationDisposed;
+            }
+        }
+
+        internal bool CancellationStartedWhileCycleActive
+        {
+            get
+            {
+                lock (_gate)
+                    return _cancellationStartedWhileCycleActive;
+            }
+        }
+
+        internal bool WatchdogWarningEmitted { get; set; }
+
+        internal void AttachCycleTask(Task cycleTask)
+        {
+            ArgumentNullException.ThrowIfNull(cycleTask);
+            lock (_gate)
+            {
+                if (_cycleTask is not null)
+                    throw new InvalidOperationException("Watchtower cycle task is already attached.");
+                _cycleTask = cycleTask;
+            }
+        }
+
+        internal Task RequestCancellation(CycleStopReason reason)
+        {
+            if (reason == CycleStopReason.None)
+                throw new ArgumentOutOfRangeException(nameof(reason));
+
+            lock (_gate)
+            {
+                if (reason > _stopReason)
+                    _stopReason = reason;
+
+                if (_cancellationTask is null)
+                {
+                    _cancellationStartedWhileCycleActive =
+                        reason != CycleStopReason.CycleFinished
+                        && (_cycleTask is null || !_cycleTask.IsCompleted);
+                    _drainStartedAt = _timeProvider.GetUtcNow();
+                    _cancellationTask = _cancellationSource.CancelAsync();
+                    _stopRequested.TrySetResult();
+                }
+
+                return _cancellationTask;
+            }
+        }
+
+        internal Task GetCancellationTaskOrThrow()
+        {
+            lock (_gate)
+            {
+                return _cancellationTask
+                    ?? throw new InvalidOperationException(
+                        "Watchtower cycle cancellation has not been requested.");
+            }
+        }
+
+        internal void MarkBothTasksObserved()
+        {
+            lock (_gate)
+                _bothTasksObserved = true;
+            _bothTasksObservedSignal.TrySetResult();
+        }
+
+        internal void MarkHostRegistrationDisposed()
+        {
+            lock (_gate)
+                _hostRegistrationDisposed = true;
+        }
+
+        internal void MarkOwnerCleared() => _ownerClearedSignal.TrySetResult();
+
+        internal TimeSpan DrainElapsed()
+        {
+            lock (_gate)
+            {
+                if (_drainStartedAt is not { } started)
+                    return TimeSpan.Zero;
+                var elapsed = _timeProvider.GetUtcNow() - started;
+                return elapsed < TimeSpan.Zero ? TimeSpan.Zero : elapsed;
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                    return;
+                _disposed = true;
+            }
+
+            _cancellationSource.Dispose();
+        }
+    }
+
+    private void PublishActiveCycle(ActiveCycle cycle)
+    {
+        lock (_activeCycleLock)
+        {
+            if (_activeCycle is not null)
+                throw new InvalidOperationException("A Watchtower cycle is already active.");
+            _activeCycle = cycle;
+        }
+    }
+
+    private void ClearTerminalCycle(ActiveCycle cycle)
+    {
+        lock (_activeCycleLock)
+        {
+            if (!ReferenceEquals(_activeCycle, cycle))
+                throw new InvalidOperationException("Watchtower active-cycle ownership changed.");
+            if (!cycle.BothTasksObserved)
+                throw new InvalidOperationException(
+                    "Cannot clear a Watchtower cycle before both tasks are observed.");
+            if (!cycle.HostRegistrationDisposed)
+                throw new InvalidOperationException(
+                    "Cannot clear a Watchtower cycle before host registration disposal.");
+            if (cycle.CycleTask is { IsCompleted: false })
+                throw new InvalidOperationException("Cannot clear a running Watchtower cycle.");
+            if (cycle.CancellationTask is { IsCompleted: false })
+                throw new InvalidOperationException(
+                    "Cannot clear a Watchtower cycle before cancellation completes.");
+            _activeCycle = null;
+            LastClearedCycleForTests = cycle;
+        }
+
+        cycle.MarkOwnerCleared();
+    }
+
+    private async Task<CycleObservation> RunSupervisedCycleAsync(CancellationToken stoppingToken)
+    {
+        var active = new ActiveCycle(Interlocked.Increment(ref _nextCycleId), _timeProvider);
+        PublishActiveCycle(active);
+
+        var hostRegistration = stoppingToken.UnsafeRegister(
+            static state =>
+                _ = ((ActiveCycle)state!).RequestCancellation(CycleStopReason.HostStopping),
+            active);
+
+        if (stoppingToken.IsCancellationRequested)
+            _ = active.RequestCancellation(CycleStopReason.HostStopping);
+
+        if (!configManager.IsWatchtowerEnabled())
+            _ = active.RequestCancellation(CycleStopReason.Disabled);
+
+        Task cycleTask;
+        try
+        {
+            var cycleWatch = Stopwatch.StartNew();
+            cycleTask = RunCycleOverride is null
+                ? RunCycleAsync(cycleWatch, active.Token)
+                : RunCycleOverride(cycleWatch, active.Token);
+        }
+        catch (Exception ex)
+        {
+            cycleTask = Task.FromException(ex);
+        }
+
+        active.AttachCycleTask(cycleTask);
+
+        var watchdogTask = Task.Delay(CycleWatchdogTimeout, _timeProvider, active.Token);
+
+        await Task.WhenAny(cycleTask, watchdogTask, active.StopRequested).ConfigureAwait(false);
+
+        if (stoppingToken.IsCancellationRequested)
+            _ = active.RequestCancellation(CycleStopReason.HostStopping);
+
+        if (!configManager.IsWatchtowerEnabled())
+            _ = active.RequestCancellation(CycleStopReason.Disabled);
+
+        if (watchdogTask.Status == TaskStatus.RanToCompletion)
+            _ = active.RequestCancellation(CycleStopReason.Watchdog);
+
+        if (cycleTask.IsCompleted)
+            _ = active.RequestCancellation(CycleStopReason.CycleFinished);
+
+        if (active.CancellationTask is null)
+            _ = active.RequestCancellation(CycleStopReason.CycleFinished);
+
+        var cancellationTask = active.GetCancellationTaskOrThrow();
+
+        if (active.StopReason == CycleStopReason.Watchdog
+            && watchdogTask.Status == TaskStatus.RanToCompletion)
+        {
+            Log.Warning(
+                "Watchtower: cycle exceeded {Budget:n0}s; cancellation requested, waiting for completion",
+                CycleWatchdogTimeout.TotalSeconds);
+            active.WatchdogWarningEmitted = true;
+        }
+
+        return await ObserveOwnedTasksAsync(
+                active,
+                cancellationTask,
+                cycleTask,
+                watchdogTask,
+                hostRegistration,
+                stoppingToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<CycleObservation> ObserveOwnedTasksAsync(
+        ActiveCycle active,
+        Task cancellationTask,
+        Task cycleTask,
+        Task watchdogTask,
+        CancellationTokenRegistration hostRegistration,
+        CancellationToken stoppingToken)
+    {
+        var cancellationObservationTask = ObserveExactTaskAsync(cancellationTask);
+        var cycleObservationTask = ObserveExactTaskAsync(cycleTask);
+
+        await Task.WhenAll(cancellationObservationTask, cycleObservationTask).ConfigureAwait(false);
+
+        var cancellationObservation = await cancellationObservationTask.ConfigureAwait(false);
+        var cycleObservation = await cycleObservationTask.ConfigureAwait(false);
+
+        if (stoppingToken.IsCancellationRequested)
+            _ = active.RequestCancellation(CycleStopReason.HostStopping);
+
+        if (!configManager.IsWatchtowerEnabled())
+            _ = active.RequestCancellation(CycleStopReason.Disabled);
+
+        ExceptionDispatchInfo? watchdogFailure = null;
+        try
+        {
+            await watchdogTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Owner cancellation cancelled the watchdog delay.
+        }
+        catch (Exception ex)
+        {
+            watchdogFailure = ExceptionDispatchInfo.Capture(ex);
+        }
+
+        ExceptionDispatchInfo? registrationFailure = null;
+        try
+        {
+            await hostRegistration.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            registrationFailure = ExceptionDispatchInfo.Capture(ex);
+        }
+
+        active.MarkHostRegistrationDisposed();
+
+        var oom = SelectOutOfMemory(
+            cancellationObservation.Exception,
+            cycleObservation.Exception,
+            watchdogFailure,
+            registrationFailure);
+
+        var expectedCycleCancellation = IsExpectedCycleCancellation(
+            active,
+            cycleObservation,
+            active.StopReason);
+
+        var cycleFailure = expectedCycleCancellation ? null : cycleObservation.Exception;
+        var failure = CombineNonfatalFailures(
+            cancellationObservation.Exception,
+            cycleFailure,
+            watchdogFailure,
+            registrationFailure);
+
+        active.MarkBothTasksObserved();
+        ClearTerminalCycle(active);
+        active.Dispose();
+
+        if (oom is not null)
+            ExceptionDispatchInfo.Capture(oom).Throw();
+
+        return new CycleObservation
+        {
+            StopReason = active.StopReason,
+            WatchdogWarningEmitted = active.WatchdogWarningEmitted,
+            Failure = failure,
+            DrainElapsed = active.DrainElapsed(),
+            ExpectedCycleCancellation = expectedCycleCancellation,
+            CancellationFailed = cancellationObservation.Exception is not null,
+            RegistrationFailed = registrationFailure is not null,
+        };
+    }
+
+    private static async Task<TaskObservation> ObserveExactTaskAsync(Task task)
+    {
+        try
+        {
+            await task.ConfigureAwait(false);
+            return new TaskObservation(TaskObservationStatus.RanToCompletion, null);
+        }
+        catch (OperationCanceledException ex)
+        {
+            return new TaskObservation(TaskObservationStatus.Canceled, ExceptionDispatchInfo.Capture(ex));
+        }
+        catch (Exception ex)
+        {
+            return new TaskObservation(TaskObservationStatus.Faulted, ExceptionDispatchInfo.Capture(ex));
+        }
+    }
+
+    private static bool IsExpectedCycleCancellation(
+        ActiveCycle active,
+        TaskObservation cycle,
+        CycleStopReason reason)
+    {
+        if (!active.CancellationStartedWhileCycleActive)
+            return false;
+        if (reason is CycleStopReason.None or CycleStopReason.CycleFinished)
+            return false;
+        if (!active.Token.IsCancellationRequested)
+            return false;
+        if (cycle.Status == TaskObservationStatus.Canceled)
+            return true;
+        return cycle.Exception?.SourceException is OperationCanceledException;
+    }
+
+    private static OutOfMemoryException? SelectOutOfMemory(params ExceptionDispatchInfo?[] sources)
+    {
+        foreach (var source in sources)
+        {
+            if (source?.SourceException.TryGetCausingException<OutOfMemoryException>(out var oom) == true)
+                return oom;
+        }
+
+        return null;
+    }
+
+    private static ExceptionDispatchInfo? CombineNonfatalFailures(params ExceptionDispatchInfo?[] sources)
+    {
+        List<Exception>? leaves = null;
+        foreach (var source in sources)
+        {
+            if (source is null)
+                continue;
+            if (source.SourceException.TryGetCausingException<OutOfMemoryException>(out _))
+                continue;
+
+            foreach (var leaf in EnumerateLeaves(source.SourceException))
+            {
+                leaves ??= [];
+                if (!leaves.Exists(existing => ReferenceEquals(existing, leaf)))
+                    leaves.Add(leaf);
+            }
+        }
+
+        if (leaves is null || leaves.Count == 0)
+            return null;
+        if (leaves.Count == 1)
+            return ExceptionDispatchInfo.Capture(leaves[0]);
+        return ExceptionDispatchInfo.Capture(new AggregateException(leaves));
+    }
+
+    private static IEnumerable<Exception> EnumerateLeaves(Exception exception)
+    {
+        if (exception is AggregateException aggregate)
+        {
+            foreach (var inner in aggregate.Flatten().InnerExceptions)
+                yield return inner;
+            yield break;
+        }
+
+        yield return exception;
+    }
+
+    private static void LogWatchdogDrainComplete(CycleObservation observation)
+    {
+        var outcome = observation.ExpectedCycleCancellation
+            ? "cancelled"
+            : "completed after cancellation";
+        Log.Information(
+            "Watchtower: timed-out cycle drained after {DrainElapsed:n1}s ({Outcome})",
+            observation.DrainElapsed.TotalSeconds,
+            outcome);
+    }
+
+    private static void LogCycleFailure(CycleObservation observation)
+    {
+        var exception = observation.Failure!.SourceException;
+        if (observation.CancellationFailed || observation.RegistrationFailed)
+        {
+            Log.Error(exception, "Watchtower: unexpected cycle cancellation failure");
+            return;
+        }
+
+        if (observation.WatchdogWarningEmitted)
+        {
+            Log.Warning(exception, "Watchtower: timed-out cycle faulted while draining");
+            return;
+        }
+
+        exception.LogWarningKnownOrStack("Watchtower loop error.");
+    }
+
+    private static bool ContainsOutOfMemory(Exception exception) =>
+        exception.TryGetCausingException<OutOfMemoryException>(out _);
+}

--- a/backend/Services/Watchtower/WatchtowerService.CycleLifetime.cs
+++ b/backend/Services/Watchtower/WatchtowerService.CycleLifetime.cs
@@ -444,12 +444,16 @@ public partial class WatchtowerService
             await task.ConfigureAwait(false);
             return new TaskObservation(TaskObservationStatus.RanToCompletion, null);
         }
-        catch (OperationCanceledException ex)
+        catch (Exception ex)
         {
-            return new TaskObservation(TaskObservationStatus.Canceled, ExceptionDispatchInfo.Capture(ex));
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
+            // CancelAsync stores every callback failure on task.Exception. await
+            // unwraps only one inner exception, which would drop a later OOM.
+            if (task.Exception is { } aggregate)
+                return new TaskObservation(TaskObservationStatus.Faulted, ExceptionDispatchInfo.Capture(aggregate));
+
+            if (ex is OperationCanceledException oce)
+                return new TaskObservation(TaskObservationStatus.Canceled, ExceptionDispatchInfo.Capture(oce));
+
             return new TaskObservation(TaskObservationStatus.Faulted, ExceptionDispatchInfo.Capture(ex));
         }
     }

--- a/backend/Services/Watchtower/WatchtowerService.CycleLifetime.cs
+++ b/backend/Services/Watchtower/WatchtowerService.CycleLifetime.cs
@@ -297,7 +297,11 @@ public partial class WatchtowerService
                 ? RunCycleAsync(cycleWatch, active.Token)
                 : RunCycleOverride(cycleWatch, active.Token);
         }
-        catch (Exception ex)
+        catch (OperationCanceledException ex)
+        {
+            cycleTask = Task.FromException(ex);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             cycleTask = Task.FromException(ex);
         }
@@ -375,7 +379,7 @@ public partial class WatchtowerService
         {
             // Owner cancellation cancelled the watchdog delay.
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             watchdogFailure = ExceptionDispatchInfo.Capture(ex);
         }
@@ -385,7 +389,11 @@ public partial class WatchtowerService
         {
             await hostRegistration.DisposeAsync().ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (OperationCanceledException ex)
+        {
+            registrationFailure = ExceptionDispatchInfo.Capture(ex);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             registrationFailure = ExceptionDispatchInfo.Capture(ex);
         }
@@ -440,7 +448,7 @@ public partial class WatchtowerService
         {
             return new TaskObservation(TaskObservationStatus.Canceled, ExceptionDispatchInfo.Capture(ex));
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             return new TaskObservation(TaskObservationStatus.Faulted, ExceptionDispatchInfo.Capture(ex));
         }

--- a/backend/Services/Watchtower/WatchtowerService.CycleLifetime.cs
+++ b/backend/Services/Watchtower/WatchtowerService.CycleLifetime.cs
@@ -449,7 +449,12 @@ public partial class WatchtowerService
             // CancelAsync stores every callback failure on task.Exception. await
             // unwraps only one inner exception, which would drop a later OOM.
             if (task.Exception is { } aggregate)
-                return new TaskObservation(TaskObservationStatus.Faulted, ExceptionDispatchInfo.Capture(aggregate));
+            {
+                var status = IsOnlyOperationCanceled(aggregate)
+                    ? TaskObservationStatus.Canceled
+                    : TaskObservationStatus.Faulted;
+                return new TaskObservation(status, ExceptionDispatchInfo.Capture(aggregate));
+            }
 
             if (ex is OperationCanceledException oce)
                 return new TaskObservation(TaskObservationStatus.Canceled, ExceptionDispatchInfo.Capture(oce));
@@ -471,7 +476,17 @@ public partial class WatchtowerService
             return false;
         if (cycle.Status == TaskObservationStatus.Canceled)
             return true;
-        return cycle.Exception?.SourceException is OperationCanceledException;
+        return IsOnlyOperationCanceled(cycle.Exception?.SourceException);
+    }
+
+    private static bool IsOnlyOperationCanceled(Exception? exception)
+    {
+        if (exception is OperationCanceledException)
+            return true;
+        if (exception is not AggregateException aggregate)
+            return false;
+        var leaves = aggregate.Flatten().InnerExceptions;
+        return leaves.Count > 0 && leaves.All(inner => inner is OperationCanceledException);
     }
 
     private static OutOfMemoryException? SelectOutOfMemory(params ExceptionDispatchInfo?[] sources)

--- a/backend/Services/Watchtower/WatchtowerService.cs
+++ b/backend/Services/Watchtower/WatchtowerService.cs
@@ -12,7 +12,7 @@ using Serilog;
 
 namespace NzbWebDAV.Services;
 
-public class WatchtowerService(
+public partial class WatchtowerService(
     ConfigManager configManager,
     SearchProfileService searchProfileService,
     PlaybackFastVerifier fastVerifier,
@@ -26,10 +26,16 @@ public class WatchtowerService(
     PreferredOrderStore preferredOrderStore,
     NzbFetchCoalescer nzbFetchCoalescer,
     BenchmarkGate benchmarkGate,
-    IDbContextFactory<DavDatabaseContext> dbContextFactory
+    IDbContextFactory<DavDatabaseContext> dbContextFactory,
+    TimeProvider? timeProvider = null
 ) : BackgroundService
 {
-    private static readonly TimeSpan Tick = TimeSpan.FromSeconds(20);
+    internal static readonly TimeSpan CycleWatchdogTimeout = TimeSpan.FromMinutes(15);
+    internal static readonly TimeSpan CycleInterval = TimeSpan.FromSeconds(20);
+    internal static readonly TimeSpan LoopErrorDelay = TimeSpan.FromSeconds(10);
+    internal static readonly TimeSpan AdmissionPollInterval = TimeSpan.FromSeconds(10);
+
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
     private static readonly TimeSpan NzbFetchTimeout = TimeSpan.FromSeconds(15);
 
     // Heartbeat throttles. The cycle loop ticks every 20s forever, so logging each
@@ -42,7 +48,6 @@ public class WatchtowerService(
     private const int ResolvesPerTick = 3;
     private const int AutoResolveBatch = 25;
     private static readonly TimeSpan AutoStageBudget = TimeSpan.FromSeconds(120);
-    private static readonly TimeSpan CycleWatchdog = TimeSpan.FromMinutes(15);
     private const int KeepFreshPerTick = 5;
     private const int ExpandsPerTick = 5;
     private const long SeasonBundleGraceSeconds = 14L * 86400L;
@@ -50,10 +55,27 @@ public class WatchtowerService(
     private int _resolveDayKey = -1;
     private int _resolvesToday;
 
-    private readonly object _ctsLock = new();
-    private CancellationTokenSource? _disabledCts;
+    private readonly object _activeCycleLock = new();
+    private ActiveCycle? _activeCycle;
+    private int _nextCycleId;
 
     private readonly SemaphoreSlim _indexerGate = new(1, 1);
+
+    internal Func<Stopwatch, CancellationToken, Task>? RunCycleOverride { get; set; }
+
+    internal Task ExecuteHostedServiceForTests(CancellationToken stoppingToken) =>
+        ExecuteAsync(stoppingToken);
+
+    internal ActiveCycle? ActiveCycleForTests
+    {
+        get
+        {
+            lock (_activeCycleLock)
+                return _activeCycle;
+        }
+    }
+
+    internal ActiveCycle? LastClearedCycleForTests { get; private set; }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -67,20 +89,18 @@ public class WatchtowerService(
                     // pause verification while a connection speed-test is running
                     if (benchmarkGate.IsPaused)
                     {
-                        await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken).ConfigureAwait(false);
+                        await Task.Delay(AdmissionPollInterval, _timeProvider, stoppingToken)
+                            .ConfigureAwait(false);
                         continue;
                     }
 
                     if (!configManager.IsWatchtowerEnabled())
                     {
-                        await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken).ConfigureAwait(false);
+                        await Task.Delay(AdmissionPollInterval, _timeProvider, stoppingToken)
+                            .ConfigureAwait(false);
                         continue;
                     }
 
-                    using var cycleCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
-                    lock (_ctsLock) _disabledCts = cycleCts;
-                    var ct = cycleCts.Token;
-                    var cycleWatch = Stopwatch.StartNew();
                     if (_logThrottle.ShouldLog(CycleStartLogKey, CycleStartLogInterval, out var skippedCycles))
                     {
                         if (skippedCycles > 0)
@@ -89,45 +109,45 @@ public class WatchtowerService(
                         else
                             LogActivity("Watchtower: cycle starting");
                     }
-                    try
+
+                    var observation = await RunSupervisedCycleAsync(stoppingToken).ConfigureAwait(false);
+
+                    if (observation.Failure is not null)
+                        LogCycleFailure(observation);
+                    else if (observation.WatchdogWarningEmitted)
+                        LogWatchdogDrainComplete(observation);
+
+                    if (stoppingToken.IsCancellationRequested
+                        || observation.StopReason == CycleStopReason.HostStopping)
                     {
-                        var cycle = RunCycleAsync(cycleWatch, ct);
-                        var winner = await Task.WhenAny(cycle, Task.Delay(CycleWatchdog, stoppingToken)).ConfigureAwait(false);
-                        if (winner != cycle)
-                        {
-                            Log.Warning("Watchtower: cycle exceeded {Budget:n0}s watchdog; abandoning and restarting",
-                                CycleWatchdog.TotalSeconds);
-#pragma warning disable CA1849 // synchronous Cancel is required here -- CancelAsync cannot be awaited while holding _ctsLock, and the cancel must be ordered before the abandoned-cycle continuation
-                            lock (_ctsLock) cycleCts.Cancel();
-#pragma warning restore CA1849
-                            _ = cycle.ContinueWith(static t => _ = t.Exception, CancellationToken.None,
-                                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                                TaskScheduler.Default);
-                        }
-                        else
-                        {
-                            await cycle.ConfigureAwait(false);
-                        }
+                        return;
                     }
-                    catch (OperationCanceledException) when (!stoppingToken.IsCancellationRequested)
+
+                    if (!configManager.IsWatchtowerEnabled()
+                        || observation.StopReason == CycleStopReason.Disabled)
                     {
                         continue;
                     }
-                    finally
-                    {
-                        lock (_ctsLock) _disabledCts = null;
-                    }
 
-                    await Task.Delay(Tick, stoppingToken).ConfigureAwait(false);
+                    if (stoppingToken.IsCancellationRequested)
+                        return;
+                    if (!configManager.IsWatchtowerEnabled())
+                        continue;
+
+                    var delay = observation.Failure is not null ? LoopErrorDelay : CycleInterval;
+                    await Task.Delay(delay, _timeProvider, stoppingToken).ConfigureAwait(false);
                 }
-                catch (OperationCanceledException) when (SigtermUtil.IsSigtermTriggered() || stoppingToken.IsCancellationRequested)
+                catch (OperationCanceledException) when (
+                    SigtermUtil.IsSigtermTriggered() || stoppingToken.IsCancellationRequested)
                 {
                     return;
                 }
-                catch (Exception e) when (e is not OutOfMemoryException)
+                catch (Exception e) when (!ContainsOutOfMemory(e))
                 {
                     e.LogWarningKnownOrStack("Watchtower loop error.");
-                    await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken).ConfigureAwait(false);
+                    if (stoppingToken.IsCancellationRequested)
+                        return;
+                    await Task.Delay(LoopErrorDelay, _timeProvider, stoppingToken).ConfigureAwait(false);
                 }
             }
         }
@@ -161,7 +181,10 @@ public class WatchtowerService(
 
         if (!e.ChangedConfig.ContainsKey(ConfigKeys.WatchtowerEnabled)) return;
         if (configManager.IsWatchtowerEnabled()) return;
-        lock (_ctsLock) _disabledCts?.Cancel();
+        lock (_activeCycleLock)
+        {
+            _ = _activeCycle?.RequestCancellation(CycleStopReason.Disabled);
+        }
     }
 
     private void LogActivity(string template, params object?[] args)
@@ -1264,12 +1287,17 @@ public class WatchtowerService(
 
     public override void Dispose()
     {
-        lock (_ctsLock)
+        var disposeGate = false;
+        lock (_activeCycleLock)
         {
-            _disabledCts?.Dispose();
-            _disabledCts = null;
+            // The per-cycle source is disposed only by ExecuteAsync after both
+            // exact tasks are observed. A live cycle may still use _indexerGate.
+            disposeGate = _activeCycle is null;
         }
-        _indexerGate.Dispose();
+
+        if (disposeGate)
+            _indexerGate.Dispose();
+
         GC.SuppressFinalize(this);
         base.Dispose();
     }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/RepairedSegmentNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/RepairedSegmentNntpClientTests.cs
@@ -97,7 +97,7 @@ public sealed class RepairedSegmentNntpClientTests
         try
         {
             var store = new RepairPatchStore(dir, 1024 * 1024);
-            await store.CatalogLoadTask;
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
             store.CommitPatch(segmentId, content, HeaderFor(content));
 
             var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
@@ -131,7 +131,7 @@ public sealed class RepairedSegmentNntpClientTests
         try
         {
             var store = new RepairPatchStore(dir, 1024 * 1024);
-            await store.CatalogLoadTask;
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
             store.CommitPatch(segmentId, content, HeaderFor(content));
 
             var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
@@ -171,7 +171,7 @@ public sealed class RepairedSegmentNntpClientTests
         try
         {
             var store = new RepairPatchStore(dir, 1024 * 1024);
-            await store.CatalogLoadTask;
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
             var inner = new ScriptedStatusNntpClient(result, failureReason, content);
             using var client = new RepairedSegmentNntpClient(inner, store);
 

--- a/tests/NzbWebDAV.Tests/Services/WatchtowerServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/WatchtowerServiceTests.cs
@@ -775,16 +775,8 @@ public sealed class WatchtowerServiceTests
         logEvent.Level == LogEventLevel.Warning
         && logEvent.MessageTemplate.Text.Contains("cancellation requested, waiting for completion");
 
-    private static bool HasException(Exception haystack, Exception needle)
-    {
-        foreach (var current in Flatten(haystack))
-        {
-            if (ReferenceEquals(current, needle))
-                return true;
-        }
-
-        return false;
-    }
+    private static bool HasException(Exception haystack, Exception needle) =>
+        Flatten(haystack).Any(current => ReferenceEquals(current, needle));
 
     private static int IndexOf(IReadOnlyList<Exception> exceptions, Exception needle)
     {

--- a/tests/NzbWebDAV.Tests/Services/WatchtowerServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/WatchtowerServiceTests.cs
@@ -723,6 +723,33 @@ public sealed class WatchtowerServiceTests
             aggregate.ToString());
     }
 
+    [Fact]
+    public async Task SynchronousFromExceptionCancellation_OnDisable_IsExpected()
+    {
+        var clock = new ControllableTimeProvider();
+        var firstReturned = NewSignal();
+        var sink = new CollectingSink();
+        using var logs = CaptureLogs(sink);
+
+        await using var run = Start(clock, (_, ct) =>
+        {
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            ct.Register(() => tcs.TrySetException(new OperationCanceledException(ct)));
+            firstReturned.TrySetResult();
+            return tcs.Task;
+        });
+
+        await firstReturned.Task.WaitAsync(TestTimeout);
+        SetEnabled(run.Config, false);
+        await WaitClearedAsync(run.Service);
+
+        Assert.DoesNotContain(
+            sink.Events,
+            e => e.MessageTemplate.Text.Contains("unexpected cycle cancellation failure"));
+        Assert.DoesNotContain(sink.Events, e => e.MessageTemplate.Text.Contains("Watchtower loop error"));
+        Assert.False(run.ExecuteTask.IsFaulted);
+    }
+
     private static HostedRun Start(
         ControllableTimeProvider clock,
         Func<Stopwatch, CancellationToken, Task> runCycle)

--- a/tests/NzbWebDAV.Tests/Services/WatchtowerServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/WatchtowerServiceTests.cs
@@ -1,0 +1,1022 @@
+using System.Diagnostics;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services;
+using NzbWebDAV.Tests.TestUtils;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace NzbWebDAV.Tests.Services;
+
+[Collection(nameof(GlobalLoggerCollection))]
+public sealed class WatchtowerServiceTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(5);
+
+    [Fact]
+    public async Task Watchdog_CooperativeCancellationDrainsBeforeNextTick()
+    {
+        var clock = new ControllableTimeProvider();
+        var scripted = new ScriptedCycle();
+        var sink = new CollectingSink();
+        using var logs = CaptureLogs(sink);
+        await using var run = Start(clock, scripted.CooperativeCancelAsync);
+
+        await scripted.FirstStarted.Task.WaitAsync(TestTimeout);
+        var cycle1 = RequireActive(run.Service);
+
+        clock.Advance(WatchtowerService.CycleWatchdogTimeout);
+        await scripted.FirstExited.Task.WaitAsync(TestTimeout);
+        await cycle1.WhenBothTasksObserved.WaitAsync(TestTimeout);
+        await cycle1.WhenOwnerCleared.WaitAsync(TestTimeout);
+
+        Assert.False(scripted.SecondStarted.Task.IsCompleted);
+        Assert.Equal(1, Volatile.Read(ref scripted.Starts));
+        Assert.Equal(1, scripted.MaximumActive);
+
+        await AdvanceScheduledAsync(clock, WatchtowerService.CycleInterval);
+        await scripted.SecondStarted.Task.WaitAsync(TestTimeout);
+
+        Assert.Equal(1, scripted.MaximumActive);
+        var warning = Assert.Single(sink.Events, IsWatchdogWarning);
+        Assert.Null(warning.Exception);
+        Assert.Equal(1, sink.Events.Count(IsWatchdogWarning));
+    }
+
+    [Fact]
+    public async Task Watchdog_DelayedDrainPreventsCycleOverlap()
+    {
+        var clock = new ControllableTimeProvider();
+        var scripted = new ScriptedCycle();
+        await using var run = Start(clock, scripted.DelayFirstCancellationAsync);
+        try
+        {
+            await scripted.FirstStarted.Task.WaitAsync(TestTimeout);
+            var cycle1 = RequireActive(run.Service);
+
+            clock.Advance(WatchtowerService.CycleWatchdogTimeout);
+            await scripted.FirstCancellation.Task.WaitAsync(TestTimeout);
+
+            Assert.Equal(1, Volatile.Read(ref scripted.Starts));
+            Assert.Equal(1, scripted.MaximumActive);
+            Assert.False(scripted.SecondStarted.Task.IsCompleted);
+            Assert.False(run.ExecuteTask.IsCompleted);
+            Assert.Same(cycle1, run.Service.ActiveCycleForTests);
+
+            clock.Advance(TimeSpan.FromHours(1));
+            Assert.False(scripted.SecondStarted.Task.IsCompleted);
+            Assert.Equal(1, Volatile.Read(ref scripted.Starts));
+
+            scripted.ReleaseFirst.TrySetResult();
+            await scripted.FirstExited.Task.WaitAsync(TestTimeout);
+            await cycle1.WhenBothTasksObserved.WaitAsync(TestTimeout);
+            await cycle1.WhenOwnerCleared.WaitAsync(TestTimeout);
+
+            await AdvanceScheduledAsync(clock, WatchtowerService.CycleInterval);
+            await scripted.SecondStarted.Task.WaitAsync(TestTimeout);
+            Assert.Equal(1, scripted.MaximumActive);
+        }
+        finally
+        {
+            scripted.ReleaseFirst.TrySetResult();
+        }
+    }
+
+    [Fact]
+    public async Task CycleFirst_DisableDuringCallbackDrainAwaitsStoredCancellationTask()
+    {
+        var clock = new ControllableTimeProvider();
+        var callbackStarted = NewSignal();
+        var releaseCallback = NewSignal();
+        var firstReturned = NewSignal();
+        var secondStarted = NewSignal();
+        var starts = 0;
+        var callbackCount = 0;
+        var storedReg = default(CancellationTokenRegistration);
+
+        await using var run = Start(clock, async (_, ct) =>
+        {
+            var ordinal = Interlocked.Increment(ref starts);
+            if (ordinal == 1)
+            {
+                storedReg = ct.Register(() =>
+                {
+                    Interlocked.Increment(ref callbackCount);
+                    callbackStarted.TrySetResult();
+                    releaseCallback.Task.GetAwaiter().GetResult();
+                });
+                firstReturned.TrySetResult();
+                return;
+            }
+
+            secondStarted.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+        });
+
+        try
+        {
+            await firstReturned.Task.WaitAsync(TestTimeout);
+            await callbackStarted.Task.WaitAsync(TestTimeout);
+            var active = RequireActive(run.Service);
+            var cancellationTask = active.GetCancellationTaskOrThrow();
+            Assert.False(cancellationTask.IsCompleted);
+
+            SetEnabled(run.Config, false);
+            Assert.Same(cancellationTask, active.RequestCancellation(
+                WatchtowerService.CycleStopReason.Disabled));
+            Assert.False(cancellationTask.IsCompleted);
+            Assert.Equal(1, Volatile.Read(ref callbackCount));
+            Assert.Same(active, run.Service.ActiveCycleForTests);
+            Assert.False(run.ExecuteTask.IsCompleted);
+            Assert.False(active.BothTasksObserved);
+
+            clock.Advance(TimeSpan.FromHours(3));
+            Assert.Equal(1, Volatile.Read(ref starts));
+            Assert.False(secondStarted.Task.IsCompleted);
+
+            releaseCallback.TrySetResult();
+            await active.WhenBothTasksObserved.WaitAsync(TestTimeout);
+            await active.WhenOwnerCleared.WaitAsync(TestTimeout);
+            Assert.Null(run.Service.ActiveCycleForTests);
+
+            await AdvanceScheduledAsync(clock, WatchtowerService.AdmissionPollInterval);
+            clock.Advance(WatchtowerService.AdmissionPollInterval);
+            clock.Advance(WatchtowerService.CycleInterval);
+            Assert.Equal(1, Volatile.Read(ref starts));
+            Assert.False(secondStarted.Task.IsCompleted);
+        }
+        finally
+        {
+            releaseCallback.TrySetResult();
+            storedReg.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task ConcurrentStopSources_ShareOneCancellationTaskAndCallbackPass()
+    {
+        var active = new WatchtowerService.ActiveCycle();
+        using var _ = active;
+        var cycleHold = NewSignal();
+        active.AttachCycleTask(cycleHold.Task);
+
+        var callbackStarted = NewSignal();
+        var releaseCallback = NewSignal();
+        var invocations = 0;
+        using var registration = active.Token.Register(() =>
+        {
+            Interlocked.Increment(ref invocations);
+            callbackStarted.TrySetResult();
+            if (!releaseCallback.Task.Wait(TestTimeout))
+                throw new TimeoutException("Callback release timed out.");
+        });
+
+        var start = NewSignal();
+        var reasons = new[]
+        {
+            WatchtowerService.CycleStopReason.CycleFinished,
+            WatchtowerService.CycleStopReason.Watchdog,
+            WatchtowerService.CycleStopReason.Disabled,
+            WatchtowerService.CycleStopReason.HostStopping,
+        };
+        var callers = reasons.Select(reason => Task.Run(async () =>
+        {
+            await start.Task.WaitAsync(TestTimeout);
+            return active.RequestCancellation(reason);
+        })).ToArray();
+
+        try
+        {
+            start.TrySetResult();
+            var tasks = await Task.WhenAll(callers);
+            var first = tasks[0];
+            Assert.All(tasks, task => Assert.Same(first, task));
+            Assert.NotSame(Task.CompletedTask, first);
+
+            await callbackStarted.Task.WaitAsync(TestTimeout);
+            Assert.False(first.IsCompleted);
+            Assert.Equal(1, Volatile.Read(ref invocations));
+            Assert.Equal(WatchtowerService.CycleStopReason.HostStopping, active.StopReason);
+            Assert.False(active.BothTasksObserved);
+
+            releaseCallback.TrySetResult();
+            await first.WaitAsync(TestTimeout);
+            Assert.False(active.BothTasksObserved);
+            Assert.False(cycleHold.Task.IsCompleted);
+
+            cycleHold.TrySetResult();
+            await cycleHold.Task.WaitAsync(TestTimeout);
+            Assert.False(active.BothTasksObserved);
+        }
+        finally
+        {
+            releaseCallback.TrySetResult();
+            cycleHold.TrySetResult();
+        }
+    }
+
+    [Fact]
+    public async Task CancellationCallbackFailure_IsObservedBeforeRetry()
+    {
+        var clock = new ControllableTimeProvider();
+        var error = new InvalidOperationException("watchtower-callback-failure");
+        var storedReg = default(CancellationTokenRegistration);
+        var firstReturned = NewSignal();
+        var secondStarted = NewSignal();
+        var starts = 0;
+        var sink = new CollectingSink();
+        using var logs = CaptureLogs(sink);
+
+        await using var run = Start(clock, async (_, ct) =>
+        {
+            var ordinal = Interlocked.Increment(ref starts);
+            if (ordinal == 1)
+            {
+                storedReg = ct.Register(() => throw error);
+                firstReturned.TrySetResult();
+                return;
+            }
+
+            secondStarted.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+        });
+
+        try
+        {
+            await firstReturned.Task.WaitAsync(TestTimeout);
+            var cycle1 = await WaitClearedAsync(run.Service);
+            Assert.True(cycle1.BothTasksObserved);
+            await WaitForPostCycleDelayAsync(clock);
+
+            var failure = Assert.Single(
+                sink.Events,
+                e => e.Exception is not null && HasException(e.Exception, error));
+            Assert.Equal(LogEventLevel.Error, failure.Level);
+            Assert.Contains("unexpected cycle cancellation failure", failure.MessageTemplate.Text);
+            Assert.Equal(1, sink.Events.Count(e => e.Exception is not null && HasException(e.Exception, error)));
+            Assert.DoesNotContain(sink.Events, IsWatchdogWarning);
+            Assert.False(secondStarted.Task.IsCompleted);
+
+            await AdvanceScheduledAsync(clock, WatchtowerService.LoopErrorDelay);
+            await secondStarted.Task.WaitAsync(TestTimeout);
+            Assert.Equal(2, Volatile.Read(ref starts));
+        }
+        finally
+        {
+            storedReg.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task CancellationCallbackOutOfMemory_IsUnwrappedAndPropagated()
+    {
+        var clock = new ControllableTimeProvider();
+        var oom = new OutOfMemoryException("watchtower-callback-oom");
+        var storedReg = default(CancellationTokenRegistration);
+        var firstReturned = NewSignal();
+        var starts = 0;
+        var sink = new CollectingSink();
+        using var logs = CaptureLogs(sink);
+
+        await using var run = Start(clock, (_, ct) =>
+        {
+            Interlocked.Increment(ref starts);
+            storedReg = ct.Register(() => throw oom);
+            firstReturned.TrySetResult();
+            return Task.CompletedTask;
+        });
+
+        try
+        {
+            await firstReturned.Task.WaitAsync(TestTimeout);
+            var thrown = await Assert.ThrowsAsync<OutOfMemoryException>(
+                () => run.ExecuteTask.WaitAsync(TestTimeout));
+            Assert.Same(oom, thrown);
+            var cycle1 = await WaitClearedAsync(run.Service);
+            Assert.True(cycle1.BothTasksObserved);
+            Assert.Equal(1, Volatile.Read(ref starts));
+            Assert.DoesNotContain(sink.Events, e => e.MessageTemplate.Text.Contains("Watchtower loop error"));
+            Assert.DoesNotContain(sink.Events, e => e.MessageTemplate.Text.Contains("cancellation failure"));
+            Assert.DoesNotContain(sink.Events, IsWatchdogWarning);
+            Assert.Null(run.Service.ActiveCycleForTests);
+        }
+        finally
+        {
+            storedReg.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task CancellationAndCycleOutOfMemory_PropagatesCancellationOom()
+    {
+        var clock = new ControllableTimeProvider();
+        var cancellationOom = new OutOfMemoryException("watchtower-callback-oom");
+        var cycleOom = new OutOfMemoryException("watchtower-cycle-oom");
+        var storedReg = default(CancellationTokenRegistration);
+        var firstReturned = NewSignal();
+        var starts = 0;
+        var sink = new CollectingSink();
+        using var logs = CaptureLogs(sink);
+
+        await using var run = Start(clock, (_, ct) =>
+        {
+            Interlocked.Increment(ref starts);
+            storedReg = ct.Register(() => throw cancellationOom);
+            firstReturned.TrySetResult();
+            throw cycleOom;
+        });
+
+        try
+        {
+            await firstReturned.Task.WaitAsync(TestTimeout);
+            var thrown = await Assert.ThrowsAsync<OutOfMemoryException>(
+                () => run.ExecuteTask.WaitAsync(TestTimeout));
+            Assert.Same(cancellationOom, thrown);
+            Assert.True((await WaitClearedAsync(run.Service)).BothTasksObserved);
+            Assert.Equal(1, Volatile.Read(ref starts));
+            Assert.DoesNotContain(sink.Events, e => e.Level is LogEventLevel.Warning or LogEventLevel.Error);
+        }
+        finally
+        {
+            storedReg.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Watchdog_DrainFaultIsObservedWithStackBeforeRetry()
+    {
+        var clock = new ControllableTimeProvider();
+        var error = new InvalidOperationException("watchtower-drain-fault");
+        var cancelled = NewSignal();
+        var secondStarted = NewSignal();
+        var starts = 0;
+        var sink = new CollectingSink();
+        using var logs = CaptureLogs(sink);
+
+        await using var run = Start(clock, async (_, ct) =>
+        {
+            var ordinal = Interlocked.Increment(ref starts);
+            if (ordinal != 1)
+            {
+                secondStarted.TrySetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+                return;
+            }
+
+            using var registration = ct.Register(() => cancelled.TrySetResult());
+            await cancelled.Task.WaitAsync(TestTimeout);
+            throw error;
+        });
+
+        await run.WaitUntilFirstCycleAsync();
+        var cycle1 = RequireActive(run.Service);
+        clock.Advance(WatchtowerService.CycleWatchdogTimeout);
+        await cancelled.Task.WaitAsync(TestTimeout);
+        await cycle1.WhenBothTasksObserved.WaitAsync(TestTimeout);
+        await cycle1.WhenOwnerCleared.WaitAsync(TestTimeout);
+        await WaitForPostCycleDelayAsync(clock);
+
+        var warning = Assert.Single(sink.Events, IsWatchdogWarning);
+        Assert.Null(warning.Exception);
+        var drainFault = Assert.Single(
+            sink.Events,
+            e => e.Exception is not null && HasException(e.Exception, error));
+        Assert.Equal(LogEventLevel.Warning, drainFault.Level);
+        Assert.Contains("faulted while draining", drainFault.MessageTemplate.Text);
+        Assert.Equal(1, sink.Events.Count(e => e.Exception is not null && HasException(e.Exception, error)));
+        Assert.False(secondStarted.Task.IsCompleted);
+        Assert.Equal(1, Volatile.Read(ref starts));
+
+        await AdvanceScheduledAsync(clock, WatchtowerService.LoopErrorDelay);
+        await secondStarted.Task.WaitAsync(TestTimeout);
+        Assert.Equal(2, Volatile.Read(ref starts));
+    }
+
+    [Fact]
+    public async Task NaturalCycleFault_UsesKnownErrorLoggingAndRetryDelay()
+    {
+        var clock = new ControllableTimeProvider();
+        var error = new IOException("watchtower-known-cycle-fault");
+        var secondStarted = NewSignal();
+        var starts = 0;
+        var sink = new CollectingSink();
+        using var logs = CaptureLogs(sink);
+
+        await using var run = Start(clock, async (_, ct) =>
+        {
+            var ordinal = Interlocked.Increment(ref starts);
+            if (ordinal == 1)
+                throw error;
+
+            secondStarted.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+        });
+
+        var cycle1 = await WaitClearedAsync(run.Service);
+        Assert.True(cycle1.BothTasksObserved);
+        await WaitForPostCycleDelayAsync(clock);
+
+        var warning = Assert.Single(
+            sink.Events,
+            e => e.MessageTemplate.Text.Contains("Watchtower loop error"));
+        Assert.Null(warning.Exception);
+        Assert.Equal(error.Message, warning.Properties["Reason"].LiteralValue());
+        Assert.DoesNotContain(sink.Events, IsWatchdogWarning);
+        Assert.False(secondStarted.Task.IsCompleted);
+
+        await AdvanceScheduledAsync(clock, WatchtowerService.LoopErrorDelay);
+        await secondStarted.Task.WaitAsync(TestTimeout);
+        Assert.Equal(2, Volatile.Read(ref starts));
+    }
+
+    [Fact]
+    public async Task HostShutdown_DrainsActiveCycleAndNeverStartsReplacement()
+    {
+        var clock = new ControllableTimeProvider();
+        var scripted = new ScriptedCycle();
+        var sink = new CollectingSink();
+        using var logs = CaptureLogs(sink);
+        await using var run = Start(clock, scripted.DelayFirstCancellationAsync);
+        try
+        {
+            await scripted.FirstStarted.Task.WaitAsync(TestTimeout);
+            await run.HostCts.CancelAsync();
+            await scripted.FirstCancellation.Task.WaitAsync(TestTimeout);
+
+            Assert.False(run.ExecuteTask.IsCompleted);
+            clock.Advance(WatchtowerService.CycleWatchdogTimeout);
+            clock.Advance(WatchtowerService.CycleInterval);
+            clock.Advance(TimeSpan.FromHours(1));
+            Assert.Equal(1, Volatile.Read(ref scripted.Starts));
+            Assert.False(scripted.SecondStarted.Task.IsCompleted);
+
+            scripted.ReleaseFirst.TrySetResult();
+            await run.ExecuteTask.WaitAsync(TestTimeout);
+            Assert.Equal(1, Volatile.Read(ref scripted.Starts));
+            Assert.DoesNotContain(sink.Events, IsWatchdogWarning);
+        }
+        finally
+        {
+            scripted.ReleaseFirst.TrySetResult();
+        }
+    }
+
+    [Fact]
+    public async Task HostShutdown_DuringWatchdogDrainSuppressesRestart()
+    {
+        var clock = new ControllableTimeProvider();
+        var scripted = new ScriptedCycle();
+        var sink = new CollectingSink();
+        using var logs = CaptureLogs(sink);
+        await using var run = Start(clock, scripted.DelayFirstCancellationAsync);
+        try
+        {
+            await scripted.FirstStarted.Task.WaitAsync(TestTimeout);
+            clock.Advance(WatchtowerService.CycleWatchdogTimeout);
+            await scripted.FirstCancellation.Task.WaitAsync(TestTimeout);
+            Assert.Contains(sink.Events, IsWatchdogWarning);
+
+            await run.HostCts.CancelAsync();
+            Assert.False(run.ExecuteTask.IsCompleted);
+            Assert.Equal(1, Volatile.Read(ref scripted.Starts));
+
+            scripted.ReleaseFirst.TrySetResult();
+            await run.ExecuteTask.WaitAsync(TestTimeout);
+            Assert.Equal(1, Volatile.Read(ref scripted.Starts));
+            Assert.False(scripted.SecondStarted.Task.IsCompleted);
+        }
+        finally
+        {
+            scripted.ReleaseFirst.TrySetResult();
+        }
+    }
+
+    [Fact]
+    public async Task Disable_DrainsActiveCycleAndDoesNotRestartWhileDisabled()
+    {
+        var clock = new ControllableTimeProvider();
+        var scripted = new ScriptedCycle();
+        await using var run = Start(clock, scripted.DelayFirstCancellationAsync);
+        try
+        {
+            await scripted.FirstStarted.Task.WaitAsync(TestTimeout);
+            var cycle1 = RequireActive(run.Service);
+            SetEnabled(run.Config, false);
+            await scripted.FirstCancellation.Task.WaitAsync(TestTimeout);
+            Assert.Equal(1, Volatile.Read(ref scripted.Starts));
+            Assert.False(scripted.SecondStarted.Task.IsCompleted);
+
+            scripted.ReleaseFirst.TrySetResult();
+            await cycle1.WhenOwnerCleared.WaitAsync(TestTimeout);
+            await AdvanceScheduledAsync(clock, WatchtowerService.AdmissionPollInterval);
+            clock.Advance(WatchtowerService.AdmissionPollInterval);
+            clock.Advance(WatchtowerService.CycleInterval);
+            Assert.Equal(1, Volatile.Read(ref scripted.Starts));
+            Assert.False(scripted.SecondStarted.Task.IsCompleted);
+
+            SetEnabled(run.Config, true);
+            await AdvanceScheduledAsync(clock, WatchtowerService.AdmissionPollInterval);
+            await scripted.SecondStarted.Task.WaitAsync(TestTimeout);
+            Assert.Equal(2, Volatile.Read(ref scripted.Starts));
+            Assert.Equal(1, scripted.MaximumActive);
+        }
+        finally
+        {
+            scripted.ReleaseFirst.TrySetResult();
+        }
+    }
+
+    [Fact]
+    public async Task Watchdog_NoncooperativeCycleRetainsOwnershipUntilExplicitTestCleanup()
+    {
+        var clock = new ControllableTimeProvider();
+        var scripted = new ScriptedCycle();
+        var sink = new CollectingSink();
+        using var logs = CaptureLogs(sink);
+        await using var run = Start(clock, scripted.DelayFirstCancellationAsync);
+        try
+        {
+            await scripted.FirstStarted.Task.WaitAsync(TestTimeout);
+            var cycle1 = RequireActive(run.Service);
+            clock.Advance(WatchtowerService.CycleWatchdogTimeout);
+            await scripted.FirstCancellation.Task.WaitAsync(TestTimeout);
+
+            clock.Advance(TimeSpan.FromHours(6));
+            Assert.False(run.ExecuteTask.IsCompleted);
+            Assert.Same(cycle1, run.Service.ActiveCycleForTests);
+            Assert.Equal(1, Volatile.Read(ref scripted.Starts));
+            Assert.Equal(1, sink.Events.Count(IsWatchdogWarning));
+            Assert.False(scripted.SecondStarted.Task.IsCompleted);
+
+            scripted.ReleaseFirst.TrySetResult();
+            await cycle1.WhenOwnerCleared.WaitAsync(TestTimeout);
+        }
+        finally
+        {
+            scripted.ReleaseFirst.TrySetResult();
+        }
+    }
+
+    [Fact]
+    public async Task Watchdog_NoncooperativeCycleAwaitsIndefinitelyWithoutReplacement()
+    {
+        var clock = new ControllableTimeProvider();
+        var scripted = new ScriptedCycle();
+        await using var run = Start(clock, scripted.DelayFirstCancellationAsync);
+        try
+        {
+            await scripted.FirstStarted.Task.WaitAsync(TestTimeout);
+            clock.Advance(WatchtowerService.CycleWatchdogTimeout);
+            await scripted.FirstCancellation.Task.WaitAsync(TestTimeout);
+
+            await run.HostCts.CancelAsync();
+            clock.Advance(TimeSpan.FromHours(2));
+            Assert.False(run.ExecuteTask.IsCompleted);
+            Assert.NotNull(run.Service.ActiveCycleForTests);
+            Assert.Equal(1, Volatile.Read(ref scripted.Starts));
+
+            scripted.ReleaseFirst.TrySetResult();
+            await run.ExecuteTask.WaitAsync(TestTimeout);
+            Assert.Equal(1, Volatile.Read(ref scripted.Starts));
+            Assert.False(scripted.SecondStarted.Task.IsCompleted);
+        }
+        finally
+        {
+            scripted.ReleaseFirst.TrySetResult();
+        }
+    }
+
+    [Fact]
+    public async Task CycleOutOfMemory_FaultsHostedExecutionWithoutRestart()
+    {
+        var clock = new ControllableTimeProvider();
+        var oom = new OutOfMemoryException("watchtower-cycle-oom");
+        var starts = 0;
+        var sink = new CollectingSink();
+        using var logs = CaptureLogs(sink);
+
+        await using var run = Start(clock, (_, _) =>
+        {
+            Interlocked.Increment(ref starts);
+            throw oom;
+        });
+
+        var thrown = await Assert.ThrowsAsync<OutOfMemoryException>(
+            () => run.ExecuteTask.WaitAsync(TestTimeout));
+        Assert.Same(oom, thrown);
+        Assert.Equal(1, Volatile.Read(ref starts));
+        Assert.DoesNotContain(sink.Events, e => e.MessageTemplate.Text.Contains("Watchtower loop error"));
+        Assert.DoesNotContain(sink.Events, IsWatchdogWarning);
+    }
+
+    [Fact]
+    public async Task Watchdog_CycleOutOfMemoryDuringDrainFaultsHostedExecution()
+    {
+        var clock = new ControllableTimeProvider();
+        var oom = new OutOfMemoryException("watchtower-drain-oom");
+        var cancelled = NewSignal();
+        var starts = 0;
+        var sink = new CollectingSink();
+        using var logs = CaptureLogs(sink);
+
+        await using var run = Start(clock, async (_, ct) =>
+        {
+            Interlocked.Increment(ref starts);
+            using var registration = ct.Register(() => cancelled.TrySetResult());
+            await cancelled.Task.WaitAsync(TestTimeout);
+            throw oom;
+        });
+
+        await run.WaitUntilFirstCycleAsync();
+        clock.Advance(WatchtowerService.CycleWatchdogTimeout);
+        await cancelled.Task.WaitAsync(TestTimeout);
+
+        var thrown = await Assert.ThrowsAsync<OutOfMemoryException>(
+            () => run.ExecuteTask.WaitAsync(TestTimeout));
+        Assert.Same(oom, thrown);
+        Assert.Equal(1, Volatile.Read(ref starts));
+        Assert.Contains(sink.Events, IsWatchdogWarning);
+        Assert.DoesNotContain(sink.Events, e => e.MessageTemplate.Text.Contains("Watchtower loop error"));
+        Assert.DoesNotContain(sink.Events, e => e.MessageTemplate.Text.Contains("faulted while draining"));
+    }
+
+    [Fact]
+    public async Task CompletedCycle_CancelsWatchdogDelayAndIgnoresLaterConfigDisable()
+    {
+        var clock = new ControllableTimeProvider();
+        var firstReturned = NewSignal();
+        var secondStarted = NewSignal();
+        var starts = 0;
+        var sink = new CollectingSink();
+        using var logs = CaptureLogs(sink);
+
+        await using var run = Start(clock, async (_, ct) =>
+        {
+            var ordinal = Interlocked.Increment(ref starts);
+            if (ordinal == 1)
+            {
+                firstReturned.TrySetResult();
+                return;
+            }
+
+            secondStarted.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+        });
+
+        await firstReturned.Task.WaitAsync(TestTimeout);
+        var cycle1 = await WaitClearedAsync(run.Service);
+        Assert.True(cycle1.BothTasksObserved);
+        Assert.Null(run.Service.ActiveCycleForTests);
+
+        SetEnabled(run.Config, false);
+        clock.Advance(WatchtowerService.CycleWatchdogTimeout);
+        clock.Advance(TimeSpan.FromHours(1));
+
+        Assert.DoesNotContain(sink.Events, IsWatchdogWarning);
+        Assert.Equal(1, Volatile.Read(ref starts));
+        Assert.False(secondStarted.Task.IsCompleted);
+        Assert.False(run.ExecuteTask.IsFaulted);
+    }
+
+    [Fact]
+    public async Task CancellationAndCycleFailures_AreAggregatedInSourceOrder()
+    {
+        var clock = new ControllableTimeProvider();
+        var callbackError = new InvalidOperationException("watchtower-callback-aggregate");
+        var cycleError = new InvalidOperationException("watchtower-cycle-aggregate");
+        var storedReg = default(CancellationTokenRegistration);
+        var firstReturned = NewSignal();
+        var sink = new CollectingSink();
+        using var logs = CaptureLogs(sink);
+
+        await using var run = Start(clock, (_, ct) =>
+        {
+            storedReg = ct.Register(() => throw callbackError);
+            firstReturned.TrySetResult();
+            throw cycleError;
+        });
+
+        try
+        {
+            await firstReturned.Task.WaitAsync(TestTimeout);
+            await WaitClearedAsync(run.Service);
+            await WaitForPostCycleDelayAsync(clock);
+
+            var failure = Assert.Single(
+                sink.Events,
+                e => e.Exception is not null && HasException(e.Exception, callbackError));
+            Assert.True(HasException(failure.Exception!, cycleError));
+            var aggregate = Assert.IsType<AggregateException>(failure.Exception);
+            var leaves = aggregate.Flatten().InnerExceptions;
+            Assert.Same(callbackError, leaves.First(ex => ReferenceEquals(ex, callbackError)));
+            Assert.Same(cycleError, leaves.First(ex => ReferenceEquals(ex, cycleError)));
+            Assert.True(
+                IndexOf(leaves, callbackError) < IndexOf(leaves, cycleError),
+                aggregate.ToString());
+        }
+        finally
+        {
+            storedReg.Dispose();
+        }
+    }
+
+    private static HostedRun Start(
+        ControllableTimeProvider clock,
+        Func<Stopwatch, CancellationToken, Task> runCycle)
+    {
+        var config = new ConfigManager();
+        SetEnabled(config, true);
+        var service = new WatchtowerService(
+            config,
+            searchProfileService: null!,
+            fastVerifier: null!,
+            hitTracker: null!,
+            rateLimiter: null!,
+            negativeCache: null!,
+            wardenStore: null!,
+            preflightCache: null!,
+            enumerator: null!,
+            episodeEnumerator: null!,
+            preferredOrderStore: null!,
+            nzbFetchCoalescer: null!,
+            benchmarkGate: new BenchmarkGate(),
+            dbContextFactory: null!,
+            timeProvider: clock)
+        {
+            RunCycleOverride = runCycle,
+        };
+        var hostCts = new CancellationTokenSource();
+        return new HostedRun(service, config, hostCts, service.ExecuteHostedServiceForTests(hostCts.Token));
+    }
+
+    private static void SetEnabled(ConfigManager config, bool enabled) =>
+        config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.WatchtowerEnabled,
+                ConfigValue = enabled ? "true" : "false",
+            },
+        ]);
+
+    private static WatchtowerService.ActiveCycle RequireActive(WatchtowerService service)
+    {
+        var active = service.ActiveCycleForTests;
+        Assert.NotNull(active);
+        return active!;
+    }
+
+    private static async Task<WatchtowerService.ActiveCycle> WaitClearedAsync(WatchtowerService service)
+    {
+        await WaitUntilAsync(
+            () => service.LastClearedCycleForTests is not null,
+            "Watchtower never cleared the active cycle");
+        var cleared = service.LastClearedCycleForTests!;
+        await cleared.WhenBothTasksObserved.WaitAsync(TestTimeout);
+        await cleared.WhenOwnerCleared.WaitAsync(TestTimeout);
+        return cleared;
+    }
+
+    private static async Task WaitForPostCycleDelayAsync(ControllableTimeProvider clock) =>
+        await WaitUntilAsync(
+            () => clock.HasScheduledTimer,
+            "Watchtower did not schedule a post-cycle delay");
+
+    private static async Task AdvanceScheduledAsync(ControllableTimeProvider clock, TimeSpan delay)
+    {
+        await WaitForPostCycleDelayAsync(clock);
+        clock.Advance(delay);
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, string message)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (!condition())
+        {
+            if (stopwatch.Elapsed > TestTimeout)
+                throw new TimeoutException(message);
+            await Task.Yield();
+        }
+    }
+
+    private static bool IsWatchdogWarning(LogEvent logEvent) =>
+        logEvent.Level == LogEventLevel.Warning
+        && logEvent.MessageTemplate.Text.Contains("cancellation requested, waiting for completion");
+
+    private static bool HasException(Exception haystack, Exception needle)
+    {
+        foreach (var current in Flatten(haystack))
+        {
+            if (ReferenceEquals(current, needle))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static int IndexOf(IReadOnlyList<Exception> exceptions, Exception needle)
+    {
+        for (var i = 0; i < exceptions.Count; i++)
+        {
+            if (ReferenceEquals(exceptions[i], needle))
+                return i;
+        }
+
+        return int.MaxValue;
+    }
+
+    private static IEnumerable<Exception> Flatten(Exception exception)
+    {
+        var stack = new Stack<Exception>();
+        stack.Push(exception);
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            yield return current;
+            if (current is AggregateException aggregate)
+            {
+                for (var i = aggregate.InnerExceptions.Count - 1; i >= 0; i--)
+                    stack.Push(aggregate.InnerExceptions[i]);
+            }
+            else if (current.InnerException is { } inner)
+            {
+                stack.Push(inner);
+            }
+        }
+    }
+
+    private static TaskCompletionSource NewSignal() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private static LoggerCapture CaptureLogs(CollectingSink sink)
+    {
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        return new LoggerCapture(previous);
+    }
+
+    private sealed class LoggerCapture(ILogger previous) : IDisposable
+    {
+        public void Dispose() => Log.Logger = previous;
+    }
+
+    private sealed class HostedRun(
+        WatchtowerService service,
+        ConfigManager config,
+        CancellationTokenSource hostCts,
+        Task executeTask) : IAsyncDisposable
+    {
+        public WatchtowerService Service { get; } = service;
+        public ConfigManager Config { get; } = config;
+        public CancellationTokenSource HostCts { get; } = hostCts;
+        public Task ExecuteTask { get; } = executeTask;
+
+        public async Task WaitUntilFirstCycleAsync() =>
+            await WaitUntilAsync(
+                () => Service.ActiveCycleForTests is not null || ExecuteTask.IsCompleted,
+                "Watchtower never published an active cycle");
+
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                if (!HostCts.IsCancellationRequested)
+                    await HostCts.CancelAsync();
+                try
+                {
+                    await ExecuteTask.WaitAsync(TestTimeout);
+                }
+                catch (Exception)
+                {
+                    // Faulted hosted execution is asserted by the test body.
+                }
+            }
+            finally
+            {
+                Service.Dispose();
+                HostCts.Dispose();
+            }
+        }
+    }
+
+    private sealed class ScriptedCycle
+    {
+        private int _active;
+        private int _maximumActive;
+
+        public int Starts;
+        public int MaximumActive => Volatile.Read(ref _maximumActive);
+
+        public TaskCompletionSource FirstStarted { get; } = NewSignal();
+        public TaskCompletionSource FirstCancellation { get; } = NewSignal();
+        public TaskCompletionSource ReleaseFirst { get; } = NewSignal();
+        public TaskCompletionSource FirstExited { get; } = NewSignal();
+        public TaskCompletionSource SecondStarted { get; } = NewSignal();
+
+        public async Task DelayFirstCancellationAsync(
+            Stopwatch _,
+            CancellationToken cancellationToken)
+        {
+            var ordinal = Begin();
+            try
+            {
+                if (ordinal == 1)
+                {
+                    using var registration = cancellationToken.Register(
+                        static state => ((TaskCompletionSource)state!).TrySetResult(),
+                        FirstCancellation);
+                    FirstStarted.TrySetResult();
+                    await ReleaseFirst.Task.ConfigureAwait(false);
+                    return;
+                }
+
+                SecondStarted.TrySetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                End(ordinal);
+            }
+        }
+
+        public async Task CooperativeCancelAsync(
+            Stopwatch _,
+            CancellationToken cancellationToken)
+        {
+            var ordinal = Begin();
+            try
+            {
+                if (ordinal == 1)
+                {
+                    FirstStarted.TrySetResult();
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+                    return;
+                }
+
+                SecondStarted.TrySetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                End(ordinal);
+            }
+        }
+
+        private int Begin()
+        {
+            var ordinal = Interlocked.Increment(ref Starts);
+            var active = Interlocked.Increment(ref _active);
+            UpdateMaximum(ref _maximumActive, active);
+            return ordinal;
+        }
+
+        private void End(int ordinal)
+        {
+            Interlocked.Decrement(ref _active);
+            if (ordinal == 1)
+                FirstExited.TrySetResult();
+        }
+
+        private static void UpdateMaximum(ref int maximum, int candidate)
+        {
+            while (true)
+            {
+                var current = Volatile.Read(ref maximum);
+                if (candidate <= current)
+                    return;
+                if (Interlocked.CompareExchange(ref maximum, candidate, current) == current)
+                    return;
+            }
+        }
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events)
+                    return _events.ToList();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events)
+                _events.Add(logEvent);
+        }
+    }
+}
+
+file static class WatchtowerLogEventPropertyValueExtensions
+{
+    public static object? LiteralValue(this LogEventPropertyValue value) =>
+        value is ScalarValue scalar ? scalar.Value : value.ToString();
+}

--- a/tests/NzbWebDAV.Tests/Services/WatchtowerServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/WatchtowerServiceTests.cs
@@ -93,14 +93,14 @@ public sealed class WatchtowerServiceTests
         var secondStarted = NewSignal();
         var starts = 0;
         var callbackCount = 0;
-        var storedReg = default(CancellationTokenRegistration);
+        using var storedReg = new StoredRegistration();
 
         await using var run = Start(clock, async (_, ct) =>
         {
             var ordinal = Interlocked.Increment(ref starts);
             if (ordinal == 1)
             {
-                storedReg = ct.Register(() =>
+                storedReg.Registration = ct.Register(() =>
                 {
                     Interlocked.Increment(ref callbackCount);
                     callbackStarted.TrySetResult();
@@ -149,7 +149,6 @@ public sealed class WatchtowerServiceTests
         finally
         {
             releaseCallback.TrySetResult();
-            storedReg.Dispose();
         }
     }
 
@@ -221,7 +220,7 @@ public sealed class WatchtowerServiceTests
     {
         var clock = new ControllableTimeProvider();
         var error = new InvalidOperationException("watchtower-callback-failure");
-        var storedReg = default(CancellationTokenRegistration);
+        using var storedReg = new StoredRegistration();
         var firstReturned = NewSignal();
         var secondStarted = NewSignal();
         var starts = 0;
@@ -233,7 +232,7 @@ public sealed class WatchtowerServiceTests
             var ordinal = Interlocked.Increment(ref starts);
             if (ordinal == 1)
             {
-                storedReg = ct.Register(() => throw error);
+                storedReg.Registration = ct.Register(() => throw error);
                 firstReturned.TrySetResult();
                 return;
             }
@@ -242,30 +241,23 @@ public sealed class WatchtowerServiceTests
             await Task.Delay(Timeout.InfiniteTimeSpan, ct);
         });
 
-        try
-        {
-            await firstReturned.Task.WaitAsync(TestTimeout);
-            var cycle1 = await WaitClearedAsync(run.Service);
-            Assert.True(cycle1.BothTasksObserved);
-            await WaitForPostCycleDelayAsync(clock);
+        await firstReturned.Task.WaitAsync(TestTimeout);
+        var cycle1 = await WaitClearedAsync(run.Service);
+        Assert.True(cycle1.BothTasksObserved);
+        await WaitForPostCycleDelayAsync(clock);
 
-            var failure = Assert.Single(
-                sink.Events,
-                e => e.Exception is not null && HasException(e.Exception, error));
-            Assert.Equal(LogEventLevel.Error, failure.Level);
-            Assert.Contains("unexpected cycle cancellation failure", failure.MessageTemplate.Text);
-            Assert.Equal(1, sink.Events.Count(e => e.Exception is not null && HasException(e.Exception, error)));
-            Assert.DoesNotContain(sink.Events, IsWatchdogWarning);
-            Assert.False(secondStarted.Task.IsCompleted);
+        var failure = Assert.Single(
+            sink.Events,
+            e => e.Exception is not null && HasException(e.Exception, error));
+        Assert.Equal(LogEventLevel.Error, failure.Level);
+        Assert.Contains("unexpected cycle cancellation failure", failure.MessageTemplate.Text);
+        Assert.Equal(1, sink.Events.Count(e => e.Exception is not null && HasException(e.Exception, error)));
+        Assert.DoesNotContain(sink.Events, IsWatchdogWarning);
+        Assert.False(secondStarted.Task.IsCompleted);
 
-            await AdvanceScheduledAsync(clock, WatchtowerService.LoopErrorDelay);
-            await secondStarted.Task.WaitAsync(TestTimeout);
-            Assert.Equal(2, Volatile.Read(ref starts));
-        }
-        finally
-        {
-            storedReg.Dispose();
-        }
+        await AdvanceScheduledAsync(clock, WatchtowerService.LoopErrorDelay);
+        await secondStarted.Task.WaitAsync(TestTimeout);
+        Assert.Equal(2, Volatile.Read(ref starts));
     }
 
     [Fact]
@@ -273,7 +265,7 @@ public sealed class WatchtowerServiceTests
     {
         var clock = new ControllableTimeProvider();
         var oom = new OutOfMemoryException("watchtower-callback-oom");
-        var storedReg = default(CancellationTokenRegistration);
+        using var storedReg = new StoredRegistration();
         var firstReturned = NewSignal();
         var starts = 0;
         var sink = new CollectingSink();
@@ -282,29 +274,22 @@ public sealed class WatchtowerServiceTests
         await using var run = Start(clock, (_, ct) =>
         {
             Interlocked.Increment(ref starts);
-            storedReg = ct.Register(() => throw oom);
+            storedReg.Registration = ct.Register(() => throw oom);
             firstReturned.TrySetResult();
             return Task.CompletedTask;
         });
 
-        try
-        {
-            await firstReturned.Task.WaitAsync(TestTimeout);
-            var thrown = await Assert.ThrowsAsync<OutOfMemoryException>(
-                () => run.ExecuteTask.WaitAsync(TestTimeout));
-            Assert.Same(oom, thrown);
-            var cycle1 = await WaitClearedAsync(run.Service);
-            Assert.True(cycle1.BothTasksObserved);
-            Assert.Equal(1, Volatile.Read(ref starts));
-            Assert.DoesNotContain(sink.Events, e => e.MessageTemplate.Text.Contains("Watchtower loop error"));
-            Assert.DoesNotContain(sink.Events, e => e.MessageTemplate.Text.Contains("cancellation failure"));
-            Assert.DoesNotContain(sink.Events, IsWatchdogWarning);
-            Assert.Null(run.Service.ActiveCycleForTests);
-        }
-        finally
-        {
-            storedReg.Dispose();
-        }
+        await firstReturned.Task.WaitAsync(TestTimeout);
+        var thrown = await Assert.ThrowsAsync<OutOfMemoryException>(
+            () => run.ExecuteTask.WaitAsync(TestTimeout));
+        Assert.Same(oom, thrown);
+        var cycle1 = await WaitClearedAsync(run.Service);
+        Assert.True(cycle1.BothTasksObserved);
+        Assert.Equal(1, Volatile.Read(ref starts));
+        Assert.DoesNotContain(sink.Events, e => e.MessageTemplate.Text.Contains("Watchtower loop error"));
+        Assert.DoesNotContain(sink.Events, e => e.MessageTemplate.Text.Contains("cancellation failure"));
+        Assert.DoesNotContain(sink.Events, IsWatchdogWarning);
+        Assert.Null(run.Service.ActiveCycleForTests);
     }
 
     [Fact]
@@ -313,7 +298,7 @@ public sealed class WatchtowerServiceTests
         var clock = new ControllableTimeProvider();
         var cancellationOom = new OutOfMemoryException("watchtower-callback-oom");
         var cycleOom = new OutOfMemoryException("watchtower-cycle-oom");
-        var storedReg = default(CancellationTokenRegistration);
+        using var storedReg = new StoredRegistration();
         var firstReturned = NewSignal();
         var starts = 0;
         var sink = new CollectingSink();
@@ -322,25 +307,18 @@ public sealed class WatchtowerServiceTests
         await using var run = Start(clock, (_, ct) =>
         {
             Interlocked.Increment(ref starts);
-            storedReg = ct.Register(() => throw cancellationOom);
+            storedReg.Registration = ct.Register(() => throw cancellationOom);
             firstReturned.TrySetResult();
             throw cycleOom;
         });
 
-        try
-        {
-            await firstReturned.Task.WaitAsync(TestTimeout);
-            var thrown = await Assert.ThrowsAsync<OutOfMemoryException>(
-                () => run.ExecuteTask.WaitAsync(TestTimeout));
-            Assert.Same(cancellationOom, thrown);
-            Assert.True((await WaitClearedAsync(run.Service)).BothTasksObserved);
-            Assert.Equal(1, Volatile.Read(ref starts));
-            Assert.DoesNotContain(sink.Events, e => e.Level is LogEventLevel.Warning or LogEventLevel.Error);
-        }
-        finally
-        {
-            storedReg.Dispose();
-        }
+        await firstReturned.Task.WaitAsync(TestTimeout);
+        var thrown = await Assert.ThrowsAsync<OutOfMemoryException>(
+            () => run.ExecuteTask.WaitAsync(TestTimeout));
+        Assert.Same(cancellationOom, thrown);
+        Assert.True((await WaitClearedAsync(run.Service)).BothTasksObserved);
+        Assert.Equal(1, Volatile.Read(ref starts));
+        Assert.DoesNotContain(sink.Events, e => e.Level is LogEventLevel.Warning or LogEventLevel.Error);
     }
 
     [Fact]
@@ -685,40 +663,33 @@ public sealed class WatchtowerServiceTests
         var clock = new ControllableTimeProvider();
         var callbackError = new InvalidOperationException("watchtower-callback-aggregate");
         var cycleError = new InvalidOperationException("watchtower-cycle-aggregate");
-        var storedReg = default(CancellationTokenRegistration);
+        using var storedReg = new StoredRegistration();
         var firstReturned = NewSignal();
         var sink = new CollectingSink();
         using var logs = CaptureLogs(sink);
 
         await using var run = Start(clock, (_, ct) =>
         {
-            storedReg = ct.Register(() => throw callbackError);
+            storedReg.Registration = ct.Register(() => throw callbackError);
             firstReturned.TrySetResult();
             throw cycleError;
         });
 
-        try
-        {
-            await firstReturned.Task.WaitAsync(TestTimeout);
-            await WaitClearedAsync(run.Service);
-            await WaitForPostCycleDelayAsync(clock);
+        await firstReturned.Task.WaitAsync(TestTimeout);
+        await WaitClearedAsync(run.Service);
+        await WaitForPostCycleDelayAsync(clock);
 
-            var failure = Assert.Single(
-                sink.Events,
-                e => e.Exception is not null && HasException(e.Exception, callbackError));
-            Assert.True(HasException(failure.Exception!, cycleError));
-            var aggregate = Assert.IsType<AggregateException>(failure.Exception);
-            var leaves = aggregate.Flatten().InnerExceptions;
-            Assert.Same(callbackError, leaves.First(ex => ReferenceEquals(ex, callbackError)));
-            Assert.Same(cycleError, leaves.First(ex => ReferenceEquals(ex, cycleError)));
-            Assert.True(
-                IndexOf(leaves, callbackError) < IndexOf(leaves, cycleError),
-                aggregate.ToString());
-        }
-        finally
-        {
-            storedReg.Dispose();
-        }
+        var failure = Assert.Single(
+            sink.Events,
+            e => e.Exception is not null && HasException(e.Exception, callbackError));
+        Assert.True(HasException(failure.Exception!, cycleError));
+        var aggregate = Assert.IsType<AggregateException>(failure.Exception);
+        var leaves = aggregate.Flatten().InnerExceptions;
+        Assert.Same(callbackError, leaves.First(ex => ReferenceEquals(ex, callbackError)));
+        Assert.Same(cycleError, leaves.First(ex => ReferenceEquals(ex, cycleError)));
+        Assert.True(
+            IndexOf(leaves, callbackError) < IndexOf(leaves, cycleError),
+            aggregate.ToString());
     }
 
     private static HostedRun Start(
@@ -864,6 +835,13 @@ public sealed class WatchtowerServiceTests
         public void Dispose() => Log.Logger = previous;
     }
 
+    private sealed class StoredRegistration : IDisposable
+    {
+        public CancellationTokenRegistration Registration { get; set; }
+
+        public void Dispose() => Registration.Dispose();
+    }
+
     private sealed class HostedRun(
         WatchtowerService service,
         ConfigManager config,
@@ -886,11 +864,18 @@ public sealed class WatchtowerServiceTests
             {
                 if (!HostCts.IsCancellationRequested)
                     await HostCts.CancelAsync();
+
+                if (ExecuteTask.IsCompleted)
+                {
+                    _ = ExecuteTask.Exception;
+                    return;
+                }
+
                 try
                 {
                     await ExecuteTask.WaitAsync(TestTimeout);
                 }
-                catch (Exception)
+                catch (Exception ex) when (ex is not OutOfMemoryException)
                 {
                     // Faulted hosted execution is asserted by the test body.
                 }

--- a/tests/NzbWebDAV.Tests/Services/WatchtowerServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/WatchtowerServiceTests.cs
@@ -293,6 +293,37 @@ public sealed class WatchtowerServiceTests
     }
 
     [Fact]
+    public async Task CancellationCallbackOomAfterSiblingFailure_PropagatesOom()
+    {
+        var clock = new ControllableTimeProvider();
+        var sibling = new InvalidOperationException("watchtower-callback-sibling");
+        var oom = new OutOfMemoryException("watchtower-callback-later-oom");
+        using var storedReg = new StoredRegistration();
+        using var oomReg = new StoredRegistration();
+        var firstReturned = NewSignal();
+        var starts = 0;
+        var sink = new CollectingSink();
+        using var logs = CaptureLogs(sink);
+
+        await using var run = Start(clock, (_, ct) =>
+        {
+            Interlocked.Increment(ref starts);
+            storedReg.Registration = ct.Register(() => throw oom);
+            oomReg.Registration = ct.Register(() => throw sibling);
+            firstReturned.TrySetResult();
+            return Task.CompletedTask;
+        });
+
+        await firstReturned.Task.WaitAsync(TestTimeout);
+        var thrown = await Assert.ThrowsAsync<OutOfMemoryException>(
+            () => run.ExecuteTask.WaitAsync(TestTimeout));
+        Assert.Same(oom, thrown);
+        Assert.Equal(1, Volatile.Read(ref starts));
+        Assert.DoesNotContain(sink.Events, e => e.MessageTemplate.Text.Contains("Watchtower loop error"));
+        Assert.Null(run.Service.ActiveCycleForTests);
+    }
+
+    [Fact]
     public async Task CancellationAndCycleOutOfMemory_PropagatesCancellationOom()
     {
         var clock = new ControllableTimeProvider();

--- a/tests/NzbWebDAV.Tests/TestUtils/ControllableTimeProvider.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/ControllableTimeProvider.cs
@@ -58,10 +58,10 @@ internal sealed class ControllableTimeProvider : TimeProvider
     {
         get
         {
+            ManualTimer[] snapshot;
             lock (_gate)
-            {
-                return _timers.Any(timer => timer.NextDue is not null);
-            }
+                snapshot = _timers.ToArray();
+            return snapshot.Any(timer => timer.NextDue is not null);
         }
     }
 
@@ -130,6 +130,7 @@ internal sealed class ControllableTimeProvider : TimeProvider
 
         public bool Change(TimeSpan dueTime, TimeSpan period)
         {
+            var now = _provider.Now;
             var fireImmediately = false;
             lock (_gate)
             {
@@ -141,7 +142,7 @@ internal sealed class ControllableTimeProvider : TimeProvider
                     return true;
                 }
 
-                _nextDue = _provider.Now + dueTime;
+                _nextDue = now + dueTime;
                 fireImmediately = dueTime == TimeSpan.Zero;
             }
 

--- a/tests/NzbWebDAV.Tests/TestUtils/ControllableTimeProvider.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/ControllableTimeProvider.cs
@@ -60,13 +60,7 @@ internal sealed class ControllableTimeProvider : TimeProvider
         {
             lock (_gate)
             {
-                foreach (var timer in _timers)
-                {
-                    if (timer.NextDue is not null)
-                        return true;
-                }
-
-                return false;
+                return _timers.Any(timer => timer.NextDue is not null);
             }
         }
     }

--- a/tests/NzbWebDAV.Tests/TestUtils/ControllableTimeProvider.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/ControllableTimeProvider.cs
@@ -54,6 +54,23 @@ internal sealed class ControllableTimeProvider : TimeProvider
         get { lock (_gate) return _now; }
     }
 
+    internal bool HasScheduledTimer
+    {
+        get
+        {
+            lock (_gate)
+            {
+                foreach (var timer in _timers)
+                {
+                    if (timer.NextDue is not null)
+                        return true;
+                }
+
+                return false;
+            }
+        }
+    }
+
     private void FireDueTimers()
     {
         while (true)


### PR DESCRIPTION
Fixes #1243

Watchtower now owns at most one cycle task. After the 15-minute watchdog fires it requests cancellation, drains until that exact `RunCycleAsync` task and the memoized `CancelAsync` task are both terminal, then maybe starts another cycle. Host shutdown is not logged as a watchdog timeout and never launches a replacement.

## Policies

- **Stuck cycle:** await indefinitely after cancellation. Never detach and never start another cycle while the old task is still running. A permanently noncooperative cycle can delay Watchtower's graceful shutdown past the host's 5-second stop timeout; the process may then be aborted. Operators see one watchdog warning and no further Watchtower cycle starts. Streaming readiness is unchanged.
- **Multiple OOMs:** propagate the cancellation-task `OutOfMemoryException` first, then the cycle-task OOM. Do not log secondary OOMs or wrap the selected OOM in a new aggregate.

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter 'FullyQualifiedName~WatchtowerServiceTests'` (18 passed)
- [ ] PR CI backend build / analyzers / xUnit
- Fake-clock cases: delayed drain overlap, cooperative timeout tick, cycle-first disable during callback drain, concurrent stop sources sharing one `CancelAsync` task, callback failure, callback OOM, two-OOM priority, drain fault, natural fault backoff, host shutdown, host shutdown during watchdog drain, disable/re-enable, noncooperative retain-ownership, completed cycle watchdog cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability Improvements**
  * Watchtower cycles now shut down cleanly, preventing overlapping or abandoned work.
  * Watchdog timeouts, cancellations, failures, and shutdown events are handled consistently.
  * Disabled Watchtower services stop active work and can restart when re-enabled.
  * Retry timing now adapts to the type of failure encountered.
  * Critical failures, including memory exhaustion, are surfaced appropriately.
  * Failure details are combined and logged consistently for improved diagnostics.
  * Active cycles are prevented from being replaced until cleanup is complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->