### PR TITLE
fix(arr): reject oversized Newznab and Watchtower list responses instead of parsing them unbounded

### DIFF
--- a/backend/Api/Controllers/SearchIndexers/SearchIndexersController.cs
+++ b/backend/Api/Controllers/SearchIndexers/SearchIndexersController.cs
@@ -3,9 +3,11 @@ using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Clients.Indexers;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Services;
 using NzbWebDAV.Utils;
+using Serilog;
 
 namespace NzbWebDAV.Api.Controllers.SearchIndexers;
 
@@ -47,7 +49,14 @@ public class SearchIndexersController(
                 var proxy = string.IsNullOrWhiteSpace(x.ProxyUrl) ? globalProxy : x.ProxyUrl;
                 var timeout = indexerConfig.GetEffectiveTimeoutSeconds(x);
                 await rateLimiter.WaitAsync(x.Name, x.MaxRequestsPerMinute, ct).ConfigureAwait(false);
-                var client = new NewznabClient(x.Url, x.ApiKey, ua, proxy, timeout, x.SkipTlsVerification);
+                var client = new NewznabClient(
+                    x.Url,
+                    x.ApiKey,
+                    indexerConfig.GetEffectiveMaxResponseBytes(x),
+                    ua,
+                    proxy,
+                    timeout,
+                    x.SkipTlsVerification);
                 var items = await client.SearchAsync(request.Query, request.Limit, ct).ConfigureAwait(false);
                 _ = hitTracker.RecordAsync(x.Name, IndexerApiHit.HitType.Search, CancellationToken.None);
                 var mapped = items
@@ -74,11 +83,23 @@ public class SearchIndexersController(
             }
             catch (Exception e) when (!e.IsCancellationException(ct) && e is not OutOfMemoryException)
             {
+                if (e is RemoteResponseException)
+                {
+                    return (Status: new SearchIndexersResponse.IndexerStatus
+                    {
+                        Name = x.Name,
+                        Ok = false,
+                        Error = e.Message,
+                        ElapsedMs = sw.ElapsedMilliseconds,
+                    }, Results: new List<SearchIndexersResponse.Result>());
+                }
+
+                Log.Warning(e, "Indexer {Indexer} search failed unexpectedly.", x.Name);
                 return (Status: new SearchIndexersResponse.IndexerStatus
                 {
                     Name = x.Name,
                     Ok = false,
-                    Error = e.Message,
+                    Error = "Indexer search failed unexpectedly.",
                     ElapsedMs = sw.ElapsedMilliseconds,
                 }, Results: new List<SearchIndexersResponse.Result>());
             }

--- a/backend/Api/Controllers/TestIndexerConnection/TestIndexerConnectionController.cs
+++ b/backend/Api/Controllers/TestIndexerConnection/TestIndexerConnectionController.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Clients.Indexers;
+using NzbWebDAV.Config;
+using NzbWebDAV.Exceptions;
 
 namespace NzbWebDAV.Api.Controllers.TestIndexerConnection;
 
@@ -19,9 +21,17 @@ public class TestIndexerConnectionController(NzbWebDAV.Config.ConfigManager conf
                 : request.ProxyUrl;
             var timeout = request.TimeoutSeconds
                           ?? (indexerConfig.TimeoutSeconds is int g && g > 0 ? g : NzbWebDAV.Config.IndexerConfig.DefaultTimeoutSeconds);
+            var probe = new IndexerConfig.ConnectionDetails
+            {
+                Name = "test",
+                Url = request.Url,
+                ApiKey = request.ApiKey,
+                MaxResponseBytes = request.MaxResponseBytes,
+            };
             var client = new NewznabClient(
                 request.Url,
                 request.ApiKey,
+                indexerConfig.GetEffectiveMaxResponseBytes(probe),
                 ua,
                 proxy,
                 timeout,
@@ -29,7 +39,8 @@ public class TestIndexerConnectionController(NzbWebDAV.Config.ConfigManager conf
             var ok = await client.TestAsync(HttpContext.RequestAborted).ConfigureAwait(false);
             return Ok(new TestIndexerConnectionResponse { Status = true, Connected = ok });
         }
-        catch (Exception e) when (e is HttpRequestException or IOException or TimeoutException or InvalidOperationException)
+        catch (Exception e) when (e is HttpRequestException or IOException or TimeoutException
+                                       or InvalidOperationException or RemoteResponseException)
         {
             return Ok(new TestIndexerConnectionResponse { Status = true, Connected = false, Error = e.Message });
         }

--- a/backend/Api/Controllers/TestIndexerConnection/TestIndexerConnectionRequest.cs
+++ b/backend/Api/Controllers/TestIndexerConnection/TestIndexerConnectionRequest.cs
@@ -11,6 +11,7 @@ public class TestIndexerConnectionRequest
     public string? UserAgent { get; init; }
     public string? ProxyUrl { get; init; }
     public int? TimeoutSeconds { get; init; }
+    public long? MaxResponseBytes { get; init; }
     public bool SkipTlsVerification { get; init; }
 
     public TestIndexerConnectionRequest(HttpContext context, ConfigManager configManager)
@@ -29,6 +30,8 @@ public class TestIndexerConnectionRequest
         ProxyUrl = context.Request.Form["proxyUrl"].FirstOrDefault();
         var rawTimeout = context.Request.Form["timeoutSeconds"].FirstOrDefault();
         TimeoutSeconds = int.TryParse(rawTimeout, out var t) && t > 0 ? t : null;
+        var rawMaxBytes = context.Request.Form["maxResponseBytes"].FirstOrDefault();
+        MaxResponseBytes = long.TryParse(rawMaxBytes, out var maxBytes) && maxBytes > 0 ? maxBytes : null;
         SkipTlsVerification = bool.TryParse(
             context.Request.Form["skipTlsVerification"].FirstOrDefault(),
             out var skipTlsVerification)

--- a/backend/Api/Controllers/Watchtower/WatchtowerDiscoverController.cs
+++ b/backend/Api/Controllers/Watchtower/WatchtowerDiscoverController.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Services;
 
 namespace NzbWebDAV.Api.Controllers.Watchtower;
@@ -22,6 +23,10 @@ public class WatchtowerDiscoverController(ListSourceEnumerator enumerator) : Bas
         try
         {
             result = await enumerator.DiscoverCatalogsAsync(url, ct).ConfigureAwait(false);
+        }
+        catch (RemoteResponseException e)
+        {
+            throw new BadHttpRequestException(e.Message);
         }
         catch (InvalidOperationException e)
         {

--- a/backend/Clients/Indexers/NewznabClient.cs
+++ b/backend/Clients/Indexers/NewznabClient.cs
@@ -1,21 +1,56 @@
+using System.Xml;
 using System.Xml.Linq;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Clients.Indexers;
 
-public class NewznabClient(
-    string baseUrl,
-    string apiKey,
-    string userAgent = "NzbDav",
-    string? proxyUrl = null,
-    int timeoutSeconds = 30,
-    bool skipTlsVerification = false)
+public class NewznabClient
 {
     private static readonly XNamespace Newznab = "http://www.newznab.com/DTD/2010/feeds/attributes/";
 
-    private readonly Uri _apiUri = NormalizeApiUri(baseUrl);
-    private readonly HttpClient _http = ProxyHttpClientPool.GetClient(proxyUrl, skipTlsVerification);
-    private readonly int _timeoutSeconds = timeoutSeconds > 0 ? timeoutSeconds : 30;
+    private readonly Uri _apiUri;
+    private readonly HttpClient _http;
+    private readonly string _apiKey;
+    private readonly string _userAgent;
+    private readonly int _timeoutSeconds;
+    private readonly long _maxResponseBytes;
+
+    public NewznabClient(
+        string baseUrl,
+        string apiKey,
+        long maxResponseBytes,
+        string userAgent = "NzbDav",
+        string? proxyUrl = null,
+        int timeoutSeconds = 30,
+        bool skipTlsVerification = false)
+        : this(
+            ProxyHttpClientPool.GetClient(proxyUrl, skipTlsVerification),
+            baseUrl,
+            apiKey,
+            maxResponseBytes,
+            userAgent,
+            timeoutSeconds)
+    {
+    }
+
+    internal NewznabClient(
+        HttpClient http,
+        string baseUrl,
+        string apiKey,
+        long maxResponseBytes,
+        string userAgent = "NzbDav",
+        int timeoutSeconds = 30)
+    {
+        ArgumentNullException.ThrowIfNull(http);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxResponseBytes);
+        _http = http;
+        _apiUri = NormalizeApiUri(baseUrl);
+        _apiKey = apiKey;
+        _userAgent = userAgent;
+        _timeoutSeconds = timeoutSeconds > 0 ? timeoutSeconds : 30;
+        _maxResponseBytes = maxResponseBytes;
+    }
 
     private static Uri NormalizeApiUri(string baseUrl)
     {
@@ -67,10 +102,12 @@ public class NewznabClient(
         for (var attempt = 0; ; attempt++)
         {
             using var req = new HttpRequestMessage(HttpMethod.Get, url);
-            req.Headers.UserAgent.ParseAdd(userAgent);
+            req.Headers.UserAgent.ParseAdd(_userAgent);
             try
             {
-                return await _http.SendAsync(req, ct).ConfigureAwait(false);
+                return await _http
+                    .SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct)
+                    .ConfigureAwait(false);
             }
             catch (Exception e) when (attempt == 0 && !ct.IsCancellationRequested
                                       && e is HttpRequestException or IOException)
@@ -80,6 +117,60 @@ public class NewznabClient(
         }
     }
 
+    private async Task<byte[]> ReadResponseBodyAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            return await HttpContentReadUtil
+                .ReadBoundedAsync(response.Content, _maxResponseBytes, ct)
+                .ConfigureAwait(false);
+        }
+        catch (NzbResponseTooLargeException e)
+        {
+            throw new RemoteResponseTooLargeException(e.MaxBytes, e.ContentLength, e);
+        }
+    }
+
+    private static async Task<XDocument> ParseXmlAsync(
+        byte[] body,
+        long maxResponseBytes,
+        CancellationToken ct)
+    {
+        var settings = new XmlReaderSettings
+        {
+            Async = true,
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+            MaxCharactersInDocument = maxResponseBytes,
+            CloseInput = false,
+        };
+
+        try
+        {
+            using var stream = new MemoryStream(body, writable: false);
+            using var reader = XmlReader.Create(stream, settings);
+            return await XDocument
+                .LoadAsync(reader, LoadOptions.None, ct)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (XmlException e)
+        {
+            throw new RemoteResponseFormatException("Indexer returned invalid XML.", e);
+        }
+    }
+
+    private static bool HasCapsElement(XDocument doc)
+    {
+        if (doc.Root?.Name.LocalName.Equals("caps", StringComparison.OrdinalIgnoreCase) == true)
+            return true;
+        return doc.Descendants().Any(e =>
+            e.Name.LocalName.Equals("caps", StringComparison.OrdinalIgnoreCase));
+    }
+
     public Task<bool> TestAsync(CancellationToken ct = default)
     {
         return WithTimeoutAsync(async token =>
@@ -87,12 +178,13 @@ public class NewznabClient(
             var url = BuildUrl(new[]
             {
                 new KeyValuePair<string, string>("t", "caps"),
-                new KeyValuePair<string, string>("apikey", apiKey),
+                new KeyValuePair<string, string>("apikey", _apiKey),
             });
             using var resp = await GetAsync(url, token).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode) return false;
-            var body = await resp.Content.ReadAsStringAsync(token).ConfigureAwait(false);
-            return body.Contains("<caps", StringComparison.OrdinalIgnoreCase);
+            var body = await ReadResponseBodyAsync(resp, token).ConfigureAwait(false);
+            var doc = await ParseXmlAsync(body, _maxResponseBytes, token).ConfigureAwait(false);
+            return HasCapsElement(doc);
         }, ct);
     }
 
@@ -112,7 +204,7 @@ public class NewznabClient(
         {
             var extra = new List<KeyValuePair<string, string>>
             {
-                new("apikey", apiKey),
+                new("apikey", _apiKey),
                 new("extended", "1"),
             };
             foreach (var (k, v) in queryParams)
@@ -120,8 +212,8 @@ public class NewznabClient(
             var url = BuildUrl(extra);
             using var resp = await GetAsync(url, token).ConfigureAwait(false);
             resp.EnsureSuccessStatusCode();
-            await using var stream = await resp.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
-            var doc = await XDocument.LoadAsync(stream, LoadOptions.None, token).ConfigureAwait(false);
+            var body = await ReadResponseBodyAsync(resp, token).ConfigureAwait(false);
+            var doc = await ParseXmlAsync(body, _maxResponseBytes, token).ConfigureAwait(false);
             if (doc.Root?.Name.LocalName == "error")
             {
                 var code = doc.Root.Attribute("code")?.Value;

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -182,6 +182,7 @@ public static class ConfigKeys
     public const string WatchtowerGrabCapPerResolve = "watchtower.grab-cap-per-resolve";
     public const string WatchtowerKeepfreshBaseSeconds = "watchtower.keepfresh-base-seconds";
     public const string WatchtowerKeepfreshMaxSeconds = "watchtower.keepfresh-max-seconds";
+    public const string WatchtowerListSourceMaxResponseBytes = "watchtower.list-source-max-response-bytes";
     public const string WatchtowerMinGrabs = "watchtower.min-grabs";
     public const string WatchtowerProfileToken = "watchtower.profile-token";
     public const string WatchtowerRanking = "watchtower.ranking";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -634,6 +634,8 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
 
             if (cfg is null) return;
             RequireOptionalMaxResponseBytes("indexers.instances MaxResponseBytes", cfg.MaxResponseBytes);
+            if (cfg.Indexers is null)
+                throw new ArgumentException("Config value for 'indexers.instances Indexers' must be an array.");
             foreach (var indexer in cfg.Indexers)
             {
                 var label = string.IsNullOrWhiteSpace(indexer.Name)

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -638,6 +638,9 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
                 throw new ArgumentException("Config value for 'indexers.instances Indexers' must be an array.");
             foreach (var indexer in cfg.Indexers)
             {
+                if (indexer is null)
+                    throw new ArgumentException(
+                        "Config value for 'indexers.instances Indexers' must not contain null entries.");
                 var label = string.IsNullOrWhiteSpace(indexer.Name)
                     ? "indexers.instances indexer MaxResponseBytes"
                     : $"indexers.instances indexer '{indexer.Name}' MaxResponseBytes";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -458,6 +458,14 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
                     RequireLongInRange(item.ConfigName, value, 5, 10080);
                     break;
 
+                case ConfigKeys.WatchtowerListSourceMaxResponseBytes:
+                    RequireLongInRange(
+                        item.ConfigName,
+                        value,
+                        1,
+                        ExternalMetadataResponseLimits.HardMaxResponseBytes);
+                    break;
+
                 case ConfigKeys.UsenetStreamingBodyBatchWidth:
                     RequireLongInRange(item.ConfigName, value, 1, 8);
                     break;
@@ -560,6 +568,7 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
 
                 case ConfigKeys.IndexersInstances:
                     RequireJson<IndexerConfig>(item.ConfigName, value, jsonOptions);
+                    RequireIndexerMaxResponseBytes(value, jsonOptions);
                     break;
 
                 case ConfigKeys.ProfilesInstances:
@@ -609,6 +618,39 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
             if (!long.TryParse(value, out var parsed) || parsed < minimum || parsed > maximum)
                 throw new ArgumentException(
                     $"Config value for '{key}' must be a whole number from {minimum} through {maximum}.");
+        }
+
+        void RequireIndexerMaxResponseBytes(string json, JsonSerializerOptions? options)
+        {
+            IndexerConfig? cfg;
+            try
+            {
+                cfg = JsonSerializer.Deserialize<IndexerConfig>(json, options);
+            }
+            catch (JsonException)
+            {
+                return;
+            }
+
+            if (cfg is null) return;
+            RequireOptionalMaxResponseBytes("indexers.instances MaxResponseBytes", cfg.MaxResponseBytes);
+            foreach (var indexer in cfg.Indexers)
+            {
+                var label = string.IsNullOrWhiteSpace(indexer.Name)
+                    ? "indexers.instances indexer MaxResponseBytes"
+                    : $"indexers.instances indexer '{indexer.Name}' MaxResponseBytes";
+                RequireOptionalMaxResponseBytes(label, indexer.MaxResponseBytes);
+            }
+        }
+
+        void RequireOptionalMaxResponseBytes(string label, long? value)
+        {
+            if (value is null) return;
+            if (value.Value < 1 || value.Value > ExternalMetadataResponseLimits.HardMaxResponseBytes)
+            {
+                throw new ArgumentException(
+                    $"Config value for '{label}' must be a whole number from 1 through {ExternalMetadataResponseLimits.HardMaxResponseBytes}.");
+            }
         }
 
         void RequireHttpUrl(string key, string value)
@@ -1958,6 +2000,15 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
         var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerSyncIntervalSeconds));
         if (v == null) return 3600;
         return int.TryParse(v, out var n) ? Math.Clamp(n, 60, 86400) : 3600;
+    }
+
+    public long GetWatchtowerListSourceMaxResponseBytes()
+    {
+        var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.WatchtowerListSourceMaxResponseBytes));
+        if (v == null) return ExternalMetadataResponseLimits.WatchtowerDefaultMaxResponseBytes;
+        if (!long.TryParse(v, out var n) || n <= 0)
+            return ExternalMetadataResponseLimits.WatchtowerDefaultMaxResponseBytes;
+        return Math.Min(n, ExternalMetadataResponseLimits.HardMaxResponseBytes);
     }
 
     public int GetWatchtowerKeepFreshBaseSeconds()

--- a/backend/Config/ExternalMetadataResponseLimits.cs
+++ b/backend/Config/ExternalMetadataResponseLimits.cs
@@ -1,0 +1,28 @@
+namespace NzbWebDAV.Config;
+
+/// <summary>
+/// Byte ceilings for untrusted Newznab XML and Watchtower list-source JSON/text.
+/// These are parser-visible <see cref="HttpContent"/> bytes after the HTTP handler
+/// (currently no automatic decompression). They are not NZB download limits.
+/// </summary>
+public static class ExternalMetadataResponseLimits
+{
+    /// <summary>
+    /// Default Newznab caps/search page ceiling. Typical 100-result extended RSS
+    /// is tens to hundreds of KiB; 4 MiB leaves headroom for verbose indexers without
+    /// approaching the 50 MiB NZB download ceiling.
+    /// </summary>
+    public const long NewznabDefaultMaxResponseBytes = 4L * 1024 * 1024;
+
+    /// <summary>
+    /// Default Watchtower manifest/catalog/list ceiling. List sync is sequential;
+    /// 8 MiB covers large JSON catalogs and URL lists with headroom.
+    /// </summary>
+    public const long WatchtowerDefaultMaxResponseBytes = 8L * 1024 * 1024;
+
+    /// <summary>
+    /// Operator-facing hard clamp for both families. Below the 50 MiB NZB
+    /// per-response ceiling; concurrent Newznab parses must still fit a small container.
+    /// </summary>
+    public const long HardMaxResponseBytes = 16L * 1024 * 1024;
+}

--- a/backend/Config/IndexerConfig.cs
+++ b/backend/Config/IndexerConfig.cs
@@ -9,6 +9,10 @@ public class IndexerConfig
     // hard-coded value, so behavior is unchanged by default. Values above 100 page the indexer.
     public const int DefaultSearchResultLimit = 100;
 
+    // Default parser-visible byte ceiling for Newznab caps/search XML. See
+    // ExternalMetadataResponseLimits for the sizing rationale.
+    public const long DefaultMaxResponseBytes = ExternalMetadataResponseLimits.NewznabDefaultMaxResponseBytes;
+
     // Global HTTP(S) proxy URL applied to every indexer that doesn't set its own ProxyUrl.
     // Empty/null = no proxy. Accepts http://host:port or http://user:pass@host:port.
     public string? ProxyUrl { get; set; }
@@ -20,6 +24,10 @@ public class IndexerConfig
     // Global max number of results to gather from each indexer per search. Individual indexers may
     // override this. Above 100 the indexer is paged. null or <= 0 = fall back to DefaultSearchResultLimit.
     public int? SearchResultLimit { get; set; }
+
+    // Global parser-visible byte ceiling for Newznab XML. null or <= 0 = DefaultMaxResponseBytes.
+    // Values above ExternalMetadataResponseLimits.HardMaxResponseBytes are clamped when read.
+    public long? MaxResponseBytes { get; set; }
 
     public List<ConnectionDetails> Indexers { get; set; } = [];
 
@@ -35,6 +43,16 @@ public class IndexerConfig
         if (indexer.SearchResultLimit is int per && per > 0) return per;
         if (SearchResultLimit is int global && global > 0) return global;
         return DefaultSearchResultLimit;
+    }
+
+    public long GetEffectiveMaxResponseBytes(ConnectionDetails indexer)
+    {
+        var raw = indexer.MaxResponseBytes is long per && per > 0
+            ? per
+            : MaxResponseBytes is long global && global > 0
+                ? global
+                : DefaultMaxResponseBytes;
+        return Math.Clamp(raw, 1, ExternalMetadataResponseLimits.HardMaxResponseBytes);
     }
 
     public bool ShouldSkipTlsVerification(string indexerName)
@@ -73,6 +91,9 @@ public class IndexerConfig
         // Per-indexer max results to gather per search. Overrides the global SearchResultLimit.
         // null or <= 0 = inherit global.
         public int? SearchResultLimit { get; set; }
+        // Per-indexer parser-visible byte ceiling for Newznab XML. Overrides the global
+        // MaxResponseBytes. null or <= 0 = inherit global.
+        public long? MaxResponseBytes { get; set; }
         // Max API search hits per reset window. null or <= 0 = unlimited.
         public int? HitLimit { get; set; }
         // Max NZB download hits per reset window. null or <= 0 = unlimited.

--- a/backend/Exceptions/ListSourceGuidanceException.cs
+++ b/backend/Exceptions/ListSourceGuidanceException.cs
@@ -1,0 +1,7 @@
+namespace NzbWebDAV.Exceptions;
+
+/// <summary>
+/// Author-controlled Watchtower list-source guidance. Safe for LastSyncError
+/// and discover 400 responses; does not carry request URLs or body excerpts.
+/// </summary>
+public sealed class ListSourceGuidanceException(string message) : InvalidOperationException(message);

--- a/backend/Exceptions/RemoteResponseException.cs
+++ b/backend/Exceptions/RemoteResponseException.cs
@@ -1,0 +1,24 @@
+namespace NzbWebDAV.Exceptions;
+
+/// <summary>
+/// Expected failure while reading an untrusted remote metadata response
+/// (Newznab XML or Watchtower list source). Messages are controlled and must not
+/// include request URLs, API keys, or body excerpts.
+/// </summary>
+public abstract class RemoteResponseException(string message, Exception? innerException)
+    : Exception(message, innerException);
+
+public sealed class RemoteResponseTooLargeException(
+    long maxBytes,
+    long? declaredBytes,
+    Exception innerException)
+    : RemoteResponseException(
+        $"Remote response exceeded the configured {maxBytes:N0}-byte limit.",
+        innerException)
+{
+    public long MaxBytes { get; } = maxBytes;
+    public long? DeclaredBytes { get; } = declaredBytes;
+}
+
+public sealed class RemoteResponseFormatException(string message, Exception innerException)
+    : RemoteResponseException(message, innerException);

--- a/backend/Extensions/ExceptionExtensions.cs
+++ b/backend/Extensions/ExceptionExtensions.cs
@@ -234,6 +234,7 @@ public static class ExceptionExtensions
             or IOException
             or UnauthorizedAccessException
             or StreamingReadTimeoutException
+            or RemoteResponseException
             || exception.IsRetryableDownloadException()
             || exception.IsNonRetryableDownloadException();
     }

--- a/backend/Services/SearchProfileService.cs
+++ b/backend/Services/SearchProfileService.cs
@@ -4,6 +4,7 @@ using NzbWebDAV.Clients.Indexers;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Utils;
 using Serilog;
@@ -634,6 +635,7 @@ public class SearchProfileService(
                 var client = new NewznabClient(
                     x.Url,
                     x.ApiKey,
+                    indexerConfig.GetEffectiveMaxResponseBytes(x),
                     searchUa,
                     proxy,
                     timeout,
@@ -675,7 +677,9 @@ public class SearchProfileService(
                 var filtered = IndexerResultFilter.Apply(limited, x.Filter, now);
                 return filtered.Select(i => new IndexerHit(x.Name, retrieveUa, proxy, i));
             }
-            catch (Exception e) when (e is HttpRequestException or TaskCanceledException or InvalidOperationException or OperationCanceledException)
+            catch (Exception e) when (e is HttpRequestException or TaskCanceledException
+                                           or InvalidOperationException or OperationCanceledException
+                                           or RemoteResponseException)
             {
                 if (!e.IsCancellationException())
                     Log.Warning("Indexer {Indexer} search failed: {Message}", x.Name, e.Message);

--- a/backend/Services/Watchtower/ListSourceEnumerator.cs
+++ b/backend/Services/Watchtower/ListSourceEnumerator.cs
@@ -60,7 +60,7 @@ public class ListSourceEnumerator
             if (body is null)
             {
                 if (page == 0)
-                    throw new InvalidOperationException("Catalog request failed or returned an empty response.");
+                    throw new ListSourceGuidanceException("Catalog request failed or returned an empty response.");
                 break;
             }
 
@@ -73,10 +73,10 @@ public class ListSourceEnumerator
                 if (page > 0) break;
                 if (root.ValueKind == JsonValueKind.Object &&
                     (root.TryGetProperty("catalogs", out _) || root.TryGetProperty("resources", out _)))
-                    throw new InvalidOperationException(
+                    throw new ListSourceGuidanceException(
                         "This URL is an addon manifest, not a catalog. Use \"Discover catalogs\" to pick which " +
                         "catalogs to add, or point this list at a catalog endpoint such as .../catalog/movie/<id>.json.");
-                throw new InvalidOperationException("Catalog response did not contain a \"metas\" array.");
+                throw new ListSourceGuidanceException("Catalog response did not contain a \"metas\" array.");
             }
 
             int pageCount = 0, newCount = 0;
@@ -108,12 +108,12 @@ public class ListSourceEnumerator
     public async Task<DiscoverResult> DiscoverCatalogsAsync(string url, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(url))
-            throw new InvalidOperationException("A manifest URL is required.");
+            throw new ListSourceGuidanceException("A manifest URL is required.");
 
         var manifestUrl = NormalizeManifestUrl(url.Trim());
         var body = await HttpGetBodyAsync(manifestUrl, ct).ConfigureAwait(false);
         if (body is null)
-            throw new InvalidOperationException("Could not fetch the addon manifest.");
+            throw new ListSourceGuidanceException("Could not fetch the addon manifest.");
 
         using var doc = ParseJsonOrThrow(body.Bytes);
         var root = doc.RootElement;
@@ -122,9 +122,9 @@ public class ListSourceEnumerator
             !root.TryGetProperty("catalogs", out var catalogs) || catalogs.ValueKind != JsonValueKind.Array)
         {
             if (root.ValueKind == JsonValueKind.Object && root.TryGetProperty("metas", out _))
-                throw new InvalidOperationException(
+                throw new ListSourceGuidanceException(
                     "That looks like a catalog endpoint, not a manifest. Add it directly as a Stremio catalog list.");
-            throw new InvalidOperationException("No catalogs were found in this addon manifest.");
+            throw new ListSourceGuidanceException("No catalogs were found in this addon manifest.");
         }
 
         var addonName = GetStr(root, "name");
@@ -148,7 +148,7 @@ public class ListSourceEnumerator
         }
 
         if (choices.Count == 0)
-            throw new InvalidOperationException("This addon manifest lists no usable catalogs.");
+            throw new ListSourceGuidanceException("This addon manifest lists no usable catalogs.");
 
         return new DiscoverResult { AddonName = addonName, Catalogs = choices };
     }
@@ -263,7 +263,7 @@ public class ListSourceEnumerator
         if (string.IsNullOrWhiteSpace(url)) return Array.Empty<WtContentRef>();
         var fetched = await HttpGetBodyAsync(url!, ct).ConfigureAwait(false);
         if (fetched is null)
-            throw new InvalidOperationException("List request failed or returned an empty response.");
+            throw new ListSourceGuidanceException("List request failed or returned an empty response.");
 
         if (LooksLikeJson(fetched.Bytes))
             return ParseJsonListOrThrow(fetched.Bytes);
@@ -410,7 +410,9 @@ public class ListSourceEnumerator
         {
             throw;
         }
-        catch (Exception e) when (e is HttpRequestException or TaskCanceledException or InvalidOperationException)
+        catch (Exception e) when (
+            e is HttpRequestException or InvalidOperationException
+            || (e is OperationCanceledException && !ct.IsCancellationRequested))
         {
             Log.Debug("Watchtower: remote list fetch failed ({FailureType})", e.GetType().Name);
             return null;

--- a/backend/Services/Watchtower/ListSourceEnumerator.cs
+++ b/backend/Services/Watchtower/ListSourceEnumerator.cs
@@ -1,6 +1,8 @@
+using System.Text;
 using System.Text.Json;
+using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
-using NzbWebDAV.Extensions;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Utils;
 using Serilog;
 
@@ -12,18 +14,36 @@ public class ListSourceEnumerator
 
     private const int MaxCatalogPages = 100;
 
+    private readonly HttpClient _http;
+    private readonly Func<long> _getMaxResponseBytes;
+
+    public ListSourceEnumerator(ConfigManager configManager)
+        : this(
+            ProxyHttpClientPool.GetClient(null),
+            configManager.GetWatchtowerListSourceMaxResponseBytes)
+    {
+    }
+
+    internal ListSourceEnumerator(HttpClient http, Func<long> getMaxResponseBytes)
+    {
+        ArgumentNullException.ThrowIfNull(http);
+        ArgumentNullException.ThrowIfNull(getMaxResponseBytes);
+        _http = http;
+        _getMaxResponseBytes = getMaxResponseBytes;
+    }
+
     public async Task<IReadOnlyList<WtContentRef>> EnumerateAsync(ListSource source, CancellationToken ct)
     {
         return source.Kind switch
         {
-            ListSource.KindStremioCatalog => await FetchStremioCatalogAsync(source.Url, source.Cap, ct).ConfigureAwait(false),
+            ListSource.KindStremioCatalog => await FetchStremioCatalogAsync(source.Name, source.Url, source.Cap, ct).ConfigureAwait(false),
             ListSource.KindUrlList => await FetchUrlListAsync(source.Url, ct).ConfigureAwait(false),
             _ => Array.Empty<WtContentRef>(),
         };
     }
 
-    private static async Task<IReadOnlyList<WtContentRef>> FetchStremioCatalogAsync(
-        string? url, int cap, CancellationToken ct)
+    private async Task<IReadOnlyList<WtContentRef>> FetchStremioCatalogAsync(
+        string sourceName, string? url, int cap, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(url)) return Array.Empty<WtContentRef>();
 
@@ -36,15 +56,15 @@ public class ListSourceEnumerator
         for (; page < MaxCatalogPages; page++)
         {
             var skip = pageSize > 0 ? page * pageSize : 0;
-            var json = await HttpGetStringAsync(BuildPagedUrl(url!, skip), ct).ConfigureAwait(false);
-            if (json is null)
+            var body = await HttpGetBodyAsync(BuildPagedUrl(url!, skip), ct).ConfigureAwait(false);
+            if (body is null)
             {
                 if (page == 0)
                     throw new InvalidOperationException("Catalog request failed or returned an empty response.");
                 break;
             }
 
-            using var doc = ParseOrThrow(json);
+            using var doc = ParseJsonOrThrow(body.Bytes);
             var root = doc.RootElement;
 
             if (root.ValueKind != JsonValueKind.Object ||
@@ -79,8 +99,8 @@ public class ListSourceEnumerator
 
         if (page >= MaxCatalogPages)
             Log.Information(
-                "Watchtower: catalog {Url} reached the {Max}-page ceiling ({Count} titles); later titles were not pulled",
-                url, MaxCatalogPages, refs.Count);
+                "Watchtower: source {Source} reached the {Max}-page ceiling ({Count} titles); later titles were not pulled",
+                sourceName, MaxCatalogPages, refs.Count);
 
         return refs;
     }
@@ -91,11 +111,11 @@ public class ListSourceEnumerator
             throw new InvalidOperationException("A manifest URL is required.");
 
         var manifestUrl = NormalizeManifestUrl(url.Trim());
-        var json = await HttpGetStringAsync(manifestUrl, ct).ConfigureAwait(false);
-        if (json is null)
-            throw new InvalidOperationException($"Could not fetch the addon manifest at {manifestUrl}.");
+        var body = await HttpGetBodyAsync(manifestUrl, ct).ConfigureAwait(false);
+        if (body is null)
+            throw new InvalidOperationException("Could not fetch the addon manifest.");
 
-        using var doc = ParseOrThrow(json);
+        using var doc = ParseJsonOrThrow(body.Bytes);
         var root = doc.RootElement;
 
         if (root.ValueKind != JsonValueKind.Object ||
@@ -209,10 +229,18 @@ public class ListSourceEnumerator
         return names.Count > 0 ? string.Join(", ", names) : null;
     }
 
-    private static JsonDocument ParseOrThrow(string json)
+    private static JsonDocument ParseJsonOrThrow(ReadOnlyMemory<byte> body)
     {
-        try { return JsonDocument.Parse(json); }
-        catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException) { throw new InvalidOperationException("The addon response was not valid JSON.", e); }
+        try
+        {
+            return JsonDocument.Parse(body);
+        }
+        catch (JsonException e)
+        {
+            throw new RemoteResponseFormatException(
+                "The addon response was not valid JSON.",
+                e);
+        }
     }
 
     public sealed class CatalogChoice
@@ -230,38 +258,45 @@ public class ListSourceEnumerator
         public required IReadOnlyList<CatalogChoice> Catalogs { get; init; }
     }
 
-    private static async Task<IReadOnlyList<WtContentRef>> FetchUrlListAsync(string? url, CancellationToken ct)
+    private async Task<IReadOnlyList<WtContentRef>> FetchUrlListAsync(string? url, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(url)) return Array.Empty<WtContentRef>();
-        var body = await HttpGetStringAsync(url!, ct).ConfigureAwait(false);
-        if (body is null)
+        var fetched = await HttpGetBodyAsync(url!, ct).ConfigureAwait(false);
+        if (fetched is null)
             throw new InvalidOperationException("List request failed or returned an empty response.");
 
-        var trimmed = body.TrimStart();
-        if (trimmed.StartsWith('[') || trimmed.StartsWith('{'))
-        {
-            var fromJson = TryParseJsonList(trimmed);
-            if (fromJson.Count > 0) return fromJson;
-        }
+        if (LooksLikeJson(fetched.Bytes))
+            return ParseJsonListOrThrow(fetched.Bytes);
 
-        var refs = new List<WtContentRef>();
-        foreach (var line in body.Split('\n')
-                     .Select(raw => raw.Trim())
-                     .Where(line => line.Length > 0 && !line.StartsWith('#')))
-        {
-            var (type, id) = SplitTypeId(line);
-            if (id.Length == 0) continue;
-            refs.Add(new WtContentRef { Type = type, ContentId = id });
-        }
-        return refs;
+        return ParsePlainList(DecodePlainText(fetched));
     }
 
-    private static List<WtContentRef> TryParseJsonList(string json)
+    private static bool LooksLikeJson(ReadOnlySpan<byte> body)
     {
-        var refs = new List<WtContentRef>();
+        var i = 0;
+        if (body.Length >= 3 && body[0] == 0xEF && body[1] == 0xBB && body[2] == 0xBF)
+            i = 3;
+        while (i < body.Length)
+        {
+            var b = body[i];
+            if (b is (byte)' ' or (byte)'\t' or (byte)'\r' or (byte)'\n')
+            {
+                i++;
+                continue;
+            }
+
+            return b is (byte)'[' or (byte)'{';
+        }
+
+        return false;
+    }
+
+    private static List<WtContentRef> ParseJsonListOrThrow(ReadOnlyMemory<byte> body)
+    {
         try
         {
-            using var doc = JsonDocument.Parse(json);
+            using var doc = JsonDocument.Parse(body);
+            var refs = new List<WtContentRef>();
             var arr = doc.RootElement.ValueKind == JsonValueKind.Array
                 ? doc.RootElement
                 : (doc.RootElement.TryGetProperty("items", out var items) ? items : default);
@@ -285,12 +320,36 @@ public class ListSourceEnumerator
                     });
                 }
             }
+
+            return refs;
         }
-        catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
+        catch (JsonException e)
         {
-            // Malformed list payload; yield whatever refs parsed before the failure.
+            throw new RemoteResponseFormatException("The list response was not valid JSON.", e);
         }
+    }
+
+    private static List<WtContentRef> ParsePlainList(string body)
+    {
+        var refs = new List<WtContentRef>();
+        using var reader = new StringReader(body);
+        string? raw;
+        while ((raw = reader.ReadLine()) is not null)
+        {
+            var line = raw.Trim();
+            if (line.Length == 0 || line.StartsWith('#')) continue;
+            var (type, id) = SplitTypeId(line);
+            if (id.Length == 0) continue;
+            refs.Add(new WtContentRef { Type = type, ContentId = id });
+        }
+
         return refs;
+    }
+
+    private static string DecodePlainText(FetchedBody fetched)
+    {
+        var text = fetched.Encoding.GetString(fetched.Bytes);
+        return text.Length > 0 && text[0] == '\uFEFF' ? text[1..] : text;
     }
 
     private static (string Type, string Id) SplitTypeId(string line)
@@ -317,18 +376,35 @@ public class ListSourceEnumerator
     private static string? GetStr(JsonElement el, string prop)
         => el.TryGetProperty(prop, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
 
-    private static async Task<string?> HttpGetStringAsync(string url, CancellationToken ct)
+    private async Task<FetchedBody?> HttpGetBodyAsync(string url, CancellationToken ct)
     {
         try
         {
-            var client = ProxyHttpClientPool.GetClient(null);
-            using var req = new HttpRequestMessage(HttpMethod.Get, url);
-            req.Headers.TryAddWithoutValidation("User-Agent", "NzbDav-Watchtower");
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            cts.CancelAfter(FetchTimeout);
-            using var resp = await client.SendAsync(req, HttpCompletionOption.ResponseContentRead, cts.Token).ConfigureAwait(false);
-            if (!resp.IsSuccessStatusCode) return null;
-            return await resp.Content.ReadAsStringAsync(cts.Token).ConfigureAwait(false);
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.TryAddWithoutValidation("User-Agent", "NzbDav-Watchtower");
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeoutCts.CancelAfter(FetchTimeout);
+            using var response = await _http
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeoutCts.Token)
+                .ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode) return null;
+
+            var encoding = GetContentEncoding(response.Content);
+            try
+            {
+                var bytes = await HttpContentReadUtil
+                    .ReadBoundedAsync(response.Content, _getMaxResponseBytes(), timeoutCts.Token)
+                    .ConfigureAwait(false);
+                return new FetchedBody(bytes, encoding);
+            }
+            catch (NzbResponseTooLargeException e)
+            {
+                throw new RemoteResponseTooLargeException(e.MaxBytes, e.ContentLength, e);
+            }
+        }
+        catch (RemoteResponseException)
+        {
+            throw;
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -336,8 +412,24 @@ public class ListSourceEnumerator
         }
         catch (Exception e) when (e is HttpRequestException or TaskCanceledException or InvalidOperationException)
         {
-            Log.Debug(e, "Watchtower: list fetch failed for {Url}", url);
+            Log.Debug("Watchtower: remote list fetch failed ({FailureType})", e.GetType().Name);
             return null;
         }
     }
+
+    private static Encoding GetContentEncoding(HttpContent content)
+    {
+        var charset = content.Headers.ContentType?.CharSet?.Trim().Trim('"');
+        if (string.IsNullOrWhiteSpace(charset)) return Encoding.UTF8;
+        try
+        {
+            return Encoding.GetEncoding(charset);
+        }
+        catch (ArgumentException)
+        {
+            return Encoding.UTF8;
+        }
+    }
+
+    private sealed record FetchedBody(byte[] Bytes, Encoding Encoding);
 }

--- a/backend/Services/Watchtower/WatchtowerService.cs
+++ b/backend/Services/Watchtower/WatchtowerService.cs
@@ -244,7 +244,7 @@ public partial class WatchtowerService(
             }
             catch (Exception e) when (e is not OperationCanceledException && e is not OutOfMemoryException)
             {
-                source.LastSyncError = e is RemoteResponseException
+                source.LastSyncError = e is RemoteResponseException or ListSourceGuidanceException
                     ? e.Message
                     : "Source synchronization failed unexpectedly.";
                 e.LogWarningKnownOrStack(

--- a/backend/Services/Watchtower/WatchtowerService.cs
+++ b/backend/Services/Watchtower/WatchtowerService.cs
@@ -244,8 +244,12 @@ public partial class WatchtowerService(
             }
             catch (Exception e) when (e is not OperationCanceledException && e is not OutOfMemoryException)
             {
-                source.LastSyncError = e.Message;
-                Log.Warning(e, "Watchtower: sync failed for source {Name}", source.Name);
+                source.LastSyncError = e is RemoteResponseException
+                    ? e.Message
+                    : "Source synchronization failed unexpectedly.";
+                e.LogWarningKnownOrStack(
+                    "Watchtower: sync failed for source {Name}.",
+                    source.Name);
             }
             source.LastSyncedAtUnix = now;
             await TrySaveBatchItemAsync(ctx, ct).ConfigureAwait(false);

--- a/backend/Utils/HttpContentReadUtil.cs
+++ b/backend/Utils/HttpContentReadUtil.cs
@@ -24,8 +24,13 @@ public static class HttpContentReadUtil
             : 0);
         var buf = new byte[BufferSize];
         int read;
-        while ((read = await input.ReadAsync(buf.AsMemory(0, buf.Length), ct).ConfigureAwait(false)) > 0)
+        while (true)
         {
+            var remaining = maxBytes - ms.Length;
+            var toRead = remaining >= buf.Length ? buf.Length : (int)(remaining + 1);
+            read = await input.ReadAsync(buf.AsMemory(0, toRead), ct).ConfigureAwait(false);
+            if (read == 0)
+                break;
             if (ms.Length + read > maxBytes)
                 throw new NzbResponseTooLargeException(maxBytes);
             await ms.WriteAsync(buf.AsMemory(0, read), ct).ConfigureAwait(false);

--- a/docs/configuration/indexers.md
+++ b/docs/configuration/indexers.md
@@ -17,6 +17,7 @@ Newznab indexers/aggregators, global request defaults, and title exclude pattern
 | Default Retrieve User-Agent | `api.user-agent` | empty → `SABnzbd/5.1.0` or `NZB_GRAB_USER_AGENT` | Fetching `.nzb` |
 | Request timeout (seconds) | in instances | `30` | Per-request timeout |
 | Search results per indexer | in instances | `100` | Page size |
+| Max indexer response (bytes) [since 1.2.8](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.8){ .nzbdav-since } | in instances (`MaxResponseBytes`) | `4194304` (4 MiB) | Reject oversized Newznab caps/search XML before parse; counts HTTP-client bytes (no automatic decompression). Per-indexer override. Max `16777216` (16 MiB). |
 | Exclude result patterns | `search.exclude-patterns` | empty | JS regex per line (case-insensitive) |
 | Synced exclude URLs | `search.exclude-sync-urls` | empty | Auto-updating JSON lists |
 | Refresh every (minutes) | `search.exclude-sync-refresh-minutes` | `720` | Sync interval 15–10080 |
@@ -36,7 +37,7 @@ InfiniDysk can pull its indexer list from one Prowlarr instance. Configure the c
 
 Use **Test Connection** to verify the URL and API key, save the settings, then use **Sync now**. Automatic sync runs on the configured interval (5–10080 minutes). The URL may include a Prowlarr URL base such as `http://prowlarr:9696/prowlarr`; credentials, query strings, and fragments are not accepted.
 
-Sync imports searchable Usenet indexers and points each one at Prowlarr's per-indexer Newznab proxy (`{prowlarrUrl}/{indexerId}/api`). Prowlarr owns each managed entry's name, proxy URL, API key, and enabled state. InfiniDysk preserves local tuning such as rate limits, filters, category overrides, proxy, TLS, timeout, and user agents. Manually configured indexers are never changed or removed.
+Sync imports searchable Usenet indexers and points each one at Prowlarr's per-indexer Newznab proxy (`{prowlarrUrl}/{indexerId}/api`). Prowlarr owns each managed entry's name, proxy URL, API key, and enabled state. InfiniDysk preserves local tuning such as rate limits, filters, category overrides, proxy, TLS, timeout, max response, and user agents. Manually configured indexers are never changed or removed.
 
 Entries that disappear or become unsupported in Prowlarr are removed only when they are marked as Prowlarr-managed. Search profiles are updated in the same write for managed renames and removals. If Prowlarr is unavailable or returns an invalid response, InfiniDysk keeps the complete last-good indexer configuration and reports the failure in Settings.
 
@@ -51,6 +52,7 @@ Entries that disappear or become unsupported in Prowlarr are removed only when t
 | Name / URL / API Key | Newznab endpoint |
 | Search / Retrieve User-Agent | Optional overrides |
 | Proxy URL | Optional override |
+| Timeout / search result limit / max response | Optional overrides |
 | Skip TLS certificate verification | Accept an invalid HTTPS certificate; off by default |
 | Max requests / minute | `0` = unlimited |
 | API hit / download limits + reset hour | Cap usage; blank reset = rolling 24h |

--- a/docs/configuration/watchtower.md
+++ b/docs/configuration/watchtower.md
@@ -34,6 +34,7 @@ Pre-resolve list titles to healthy releases. Feature overview: [Watchtower](../f
 | Max re-check interval | `watchtower.keepfresh-max-seconds` | 7d | Backoff cap |
 | Dead-item retry | `watchtower.unavailable-retry-seconds` | 6h | Re-search cadence |
 | List sync interval | `watchtower.sync-interval-seconds` | 1h | Remote list refresh |
+| Max list-source response (bytes) [since 1.2.8](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.8){ .nzbdav-since } | `watchtower.list-source-max-response-bytes` | `8388608` (8 MiB) | Reject oversized Stremio/list bodies before parse; counts HTTP-client bytes (no automatic decompression). Max `16777216` (16 MiB). |
 | Verbose activity logging | `watchtower.verbose-logging` | off | Chatty Logs output |
 
 `watchtower.resolve-concurrency` (default `3`) exists in the backend but is not exposed in this Settings tab.

--- a/frontend/app/routes/settings/indexers/indexers.test.ts
+++ b/frontend/app/routes/settings/indexers/indexers.test.ts
@@ -1,18 +1,32 @@
 import { describe, expect, it } from "vitest";
 import { isIndexersSettingsUpdated, isIndexersSettingsValid } from "./indexers";
 
+type IndexerConnection = {
+  Name: string;
+  Url: string;
+  ApiKey: string;
+  Enabled: boolean;
+  ProwlarrIndexerId?: number;
+  MaxResponseBytes?: number;
+};
+
+type IndexerInstances = {
+  MaxResponseBytes?: number;
+  Indexers: IndexerConnection[];
+};
+
+const validIndexer: IndexerConnection = {
+  Name: "Prowlarr indexer",
+  Url: "http://prowlarr:9696/7/api",
+  ApiKey: "prowlarr-key",
+  Enabled: true,
+  ProwlarrIndexerId: 7,
+};
+
+const validIndexers: IndexerInstances = { Indexers: [validIndexer] };
+
 const validConfig: Record<string, string> = {
-  "indexers.instances": JSON.stringify({
-    Indexers: [
-      {
-        Name: "Prowlarr indexer",
-        Url: "http://prowlarr:9696/7/api",
-        ApiKey: "prowlarr-key",
-        Enabled: true,
-        ProwlarrIndexerId: 7,
-      },
-    ],
-  }),
+  "indexers.instances": JSON.stringify(validIndexers),
   "api.user-agent": "",
   "api.search-user-agent": "",
   "search.exclude-patterns": "",
@@ -69,37 +83,32 @@ describe("Indexer settings", () => {
 
   it("rejects MaxResponseBytes of zero or above the hard clamp", () => {
     const hardMax = 16 * 1024 * 1024;
-    const withGlobal = {
+    const withGlobal: Record<string, string> = {
       ...validConfig,
       "indexers.instances": JSON.stringify({
         MaxResponseBytes: 0,
-        Indexers: JSON.parse(validConfig["indexers.instances"]).Indexers,
-      }),
+        Indexers: validIndexers.Indexers,
+      } satisfies IndexerInstances),
     };
     expect(isIndexersSettingsValid(withGlobal)).toBe(false);
 
-    const withPerIndexer = {
+    const withPerIndexer: Record<string, string> = {
       ...validConfig,
       "indexers.instances": JSON.stringify({
-        Indexers: [
-          {
-            ...JSON.parse(validConfig["indexers.instances"]).Indexers[0],
-            MaxResponseBytes: hardMax + 1,
-          },
-        ],
-      }),
+        Indexers: [{ ...validIndexer, MaxResponseBytes: hardMax + 1 }],
+      } satisfies IndexerInstances),
     };
     expect(isIndexersSettingsValid(withPerIndexer)).toBe(false);
   });
 
   it("accepts MaxResponseBytes at the hard clamp", () => {
     const hardMax = 16 * 1024 * 1024;
-    const next = {
+    const next: Record<string, string> = {
       ...validConfig,
       "indexers.instances": JSON.stringify({
         MaxResponseBytes: hardMax,
-        Indexers: JSON.parse(validConfig["indexers.instances"]).Indexers,
-      }),
+        Indexers: validIndexers.Indexers,
+      } satisfies IndexerInstances),
     };
     expect(isIndexersSettingsValid(next)).toBe(true);
   });

--- a/frontend/app/routes/settings/indexers/indexers.test.ts
+++ b/frontend/app/routes/settings/indexers/indexers.test.ts
@@ -67,15 +67,40 @@ describe("Indexer settings", () => {
     }
   });
 
-  it("requires the Prowlarr URL and API key as a pair", () => {
-    expect(isIndexersSettingsValid({ ...validConfig, "prowlarr.url": "" })).toBe(false);
-    expect(isIndexersSettingsValid({ ...validConfig, "prowlarr.api-key": "" })).toBe(false);
-    expect(
-      isIndexersSettingsValid({
-        ...validConfig,
-        "prowlarr.url": "",
-        "prowlarr.api-key": "",
+  it("rejects MaxResponseBytes of zero or above the hard clamp", () => {
+    const hardMax = 16 * 1024 * 1024;
+    const withGlobal = {
+      ...validConfig,
+      "indexers.instances": JSON.stringify({
+        MaxResponseBytes: 0,
+        Indexers: JSON.parse(validConfig["indexers.instances"]).Indexers,
       }),
-    ).toBe(true);
+    };
+    expect(isIndexersSettingsValid(withGlobal)).toBe(false);
+
+    const withPerIndexer = {
+      ...validConfig,
+      "indexers.instances": JSON.stringify({
+        Indexers: [
+          {
+            ...JSON.parse(validConfig["indexers.instances"]).Indexers[0],
+            MaxResponseBytes: hardMax + 1,
+          },
+        ],
+      }),
+    };
+    expect(isIndexersSettingsValid(withPerIndexer)).toBe(false);
+  });
+
+  it("accepts MaxResponseBytes at the hard clamp", () => {
+    const hardMax = 16 * 1024 * 1024;
+    const next = {
+      ...validConfig,
+      "indexers.instances": JSON.stringify({
+        MaxResponseBytes: hardMax,
+        Indexers: JSON.parse(validConfig["indexers.instances"]).Indexers,
+      }),
+    };
+    expect(isIndexersSettingsValid(next)).toBe(true);
   });
 });

--- a/frontend/app/routes/settings/indexers/indexers.tsx
+++ b/frontend/app/routes/settings/indexers/indexers.tsx
@@ -1666,7 +1666,15 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
 
   useEffect(() => {
     setTestState("idle");
-  }, [url, apiKey, searchUserAgent, proxyUrl, timeoutSeconds, maxResponseBytes, skipTlsVerification]);
+  }, [
+    url,
+    apiKey,
+    searchUserAgent,
+    proxyUrl,
+    timeoutSeconds,
+    maxResponseBytes,
+    skipTlsVerification,
+  ]);
 
   const handleTest = useCallback(async () => {
     if (!url.trim() || !apiKey.trim()) return;
@@ -1690,7 +1698,15 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
     } catch {
       setTestState("error");
     }
-  }, [url, apiKey, searchUserAgent, proxyUrl, timeoutSeconds, maxResponseBytes, skipTlsVerification]);
+  }, [
+    url,
+    apiKey,
+    searchUserAgent,
+    proxyUrl,
+    timeoutSeconds,
+    maxResponseBytes,
+    skipTlsVerification,
+  ]);
 
   const handleSave = useCallback(() => {
     const rpm = parseInt(maxRpm || "0", 10);

--- a/frontend/app/routes/settings/indexers/indexers.tsx
+++ b/frontend/app/routes/settings/indexers/indexers.tsx
@@ -72,6 +72,7 @@ interface ConnectionDetails {
   ProxyUrl?: string;
   TimeoutSeconds?: number;
   SearchResultLimit?: number;
+  MaxResponseBytes?: number;
   HitLimit?: number;
   DownloadLimit?: number;
   HitLimitResetTime?: number;
@@ -86,6 +87,7 @@ interface IndexerConfig {
   ProxyUrl?: string;
   TimeoutSeconds?: number;
   SearchResultLimit?: number;
+  MaxResponseBytes?: number;
   Indexers: ConnectionDetails[];
 }
 
@@ -102,6 +104,10 @@ const DEFAULT_TIMEOUT_SECONDS = 30;
 // Hard fallback for results gathered per indexer per search; above this the indexer is paged.
 // Mirrors IndexerConfig.DefaultSearchResultLimit in the backend.
 const DEFAULT_SEARCH_RESULT_LIMIT = 100;
+
+// Mirrors IndexerConfig.DefaultMaxResponseBytes / ExternalMetadataResponseLimits.
+const DEFAULT_MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
+const MAX_RESPONSE_BYTES_HARD_CLAMP = 16 * 1024 * 1024;
 
 // Mirrors ConfigManager.DefaultProwlarrSyncIntervalMinutes and validation bounds.
 const DEFAULT_PROWLARR_SYNC_INTERVAL_MINUTES = 60;
@@ -264,6 +270,9 @@ function parseConfig(raw: string): IndexerConfig {
     if (typeof parsed.SearchResultLimit === "number") {
       config.SearchResultLimit = parsed.SearchResultLimit;
     }
+    if (typeof parsed.MaxResponseBytes === "number") {
+      config.MaxResponseBytes = parsed.MaxResponseBytes;
+    }
     return config;
   } catch {
     return { ProxyUrl: "", Indexers: [] };
@@ -277,6 +286,8 @@ function serializeConfig(c: IndexerConfig): string {
     out.TimeoutSeconds = c.TimeoutSeconds;
   if (typeof c.SearchResultLimit === "number" && c.SearchResultLimit > 0)
     out.SearchResultLimit = c.SearchResultLimit;
+  if (typeof c.MaxResponseBytes === "number" && c.MaxResponseBytes > 0)
+    out.MaxResponseBytes = c.MaxResponseBytes;
   return JSON.stringify(out);
 }
 
@@ -285,6 +296,17 @@ function isTimeoutValid(raw: string): boolean {
   if (!raw.trim()) return true;
   const n = Number(raw);
   return Number.isInteger(n) && n > 0 && raw.trim() === n.toString();
+}
+
+function isMaxResponseBytesValid(raw: string): boolean {
+  if (!raw.trim()) return true;
+  const n = Number(raw);
+  return (
+    Number.isInteger(n) &&
+    n >= 1 &&
+    n <= MAX_RESPONSE_BYTES_HARD_CLAMP &&
+    raw.trim() === n.toString()
+  );
 }
 
 function isCategoryListValid(raw: string): boolean {
@@ -396,10 +418,21 @@ export function IndexersSettings({
     (value: string) => {
       const trimmed = value.replace(/[^0-9]/g, "");
       const n = trimmed === "" ? undefined : parseInt(trimmed, 10);
-      const next: IndexerConfig = {
-        ...indexerConfig,
-        ...(n && n > 0 ? { SearchResultLimit: n } : {}),
-      };
+      const next: IndexerConfig = { ...indexerConfig };
+      if (n && n > 0) next.SearchResultLimit = n;
+      else delete next.SearchResultLimit;
+      setNewConfig({ ...config, "indexers.instances": serializeConfig(next) });
+    },
+    [config, indexerConfig, setNewConfig],
+  );
+
+  const handleMaxResponseBytesChange = useCallback(
+    (value: string) => {
+      const trimmed = value.replace(/[^0-9]/g, "");
+      const n = trimmed === "" ? undefined : parseInt(trimmed, 10);
+      const next: IndexerConfig = { ...indexerConfig };
+      if (n && n > 0) next.MaxResponseBytes = n;
+      else delete next.MaxResponseBytes;
       setNewConfig({ ...config, "indexers.instances": serializeConfig(next) });
     },
     [config, indexerConfig, setNewConfig],
@@ -594,6 +627,10 @@ export function IndexersSettings({
     typeof indexerConfig.SearchResultLimit === "number" && indexerConfig.SearchResultLimit > 0
       ? indexerConfig.SearchResultLimit.toString()
       : "";
+  const globalMaxResponseBytesRaw =
+    typeof indexerConfig.MaxResponseBytes === "number" && indexerConfig.MaxResponseBytes > 0
+      ? indexerConfig.MaxResponseBytes.toString()
+      : "";
 
   return (
     <SettingsPage className="mb-6">
@@ -698,6 +735,27 @@ export function IndexersSettings({
               value={globalSearchLimitRaw}
               onChange={(e) => handleSearchLimitChange(e.target.value)}
             />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="indexers-default-max-response-bytes">
+              Max indexer response (bytes){" "}
+              <span className="text-[11px] font-normal text-base-content/45">
+                (blank = {DEFAULT_MAX_RESPONSE_BYTES.toLocaleString()} / 4 MiB; max{" "}
+                {MAX_RESPONSE_BYTES_HARD_CLAMP.toLocaleString()})
+              </span>
+            </Label>
+            <Input
+              type="text"
+              id="indexers-default-max-response-bytes"
+              className={`w-full max-w-48 ${!isMaxResponseBytesValid(globalMaxResponseBytesRaw) ? "input-error" : ""}`}
+              placeholder={DEFAULT_MAX_RESPONSE_BYTES.toString()}
+              value={globalMaxResponseBytesRaw}
+              onChange={(e) => handleMaxResponseBytesChange(e.target.value)}
+            />
+            <HelpText>
+              Caps how large a Newznab caps or search XML body may be before it is parsed. Counts
+              the bytes the HTTP client delivers (not decompressed; automatic gzip is off).
+            </HelpText>
           </div>
         </ManagedSetting>
       </SettingsCard>
@@ -1511,6 +1569,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
   const [proxyUrl, setProxyUrl] = useState("");
   const [timeoutSeconds, setTimeoutSeconds] = useState("");
   const [searchResultLimit, setSearchResultLimit] = useState("");
+  const [maxResponseBytes, setMaxResponseBytes] = useState("");
   const [maxRpm, setMaxRpm] = useState("0");
   const [hitLimit, setHitLimit] = useState("");
   const [downloadLimit, setDownloadLimit] = useState("");
@@ -1567,6 +1626,11 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
           ? indexer.SearchResultLimit.toString()
           : "",
       );
+      setMaxResponseBytes(
+        indexer?.MaxResponseBytes && indexer.MaxResponseBytes > 0
+          ? indexer.MaxResponseBytes.toString()
+          : "",
+      );
       setMaxRpm((indexer?.MaxRequestsPerMinute ?? 0).toString());
       setHitLimit(indexer?.HitLimit && indexer.HitLimit > 0 ? indexer.HitLimit.toString() : "");
       setDownloadLimit(
@@ -1602,7 +1666,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
 
   useEffect(() => {
     setTestState("idle");
-  }, [url, apiKey, searchUserAgent, proxyUrl, timeoutSeconds, skipTlsVerification]);
+  }, [url, apiKey, searchUserAgent, proxyUrl, timeoutSeconds, maxResponseBytes, skipTlsVerification]);
 
   const handleTest = useCallback(async () => {
     if (!url.trim() || !apiKey.trim()) return;
@@ -1614,6 +1678,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
       if (searchUserAgent.trim()) fd.append("userAgent", searchUserAgent);
       if (proxyUrl.trim()) fd.append("proxyUrl", proxyUrl);
       if (timeoutSeconds.trim()) fd.append("timeoutSeconds", timeoutSeconds);
+      if (maxResponseBytes.trim()) fd.append("maxResponseBytes", maxResponseBytes);
       fd.append("skipTlsVerification", skipTlsVerification.toString());
       const r = await fetch(withUrlBase("/api/test-indexer-connection"), {
         method: "POST",
@@ -1625,12 +1690,13 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
     } catch {
       setTestState("error");
     }
-  }, [url, apiKey, searchUserAgent, proxyUrl, timeoutSeconds, skipTlsVerification]);
+  }, [url, apiKey, searchUserAgent, proxyUrl, timeoutSeconds, maxResponseBytes, skipTlsVerification]);
 
   const handleSave = useCallback(() => {
     const rpm = parseInt(maxRpm || "0", 10);
     const timeout = parseInt(timeoutSeconds || "0", 10);
     const srl = parseInt(searchResultLimit || "0", 10);
+    const maxBytes = parseInt(maxResponseBytes || "0", 10);
     const hl = parseInt(hitLimit || "0", 10);
     const dl = parseInt(downloadLimit || "0", 10);
     const hr = hitResetTime.trim() === "" ? NaN : parseInt(hitResetTime, 10);
@@ -1672,6 +1738,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
       ...(proxyUrl.trim() ? { ProxyUrl: proxyUrl.trim() } : {}),
       ...(Number.isFinite(timeout) && timeout > 0 ? { TimeoutSeconds: timeout } : {}),
       ...(Number.isFinite(srl) && srl > 0 ? { SearchResultLimit: srl } : {}),
+      ...(Number.isFinite(maxBytes) && maxBytes > 0 ? { MaxResponseBytes: maxBytes } : {}),
       MaxRequestsPerMinute: Number.isFinite(rpm) && rpm > 0 ? rpm : 0,
       ...(Number.isFinite(hl) && hl > 0 ? { HitLimit: hl } : {}),
       ...(Number.isFinite(dl) && dl > 0 ? { DownloadLimit: dl } : {}),
@@ -1703,6 +1770,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
     proxyUrl,
     timeoutSeconds,
     searchResultLimit,
+    maxResponseBytes,
     maxRpm,
     hitLimit,
     downloadLimit,
@@ -1738,6 +1806,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
   })();
   const isProxyValid = isProxyUrlValid(proxyUrl);
   const isTimeoutFieldValid = isTimeoutValid(timeoutSeconds);
+  const isMaxResponseBytesFieldValid = isMaxResponseBytesValid(maxResponseBytes);
   const isNonNegIntOrBlank = (raw: string) => {
     if (!raw.trim()) return true;
     const n = Number(raw);
@@ -1760,6 +1829,7 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
     isRpmValid &&
     isProxyValid &&
     isTimeoutFieldValid &&
+    isMaxResponseBytesFieldValid &&
     isHitLimitValid &&
     isSearchResultLimitValid &&
     isDownloadLimitValid &&
@@ -1963,6 +2033,23 @@ function IndexerModal({ show, indexer, onClose, onSave }: IndexerModalProps) {
             placeholder="Use global default"
             value={searchResultLimit}
             onChange={(e) => setSearchResultLimit(e.target.value.replace(/[^0-9]/g, ""))}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="indexer-max-response-bytes">
+            Max indexer response (bytes){" "}
+            <span className="text-[11px] font-normal text-base-content/45">
+              (blank = use global default)
+            </span>
+          </Label>
+          <Input
+            type="text"
+            id="indexer-max-response-bytes"
+            className={`w-full max-w-48 ${!isMaxResponseBytesFieldValid && maxResponseBytes !== "" ? "input-error" : ""}`}
+            placeholder="Use global default"
+            value={maxResponseBytes}
+            onChange={(e) => setMaxResponseBytes(e.target.value.replace(/[^0-9]/g, ""))}
           />
         </div>
 
@@ -2274,6 +2361,13 @@ export function isIndexersSettingsValid(newConfig: Record<string, string>) {
       (!Number.isInteger(c.SearchResultLimit) || c.SearchResultLimit <= 0)
     )
       return false;
+    if (
+      c.MaxResponseBytes !== undefined &&
+      (!Number.isInteger(c.MaxResponseBytes) ||
+        c.MaxResponseBytes < 1 ||
+        c.MaxResponseBytes > MAX_RESPONSE_BYTES_HARD_CLAMP)
+    )
+      return false;
     for (const i of c.Indexers) {
       if (!i.Name.trim()) return false;
       if (!i.ApiKey.trim()) return false;
@@ -2291,6 +2385,13 @@ export function isIndexersSettingsValid(newConfig: Record<string, string>) {
       if (
         i.SearchResultLimit !== undefined &&
         (!Number.isInteger(i.SearchResultLimit) || i.SearchResultLimit <= 0)
+      )
+        return false;
+      if (
+        i.MaxResponseBytes !== undefined &&
+        (!Number.isInteger(i.MaxResponseBytes) ||
+          i.MaxResponseBytes < 1 ||
+          i.MaxResponseBytes > MAX_RESPONSE_BYTES_HARD_CLAMP)
       )
         return false;
       if (i.HitLimit !== undefined && (!Number.isInteger(i.HitLimit) || i.HitLimit < 0))

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -43,7 +43,11 @@ import {
 } from "./repairs/repairs";
 import { isWatchdogSettingsUpdated, WatchdogSettings } from "./watchdog/watchdog";
 import { isPreflightSettingsUpdated, PreflightSettings } from "./preflight/preflight";
-import { isWatchtowerSettingsUpdated, WatchtowerSettings } from "./watchtower/watchtower";
+import {
+  isWatchtowerSettingsUpdated,
+  isWatchtowerSettingsValid,
+  WatchtowerSettings,
+} from "./watchtower/watchtower";
 import { isWardenSettingsUpdated, WardenSettings } from "./warden/warden";
 import { isRcloneSettingsUpdated, RcloneSettings } from "./rclone/rclone";
 import { SupportSettings } from "./support/support";
@@ -354,7 +358,9 @@ function Body(props: BodyProps) {
                       ? "Invalid Search Profiles settings"
                       : isRepairsUpdated && !isRepairsSettingsValid(newConfig)
                         ? "Invalid Repairs settings"
-                        : "Save";
+                        : isWatchtowerUpdated && !isWatchtowerSettingsValid(newConfig)
+                          ? "Invalid Watchtower settings"
+                          : "Save";
   const saveButtonVariant =
     saveButtonLabel === "Save" ? "primary" : saveButtonLabel === "Saved" ? "success" : "secondary";
   const isSaveButtonDisabled = saveButtonLabel !== "Save";

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -192,6 +192,7 @@ const defaultConfig = {
   "watchtower.daily-resolve-budget": "60",
   "watchtower.auto-throughput": "false",
   "watchtower.sync-interval-seconds": "3600",
+  "watchtower.list-source-max-response-bytes": "8388608",
   "watchtower.series-scope": "latest-season",
   "watchtower.season-bundles": "true",
   "watchtower.series-max-episodes": "50",

--- a/frontend/app/routes/settings/watchtower/watchtower.test.ts
+++ b/frontend/app/routes/settings/watchtower/watchtower.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  isWatchtowerListSourceMaxResponseBytesValid,
+  isWatchtowerSettingsValid,
+} from "./watchtower";
+
+describe("isWatchtowerListSourceMaxResponseBytesValid", () => {
+  it("accepts the default and the hard clamp", () => {
+    expect(isWatchtowerListSourceMaxResponseBytesValid("8388608")).toBe(true);
+    expect(isWatchtowerListSourceMaxResponseBytesValid("1")).toBe(true);
+    expect(isWatchtowerListSourceMaxResponseBytesValid("16777216")).toBe(true);
+  });
+
+  it("rejects zero, decimals, and values above the hard clamp", () => {
+    expect(isWatchtowerListSourceMaxResponseBytesValid("0")).toBe(false);
+    expect(isWatchtowerListSourceMaxResponseBytesValid("1.5")).toBe(false);
+    expect(isWatchtowerListSourceMaxResponseBytesValid("16777217")).toBe(false);
+    expect(isWatchtowerListSourceMaxResponseBytesValid("")).toBe(false);
+    expect(isWatchtowerListSourceMaxResponseBytesValid(" 8388608")).toBe(false);
+  });
+});
+
+describe("isWatchtowerSettingsValid", () => {
+  it("gates save on the list-source response-size field", () => {
+    expect(
+      isWatchtowerSettingsValid({ "watchtower.list-source-max-response-bytes": "8388608" }),
+    ).toBe(true);
+    expect(isWatchtowerSettingsValid({ "watchtower.list-source-max-response-bytes": "0" })).toBe(
+      false,
+    );
+  });
+});

--- a/frontend/app/routes/settings/watchtower/watchtower.tsx
+++ b/frontend/app/routes/settings/watchtower/watchtower.tsx
@@ -594,10 +594,15 @@ export function WatchtowerSettings({ config, setNewConfig }: WatchtowerSettingsP
           <Form.Group className="flex flex-col gap-2">
             <Form.Label>Max list-source response (bytes)</Form.Label>
             <Form.Control
-              className="w-full max-w-48"
-              type="number"
-              min={1}
-              max={16 * 1024 * 1024}
+              className={`w-full max-w-48 ${
+                isWatchtowerListSourceMaxResponseBytesValid(
+                  config["watchtower.list-source-max-response-bytes"] ?? "8388608",
+                )
+                  ? ""
+                  : "input-error"
+              }`}
+              type="text"
+              inputMode="numeric"
               disabled={!enabled}
               value={config["watchtower.list-source-max-response-bytes"] ?? "8388608"}
               onChange={(e) => set("watchtower.list-source-max-response-bytes", e.target.value)}
@@ -666,4 +671,22 @@ export function isWatchtowerSettingsUpdated(
     "watchtower.list-source-max-response-bytes",
     "watchtower.verbose-logging",
   ].some((k) => config[k] !== newConfig[k]);
+}
+
+const LIST_SOURCE_MAX_RESPONSE_BYTES_HARD_CLAMP = 16 * 1024 * 1024;
+
+export function isWatchtowerListSourceMaxResponseBytesValid(raw: string): boolean {
+  const n = Number(raw);
+  return (
+    Number.isInteger(n) &&
+    n >= 1 &&
+    n <= LIST_SOURCE_MAX_RESPONSE_BYTES_HARD_CLAMP &&
+    raw.trim() === n.toString()
+  );
+}
+
+export function isWatchtowerSettingsValid(newConfig: Record<string, string>): boolean {
+  return isWatchtowerListSourceMaxResponseBytesValid(
+    newConfig["watchtower.list-source-max-response-bytes"] ?? "8388608",
+  );
 }

--- a/frontend/app/routes/settings/watchtower/watchtower.tsx
+++ b/frontend/app/routes/settings/watchtower/watchtower.tsx
@@ -90,6 +90,7 @@ export function WatchtowerSettings({ config, setNewConfig }: WatchtowerSettingsP
           "watchtower.keepfresh-base-seconds",
           "watchtower.keepfresh-max-seconds",
           "watchtower.unavailable-retry-seconds",
+          "watchtower.list-source-max-response-bytes",
           "watchtower.verbose-logging",
         ]}
       >
@@ -589,6 +590,24 @@ export function WatchtowerSettings({ config, setNewConfig }: WatchtowerSettingsP
               How often remote lists are re-fetched to catch additions/removals. Default 3600.
             </p>
           </Form.Group>
+
+          <Form.Group className="flex flex-col gap-2">
+            <Form.Label>Max list-source response (bytes)</Form.Label>
+            <Form.Control
+              className="w-full max-w-48"
+              type="number"
+              min={1}
+              max={16 * 1024 * 1024}
+              disabled={!enabled}
+              value={config["watchtower.list-source-max-response-bytes"] ?? "8388608"}
+              onChange={(e) => set("watchtower.list-source-max-response-bytes", e.target.value)}
+            />
+            <p className="m-0 text-[11px] leading-relaxed text-base-content/45">
+              Caps how large a Stremio manifest, catalog page, or URL-list body may be before it is
+              parsed. Counts the bytes the HTTP client delivers (not decompressed; automatic gzip is
+              off). Default 8,388,608 (8 MiB). Maximum 16,777,216 (16 MiB).
+            </p>
+          </Form.Group>
         </SettingsCard>
         <SettingsCard
           icon="bug_report"
@@ -644,6 +663,7 @@ export function isWatchtowerSettingsUpdated(
     "watchtower.keepfresh-base-seconds",
     "watchtower.keepfresh-max-seconds",
     "watchtower.unavailable-retry-seconds",
+    "watchtower.list-source-max-response-bytes",
     "watchtower.verbose-logging",
   ].some((k) => config[k] !== newConfig[k]);
 }

--- a/frontend/app/routes/settings/watchtower/watchtower.tsx
+++ b/frontend/app/routes/settings/watchtower/watchtower.tsx
@@ -678,6 +678,7 @@ const LIST_SOURCE_MAX_RESPONSE_BYTES_HARD_CLAMP = 16 * 1024 * 1024;
 export function isWatchtowerListSourceMaxResponseBytesValid(raw: string): boolean {
   const n = Number(raw);
   return (
+    raw === raw.trim() &&
     Number.isInteger(n) &&
     n >= 1 &&
     n <= LIST_SOURCE_MAX_RESPONSE_BYTES_HARD_CLAMP &&

--- a/tests/NzbWebDAV.Tests/Clients/NewznabClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/NewznabClientTests.cs
@@ -1,0 +1,354 @@
+using System.Net;
+using System.Text;
+using NzbWebDAV.Clients.Indexers;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Tests.TestUtils;
+
+namespace NzbWebDAV.Tests.Clients;
+
+public class NewznabClientTests
+{
+    private const string ApiKey = "DO_NOT_LOG_INDEXER_KEY";
+    private const string BodyMarker = "DO_NOT_LOG_BODY_MARKER";
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(0)]
+    public async Task QueryAsync_ValidBody_AtOrBelowLimit_IsAccepted(int headroom)
+    {
+        var body = SearchXml();
+        var limit = body.Length + headroom;
+        using var handler = OkHandler(body);
+        using var http = new HttpClient(handler);
+        var client = Create(http, limit);
+
+        var items = await client.QueryAsync(SearchParams());
+
+        var item = Assert.Single(items);
+        Assert.Equal("Example Release", item.Title);
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task QueryAsync_OneByteOverLimit_RejectsWithoutPartialResult()
+    {
+        var body = SearchXml();
+        var limit = body.Length - 1;
+        using var handler = OkHandler(body);
+        using var http = new HttpClient(handler);
+        var client = Create(http, limit);
+
+        var ex = await Assert.ThrowsAsync<RemoteResponseTooLargeException>(
+            () => client.QueryAsync(SearchParams()));
+
+        Assert.Equal(limit, ex.MaxBytes);
+        Assert.DoesNotContain(ApiKey, ex.Message);
+        Assert.DoesNotContain(BodyMarker, ex.Message);
+    }
+
+    [Fact]
+    public async Task TestAsync_ValidCaps_AtLimit_Succeeds()
+    {
+        var body = CapsXml();
+        using var handler = OkHandler(body);
+        using var http = new HttpClient(handler);
+        var client = Create(http, body.Length);
+
+        Assert.True(await client.TestAsync());
+    }
+
+    [Fact]
+    public async Task TestAsync_OneByteOverLimit_Rejects()
+    {
+        var body = CapsXml();
+        using var handler = OkHandler(body);
+        using var http = new HttpClient(handler);
+        var client = Create(http, body.Length - 1);
+
+        await Assert.ThrowsAsync<RemoteResponseTooLargeException>(() => client.TestAsync());
+    }
+
+    [Fact]
+    public async Task QueryAsync_DeclaredLengthAboveLimit_RejectsBeforeStreamRead()
+    {
+        var limit = 64;
+        using var content = new FailIfOpenedContent(limit + 1);
+        using var handler = new ScriptedHandler((_, _) => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = content,
+        });
+        using var http = new HttpClient(handler);
+        var client = Create(http, limit);
+
+        var ex = await Assert.ThrowsAsync<RemoteResponseTooLargeException>(
+            () => client.QueryAsync(SearchParams()));
+
+        Assert.Equal(limit, ex.MaxBytes);
+        Assert.Equal(limit + 1, ex.DeclaredBytes);
+        Assert.False(content.StreamOpened);
+    }
+
+    [Fact]
+    public async Task QueryAsync_DeclaredAtLimit_ActualShorter_Parses()
+    {
+        var body = SearchXml();
+        var limit = body.Length + 32;
+        var stream = new TrackingStream(body);
+        using var handler = new ScriptedHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamHttpContent(stream, declaredLength: limit),
+            };
+            return response;
+        });
+        using var http = new HttpClient(handler);
+        var client = Create(http, limit);
+
+        var items = await client.QueryAsync(SearchParams());
+        Assert.Equal("Example Release", Assert.Single(items).Title);
+        Assert.True(stream.Disposed);
+    }
+
+    [Fact]
+    public async Task QueryAsync_DeclaredBelowLimit_ActualOver_RejectsByStreamCount()
+    {
+        var body = SearchXml();
+        var limit = body.Length;
+        var over = PadUtf8(body, limit + 1);
+        var stream = new TrackingStream(over);
+        using var handler = new ScriptedHandler((_, _) => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamHttpContent(stream, declaredLength: limit - 1),
+        });
+        using var http = new HttpClient(handler);
+        var client = Create(http, limit);
+
+        await Assert.ThrowsAsync<RemoteResponseTooLargeException>(() => client.QueryAsync(SearchParams()));
+        Assert.True(stream.Disposed);
+    }
+
+    [Fact]
+    public async Task QueryAsync_ChunkedUndeclared_ExactLimitSucceeds()
+    {
+        var body = SearchXml();
+        var stream = new TrackingStream(body);
+        using var handler = new ScriptedHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamHttpContent(stream),
+            };
+            response.Headers.TransferEncodingChunked = true;
+            return response;
+        });
+        using var http = new HttpClient(handler);
+        var client = Create(http, body.Length);
+
+        var items = await client.QueryAsync(SearchParams());
+        Assert.Equal("Example Release", Assert.Single(items).Title);
+    }
+
+    [Fact]
+    public async Task QueryAsync_NonEofOversize_RejectsBeforeEagerBuffering()
+    {
+        var body = SearchXml();
+        var limit = body.Length;
+        var prefix = PadUtf8(body, limit + 1);
+        var stream = new PrefixThenBlockStream(prefix);
+        using var handler = new ScriptedHandler((_, _) => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamHttpContent(stream),
+        });
+        using var http = new HttpClient(handler);
+        var client = Create(http, limit);
+        using var guard = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var ex = await Assert.ThrowsAsync<RemoteResponseTooLargeException>(
+            () => client.QueryAsync(SearchParams(), guard.Token));
+
+        Assert.Equal(limit, ex.MaxBytes);
+        Assert.False(stream.EnteredWait);
+        Assert.True(stream.Disposed);
+    }
+
+    [Fact]
+    public async Task QueryAsync_MultibyteUtf8Title_IsBoundedByBytes()
+    {
+        var body = SearchXml("Café 🎬");
+        Assert.True(Encoding.UTF8.GetCharCount(body) < body.Length);
+
+        using (var handler = OkHandler(body))
+        using (var http = new HttpClient(handler))
+        {
+            var items = await Create(http, body.Length).QueryAsync(SearchParams());
+            Assert.Equal("Café 🎬", Assert.Single(items).Title);
+        }
+
+        using var overHandler = OkHandler(body);
+        using var overHttp = new HttpClient(overHandler);
+        await Assert.ThrowsAsync<RemoteResponseTooLargeException>(
+            () => Create(overHttp, body.Length - 1).QueryAsync(SearchParams()));
+    }
+
+    [Fact]
+    public async Task QueryAsync_CallerCancellationDuringBodyRead_IsCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        var stream = new BlockingReadStream();
+        using var handler = new ScriptedHandler((_, _) => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamHttpContent(stream),
+        });
+        using var http = new HttpClient(handler);
+        var client = Create(http, 1024);
+
+        var task = client.QueryAsync(SearchParams(), cts.Token);
+        await stream.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cts.Cancel();
+
+        var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+        Assert.True(cts.IsCancellationRequested);
+        Assert.IsNotType<RemoteResponseTooLargeException>(ex);
+        Assert.IsNotType<RemoteResponseFormatException>(ex);
+        Assert.Equal(1, handler.RequestCount);
+        Assert.True(stream.Disposed);
+    }
+
+    [Fact]
+    public async Task QueryAsync_AlreadyCancelled_DoesNotParse()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        using var handler = OkHandler(SearchXml());
+        using var http = new HttpClient(handler);
+        var client = Create(http, 4096);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => client.QueryAsync(SearchParams(), cts.Token));
+    }
+
+    [Fact]
+    public async Task QueryAsync_MalformedXml_IsControlledFormatError()
+    {
+        var xml = Encoding.UTF8.GetBytes("""<?xml version="1.0"?><rss><channel><item><title>x</item></channel></rss>""");
+        using var handler = OkHandler(xml);
+        using var http = new HttpClient(handler);
+        var client = Create(http, 4096);
+
+        var ex = await Assert.ThrowsAsync<RemoteResponseFormatException>(
+            () => client.QueryAsync(SearchParams()));
+
+        Assert.Equal("Indexer returned invalid XML.", ex.Message);
+        Assert.DoesNotContain("<item>", ex.Message);
+        Assert.DoesNotContain(ApiKey, ex.Message);
+        Assert.DoesNotContain(BodyMarker, ex.Message);
+    }
+
+    [Fact]
+    public async Task QueryAsync_NewznabErrorElement_IsProtocolErrorNotFormat()
+    {
+        var xml = Encoding.UTF8.GetBytes(
+            """<?xml version="1.0"?><error code="100" description="Missing parameter"/>""");
+        using var handler = OkHandler(xml);
+        using var http = new HttpClient(handler);
+        var client = Create(http, 4096);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => client.QueryAsync(SearchParams()));
+        Assert.Contains("[100]", ex.Message);
+        Assert.Contains("Missing parameter", ex.Message);
+        Assert.IsNotType<RemoteResponseFormatException>(ex);
+    }
+
+    [Fact]
+    public async Task QueryAsync_Doctype_IsFormatErrorWithoutResolverAccess()
+    {
+        var xml = Encoding.UTF8.GetBytes(
+            """<?xml version="1.0"?><!DOCTYPE caps SYSTEM "http://127.0.0.1:1/should-not-resolve"><caps></caps>""");
+        using var handler = OkHandler(xml);
+        using var http = new HttpClient(handler);
+        var client = Create(http, 4096);
+
+        var ex = await Assert.ThrowsAsync<RemoteResponseFormatException>(() => client.QueryAsync(SearchParams()));
+        Assert.Equal("Indexer returned invalid XML.", ex.Message);
+        Assert.DoesNotContain("127.0.0.1", ex.Message);
+    }
+
+    [Fact]
+    public async Task QueryAsync_NonSuccessStatus_DoesNotRetry()
+    {
+        using var handler = new ScriptedHandler((_, _) => new HttpResponseMessage(HttpStatusCode.BadGateway));
+        using var http = new HttpClient(handler);
+        var client = Create(http, 4096);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => client.QueryAsync(SearchParams()));
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task GetAsync_RetriesOnceOnFirstTransportFailure()
+    {
+        var body = SearchXml();
+        var calls = 0;
+        using var retryHandler = new ScriptedHandler((_, _) =>
+        {
+            calls++;
+            if (calls == 1) throw new HttpRequestException("transient");
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(body) };
+        });
+        using var http = new HttpClient(retryHandler);
+        var client = Create(http, body.Length + 16);
+
+        var items = await client.QueryAsync(SearchParams());
+        Assert.Equal("Example Release", Assert.Single(items).Title);
+        Assert.Equal(2, retryHandler.RequestCount);
+    }
+
+    [Fact]
+    public async Task QueryAsync_Oversize_DoesNotEmbedApiKeyOrBody()
+    {
+        using var handler = OkHandler(SearchXml(BodyMarker));
+        using var http = new HttpClient(handler);
+        var client = Create(http, 8);
+
+        var ex = await Assert.ThrowsAsync<RemoteResponseTooLargeException>(
+            () => client.QueryAsync(SearchParams()));
+        Assert.DoesNotContain(ApiKey, ex.ToString());
+        Assert.DoesNotContain(BodyMarker, ex.Message);
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    private static NewznabClient Create(HttpClient http, long maxResponseBytes) =>
+        new(http, "http://indexer.example/api", ApiKey, maxResponseBytes);
+
+    private static Dictionary<string, string> SearchParams() => new()
+    {
+        ["t"] = "search",
+        ["q"] = "query",
+        ["limit"] = "100",
+    };
+
+    private static ScriptedHandler OkHandler(byte[] body) =>
+        new((_, _) => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(body),
+        });
+
+    private static byte[] CapsXml() =>
+        Encoding.UTF8.GetBytes("""<?xml version="1.0"?><caps><server version="1.0" title="t"/></caps>""");
+
+    private static byte[] SearchXml(string title = "Example Release") =>
+        Encoding.UTF8.GetBytes(
+            $"""<?xml version="1.0"?><rss version="2.0" xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/"><channel><item><title>{title}</title><guid>g1</guid><link>http://nzb.example/a.nzb</link><enclosure url="http://nzb.example/a.nzb" length="10"/></item></channel></rss>""");
+
+    private static byte[] PadUtf8(byte[] body, int targetLength)
+    {
+        if (body.Length > targetLength)
+            throw new InvalidOperationException("body already larger than target");
+        if (body.Length == targetLength) return body;
+        var padded = new byte[targetLength];
+        Buffer.BlockCopy(body, 0, padded, 0, body.Length);
+        Array.Fill(padded, (byte)' ', body.Length, targetLength - body.Length);
+        return padded;
+    }
+}

--- a/tests/NzbWebDAV.Tests/Config/ExternalMetadataResponseLimitsConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/ExternalMetadataResponseLimitsConfigTests.cs
@@ -1,0 +1,149 @@
+using System.Text.Json;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+public class ExternalMetadataResponseLimitsConfigTests
+{
+    [Fact]
+    public void WatchtowerGetter_UsesDefaultWhenUnset()
+    {
+        var config = new ConfigManager();
+        Assert.Equal(
+            ExternalMetadataResponseLimits.WatchtowerDefaultMaxResponseBytes,
+            config.GetWatchtowerListSourceMaxResponseBytes());
+    }
+
+    [Fact]
+    public void WatchtowerGetter_ClampsAboveHardMax()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues([
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.WatchtowerListSourceMaxResponseBytes,
+                ConfigValue = (ExternalMetadataResponseLimits.HardMaxResponseBytes + 1).ToString(),
+            },
+        ]);
+
+        Assert.Equal(
+            ExternalMetadataResponseLimits.HardMaxResponseBytes,
+            config.GetWatchtowerListSourceMaxResponseBytes());
+    }
+
+    [Fact]
+    public void WatchtowerGetter_ZeroFallsBackToDefault()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues([
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.WatchtowerListSourceMaxResponseBytes,
+                ConfigValue = "0",
+            },
+        ]);
+
+        Assert.Equal(
+            ExternalMetadataResponseLimits.WatchtowerDefaultMaxResponseBytes,
+            config.GetWatchtowerListSourceMaxResponseBytes());
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-1")]
+    [InlineData("16777217")]
+    public void WatchtowerSave_RejectsOutOfRange(string value)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            ConfigManager.ValidateConfigItems([
+                new ConfigItem
+                {
+                    ConfigName = ConfigKeys.WatchtowerListSourceMaxResponseBytes,
+                    ConfigValue = value,
+                },
+            ]));
+    }
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("8388608")]
+    [InlineData("16777216")]
+    public void WatchtowerSave_AcceptsBounds(string value)
+    {
+        ConfigManager.ValidateConfigItems([
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.WatchtowerListSourceMaxResponseBytes,
+                ConfigValue = value,
+            },
+        ]);
+    }
+
+    [Fact]
+    public void IndexerConfig_GetEffective_UsesDefaultThenPerIndexerThenClamp()
+    {
+        var cfg = new IndexerConfig();
+        var indexer = new IndexerConfig.ConnectionDetails
+        {
+            Name = "A",
+            Url = "http://example/api",
+            ApiKey = "k",
+        };
+        Assert.Equal(ExternalMetadataResponseLimits.NewznabDefaultMaxResponseBytes, cfg.GetEffectiveMaxResponseBytes(indexer));
+
+        cfg.MaxResponseBytes = 1024;
+        Assert.Equal(1024, cfg.GetEffectiveMaxResponseBytes(indexer));
+
+        indexer.MaxResponseBytes = 2048;
+        Assert.Equal(2048, cfg.GetEffectiveMaxResponseBytes(indexer));
+
+        indexer.MaxResponseBytes = ExternalMetadataResponseLimits.HardMaxResponseBytes + 5;
+        Assert.Equal(ExternalMetadataResponseLimits.HardMaxResponseBytes, cfg.GetEffectiveMaxResponseBytes(indexer));
+    }
+
+    [Fact]
+    public void IndexerInstances_RejectsZeroAndOverHardMax()
+    {
+        var tooBig = JsonSerializer.Serialize(new IndexerConfig
+        {
+            MaxResponseBytes = ExternalMetadataResponseLimits.HardMaxResponseBytes + 1,
+            Indexers = [],
+        });
+        Assert.Throws<ArgumentException>(() =>
+            ConfigManager.ValidateConfigItems([
+                new ConfigItem { ConfigName = ConfigKeys.IndexersInstances, ConfigValue = tooBig },
+            ]));
+
+        var zero = JsonSerializer.Serialize(new IndexerConfig
+        {
+            Indexers =
+            [
+                new IndexerConfig.ConnectionDetails
+                {
+                    Name = "A",
+                    Url = "http://example/api",
+                    ApiKey = "k",
+                    MaxResponseBytes = 0,
+                },
+            ],
+        });
+        Assert.Throws<ArgumentException>(() =>
+            ConfigManager.ValidateConfigItems([
+                new ConfigItem { ConfigName = ConfigKeys.IndexersInstances, ConfigValue = zero },
+            ]));
+    }
+
+    [Fact]
+    public void IndexerInstances_AcceptsExactHardMax()
+    {
+        var json = JsonSerializer.Serialize(new IndexerConfig
+        {
+            MaxResponseBytes = ExternalMetadataResponseLimits.HardMaxResponseBytes,
+            Indexers = [],
+        });
+        ConfigManager.ValidateConfigItems([
+            new ConfigItem { ConfigName = ConfigKeys.IndexersInstances, ConfigValue = json },
+        ]);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Config/ExternalMetadataResponseLimitsConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/ExternalMetadataResponseLimitsConfigTests.cs
@@ -146,4 +146,16 @@ public class ExternalMetadataResponseLimitsConfigTests
             new ConfigItem { ConfigName = ConfigKeys.IndexersInstances, ConfigValue = json },
         ]);
     }
+
+    [Fact]
+    public void IndexerInstances_RejectsNullIndexersArray()
+    {
+        const string json = """{"Indexers":null}""";
+        var ex = Assert.Throws<ArgumentException>(() =>
+            ConfigManager.ValidateConfigItems([
+                new ConfigItem { ConfigName = ConfigKeys.IndexersInstances, ConfigValue = json },
+            ]));
+        Assert.Contains("Indexers", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("array", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/tests/NzbWebDAV.Tests/Config/ExternalMetadataResponseLimitsConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/ExternalMetadataResponseLimitsConfigTests.cs
@@ -158,4 +158,15 @@ public class ExternalMetadataResponseLimitsConfigTests
         Assert.Contains("Indexers", ex.Message, StringComparison.Ordinal);
         Assert.Contains("array", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public void IndexerInstances_RejectsNullIndexerEntries()
+    {
+        const string json = """{"Indexers":[null]}""";
+        var ex = Assert.Throws<ArgumentException>(() =>
+            ConfigManager.ValidateConfigItems([
+                new ConfigItem { ConfigName = ConfigKeys.IndexersInstances, ConfigValue = json },
+            ]));
+        Assert.Contains("null", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/tests/NzbWebDAV.Tests/Extensions/ExceptionExtensionsTests.cs
+++ b/tests/NzbWebDAV.Tests/Extensions/ExceptionExtensionsTests.cs
@@ -1,4 +1,5 @@
 using System.Net.Sockets;
+using System.Xml;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Exceptions;
@@ -47,6 +48,39 @@ public class ExceptionExtensionsTests
         var io = new IOException("Unable to read data from the transport connection.");
         Assert.True(io.TryGetKnownErrorMessage(out var ioReason));
         Assert.Equal("Unable to read data from the transport connection.", ioReason);
+    }
+
+    [Fact]
+    public void TryGetKnownErrorMessage_RecognizesRemoteResponseTooLarge()
+    {
+        var inner = new NzbResponseTooLargeException(100);
+        var ex = new RemoteResponseTooLargeException(100, null, inner);
+
+        Assert.True(ex.TryGetKnownErrorMessage(out var reason));
+        Assert.Equal(ex.Message, reason);
+        Assert.DoesNotContain("NZB response", reason);
+        Assert.Contains("100", reason);
+    }
+
+    [Fact]
+    public void TryGetKnownErrorMessage_RecognizesRemoteResponseFormat()
+    {
+        var ex = new RemoteResponseFormatException(
+            "Indexer returned invalid XML.",
+            new XmlException("secret DO_NOT_LOG_BODY_MARKER at line 1"));
+
+        Assert.True(ex.TryGetKnownErrorMessage(out var reason));
+        Assert.Equal("Indexer returned invalid XML.", reason);
+        Assert.DoesNotContain("DO_NOT_LOG_BODY_MARKER", reason);
+    }
+
+    [Fact]
+    public void TryGetKnownErrorMessage_DoesNotTreatInvalidOperationAsKnownRemote()
+    {
+        var ex = new InvalidOperationException("unexpected bug DO_NOT_LOG_BODY_MARKER");
+
+        Assert.False(ex.TryGetKnownErrorMessage(out var reason));
+        Assert.Equal(string.Empty, reason);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Extensions/RemoteResponseExceptionLoggingTests.cs
+++ b/tests/NzbWebDAV.Tests/Extensions/RemoteResponseExceptionLoggingTests.cs
@@ -1,0 +1,100 @@
+using System.Xml;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Tests.TestUtils;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace NzbWebDAV.Tests.Extensions;
+
+[Collection(nameof(GlobalLoggerCollection))]
+public class RemoteResponseExceptionLoggingTests
+{
+    private const string Secret = "DO_NOT_LOG_BODY_MARKER";
+
+    [Fact]
+    public void LogWarningKnownOrStack_RemoteTooLarge_IsWarningWithoutException()
+    {
+        var inner = new NzbResponseTooLargeException(100);
+        var ex = new RemoteResponseTooLargeException(100, null, inner);
+        var events = Capture(() =>
+            ex.LogWarningKnownOrStack("Watchtower: sync failed for source {Name}.", "My Catalog"));
+
+        var warning = Assert.Single(events, e => e.Level == LogEventLevel.Warning);
+        Assert.Null(warning.Exception);
+        var rendered = warning.RenderMessage();
+        Assert.Contains("My Catalog", rendered);
+        Assert.Contains("Reason:", rendered);
+        Assert.DoesNotContain(Secret, rendered);
+        Assert.DoesNotContain("NZB response", rendered);
+    }
+
+    [Fact]
+    public void LogWarningKnownOrStack_RemoteFormat_IsWarningWithoutException()
+    {
+        var ex = new RemoteResponseFormatException(
+            "Indexer returned invalid XML.",
+            new XmlException($"bad xml {Secret}"));
+        var events = Capture(() =>
+            ex.LogWarningKnownOrStack("Indexer {Indexer} search failed.", "ExampleIndexer"));
+
+        var warning = Assert.Single(events, e => e.Level == LogEventLevel.Warning);
+        Assert.Null(warning.Exception);
+        var rendered = warning.RenderMessage();
+        Assert.Contains("ExampleIndexer", rendered);
+        Assert.Contains("Indexer returned invalid XML.", rendered);
+        Assert.DoesNotContain(Secret, rendered);
+    }
+
+    [Fact]
+    public void LogWarningKnownOrStack_Unexpected_KeepsStackWithoutSecretInTemplate()
+    {
+        var ex = new InvalidOperationException($"boom {Secret}");
+        var events = Capture(() =>
+            ex.LogWarningKnownOrStack("Watchtower: sync failed for source {Name}.", "My Catalog"));
+
+        var warning = Assert.Single(events, e => e.Level == LogEventLevel.Warning);
+        Assert.Same(ex, warning.Exception);
+        Assert.Contains("My Catalog", warning.RenderMessage());
+        Assert.DoesNotContain("https://", warning.RenderMessage());
+    }
+
+    private static IReadOnlyList<LogEvent> Capture(Action action)
+    {
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        try
+        {
+            action();
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+
+        return sink.Events;
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events) return _events.ToArray();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events) _events.Add(logEvent);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Extensions/RemoteResponseExceptionLoggingTests.cs
+++ b/tests/NzbWebDAV.Tests/Extensions/RemoteResponseExceptionLoggingTests.cs
@@ -3,7 +3,6 @@ using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Tests.TestUtils;
 using Serilog;
-using Serilog.Core;
 using Serilog.Events;
 
 namespace NzbWebDAV.Tests.Extensions;
@@ -62,7 +61,7 @@ public class RemoteResponseExceptionLoggingTests
 
     private static IReadOnlyList<LogEvent> Capture(Action action)
     {
-        var sink = new CollectingSink();
+        var sink = new CollectingLogEventSink();
         var previous = Log.Logger;
         Log.Logger = new LoggerConfiguration()
             .MinimumLevel.Debug()
@@ -78,23 +77,5 @@ public class RemoteResponseExceptionLoggingTests
         }
 
         return sink.Events;
-    }
-
-    private sealed class CollectingSink : ILogEventSink
-    {
-        private readonly List<LogEvent> _events = [];
-
-        public IReadOnlyList<LogEvent> Events
-        {
-            get
-            {
-                lock (_events) return _events.ToArray();
-            }
-        }
-
-        public void Emit(LogEvent logEvent)
-        {
-            lock (_events) _events.Add(logEvent);
-        }
     }
 }

--- a/tests/NzbWebDAV.Tests/Services/ArrMonitoringAggregationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrMonitoringAggregationTests.cs
@@ -214,7 +214,8 @@ public sealed class ArrMonitoringAggregationTests
 
             var warning = Assert.Single(
                 sink.Events,
-                e => e.Level == LogEventLevel.Warning && e.Properties.ContainsKey("Reason"));
+                e => e.Level == LogEventLevel.Warning
+                     && e.MessageTemplate.Text.Contains("stuck queue item", StringComparison.Ordinal));
             Assert.Equal(
                 "Found archive file, might need to be extracted: release.part01.rar",
                 warning.Properties["Reason"].LiteralValue());

--- a/tests/NzbWebDAV.Tests/Services/Watchtower/ListSourceEnumeratorTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Watchtower/ListSourceEnumeratorTests.cs
@@ -105,7 +105,7 @@ public class ListSourceEnumeratorTests
         using var http = new HttpClient(handler);
         var enumerator = new ListSourceEnumerator(http, () => 4096);
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+        var ex = await Assert.ThrowsAsync<ListSourceGuidanceException>(
             () => enumerator.DiscoverCatalogsAsync(SecretUrl, CancellationToken.None));
         Assert.Equal("Could not fetch the addon manifest.", ex.Message);
         Assert.DoesNotContain(UserInfo, ex.Message);
@@ -126,7 +126,7 @@ public class ListSourceEnumeratorTests
             .CreateLogger();
         try
         {
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            var ex = await Assert.ThrowsAsync<ListSourceGuidanceException>(
                 () => enumerator.EnumerateAsync(UrlListSource(), CancellationToken.None));
             Assert.Equal("List request failed or returned an empty response.", ex.Message);
         }
@@ -262,7 +262,7 @@ public class ListSourceEnumeratorTests
         using var http = new HttpClient(handler);
         var enumerator = new ListSourceEnumerator(http, () => body.Length);
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+        var ex = await Assert.ThrowsAsync<ListSourceGuidanceException>(
             () => enumerator.EnumerateAsync(CatalogSource(), CancellationToken.None));
         Assert.Contains("addon manifest", ex.Message);
     }
@@ -275,7 +275,7 @@ public class ListSourceEnumeratorTests
         using var http = new HttpClient(handler);
         var enumerator = new ListSourceEnumerator(http, () => body.Length);
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+        var ex = await Assert.ThrowsAsync<ListSourceGuidanceException>(
             () => enumerator.DiscoverCatalogsAsync("https://addon.example/manifest.json", CancellationToken.None));
         Assert.Equal("No catalogs were found in this addon manifest.", ex.Message);
     }
@@ -372,7 +372,7 @@ public class ListSourceEnumeratorTests
         using var http = new HttpClient(handler);
         var enumerator = new ListSourceEnumerator(http, () => 4096);
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+        var ex = await Assert.ThrowsAsync<ListSourceGuidanceException>(
             () => enumerator.EnumerateAsync(CatalogSource(), CancellationToken.None));
         Assert.Equal("Catalog request failed or returned an empty response.", ex.Message);
     }

--- a/tests/NzbWebDAV.Tests/Services/Watchtower/ListSourceEnumeratorTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Watchtower/ListSourceEnumeratorTests.cs
@@ -1,0 +1,438 @@
+using System.Net;
+using System.Text;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Services;
+using NzbWebDAV.Tests.TestUtils;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace NzbWebDAV.Tests.Services.Watchtower;
+
+[Collection(nameof(GlobalLoggerCollection))]
+public class ListSourceEnumeratorTests
+{
+    private const string UserInfo = "DO_NOT_LOG_USERINFO";
+    private const string QueryToken = "DO_NOT_LOG_QUERY_TOKEN";
+    private const string BodyMarker = "DO_NOT_LOG_BODY_MARKER";
+    private const string SecretUrl = $"https://{UserInfo}@lists.example/list?token={QueryToken}";
+
+    [Fact]
+    public async Task EnumerateAsync_Manual_MakesNoRequest()
+    {
+        using var handler = new ScriptedHandler((_, _) => throw new InvalidOperationException("no HTTP"));
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => 4096);
+
+        var refs = await enumerator.EnumerateAsync(new ListSource
+        {
+            Kind = ListSource.KindManual,
+            Name = "Manual",
+        }, CancellationToken.None);
+
+        Assert.Empty(refs);
+        Assert.Equal(0, handler.RequestCount);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(0)]
+    public async Task StremioCatalog_ValidBody_AtOrBelowLimit_IsAccepted(int headroom)
+    {
+        var body = StremioPage("tt1", "A");
+        using var handler = OkHandler(body);
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => body.Length + headroom);
+
+        var refs = await enumerator.EnumerateAsync(CatalogSource(), CancellationToken.None);
+
+        var item = Assert.Single(refs);
+        Assert.Equal("movie", item.Type);
+        Assert.Equal("tt1", item.ContentId);
+        Assert.Equal("A", item.Title);
+    }
+
+    [Fact]
+    public async Task StremioCatalog_OneByteOverLimit_Rejects()
+    {
+        var body = StremioPage("tt1", "A");
+        using var handler = OkHandler(body);
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => body.Length - 1);
+
+        var ex = await Assert.ThrowsAsync<RemoteResponseTooLargeException>(
+            () => enumerator.EnumerateAsync(CatalogSource(), CancellationToken.None));
+        Assert.Equal(body.Length - 1, ex.MaxBytes);
+        Assert.DoesNotContain(UserInfo, ex.Message);
+        Assert.DoesNotContain(QueryToken, ex.Message);
+    }
+
+    [Fact]
+    public async Task DiscoverCatalogs_ValidManifest_ParsesChoices()
+    {
+        var body = ManifestJson();
+        using var handler = OkHandler(body);
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => body.Length);
+
+        var result = await enumerator.DiscoverCatalogsAsync("https://addon.example/manifest.json", CancellationToken.None);
+
+        Assert.Equal("Addon", result.AddonName);
+        var choice = Assert.Single(result.Catalogs);
+        Assert.Equal("movie", choice.Type);
+        Assert.Equal("top", choice.Id);
+    }
+
+    [Fact]
+    public async Task DiscoverCatalogs_Oversize_RejectsWithoutUrl()
+    {
+        var body = ManifestJson();
+        using var handler = OkHandler(body);
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => body.Length - 1);
+
+        var ex = await Assert.ThrowsAsync<RemoteResponseTooLargeException>(
+            () => enumerator.DiscoverCatalogsAsync(SecretUrl, CancellationToken.None));
+        Assert.DoesNotContain(UserInfo, ex.Message);
+        Assert.DoesNotContain(QueryToken, ex.Message);
+        Assert.DoesNotContain("https://", ex.Message);
+    }
+
+    [Fact]
+    public async Task DiscoverCatalogs_FetchFailure_DoesNotEchoUrl()
+    {
+        using var handler = new ScriptedHandler((_, _) => new HttpResponseMessage(HttpStatusCode.NotFound));
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => 4096);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => enumerator.DiscoverCatalogsAsync(SecretUrl, CancellationToken.None));
+        Assert.Equal("Could not fetch the addon manifest.", ex.Message);
+        Assert.DoesNotContain(UserInfo, ex.Message);
+        Assert.DoesNotContain(QueryToken, ex.Message);
+    }
+
+    [Fact]
+    public async Task HttpGet_TransportFailure_DebugLogOmitsUrlAndSecrets()
+    {
+        using var handler = new ScriptedHandler((_, _) => throw new HttpRequestException($"fail {UserInfo} {QueryToken}"));
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => 4096);
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        try
+        {
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => enumerator.EnumerateAsync(UrlListSource(), CancellationToken.None));
+            Assert.Equal("List request failed or returned an empty response.", ex.Message);
+        }
+        finally
+        {
+            Log.Logger = previous;
+        }
+
+        var debug = Assert.Single(sink.Events, e => e.Level == LogEventLevel.Debug);
+        var rendered = debug.RenderMessage();
+        Assert.Contains("remote list fetch failed", rendered);
+        Assert.Contains("HttpRequestException", rendered);
+        Assert.DoesNotContain(UserInfo, rendered);
+        Assert.DoesNotContain(QueryToken, rendered);
+        Assert.DoesNotContain("https://", rendered);
+        Assert.Null(debug.Exception);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(0)]
+    public async Task UrlList_JsonArray_AtOrBelowLimit_IsAccepted(int headroom)
+    {
+        var body = Encoding.UTF8.GetBytes("""["tt0111161"]""");
+        using var handler = OkHandler(body);
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => body.Length + headroom);
+
+        var refs = await enumerator.EnumerateAsync(UrlListSource(), CancellationToken.None);
+        var item = Assert.Single(refs);
+        Assert.Equal("movie", item.Type);
+        Assert.Equal("tt0111161", item.ContentId);
+    }
+
+    [Fact]
+    public async Task UrlList_JsonItemsObject_Parses()
+    {
+        var body = Encoding.UTF8.GetBytes("""{"items":[{"id":"tt2","type":"series","name":"Show"}]}""");
+        using var handler = OkHandler(body);
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => body.Length);
+
+        var refs = await enumerator.EnumerateAsync(UrlListSource(), CancellationToken.None);
+        var item = Assert.Single(refs);
+        Assert.Equal("series", item.Type);
+        Assert.Equal("tt2", item.ContentId);
+        Assert.Equal("Show", item.Title);
+    }
+
+    [Fact]
+    public async Task UrlList_PlainText_AtLimit_IsAccepted()
+    {
+        var body = Encoding.UTF8.GetBytes("tt0111161\n# comment\nseries:tt90\n");
+        using var handler = OkHandler(body);
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => body.Length);
+
+        var refs = await enumerator.EnumerateAsync(UrlListSource(), CancellationToken.None);
+        Assert.Equal(2, refs.Count);
+        Assert.Equal("tt0111161", refs[0].ContentId);
+        Assert.Equal("series", refs[1].Type);
+        Assert.Equal("tt90", refs[1].ContentId);
+    }
+
+    [Fact]
+    public async Task UrlList_PlainText_OneByteOver_Rejects()
+    {
+        var body = Encoding.UTF8.GetBytes("tt0111161\n");
+        using var handler = OkHandler(body);
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => body.Length - 1);
+
+        await Assert.ThrowsAsync<RemoteResponseTooLargeException>(
+            () => enumerator.EnumerateAsync(UrlListSource(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task UrlList_BlankAndCommentsOnly_ReturnsEmpty()
+    {
+        var body = Encoding.UTF8.GetBytes("\n# only comments\n  \n");
+        using var handler = OkHandler(body);
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => body.Length);
+
+        var refs = await enumerator.EnumerateAsync(UrlListSource(), CancellationToken.None);
+        Assert.Empty(refs);
+    }
+
+    [Fact]
+    public async Task UrlList_MalformedJsonLooking_FailsClosed()
+    {
+        var body = Encoding.UTF8.GetBytes("""{"items": [""");
+        using var handler = OkHandler(body);
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => 4096);
+
+        var ex = await Assert.ThrowsAsync<RemoteResponseFormatException>(
+            () => enumerator.EnumerateAsync(UrlListSource(), CancellationToken.None));
+        Assert.Equal("The list response was not valid JSON.", ex.Message);
+        Assert.DoesNotContain(BodyMarker, ex.Message);
+    }
+
+    [Fact]
+    public async Task UrlList_ValidJsonWithoutArray_ReturnsEmptyWithoutLineFallback()
+    {
+        var body = Encoding.UTF8.GetBytes("""{"not":"a-list"}""");
+        using var handler = OkHandler(body);
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => body.Length);
+
+        var refs = await enumerator.EnumerateAsync(UrlListSource(), CancellationToken.None);
+        Assert.Empty(refs);
+    }
+
+    [Fact]
+    public async Task StremioCatalog_MalformedJson_IsControlledFormatError()
+    {
+        var body = Encoding.UTF8.GetBytes("""{"metas":""");
+        using var handler = OkHandler(body);
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => 4096);
+
+        var ex = await Assert.ThrowsAsync<RemoteResponseFormatException>(
+            () => enumerator.EnumerateAsync(CatalogSource(), CancellationToken.None));
+        Assert.Equal("The addon response was not valid JSON.", ex.Message);
+    }
+
+    [Fact]
+    public async Task StremioCatalog_ValidJsonWithoutMetas_IsCatalogGuidance()
+    {
+        var body = Encoding.UTF8.GetBytes("""{"catalogs":[]}""");
+        using var handler = OkHandler(body);
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => body.Length);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => enumerator.EnumerateAsync(CatalogSource(), CancellationToken.None));
+        Assert.Contains("addon manifest", ex.Message);
+    }
+
+    [Fact]
+    public async Task DiscoverCatalogs_ValidJsonWithoutCatalogs_IsGuidance()
+    {
+        var body = Encoding.UTF8.GetBytes("""{"name":"X"}""");
+        using var handler = OkHandler(body);
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => body.Length);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => enumerator.DiscoverCatalogsAsync("https://addon.example/manifest.json", CancellationToken.None));
+        Assert.Equal("No catalogs were found in this addon manifest.", ex.Message);
+    }
+
+    [Fact]
+    public async Task StremioCatalog_NonEofOversize_RejectsBeforeEagerBuffering()
+    {
+        var body = StremioPage("tt1", "A");
+        var limit = body.Length;
+        var prefix = PadUtf8(body, limit + 1);
+        var stream = new PrefixThenBlockStream(prefix);
+        using var handler = new ScriptedHandler((_, _) => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamHttpContent(stream),
+        });
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => limit);
+        using var guard = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var ex = await Assert.ThrowsAsync<RemoteResponseTooLargeException>(
+            () => enumerator.EnumerateAsync(CatalogSource(), guard.Token));
+        Assert.False(stream.EnteredWait);
+        Assert.True(stream.Disposed);
+    }
+
+    [Fact]
+    public async Task StremioCatalog_MultibyteUtf8Title_IsBoundedByBytes()
+    {
+        var body = StremioPage("tt1", "Café 🎬");
+        Assert.True(Encoding.UTF8.GetCharCount(body) < body.Length);
+
+        using (var handler = OkHandler(body))
+        using (var http = new HttpClient(handler))
+        {
+            var refs = await new ListSourceEnumerator(http, () => body.Length)
+                .EnumerateAsync(CatalogSource(), CancellationToken.None);
+            Assert.Equal("Café 🎬", Assert.Single(refs).Title);
+        }
+
+        using var overHandler = OkHandler(body);
+        using var overHttp = new HttpClient(overHandler);
+        await Assert.ThrowsAsync<RemoteResponseTooLargeException>(
+            () => new ListSourceEnumerator(overHttp, () => body.Length - 1)
+                .EnumerateAsync(CatalogSource(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task UrlList_CallerCancellationDuringBodyRead_IsCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        var stream = new BlockingReadStream();
+        using var handler = new ScriptedHandler((_, _) => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamHttpContent(stream),
+        });
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => 1024);
+
+        var task = enumerator.EnumerateAsync(UrlListSource(), cts.Token);
+        await stream.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+        Assert.True(stream.Disposed);
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task UrlList_ChunkedUndeclared_ExactLimitSucceeds()
+    {
+        var body = Encoding.UTF8.GetBytes("tt0111161\n");
+        var stream = new TrackingStream(body);
+        using var handler = new ScriptedHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamHttpContent(stream),
+            };
+            response.Headers.TransferEncodingChunked = true;
+            return response;
+        });
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => body.Length);
+
+        var refs = await enumerator.EnumerateAsync(UrlListSource(), CancellationToken.None);
+        Assert.Equal("tt0111161", Assert.Single(refs).ContentId);
+        Assert.True(stream.Disposed);
+    }
+
+    [Fact]
+    public async Task StremioCatalog_NonSuccessStatus_IsFetchFailed()
+    {
+        using var handler = new ScriptedHandler((_, _) => new HttpResponseMessage(HttpStatusCode.BadGateway));
+        using var http = new HttpClient(handler);
+        var enumerator = new ListSourceEnumerator(http, () => 4096);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => enumerator.EnumerateAsync(CatalogSource(), CancellationToken.None));
+        Assert.Equal("Catalog request failed or returned an empty response.", ex.Message);
+    }
+
+    private static ListSource CatalogSource() => new()
+    {
+        Kind = ListSource.KindStremioCatalog,
+        Name = "My Catalog",
+        Url = SecretUrl,
+        Cap = 10,
+    };
+
+    private static ListSource UrlListSource() => new()
+    {
+        Kind = ListSource.KindUrlList,
+        Name = "My List",
+        Url = SecretUrl,
+    };
+
+    private static ScriptedHandler OkHandler(byte[] body) =>
+        new((_, _) => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(body),
+        });
+
+    private static byte[] StremioPage(string id, string name) =>
+        Encoding.UTF8.GetBytes(
+            $$"""{"metas":[{"type":"movie","id":"{{id}}","name":"{{name}}"}]}""");
+
+    private static byte[] ManifestJson() =>
+        Encoding.UTF8.GetBytes(
+            """{"name":"Addon","catalogs":[{"type":"movie","id":"top","name":"Top"}]}""");
+
+    private static byte[] PadUtf8(byte[] body, int targetLength)
+    {
+        if (body.Length > targetLength)
+            throw new InvalidOperationException("body already larger than target");
+        if (body.Length == targetLength) return body;
+        var padded = new byte[targetLength];
+        Buffer.BlockCopy(body, 0, padded, 0, body.Length);
+        Array.Fill(padded, (byte)' ', body.Length, targetLength - body.Length);
+        return padded;
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_events) return _events.ToArray();
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_events) _events.Add(logEvent);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Watchtower/ListSourceEnumeratorTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Watchtower/ListSourceEnumeratorTests.cs
@@ -5,7 +5,6 @@ using NzbWebDAV.Exceptions;
 using NzbWebDAV.Services;
 using NzbWebDAV.Tests.TestUtils;
 using Serilog;
-using Serilog.Core;
 using Serilog.Events;
 
 namespace NzbWebDAV.Tests.Services.Watchtower;
@@ -119,7 +118,7 @@ public class ListSourceEnumeratorTests
         using var handler = new ScriptedHandler((_, _) => throw new HttpRequestException($"fail {UserInfo} {QueryToken}"));
         using var http = new HttpClient(handler);
         var enumerator = new ListSourceEnumerator(http, () => 4096);
-        var sink = new CollectingSink();
+        var sink = new CollectingLogEventSink();
         var previous = Log.Logger;
         Log.Logger = new LoggerConfiguration()
             .MinimumLevel.Debug()
@@ -416,23 +415,5 @@ public class ListSourceEnumeratorTests
         Buffer.BlockCopy(body, 0, padded, 0, body.Length);
         Array.Fill(padded, (byte)' ', body.Length, targetLength - body.Length);
         return padded;
-    }
-
-    private sealed class CollectingSink : ILogEventSink
-    {
-        private readonly List<LogEvent> _events = [];
-
-        public IReadOnlyList<LogEvent> Events
-        {
-            get
-            {
-                lock (_events) return _events.ToArray();
-            }
-        }
-
-        public void Emit(LogEvent logEvent)
-        {
-            lock (_events) _events.Add(logEvent);
-        }
     }
 }

--- a/tests/NzbWebDAV.Tests/TestUtils/BoundedHttpTestSupport.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/BoundedHttpTestSupport.cs
@@ -93,7 +93,7 @@ internal sealed class PrefixThenBlockStream(byte[] prefix) : Stream
     }
 
     public override int Read(byte[] buffer, int offset, int count) =>
-        ReadCore(buffer.AsSpan(offset, count), CancellationToken.None);
+        throw new NotSupportedException();
 
     public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
     {
@@ -162,12 +162,8 @@ internal sealed class BlockingReadStream : Stream
         set => throw new NotSupportedException();
     }
 
-    public override int Read(byte[] buffer, int offset, int count)
-    {
-        Started.TrySetResult();
-        CancellationToken.None.WaitHandle.WaitOne();
-        return 0;
-    }
+    public override int Read(byte[] buffer, int offset, int count) =>
+        throw new NotSupportedException();
 
     public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
     {

--- a/tests/NzbWebDAV.Tests/TestUtils/BoundedHttpTestSupport.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/BoundedHttpTestSupport.cs
@@ -1,0 +1,246 @@
+using System.Net;
+
+namespace NzbWebDAV.Tests.TestUtils;
+
+internal sealed class ScriptedHandler(
+    Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> respond)
+    : HttpMessageHandler
+{
+    public int RequestCount { get; private set; }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        RequestCount++;
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(respond(request, cancellationToken));
+    }
+}
+
+internal sealed class TrackingStream(byte[] payload, int maxRead = int.MaxValue) : Stream
+{
+    private int _offset;
+    public int ReadCount { get; private set; }
+    public bool Disposed { get; private set; }
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        var n = ReadCore(buffer.AsSpan(offset, count));
+        return n;
+    }
+
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult(ReadCore(buffer.Span));
+    }
+
+    private int ReadCore(Span<byte> buffer)
+    {
+        ObjectDisposedException.ThrowIf(Disposed, this);
+        if (_offset >= payload.Length) return 0;
+        var take = Math.Min(Math.Min(buffer.Length, payload.Length - _offset), maxRead);
+        payload.AsSpan(_offset, take).CopyTo(buffer);
+        _offset += take;
+        ReadCount += take;
+        return take;
+    }
+
+    public override void Flush() { }
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        Disposed = true;
+        base.Dispose(disposing);
+    }
+
+    public override ValueTask DisposeAsync()
+    {
+        Disposed = true;
+        return ValueTask.CompletedTask;
+    }
+}
+
+internal sealed class PrefixThenBlockStream(byte[] prefix) : Stream
+{
+    private int _offset;
+    public bool EnteredWait { get; private set; }
+    public bool Disposed { get; private set; }
+    public int BytesDelivered { get; private set; }
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override int Read(byte[] buffer, int offset, int count) =>
+        ReadCore(buffer.AsSpan(offset, count), CancellationToken.None);
+
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        if (_offset < prefix.Length)
+            return ValueTask.FromResult(ReadCore(buffer.Span, cancellationToken));
+        return WaitAsync(cancellationToken);
+    }
+
+    private int ReadCore(Span<byte> buffer, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ObjectDisposedException.ThrowIf(Disposed, this);
+        if (_offset >= prefix.Length)
+        {
+            EnteredWait = true;
+            cancellationToken.WaitHandle.WaitOne();
+            cancellationToken.ThrowIfCancellationRequested();
+            return 0;
+        }
+
+        var take = Math.Min(buffer.Length, prefix.Length - _offset);
+        prefix.AsSpan(_offset, take).CopyTo(buffer);
+        _offset += take;
+        BytesDelivered += take;
+        return take;
+    }
+
+    private async ValueTask<int> WaitAsync(CancellationToken cancellationToken)
+    {
+        EnteredWait = true;
+        var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var reg = cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken));
+        return await tcs.Task.ConfigureAwait(false);
+    }
+
+    public override void Flush() { }
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        Disposed = true;
+        base.Dispose(disposing);
+    }
+
+    public override ValueTask DisposeAsync()
+    {
+        Disposed = true;
+        return ValueTask.CompletedTask;
+    }
+}
+
+internal sealed class BlockingReadStream : Stream
+{
+    public TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    public bool Disposed { get; private set; }
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        Started.TrySetResult();
+        CancellationToken.None.WaitHandle.WaitOne();
+        return 0;
+    }
+
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        Started.TrySetResult();
+        var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var reg = cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken));
+        return await tcs.Task.ConfigureAwait(false);
+    }
+
+    public override void Flush() { }
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        Disposed = true;
+        base.Dispose(disposing);
+    }
+
+    public override ValueTask DisposeAsync()
+    {
+        Disposed = true;
+        return ValueTask.CompletedTask;
+    }
+}
+
+internal sealed class StreamHttpContent(Stream stream, long? declaredLength = null) : HttpContent
+{
+    public Stream Stream { get; } = stream;
+
+    protected override Task SerializeToStreamAsync(Stream destination, TransportContext? context) =>
+        Stream.CopyToAsync(destination);
+
+    protected override Task<Stream> CreateContentReadStreamAsync() => Task.FromResult(Stream);
+
+    protected override bool TryComputeLength(out long length)
+    {
+        if (declaredLength is { } declared)
+        {
+            length = declared;
+            return true;
+        }
+
+        length = 0;
+        return false;
+    }
+}
+
+internal sealed class FailIfOpenedContent : HttpContent
+{
+    public bool StreamOpened { get; private set; }
+
+    public FailIfOpenedContent(long declaredLength)
+    {
+        Headers.ContentLength = declaredLength;
+    }
+
+    protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+    {
+        StreamOpened = true;
+        throw new InvalidOperationException("content stream should not be opened");
+    }
+
+    protected override Task<Stream> CreateContentReadStreamAsync()
+    {
+        StreamOpened = true;
+        throw new InvalidOperationException("content stream should not be opened");
+    }
+
+    protected override bool TryComputeLength(out long length)
+    {
+        length = Headers.ContentLength ?? 0;
+        return Headers.ContentLength is not null;
+    }
+}

--- a/tests/NzbWebDAV.Tests/TestUtils/CollectingLogEventSink.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/CollectingLogEventSink.cs
@@ -1,0 +1,22 @@
+using Serilog.Core;
+using Serilog.Events;
+
+namespace NzbWebDAV.Tests.TestUtils;
+
+internal sealed class CollectingLogEventSink : ILogEventSink
+{
+    private readonly List<LogEvent> _events = [];
+
+    public IReadOnlyList<LogEvent> Events
+    {
+        get
+        {
+            lock (_events) return _events.ToArray();
+        }
+    }
+
+    public void Emit(LogEvent logEvent)
+    {
+        lock (_events) _events.Add(logEvent);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Utils/HttpContentReadUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/HttpContentReadUtilTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text;
 using NzbWebDAV.Exceptions;
+using NzbWebDAV.Tests.TestUtils;
 using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Tests.Utils;
@@ -58,6 +59,94 @@ public class HttpContentReadUtilTests
         var bytes = await HttpContentReadUtil.ReadBoundedAsync(content, Limit, CancellationToken.None);
 
         Assert.Equal(payload, bytes);
+    }
+
+    [Fact]
+    public async Task ReadBoundedAsync_RejectsLyingSmallDeclarationByStreamCount()
+    {
+        var payload = new byte[Limit + 1];
+        Array.Fill(payload, (byte)'a');
+        var stream = new TrackingStream(payload);
+        using var content = new StreamHttpContent(stream, declaredLength: Limit - 1);
+
+        var ex = await Assert.ThrowsAsync<NzbResponseTooLargeException>(
+            () => HttpContentReadUtil.ReadBoundedAsync(content, Limit, CancellationToken.None));
+
+        Assert.Equal(Limit, ex.MaxBytes);
+        Assert.Null(ex.ContentLength);
+        Assert.True(stream.Disposed);
+    }
+
+    [Fact]
+    public async Task ReadBoundedAsync_AcceptsDeclaredAtLimitWithShorterActualBody()
+    {
+        var payload = Encoding.ASCII.GetBytes("hello");
+        using var content = new StreamHttpContent(new TrackingStream(payload), declaredLength: Limit);
+
+        var bytes = await HttpContentReadUtil.ReadBoundedAsync(content, Limit, CancellationToken.None);
+
+        Assert.Equal(payload, bytes);
+    }
+
+    [Fact]
+    public async Task ReadBoundedAsync_RejectsDeclaredOversizeBeforeOpeningStream()
+    {
+        using var content = new FailIfOpenedContent(Limit + 1);
+
+        var ex = await Assert.ThrowsAsync<NzbResponseTooLargeException>(
+            () => HttpContentReadUtil.ReadBoundedAsync(content, Limit, CancellationToken.None));
+
+        Assert.Equal(Limit, ex.MaxBytes);
+        Assert.Equal(Limit + 1, ex.ContentLength);
+        Assert.False(content.StreamOpened);
+    }
+
+    [Fact]
+    public async Task ReadBoundedAsync_NonSeekableUndeclared_ExactLimitSucceedsAndOneOverRejects()
+    {
+        var exact = Enumerable.Repeat((byte)'x', (int)Limit).ToArray();
+        var stream = new TrackingStream(exact);
+        using (var content = new StreamHttpContent(stream))
+        {
+            var bytes = await HttpContentReadUtil.ReadBoundedAsync(content, Limit, CancellationToken.None);
+            Assert.Equal(exact, bytes);
+            Assert.True(stream.Disposed);
+        }
+
+        var over = new TrackingStream(Enumerable.Repeat((byte)'x', (int)Limit + 1).ToArray());
+        using var overContent = new StreamHttpContent(over);
+        await Assert.ThrowsAsync<NzbResponseTooLargeException>(
+            () => HttpContentReadUtil.ReadBoundedAsync(overContent, Limit, CancellationToken.None));
+        Assert.True(over.Disposed);
+    }
+
+    [Fact]
+    public async Task ReadBoundedAsync_CancellationDuringBlockedRead_IsCancellationNotSize()
+    {
+        using var cts = new CancellationTokenSource();
+        var stream = new BlockingReadStream();
+        using var content = new StreamHttpContent(stream);
+
+        var read = HttpContentReadUtil.ReadBoundedAsync(content, Limit, cts.Token);
+        await stream.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => read);
+        Assert.True(stream.Disposed);
+    }
+
+    [Fact]
+    public async Task ReadBoundedAsync_OversizePrefix_StopsAtLimitPlusOneByte()
+    {
+        var payload = Enumerable.Repeat((byte)'a', 1 << 16).ToArray();
+        var stream = new TrackingStream(payload);
+        using var content = new StreamHttpContent(stream);
+
+        await Assert.ThrowsAsync<NzbResponseTooLargeException>(
+            () => HttpContentReadUtil.ReadBoundedAsync(content, Limit, CancellationToken.None));
+
+        Assert.True(stream.ReadCount <= Limit + 1, $"read {stream.ReadCount} bytes past the proving byte");
+        Assert.True(stream.Disposed);
     }
 
     private sealed class UndeclaredLengthContent(byte[] payload) : HttpContent


### PR DESCRIPTION
Fixes #1247

## Summary

- Bound Newznab caps/search XML and Watchtower Stremio/list HTTP bodies with `HttpContentReadUtil.ReadBoundedAsync` after `HttpCompletionOption.ResponseHeadersRead`. Oversized responses are rejected entirely; a prefix is never parsed.
- Classify oversized and malformed remote payloads as expected source/indexer failures (`RemoteResponseTooLargeException` / `RemoteResponseFormatException`) with a concise safe message and no Warning/Error stack. Unexpected defects still log with a stack.
- Remove credential-bearing request URLs from touched Watchtower logs. API keys, URL user-info, query tokens, and body markers stay out of messages, status text, and `LastSyncError`.

## Limit contract

Limits apply to **parser-visible `HttpContent` bytes** after the HTTP handler. Pooled handlers do **not** auto-decompress. `Content-Length` is only an early check; missing, lying, or chunked/non-seekable bodies are counted while streaming. Exactly the configured byte count is valid; the next byte is rejected.

## Chosen defaults

Issue 1247 has no operational size telemetry. These values are conservative headroom, **not** the 50 MiB NZB download ceiling (`NzbFetchLimits` is unchanged):

| Family | Default | Hard clamp | Min |
|--------|---------|------------|-----|
| Newznab | 4 MiB (`4194304`) | 16 MiB (`16777216`) | 1 |
| Watchtower | 8 MiB (`8388608`) | 16 MiB (`16777216`) | 1 |

Typical 100-result Newznab XML is tens–hundreds of KiB; 4 MiB is headroom for verbose indexers. Watchtower list sync is sequential; 8 MiB covers catalogs and URL lists. Zero/negative is invalid (no unlimited sentinel). Older/hand-edited values: `<= 0` → default; above hard max → clamp on read; save validation rejects out of range.

## Compatibility

JSON-looking URL lists (first non-whitespace byte `[` or `{` after an optional UTF-8 BOM) are **fail-closed**: invalid JSON throws `RemoteResponseFormatException` (`The list response was not valid JSON.`) instead of falling back to plain-text IDs. Valid JSON with no array yields an empty list.

## Test plan

- [x] Generated boundary tests: exact-at-limit and one-byte-over for Newznab XML, Stremio JSON, JSON URL lists, and plain lists
- [x] Declared oversize before stream open; lying small `Content-Length`; undeclared/chunked non-seekable streams
- [x] Non-EOF oversize discriminator (`ResponseHeadersRead` + remaining+1 read cap; stream never enters post-prefix wait)
- [x] Multibyte UTF-8 titles bounded by bytes, not characters
- [x] Caller cancellation during blocked read; DTD/DOCTYPE prohibited; malformed XML vs Newznab `<error>`
- [x] Fail-closed malformed JSON lists; Watchtower Debug log omits URL/user-info/query token
- [x] Config save rejects 0 / negative / hard-max+1; getter clamps; indexer settings UI validation
- [ ] Full frontend lint/typecheck/build and remaining backend suites: PR CI (`ci.yml`)

## Deviations

- Numeric defaults chosen without issue-1247 operational evidence (issue comments empty). Documented in `ExternalMetadataResponseLimits`.
- Docs `since` pills use **1.2.8** (next patch after current `1.2.7`).
- `HttpContentReadUtil` caps each read to remaining+1 (allowed by the plan).
- WatchtowerService `LastSyncError` mapping is covered by enumerator + `ExceptionExtensions` tests, not a full hosted-service/SQLite test.
- No dedicated Newznab internal-timeout unit test (timeout translation unchanged; avoided a 1s wait).

NZB download limits, `WardenRemoteSourceService`, oversized-payload retries, and `CHANGELOG.md` are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum response-size limits for indexers and Watchtower sources.
  * Added global and per-indexer limits in settings, with validation and safe defaults.
  * Added protected handling for oversized or malformed remote metadata responses.
* **Bug Fixes**
  * Improved error messages for remote connection, search, and synchronization failures.
  * Prevented sensitive response content and URLs from appearing in errors or logs.
* **Documentation**
  * Documented new response-size settings, limits, defaults, and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->