### PR TITLE
fix(ui): prevent malformed websocket traffic from stopping the frontend

### DIFF
--- a/frontend/coverage-thresholds.json
+++ b/frontend/coverage-thresholds.json
@@ -1,9 +1,9 @@
 {
   "global": {
-    "branches": 24,
+    "branches": 27,
     "functions": 23,
-    "lines": 28,
-    "statements": 27
+    "lines": 31,
+    "statements": 30
   },
   "globs": {
     "app/clients/**": {

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -3,6 +3,10 @@ import express from "express";
 import http from "http";
 import { WebSocketServer } from "ws";
 import { shouldCompressResponse } from "./server/compression-filter.js";
+import {
+  attachHttpServerLifecycle,
+  attachWebsocketServerErrorListener,
+} from "./server/http-server-lifecycle.js";
 import { logger, requestLogger } from "./server/logger.js";
 import { securityHeadersMiddleware } from "./server/security-headers.js";
 import { websocketUpgradeGuard } from "./server/websocket-upgrade-guard.js";
@@ -138,6 +142,7 @@ const setServerModule = (serverModule: ServerBuildModule) => {
 };
 
 // Handle development vs production
+let closeDevelopmentServer: (() => Promise<void>) | null = null;
 if (DEVELOPMENT) {
   logger.info("Starting frontend development server");
   const viteDevServer = await import("vite").then((vite) =>
@@ -145,6 +150,7 @@ if (DEVELOPMENT) {
       server: { middlewareMode: true },
     }),
   );
+  closeDevelopmentServer = () => Promise.resolve(viteDevServer.close());
   // Vite's dev middlewares handle their own `base` prefix, so they stay on the
   // root app; only the SSR module goes on the URL_BASE-mounted router.
   app.use(viteDevServer.middlewares);
@@ -186,14 +192,69 @@ if (URL_BASE) {
 
 // Create both the http and websocket servers
 const server = http.createServer(app);
+let websocketServer: WebSocketServer | null = null;
+
+const disposeStartupResources = async () => {
+  const operations: Promise<unknown>[] = [];
+  const closingWebsocket = websocketServer;
+  if (closingWebsocket) {
+    operations.push(
+      new Promise<void>((resolve) => {
+        closingWebsocket.close(() => resolve());
+      }),
+    );
+  }
+  if (closeDevelopmentServer) operations.push(closeDevelopmentServer());
+  await Promise.allSettled(operations);
+};
+
+const httpLifecycle = attachHttpServerLifecycle(server, {
+  configuredPort: PORT,
+  logError: (message, detail) => {
+    if (detail) logger.error(message, detail);
+    else logger.error(message);
+  },
+  onListening: () => {
+    if (websocketServer == null) return;
+    setWebsocketServer(websocketServer);
+    logger.info(`Frontend server listening on http://localhost:${PORT}${URL_BASE}`);
+  },
+  disposeStartupResources: async () => {
+    await disposeStartupResources();
+    // Vite close leaves watcher handles in middleware mode, so drain alone
+    // cannot terminate. Exit after cleanup so supervisors see status 1.
+    process.exit(1);
+  },
+  markFatal: (exitCode, fatalPhase) => {
+    process.exitCode = exitCode;
+    if (fatalPhase === "runtime") {
+      process.exit(exitCode);
+    }
+  },
+});
+
 // Allow long-lived proxied API calls (Usenet speed tests can run for many
 // minutes on large data budgets). Node defaults are 5 minutes / 60s headers.
 const LONG_RUNNING_REQUEST_TIMEOUT_MS = 3 * 60 * 60 * 1000; // 3 hours
 server.requestTimeout = LONG_RUNNING_REQUEST_TIMEOUT_MS;
 server.headersTimeout = LONG_RUNNING_REQUEST_TIMEOUT_MS + 1000;
-setWebsocketServer(new WebSocketServer({ server, path: `${URL_BASE}/ws`, maxPayload: 64 * 1024 }));
 
-// Begin listening for connections
-server.listen(PORT, () => {
-  logger.info(`Frontend server listening on http://localhost:${PORT}${URL_BASE}`);
+websocketServer = new WebSocketServer({
+  server,
+  path: `${URL_BASE}/ws`,
+  maxPayload: 64 * 1024,
 });
+// Issue 1234 owns general browser WebSocketServer error handling. This listener
+// only suppresses HTTP errors already owned by attachHttpServerLifecycle; `ws`
+// forwards the same Error object on bind failure. Rebase 1234 onto this listener
+// rather than adding a second one.
+attachWebsocketServerErrorListener(websocketServer, {
+  isOwned: httpLifecycle.owns,
+  onUnexpectedError: (error) => {
+    logger.error("Unexpected frontend WebSocket server error", error);
+    process.exitCode = 1;
+    process.exit(1);
+  },
+});
+
+server.listen(PORT);

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -8,6 +8,7 @@ import {
   attachWebsocketServerErrorListener,
 } from "./server/http-server-lifecycle.js";
 import { logger, requestLogger } from "./server/logger.js";
+import { MAX_WEBSOCKET_PAYLOAD_BYTES } from "./server/websocket-policy.js";
 import { securityHeadersMiddleware } from "./server/security-headers.js";
 import { websocketUpgradeGuard } from "./server/websocket-upgrade-guard.js";
 import {
@@ -242,16 +243,15 @@ server.headersTimeout = LONG_RUNNING_REQUEST_TIMEOUT_MS + 1000;
 websocketServer = new WebSocketServer({
   server,
   path: `${URL_BASE}/ws`,
-  maxPayload: 64 * 1024,
+  maxPayload: MAX_WEBSOCKET_PAYLOAD_BYTES,
 });
-// Issue 1234 owns general browser WebSocketServer error handling. This listener
-// only suppresses HTTP errors already owned by attachHttpServerLifecycle; `ws`
-// forwards the same Error object on bind failure. Rebase 1234 onto this listener
-// rather than adding a second one.
+// Issue 1234 owns accepted-socket and pre-auth handling. This is the one WSS
+// error listener: suppress HTTP errors already owned by attachHttpServerLifecycle
+// (`ws` forwards the same Error object on bind failure) and fatalize the rest.
 attachWebsocketServerErrorListener(websocketServer, {
   isOwned: httpLifecycle.owns,
   onUnexpectedError: (error) => {
-    logger.error("Unexpected frontend WebSocket server error", error);
+    logger.error("Unexpected browser websocket server error; frontend will exit", error);
     process.exitCode = 1;
     process.exit(1);
   },

--- a/frontend/server/__fixtures__/websocket-probe.ts
+++ b/frontend/server/__fixtures__/websocket-probe.ts
@@ -1,0 +1,128 @@
+import http from "node:http";
+import net from "node:net";
+import { WebSocket, WebSocketServer } from "ws";
+import { attachWebsocketServerErrorListener } from "../http-server-lifecycle";
+import {
+  attachBrowserWebsocketErrorListener,
+  errorCode,
+  MAX_WEBSOCKET_PAYLOAD_BYTES,
+  reportBrowserSocketError,
+} from "../websocket-policy";
+import { initializeWebsocketServer } from "../websocket.server";
+import {
+  deferred,
+  listenOnLoopback,
+  oversizedMaskedBinaryFrame,
+  waitForClose,
+  waitForOpen,
+  websocketUpgradeRequest,
+} from "../websocket-test-helpers";
+
+const mode = process.env["WEBSOCKET_PROBE_MODE"];
+const auth = deferred<boolean>();
+let acceptedErrorCode: string | null = null;
+let resolveAccepted: (code: string | null) => void = () => {};
+const accepted = new Promise<string | null>((resolve) => {
+  resolveAccepted = resolve;
+});
+
+function report(error: unknown, context: Parameters<typeof reportBrowserSocketError>[1]): void {
+  reportBrowserSocketError(error, context);
+  const code = errorCode(error);
+  process.stdout.write(`ACCEPTED_ERROR_CODE=${code}\n`);
+  if (acceptedErrorCode == null) {
+    acceptedErrorCode = code;
+    resolveAccepted(code);
+  }
+}
+
+const httpServer = http.createServer();
+const wss = new WebSocketServer({
+  server: httpServer,
+  path: "/ws",
+  maxPayload: MAX_WEBSOCKET_PAYLOAD_BYTES,
+});
+attachWebsocketServerErrorListener(wss, {
+  isOwned: () => false,
+  onUnexpectedError: (error) => {
+    process.stderr.write(`WSS_FATAL ${error.message}\n`);
+    process.exitCode = 1;
+    process.exit(1);
+  },
+});
+initializeWebsocketServer(wss, {
+  authenticate: () => auth.promise,
+  startBackendClient: () => {},
+  reportBrowserSocketError: report,
+  registerBrowserSocketErrorListener:
+    mode === "oversized-pre-auth-listener-removed" ? () => {} : attachBrowserWebsocketErrorListener,
+});
+
+const address = await listenOnLoopback(httpServer);
+const url = `ws://127.0.0.1:${address.port}/ws`;
+let clientCloseCode: number | null = null;
+let rawSocket: net.Socket | undefined;
+
+try {
+  if (mode === "pipelined-oversized") {
+    const socket = net.connect(address.port, "127.0.0.1");
+    rawSocket = socket;
+    socket.on("error", () => {});
+    await new Promise<void>((resolve, reject) => {
+      socket.once("connect", () => resolve());
+      socket.once("error", reject);
+    });
+    socket.write(
+      Buffer.concat([
+        websocketUpgradeRequest(address.port),
+        oversizedMaskedBinaryFrame(MAX_WEBSOCKET_PAYLOAD_BYTES + 1),
+      ]),
+    );
+    await Promise.race([
+      accepted,
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("accepted error timeout")), 8000),
+      ),
+    ]);
+    socket.destroy();
+    rawSocket = undefined;
+  } else {
+    const client = new WebSocket(url);
+    client.on("error", () => {});
+    await waitForOpen(client);
+    const closed = waitForClose(client);
+    client.send(Buffer.alloc(MAX_WEBSOCKET_PAYLOAD_BYTES + 1));
+    clientCloseCode = await closed;
+    await Promise.race([
+      accepted,
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("accepted error timeout")), 8000),
+      ),
+    ]);
+  }
+
+  const healthy = new WebSocket(url);
+  healthy.on("error", () => {});
+  await waitForOpen(healthy);
+  healthy.close();
+  await waitForClose(healthy);
+
+  const observation = {
+    acceptedErrorCode,
+    clientCloseCode,
+    nextConnectionOpened: true,
+  };
+  process.stdout.write(`PROBE_RESULT=${JSON.stringify(observation)}\n`);
+  process.stdout.write("probe-complete\n");
+  process.exitCode = 0;
+} finally {
+  rawSocket?.destroy();
+  auth.resolve(false);
+  for (const client of wss.clients) client.terminate();
+  await new Promise<void>((resolve) => {
+    wss.close(() => resolve());
+  });
+  await new Promise<void>((resolve) => {
+    httpServer.close(() => resolve());
+  });
+}

--- a/frontend/server/http-server-lifecycle.test.ts
+++ b/frontend/server/http-server-lifecycle.test.ts
@@ -14,7 +14,7 @@ import {
   formatStartupListenError,
   isHttpServerErrorOwned,
   markHttpServerErrorOwned,
-  type HttpServerLifecycleOptions,
+  type FatalPhase,
 } from "./http-server-lifecycle";
 
 const FRONTEND_ROOT = fileURLToPath(new URL("..", import.meta.url));
@@ -28,20 +28,21 @@ function systemError(
   return Object.assign(new Error(message), fields);
 }
 
-function lifecycleOptions(
-  overrides: Partial<HttpServerLifecycleOptions> = {},
-): HttpServerLifecycleOptions & {
-  logError: ReturnType<typeof vi.fn>;
-  onListening: ReturnType<typeof vi.fn>;
-  disposeStartupResources: ReturnType<typeof vi.fn>;
-  markFatal: ReturnType<typeof vi.fn>;
-} {
+type LifecycleTestOptions = {
+  configuredPort: number;
+  logError: ReturnType<typeof vi.fn<(message: string, detail?: Error) => void>>;
+  onListening: ReturnType<typeof vi.fn<() => void>>;
+  disposeStartupResources: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  markFatal: ReturnType<typeof vi.fn<(exitCode: number, phase: FatalPhase) => void>>;
+};
+
+function lifecycleOptions(overrides: Partial<LifecycleTestOptions> = {}): LifecycleTestOptions {
   return {
     configuredPort: 3000,
-    logError: vi.fn(),
-    onListening: vi.fn(),
-    disposeStartupResources: vi.fn(() => Promise.resolve()),
-    markFatal: vi.fn(),
+    logError: vi.fn<(message: string, detail?: Error) => void>(),
+    onListening: vi.fn<() => void>(),
+    disposeStartupResources: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    markFatal: vi.fn<(exitCode: number, phase: FatalPhase) => void>(),
     ...overrides,
   };
 }
@@ -140,7 +141,7 @@ describe("formatStartupListenError", () => {
     expect(message).toContain("Frontend server could not start");
     expect(message).toContain("EACCES");
     expect(message).toContain("0.0.0.0");
-    expect(message).toContain("80");
+    expect(message).toContain("port 80");
     expect(message).toContain(
       "Use an unprivileged PORT or grant the runtime permission to bind it",
     );
@@ -402,7 +403,7 @@ describe("attachWebsocketServerErrorListener", () => {
     expect(options.logError).toHaveBeenCalledOnce();
   });
 
-  it("exports identity mark helpers for issue 1234", () => {
+  it("marks and detects HTTP-owned errors by identity", () => {
     const error = new Error("owned-elsewhere");
     expect(isHttpServerErrorOwned(error)).toBe(false);
     markHttpServerErrorOwned(error);

--- a/frontend/server/http-server-lifecycle.test.ts
+++ b/frontend/server/http-server-lifecycle.test.ts
@@ -1,0 +1,496 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  attachHttpServerLifecycle,
+  attachWebsocketServerErrorListener,
+  formatStartupListenError,
+  isHttpServerErrorOwned,
+  markHttpServerErrorOwned,
+  type HttpServerLifecycleOptions,
+} from "./http-server-lifecycle";
+
+const FRONTEND_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const SECRET_MARKER = "DO_NOT_LOG_SECRET_MARKER";
+const DUMMY_API_KEY = "1246-dummy-frontend-backend-api-key";
+
+function systemError(
+  message: string,
+  fields: { code?: unknown; address?: unknown; port?: unknown; syscall?: unknown },
+): Error {
+  return Object.assign(new Error(message), fields);
+}
+
+function lifecycleOptions(
+  overrides: Partial<HttpServerLifecycleOptions> = {},
+): HttpServerLifecycleOptions & {
+  logError: ReturnType<typeof vi.fn>;
+  onListening: ReturnType<typeof vi.fn>;
+  disposeStartupResources: ReturnType<typeof vi.fn>;
+  markFatal: ReturnType<typeof vi.fn>;
+} {
+  return {
+    configuredPort: 3000,
+    logError: vi.fn(),
+    onListening: vi.fn(),
+    disposeStartupResources: vi.fn(() => Promise.resolve()),
+    markFatal: vi.fn(),
+    ...overrides,
+  };
+}
+
+function listen(server: http.Server | net.Server): Promise<AddressInfo> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("server has no address"));
+        return;
+      }
+      resolve(address);
+    });
+  });
+}
+
+function listenOnLoopback(server: http.Server | net.Server): Promise<AddressInfo> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("server has no address"));
+        return;
+      }
+      resolve(address);
+    });
+  });
+}
+
+function closeServer(server: http.Server | net.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+function waitForExit(
+  child: ChildProcess,
+  timeoutMs: number,
+  output: () => string,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(
+        new Error(
+          `frontend child did not exit within ${timeoutMs}ms\n--- child output ---\n${output()}`,
+        ),
+      );
+    }, timeoutMs);
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal });
+    });
+  });
+}
+
+describe("formatStartupListenError", () => {
+  it("formats EADDRINUSE with address, port, and a corrective action", () => {
+    const error = systemError(SECRET_MARKER, {
+      code: "EADDRINUSE",
+      address: "127.0.0.1",
+      port: 45678,
+      syscall: "listen",
+    });
+
+    const message = formatStartupListenError(error, 3000);
+
+    expect(message).toContain("Frontend server could not start");
+    expect(message).toContain("EADDRINUSE");
+    expect(message).toContain("127.0.0.1");
+    expect(message).toContain("45678");
+    expect(message).toContain("Stop the other listener or set PORT to an available port");
+    expect(message).not.toContain(SECRET_MARKER);
+    expect(message).not.toContain("\n");
+  });
+
+  it("formats EACCES without attempting a privileged bind", () => {
+    const error = systemError(SECRET_MARKER, {
+      code: "EACCES",
+      address: "0.0.0.0",
+      port: 80,
+      syscall: "listen",
+    });
+
+    const message = formatStartupListenError(error, 3000);
+
+    expect(message).toContain("Frontend server could not start");
+    expect(message).toContain("EACCES");
+    expect(message).toContain("0.0.0.0");
+    expect(message).toContain("80");
+    expect(message).toContain(
+      "Use an unprivileged PORT or grant the runtime permission to bind it",
+    );
+    expect(message).not.toContain(SECRET_MARKER);
+  });
+
+  it("formats unknown codes without interpolating the raw Error message", () => {
+    const error = systemError(SECRET_MARKER, {
+      code: "EFOO",
+      address: "127.0.0.1",
+      port: 3000,
+    });
+
+    const message = formatStartupListenError(error, 3000);
+
+    expect(message).toContain("code EFOO");
+    expect(message).toContain(
+      "Check the bind configuration and operating-system limits, then restart",
+    );
+    expect(message).not.toContain(SECRET_MARKER);
+  });
+
+  it("formats EADDRNOTAVAIL and descriptor-limit codes", () => {
+    expect(
+      formatStartupListenError(
+        systemError(SECRET_MARKER, { code: "EADDRNOTAVAIL", address: "192.0.2.1", port: 3000 }),
+        3000,
+      ),
+    ).toContain("the local address is unavailable");
+    expect(
+      formatStartupListenError(
+        systemError(SECRET_MARKER, { code: "EMFILE", address: "127.0.0.1", port: 3000 }),
+        3000,
+      ),
+    ).toContain("the file-descriptor limit was reached");
+    expect(
+      formatStartupListenError(
+        systemError(SECRET_MARKER, { code: "ENFILE", address: "127.0.0.1", port: 3000 }),
+        3000,
+      ),
+    ).toContain("the file-descriptor limit was reached");
+  });
+
+  it("falls back when metadata is absent, malformed, or injects control characters", () => {
+    const error = systemError(SECRET_MARKER, {
+      code: 123,
+      address: "127.0.0.1\ninjected",
+      port: 1.5,
+    });
+
+    const message = formatStartupListenError(error, 3000);
+
+    expect(message).toContain("address default interface");
+    expect(message).toContain("port 3000");
+    expect(message).toContain("code UNKNOWN");
+    expect(message).not.toContain("injected");
+    expect(message).not.toContain(SECRET_MARKER);
+    expect(message).not.toContain("\n");
+  });
+
+  it("rejects overlong tokens and out-of-range ports", () => {
+    const error = systemError(SECRET_MARKER, {
+      code: `EADDRINUSE${"x".repeat(200)}`,
+      address: "a".repeat(200),
+      port: 70000,
+    });
+
+    const message = formatStartupListenError(error, 4123);
+
+    expect(message).toContain("address default interface");
+    expect(message).toContain("port 4123");
+    expect(message).toContain("code UNKNOWN");
+    expect(message).not.toContain("EADDRINUSE");
+    expect(() => formatStartupListenError(error, 4123)).not.toThrow();
+  });
+
+  it("accepts the legal TCP port range and rejects negatives", () => {
+    expect(
+      formatStartupListenError(
+        systemError("x", { code: "EADDRINUSE", address: "127.0.0.1", port: 0 }),
+        3000,
+      ),
+    ).toContain("port 0");
+    expect(
+      formatStartupListenError(
+        systemError("x", { code: "EADDRINUSE", address: "127.0.0.1", port: 65535 }),
+        3000,
+      ),
+    ).toContain("port 65535");
+    expect(
+      formatStartupListenError(
+        systemError(SECRET_MARKER, { code: "EADDRINUSE", address: "127.0.0.1", port: -1 }),
+        3000,
+      ),
+    ).toContain("port 3000");
+  });
+});
+
+describe("attachHttpServerLifecycle", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers an error listener immediately and never touches process.exit", () => {
+    const server = http.createServer();
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as typeof process.exit);
+    const previousExitCode = process.exitCode;
+    const options = lifecycleOptions();
+
+    expect(server.listenerCount("error")).toBe(0);
+    const listeningBefore = server.listenerCount("listening");
+    attachHttpServerLifecycle(server, options);
+    expect(server.listenerCount("error")).toBe(1);
+    expect(server.listenerCount("listening")).toBe(listeningBefore + 1);
+
+    const error = systemError(SECRET_MARKER, {
+      code: "EADDRINUSE",
+      address: "127.0.0.1",
+      port: 3000,
+    });
+    server.emit("error", error);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(previousExitCode);
+  });
+
+  it("treats a pre-listening error as an exactly-once startup failure", async () => {
+    const server = http.createServer();
+    let resolveDispose: (() => void) | undefined;
+    const options = lifecycleOptions({
+      disposeStartupResources: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveDispose = resolve;
+          }),
+      ),
+    });
+    const lifecycle = attachHttpServerLifecycle(server, options);
+    const first = systemError(SECRET_MARKER, {
+      code: "EADDRINUSE",
+      address: "127.0.0.1",
+      port: 45678,
+    });
+    const second = systemError("another", { code: "EACCES", address: "127.0.0.1", port: 3000 });
+
+    server.emit("error", first);
+    expect(lifecycle.owns(first)).toBe(true);
+
+    server.emit("error", first);
+    server.emit("error", second);
+
+    expect(options.logError).toHaveBeenCalledOnce();
+    expect(options.logError.mock.calls[0]).toEqual([
+      expect.stringContaining("Frontend server could not start"),
+    ]);
+    expect(options.markFatal).toHaveBeenCalledOnce();
+    expect(options.markFatal).toHaveBeenCalledWith(1, "startup");
+    expect(options.disposeStartupResources).toHaveBeenCalledOnce();
+    expect(options.onListening).not.toHaveBeenCalled();
+    expect(lifecycle.owns(second)).toBe(true);
+
+    resolveDispose?.();
+    await lifecycle.failure();
+  });
+
+  it("invokes onListening exactly once and ignores a later startup callback", async () => {
+    const server = http.createServer();
+    const options = lifecycleOptions();
+    attachHttpServerLifecycle(server, options);
+
+    const address = await listenOnLoopback(server);
+    expect(address.port).toBeGreaterThan(0);
+    expect(options.onListening).toHaveBeenCalledOnce();
+    expect(options.markFatal).not.toHaveBeenCalled();
+    expect(options.disposeStartupResources).not.toHaveBeenCalled();
+    expect(options.logError).not.toHaveBeenCalled();
+
+    server.emit("listening");
+    expect(options.onListening).toHaveBeenCalledOnce();
+
+    await closeServer(server);
+  });
+
+  it("does not initialize after a late listening event that follows failure", () => {
+    const server = http.createServer();
+    const options = lifecycleOptions();
+    attachHttpServerLifecycle(server, options);
+
+    server.emit(
+      "error",
+      systemError(SECRET_MARKER, { code: "EADDRINUSE", address: "127.0.0.1", port: 3000 }),
+    );
+    server.emit("listening");
+
+    expect(options.onListening).not.toHaveBeenCalled();
+    expect(options.markFatal).toHaveBeenCalledWith(1, "startup");
+  });
+
+  it("describes a post-listening error as a runtime failure", async () => {
+    const server = http.createServer();
+    const options = lifecycleOptions();
+    const lifecycle = attachHttpServerLifecycle(server, options);
+    const error = systemError(SECRET_MARKER, {
+      code: "ECONNRESET",
+      address: "127.0.0.1",
+      port: 3000,
+    });
+
+    server.emit("listening");
+    server.emit("error", error);
+
+    expect(options.onListening).toHaveBeenCalledOnce();
+    expect(options.logError).toHaveBeenCalledOnce();
+    expect(options.logError).toHaveBeenCalledWith(
+      "Unexpected frontend HTTP server error after startup",
+      error,
+    );
+    expect(options.markFatal).toHaveBeenCalledWith(1, "runtime");
+    expect(options.disposeStartupResources).toHaveBeenCalledOnce();
+    expect(lifecycle.owns(error)).toBe(true);
+    await lifecycle.failure();
+  });
+});
+
+describe("attachWebsocketServerErrorListener", () => {
+  it("suppresses the exact HTTP-owned Error and forwards any other WSS error", () => {
+    const server = http.createServer();
+    const options = lifecycleOptions();
+    const lifecycle = attachHttpServerLifecycle(server, options);
+    const onUnexpectedError = vi.fn();
+    const websocketServer = new EventEmitter();
+    attachWebsocketServerErrorListener(websocketServer, {
+      isOwned: lifecycle.owns,
+      onUnexpectedError,
+    });
+
+    const forwarded = systemError(SECRET_MARKER, {
+      code: "EADDRINUSE",
+      address: "127.0.0.1",
+      port: 3000,
+    });
+    server.emit("error", forwarded);
+    websocketServer.emit("error", forwarded);
+
+    expect(options.logError).toHaveBeenCalledOnce();
+    expect(onUnexpectedError).not.toHaveBeenCalled();
+
+    const independent = systemError("wss-only", {
+      code: "EADDRINUSE",
+      address: "127.0.0.1",
+      port: 3000,
+    });
+    websocketServer.emit("error", independent);
+
+    expect(onUnexpectedError).toHaveBeenCalledOnce();
+    expect(onUnexpectedError).toHaveBeenCalledWith(independent);
+    expect(options.logError).toHaveBeenCalledOnce();
+  });
+
+  it("exports identity mark helpers for issue 1234", () => {
+    const error = new Error("owned-elsewhere");
+    expect(isHttpServerErrorOwned(error)).toBe(false);
+    markHttpServerErrorOwned(error);
+    expect(isHttpServerErrorOwned(error)).toBe(true);
+  });
+});
+
+describe("occupied ephemeral port child process", () => {
+  it("exits 1 with one controlled EADDRINUSE line and no backend connection", async () => {
+    const reservation = net.createServer();
+    const fakeBackend = net.createServer();
+    let child: ChildProcess | undefined;
+    let configPath: string | undefined;
+    let killedByHarness = false;
+    let stdout = "";
+    let stderr = "";
+    let backendConnections = 0;
+
+    const output = () => `${stdout}\n${stderr}`;
+
+    try {
+      const reserved = await listen(reservation);
+      fakeBackend.on("connection", () => {
+        backendConnections += 1;
+      });
+      const backendAddress = await listenOnLoopback(fakeBackend);
+      configPath = await mkdtemp(path.join(tmpdir(), "nzbdav-1246-"));
+
+      const childEnv: NodeJS.ProcessEnv = {
+        ...process.env,
+        NODE_ENV: "development",
+        PORT: String(reserved.port),
+        NO_COLOR: "1",
+        FRONTEND_BACKEND_API_KEY: DUMMY_API_KEY,
+        BACKEND_URL: `http://127.0.0.1:${backendAddress.port}`,
+        CONFIG_PATH: configPath,
+      };
+      delete childEnv["NODE_OPTIONS"];
+
+      child = spawn(process.execPath, ["--import", "tsx", "server.ts"], {
+        cwd: FRONTEND_ROOT,
+        env: childEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      child.stdout?.setEncoding("utf8");
+      child.stderr?.setEncoding("utf8");
+      child.stdout?.on("data", (chunk: string) => {
+        stdout += chunk;
+      });
+      child.stderr?.on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+
+      const result = await waitForExit(child, 45_000, output);
+
+      expect(killedByHarness).toBe(false);
+      expect(result.code).toBe(1);
+      expect(result.signal).toBeNull();
+
+      const combined = output();
+      expect(combined.match(/Frontend server could not start/g)).toHaveLength(1);
+      expect(combined).toContain("EADDRINUSE");
+      expect(combined).toContain(String(reserved.port));
+      expect(combined).toContain("address ");
+      expect(combined).toContain("Stop the other listener or set PORT to an available port");
+      expect(combined).not.toContain("Unhandled 'error' event");
+      expect(combined).not.toContain("at Server.setupListenHandle");
+      expect(combined).not.toContain(SECRET_MARKER);
+      expect(combined).not.toContain(DUMMY_API_KEY);
+      expect(combined).not.toContain("Frontend server listening");
+      expect(combined).not.toContain("Backend websocket connected");
+      expect(combined).not.toContain("Backend websocket reconnected");
+      expect(combined).not.toContain("Waiting for backend to start");
+      expect(combined).not.toContain("Could not connect to backend websocket");
+      expect(backendConnections).toBe(0);
+    } finally {
+      if (child && child.exitCode === null && child.signalCode === null) {
+        killedByHarness = true;
+        child.kill("SIGKILL");
+        await waitForExit(child, 5_000, output).catch(() => undefined);
+      }
+      child?.stdout?.destroy();
+      child?.stderr?.destroy();
+      await Promise.allSettled([closeServer(reservation), closeServer(fakeBackend)]);
+      if (configPath) {
+        await rm(configPath, { recursive: true, force: true });
+      }
+    }
+    expect(killedByHarness).toBe(false);
+  }, 60_000);
+});

--- a/frontend/server/http-server-lifecycle.test.ts
+++ b/frontend/server/http-server-lifecycle.test.ts
@@ -402,6 +402,25 @@ describe("attachWebsocketServerErrorListener", () => {
     expect(options.logError).toHaveBeenCalledOnce();
   });
 
+  it("registers one listener and fatalizes repeated unowned errors once", () => {
+    const websocketServer = new EventEmitter();
+    const failServerOnce = vi.fn();
+    attachWebsocketServerErrorListener(websocketServer, {
+      isOwned: () => false,
+      onUnexpectedError: failServerOnce,
+    });
+
+    expect(websocketServer.listenerCount("error")).toBe(1);
+
+    const error = new Error("test server failure");
+    expect(() => websocketServer.emit("error", error)).not.toThrow();
+    expect(failServerOnce).toHaveBeenCalledOnce();
+    expect(failServerOnce).toHaveBeenCalledWith(error);
+
+    websocketServer.emit("error", new Error("second unowned failure"));
+    expect(failServerOnce).toHaveBeenCalledOnce();
+  });
+
   it("exports identity mark helpers for issue 1234", () => {
     const error = new Error("owned-elsewhere");
     expect(isHttpServerErrorOwned(error)).toBe(false);

--- a/frontend/server/http-server-lifecycle.test.ts
+++ b/frontend/server/http-server-lifecycle.test.ts
@@ -14,7 +14,7 @@ import {
   formatStartupListenError,
   isHttpServerErrorOwned,
   markHttpServerErrorOwned,
-  type HttpServerLifecycleOptions,
+  type FatalPhase,
 } from "./http-server-lifecycle";
 
 const FRONTEND_ROOT = fileURLToPath(new URL("..", import.meta.url));
@@ -28,20 +28,23 @@ function systemError(
   return Object.assign(new Error(message), fields);
 }
 
+type LifecycleTestOptions = {
+  configuredPort: number;
+  logError: ReturnType<typeof vi.fn<(message: string, detail?: Error) => void>>;
+  onListening: ReturnType<typeof vi.fn<() => void>>;
+  disposeStartupResources: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  markFatal: ReturnType<typeof vi.fn<(exitCode: number, phase: FatalPhase) => void>>;
+};
+
 function lifecycleOptions(
-  overrides: Partial<HttpServerLifecycleOptions> = {},
-): HttpServerLifecycleOptions & {
-  logError: ReturnType<typeof vi.fn>;
-  onListening: ReturnType<typeof vi.fn>;
-  disposeStartupResources: ReturnType<typeof vi.fn>;
-  markFatal: ReturnType<typeof vi.fn>;
-} {
+  overrides: Partial<LifecycleTestOptions> = {},
+): LifecycleTestOptions {
   return {
     configuredPort: 3000,
-    logError: vi.fn(),
-    onListening: vi.fn(),
-    disposeStartupResources: vi.fn(() => Promise.resolve()),
-    markFatal: vi.fn(),
+    logError: vi.fn<(message: string, detail?: Error) => void>(),
+    onListening: vi.fn<() => void>(),
+    disposeStartupResources: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    markFatal: vi.fn<(exitCode: number, phase: FatalPhase) => void>(),
     ...overrides,
   };
 }
@@ -140,7 +143,7 @@ describe("formatStartupListenError", () => {
     expect(message).toContain("Frontend server could not start");
     expect(message).toContain("EACCES");
     expect(message).toContain("0.0.0.0");
-    expect(message).toContain("80");
+    expect(message).toContain("port 80");
     expect(message).toContain(
       "Use an unprivileged PORT or grant the runtime permission to bind it",
     );
@@ -421,7 +424,7 @@ describe("attachWebsocketServerErrorListener", () => {
     expect(failServerOnce).toHaveBeenCalledOnce();
   });
 
-  it("exports identity mark helpers for issue 1234", () => {
+  it("marks and detects HTTP-owned errors by identity", () => {
     const error = new Error("owned-elsewhere");
     expect(isHttpServerErrorOwned(error)).toBe(false);
     markHttpServerErrorOwned(error);

--- a/frontend/server/http-server-lifecycle.ts
+++ b/frontend/server/http-server-lifecycle.ts
@@ -1,0 +1,160 @@
+import type { Server as HttpServer } from "node:http";
+
+type ListenSystemError = Error & {
+  code?: unknown;
+  address?: unknown;
+  port?: unknown;
+  syscall?: unknown;
+};
+
+type ListenErrorContext = Readonly<{
+  code: string;
+  address: string;
+  port: number;
+}>;
+
+export type FatalPhase = "startup" | "runtime";
+
+export type HttpServerLifecycleOptions = Readonly<{
+  configuredPort: number;
+  logError: (message: string, detail?: Error) => void;
+  onListening: () => void;
+  disposeStartupResources: () => Promise<void>;
+  markFatal: (exitCode: number, phase: FatalPhase) => void;
+}>;
+
+export type HttpServerLifecycle = Readonly<{
+  owns: (error: Error) => boolean;
+  failure: () => Promise<void> | null;
+}>;
+
+export type WebsocketServerErrorTarget = {
+  on(event: "error", listener: (error: Error) => void): unknown;
+};
+
+export type WebsocketServerErrorListenerOptions = Readonly<{
+  isOwned: (error: Error) => boolean;
+  onUnexpectedError: (error: Error) => void;
+}>;
+
+const ownedHttpServerErrors = new WeakSet<Error>();
+
+export function markHttpServerErrorOwned(error: Error): void {
+  ownedHttpServerErrors.add(error);
+}
+
+export function isHttpServerErrorOwned(error: Error): boolean {
+  return ownedHttpServerErrors.has(error);
+}
+
+function safeToken(value: unknown, fallback: string): string {
+  if (typeof value !== "string") return fallback;
+  if (value.length === 0 || value.length > 128 || /[\r\n\0]/.test(value)) return fallback;
+  return value;
+}
+
+function listenPort(value: unknown, configuredPort: number): number {
+  if (typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 65535) {
+    return value;
+  }
+  return configuredPort;
+}
+
+function listenErrorContext(error: Error, configuredPort: number): ListenErrorContext {
+  const systemError = error as ListenSystemError;
+  return {
+    code: safeToken(systemError.code, "UNKNOWN"),
+    address: safeToken(systemError.address, "default interface"),
+    port: listenPort(systemError.port, configuredPort),
+  };
+}
+
+export function formatStartupListenError(error: Error, configuredPort: number): string {
+  const { code, address, port } = listenErrorContext(error, configuredPort);
+  const endpoint = `address ${address}, port ${port}, code ${code}`;
+
+  switch (code) {
+    case "EADDRINUSE":
+      return (
+        `Frontend server could not start (${endpoint}): the address is already in use. ` +
+        "Stop the other listener or set PORT to an available port."
+      );
+    case "EACCES":
+      return (
+        `Frontend server could not start (${endpoint}): permission to bind was denied. ` +
+        "Use an unprivileged PORT or grant the runtime permission to bind it."
+      );
+    case "EADDRNOTAVAIL":
+      return (
+        `Frontend server could not start (${endpoint}): the local address is unavailable. ` +
+        "Correct the bind configuration and restart the frontend."
+      );
+    case "EMFILE":
+    case "ENFILE":
+      return (
+        `Frontend server could not start (${endpoint}): the file-descriptor limit was reached. ` +
+        "Close leaked descriptors or raise the limit before restarting."
+      );
+    default:
+      return (
+        `Frontend server could not start (${endpoint}). ` +
+        "Check the bind configuration and operating-system limits, then restart."
+      );
+  }
+}
+
+export function attachHttpServerLifecycle(
+  server: HttpServer,
+  options: HttpServerLifecycleOptions,
+): HttpServerLifecycle {
+  let phase: "starting" | "listening" | "failing" = "starting";
+  let failure: Promise<void> | null = null;
+
+  server.on("error", (error: Error) => {
+    if (error instanceof Error) {
+      markHttpServerErrorOwned(error);
+    }
+    if (phase === "failing") return;
+
+    const fatalPhase: FatalPhase = phase === "starting" ? "startup" : "runtime";
+    phase = "failing";
+
+    if (fatalPhase === "startup") {
+      options.logError(formatStartupListenError(error, options.configuredPort));
+    } else {
+      options.logError("Unexpected frontend HTTP server error after startup", error);
+    }
+
+    options.markFatal(1, fatalPhase);
+    if (failure === null) {
+      try {
+        failure = Promise.resolve(options.disposeStartupResources()).catch(() => {
+          return;
+        });
+      } catch {
+        failure = Promise.resolve();
+      }
+    }
+  });
+
+  server.once("listening", () => {
+    if (phase !== "starting") return;
+    phase = "listening";
+    options.onListening();
+  });
+
+  return {
+    owns: isHttpServerErrorOwned,
+    failure: () => failure,
+  };
+}
+
+export function attachWebsocketServerErrorListener(
+  websocketServer: WebsocketServerErrorTarget,
+  options: WebsocketServerErrorListenerOptions,
+): void {
+  websocketServer.on("error", (error: Error) => {
+    if (error instanceof Error && options.isOwned(error)) return;
+    options.onUnexpectedError(error);
+  });
+}

--- a/frontend/server/http-server-lifecycle.ts
+++ b/frontend/server/http-server-lifecycle.ts
@@ -153,8 +153,11 @@ export function attachWebsocketServerErrorListener(
   websocketServer: WebsocketServerErrorTarget,
   options: WebsocketServerErrorListenerOptions,
 ): void {
+  let unexpectedFailureClaimed = false;
   websocketServer.on("error", (error: Error) => {
     if (error instanceof Error && options.isOwned(error)) return;
+    if (unexpectedFailureClaimed) return;
+    unexpectedFailureClaimed = true;
     options.onUnexpectedError(error);
   });
 }

--- a/frontend/server/websocket-policy.test.ts
+++ b/frontend/server/websocket-policy.test.ts
@@ -1,0 +1,136 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "./logger";
+import { resetClientErrorLogThrottleForTests } from "./request-log-throttle";
+import {
+  attachBrowserWebsocketErrorListener,
+  MAX_WEBSOCKET_PAYLOAD_BYTES,
+  reportBrowserSocketError,
+} from "./websocket-policy";
+
+const PAYLOAD_MARKER = "FAKE_PAYLOAD_MARKER_xyzzy";
+
+function codedError(code: string, message: string): Error {
+  return Object.assign(new Error(message), { code });
+}
+
+describe("browser websocket error policy", () => {
+  beforeEach(() => {
+    resetClientErrorLogThrottleForTests();
+  });
+
+  afterEach(() => {
+    resetClientErrorLogThrottleForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("uses a 64 KiB payload limit", () => {
+    expect(MAX_WEBSOCKET_PAYLOAD_BYTES).toBe(64 * 1024);
+  });
+
+  it("warns for oversized frames without the Error object or payload marker", () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const errorLog = vi.spyOn(logger, "error").mockImplementation(() => {});
+    const error = codedError("WS_ERR_UNSUPPORTED_MESSAGE_LENGTH", PAYLOAD_MARKER);
+
+    reportBrowserSocketError(error, {
+      remote: "127.0.0.1",
+      isAuthenticated: () => false,
+    });
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]?.[1]).toBeUndefined();
+    const message = String(warn.mock.calls[0]?.[0]);
+    expect(message).toContain("Browser websocket rejected oversized frame");
+    expect(message).toContain("127.0.0.1");
+    expect(message).toContain("pre-auth");
+    expect(message).toContain(String(MAX_WEBSOCKET_PAYLOAD_BYTES));
+    expect(message).not.toContain(PAYLOAD_MARKER);
+    expect(errorLog).not.toHaveBeenCalled();
+  });
+
+  it("warns for expected transport errors without the Error object", () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const errorLog = vi.spyOn(logger, "error").mockImplementation(() => {});
+    const error = codedError("ECONNRESET", PAYLOAD_MARKER);
+
+    reportBrowserSocketError(error, {
+      remote: "127.0.0.1",
+      isAuthenticated: () => true,
+    });
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]?.[1]).toBeUndefined();
+    const message = String(warn.mock.calls[0]?.[0]);
+    expect(message).toContain("Browser websocket peer error");
+    expect(message).toContain("127.0.0.1");
+    expect(message).toContain("authenticated");
+    expect(message).toContain("ECONNRESET");
+    expect(message).not.toContain(PAYLOAD_MARKER);
+    expect(errorLog).not.toHaveBeenCalled();
+  });
+
+  it("warns for other WS_ERR_* codes with the bounded code only", () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    reportBrowserSocketError(codedError("WS_ERR_INVALID_UTF8", PAYLOAD_MARKER), {
+      remote: "10.0.0.2",
+      isAuthenticated: () => false,
+    });
+
+    const message = String(warn.mock.calls[0]?.[0]);
+    expect(message).toContain("WS_ERR_INVALID_UTF8");
+    expect(message).not.toContain(PAYLOAD_MARKER);
+  });
+
+  it("logs unexpected errors with the original Error object", () => {
+    const errorLog = vi.spyOn(logger, "error").mockImplementation(() => {});
+    const error = codedError("EPROTO", "unexpected-socket-failure");
+
+    reportBrowserSocketError(error, {
+      remote: "127.0.0.1",
+      isAuthenticated: () => false,
+    });
+
+    expect(errorLog).toHaveBeenCalledOnce();
+    expect(errorLog).toHaveBeenCalledWith(
+      "Unexpected browser websocket error from 127.0.0.1 during pre-auth",
+      error,
+    );
+  });
+
+  it("throttles repeated expected errors under a coarse key that omits the remote address", () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const first = codedError("WS_ERR_UNSUPPORTED_MESSAGE_LENGTH", PAYLOAD_MARKER);
+    const second = codedError("WS_ERR_UNSUPPORTED_MESSAGE_LENGTH", PAYLOAD_MARKER);
+
+    reportBrowserSocketError(first, {
+      remote: "127.0.0.1",
+      isAuthenticated: () => false,
+    });
+    reportBrowserSocketError(second, {
+      remote: "10.0.0.9",
+      isAuthenticated: () => false,
+    });
+
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("attaches an error listener that does not close or terminate the socket", () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const close = vi.fn();
+    const terminate = vi.fn();
+    const socket = Object.assign(new EventEmitter(), { close, terminate });
+
+    attachBrowserWebsocketErrorListener(socket, {
+      remote: "127.0.0.1",
+      isAuthenticated: () => false,
+    });
+
+    expect(socket.listenerCount("error")).toBe(1);
+    socket.emit("error", codedError("WS_ERR_UNSUPPORTED_MESSAGE_LENGTH", PAYLOAD_MARKER));
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(close).not.toHaveBeenCalled();
+    expect(terminate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/server/websocket-policy.ts
+++ b/frontend/server/websocket-policy.ts
@@ -1,0 +1,77 @@
+import { logger } from "./logger.js";
+import { shouldLogClientError } from "./request-log-throttle.js";
+
+export const MAX_WEBSOCKET_PAYLOAD_BYTES = 64 * 1024;
+
+const EXPECTED_TRANSPORT_CODES = new Set(["ECONNRESET", "EPIPE", "ETIMEDOUT", "ECONNABORTED"]);
+
+export type BrowserWebsocketErrorContext = Readonly<{
+  remote: string;
+  isAuthenticated: () => boolean;
+}>;
+
+export type BrowserWebsocketErrorReporter = (
+  error: unknown,
+  context: BrowserWebsocketErrorContext,
+) => void;
+
+export type BrowserWebsocketErrorTarget = {
+  on(event: "error", listener: (error: Error) => void): unknown;
+};
+
+export function errorCode(error: unknown): string | null {
+  if (!error || typeof error !== "object" || !("code" in error)) return null;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? code : null;
+}
+
+function authPhase(context: BrowserWebsocketErrorContext): "authenticated" | "pre-auth" {
+  return context.isAuthenticated() ? "authenticated" : "pre-auth";
+}
+
+function logExpectedBrowserWebsocketWarning(message: string, throttleKey: string): void {
+  const { log, suppressed } = shouldLogClientError(throttleKey);
+  if (!log) return;
+  if (suppressed > 0) {
+    logger.warn(`${message} (+${suppressed} similar suppressed)`);
+    return;
+  }
+  logger.warn(message);
+}
+
+export function reportBrowserSocketError(
+  error: unknown,
+  context: BrowserWebsocketErrorContext,
+): void {
+  const code = errorCode(error);
+  const phase = authPhase(context);
+
+  if (code === "WS_ERR_UNSUPPORTED_MESSAGE_LENGTH") {
+    logExpectedBrowserWebsocketWarning(
+      `Browser websocket rejected oversized frame from ${context.remote} during ${phase} ` +
+        `(limit ${MAX_WEBSOCKET_PAYLOAD_BYTES} bytes)`,
+      `websocket:${phase}:oversized`,
+    );
+    return;
+  }
+
+  if (code?.startsWith("WS_ERR_") || EXPECTED_TRANSPORT_CODES.has(code ?? "")) {
+    logExpectedBrowserWebsocketWarning(
+      `Browser websocket peer error from ${context.remote} during ${phase} (${code})`,
+      `websocket:${phase}:${code}`,
+    );
+    return;
+  }
+
+  logger.error(`Unexpected browser websocket error from ${context.remote} during ${phase}`, error);
+}
+
+export function attachBrowserWebsocketErrorListener(
+  socket: BrowserWebsocketErrorTarget,
+  context: BrowserWebsocketErrorContext,
+  report: BrowserWebsocketErrorReporter = reportBrowserSocketError,
+): void {
+  socket.on("error", (error) => {
+    report(error, context);
+  });
+}

--- a/frontend/server/websocket-test-helpers.ts
+++ b/frontend/server/websocket-test-helpers.ts
@@ -1,0 +1,97 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import WebSocket from "ws";
+
+export function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+export function listenOnLoopback(server: http.Server): Promise<AddressInfo> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("server has no address"));
+        return;
+      }
+      resolve(address);
+    });
+  });
+}
+
+export function closeServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+export function waitForOpen(ws: WebSocket, timeoutMs = 5_000): Promise<void> {
+  if (ws.readyState === WebSocket.OPEN) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("WebSocket open timed out")), timeoutMs);
+    ws.once("open", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+export function waitForClose(ws: WebSocket, timeoutMs = 5_000): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("WebSocket close timed out")), timeoutMs);
+    ws.once("close", (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+}
+
+export function connectClient(port: number): WebSocket {
+  const client = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+  client.on("error", () => {});
+  return client;
+}
+
+export function websocketUpgradeRequest(port: number): Buffer {
+  const key = Buffer.from("1234567890abcdef").toString("base64");
+  return Buffer.from(
+    `GET /ws HTTP/1.1\r\n` +
+      `Host: 127.0.0.1:${port}\r\n` +
+      `Upgrade: websocket\r\n` +
+      `Connection: Upgrade\r\n` +
+      `Sec-WebSocket-Key: ${key}\r\n` +
+      `Sec-WebSocket-Version: 13\r\n` +
+      `\r\n`,
+  );
+}
+
+export function oversizedMaskedBinaryFrame(payloadLength: number): Buffer {
+  const header = Buffer.alloc(2 + 8 + 4);
+  header[0] = 0x82;
+  header[1] = 0x80 | 127;
+  header.writeBigUInt64BE(BigInt(payloadLength), 2);
+  return Buffer.concat([header, Buffer.alloc(payloadLength)]);
+}
+
+export async function waitUntil(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("waitUntil timed out");
+}

--- a/frontend/server/websocket.server.errors.test.ts
+++ b/frontend/server/websocket.server.errors.test.ts
@@ -3,7 +3,6 @@ import { existsSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import http from "node:http";
 import net from "node:net";
-import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -18,6 +17,17 @@ import {
   reportBrowserSocketError,
 } from "./websocket-policy";
 import { initializeWebsocketServer, type WebsocketServerDependencies } from "./websocket.server";
+import {
+  closeServer,
+  connectClient,
+  deferred,
+  listenOnLoopback,
+  oversizedMaskedBinaryFrame,
+  waitForClose,
+  waitForOpen,
+  waitUntil,
+  websocketUpgradeRequest,
+} from "./websocket-test-helpers";
 
 vi.hoisted(() => {
   process.env["SESSION_KEY"] ??= "1234-in-process-session-key";
@@ -27,270 +37,9 @@ vi.hoisted(() => {
 
 const FRONTEND_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const PROBE_PATH = fileURLToPath(new URL("./__fixtures__/websocket-probe.ts", import.meta.url));
 const DUMMY_API_KEY = "1234-dummy-frontend-backend-api-key";
 const DUMMY_SESSION_KEY = "1234-dummy-session-key";
-
-const PROBE_SOURCE = `
-import { register } from "node:module";
-import http from "node:http";
-import net from "node:net";
-import path from "node:path";
-import { pathToFileURL } from "node:url";
-import { WebSocket, WebSocketServer } from "ws";
-
-const frontendRoot = process.env.FRONTEND_ROOT;
-const mode = process.env.WEBSOCKET_PROBE_MODE;
-const appHref = pathToFileURL(path.join(frontendRoot, "app")).href + "/";
-register("data:text/javascript," + encodeURIComponent(\`
-export async function resolve(specifier, context, nextResolve) {
-  if (specifier.startsWith("~/")) {
-    return nextResolve(new URL(specifier.slice(2), \${JSON.stringify(appHref)}).href, context);
-  }
-  return nextResolve(specifier, context);
-}
-\`));
-
-const [{ initializeWebsocketServer }, policy, { attachWebsocketServerErrorListener }] = await Promise.all([
-  import(pathToFileURL(path.join(frontendRoot, "server/websocket.server.ts")).href),
-  import(pathToFileURL(path.join(frontendRoot, "server/websocket-policy.ts")).href),
-  import(pathToFileURL(path.join(frontendRoot, "server/http-server-lifecycle.ts")).href),
-]);
-const { MAX_WEBSOCKET_PAYLOAD_BYTES, attachBrowserWebsocketErrorListener, reportBrowserSocketError, errorCode } = policy;
-
-function deferred() {
-  let resolve;
-  const promise = new Promise((res) => { resolve = res; });
-  return { promise, resolve };
-}
-
-function listenOnLoopback(server) {
-  return new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => resolve(server.address()));
-  });
-}
-
-function waitForOpen(ws, timeoutMs = 5000) {
-  if (ws.readyState === WebSocket.OPEN) return Promise.resolve();
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error("open timeout")), timeoutMs);
-    ws.once("open", () => { clearTimeout(timer); resolve(); });
-  });
-}
-
-function waitForClose(ws, timeoutMs = 5000) {
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error("close timeout")), timeoutMs);
-    ws.once("close", (code) => { clearTimeout(timer); resolve(code); });
-  });
-}
-
-function websocketUpgradeRequest(port) {
-  const key = Buffer.from("1234567890abcdef").toString("base64");
-  return Buffer.from(
-    "GET /ws HTTP/1.1\\r\\n" +
-    "Host: 127.0.0.1:" + port + "\\r\\n" +
-    "Upgrade: websocket\\r\\n" +
-    "Connection: Upgrade\\r\\n" +
-    "Sec-WebSocket-Key: " + key + "\\r\\n" +
-    "Sec-WebSocket-Version: 13\\r\\n" +
-    "\\r\\n",
-  );
-}
-
-function oversizedMaskedBinaryFrame(payloadLength) {
-  const header = Buffer.alloc(2 + 8 + 4);
-  header[0] = 0x82;
-  header[1] = 0x80 | 127;
-  header.writeBigUInt64BE(BigInt(payloadLength), 2);
-  return Buffer.concat([header, Buffer.alloc(payloadLength)]);
-}
-
-const auth = deferred();
-let acceptedErrorCode = null;
-let resolveAccepted = () => {};
-const accepted = new Promise((resolve) => { resolveAccepted = resolve; });
-
-function report(error, context) {
-  reportBrowserSocketError(error, context);
-  const code = errorCode(error);
-  process.stdout.write("ACCEPTED_ERROR_CODE=" + code + "\\n");
-  if (acceptedErrorCode == null) {
-    acceptedErrorCode = code;
-    resolveAccepted(code);
-  }
-}
-
-const httpServer = http.createServer();
-const wss = new WebSocketServer({
-  server: httpServer,
-  path: "/ws",
-  maxPayload: MAX_WEBSOCKET_PAYLOAD_BYTES,
-});
-attachWebsocketServerErrorListener(wss, {
-  isOwned: () => false,
-  onUnexpectedError: (error) => {
-    process.stderr.write("WSS_FATAL " + error.message + "\\n");
-    process.exitCode = 1;
-    process.exit(1);
-  },
-});
-initializeWebsocketServer(wss, {
-  authenticate: () => auth.promise,
-  startBackendClient: () => {},
-  reportBrowserSocketError: report,
-  registerBrowserSocketErrorListener: mode === "oversized-pre-auth-listener-removed"
-    ? () => {}
-    : attachBrowserWebsocketErrorListener,
-});
-
-const address = await listenOnLoopback(httpServer);
-const url = "ws://127.0.0.1:" + address.port + "/ws";
-let clientCloseCode = null;
-let nextConnectionOpened = false;
-
-try {
-  if (mode === "pipelined-oversized") {
-    const socket = net.connect(address.port, "127.0.0.1");
-    socket.on("error", () => {});
-    await new Promise((resolve, reject) => {
-      socket.once("connect", resolve);
-      socket.once("error", reject);
-    });
-    socket.write(Buffer.concat([
-      websocketUpgradeRequest(address.port),
-      oversizedMaskedBinaryFrame(MAX_WEBSOCKET_PAYLOAD_BYTES + 1),
-    ]));
-    await Promise.race([
-      accepted,
-      new Promise((_, reject) => setTimeout(() => reject(new Error("accepted error timeout")), 8000)),
-    ]);
-    socket.destroy();
-  } else {
-    const client = new WebSocket(url);
-    client.on("error", () => {});
-    await waitForOpen(client);
-    const closed = waitForClose(client);
-    client.send(Buffer.alloc(MAX_WEBSOCKET_PAYLOAD_BYTES + 1));
-    clientCloseCode = await closed;
-    await Promise.race([
-      accepted,
-      new Promise((_, reject) => setTimeout(() => reject(new Error("accepted error timeout")), 8000)),
-    ]);
-  }
-
-  const healthy = new WebSocket(url);
-  healthy.on("error", () => {});
-  await waitForOpen(healthy);
-  nextConnectionOpened = true;
-  healthy.close();
-  await waitForClose(healthy);
-
-  const observation = { acceptedErrorCode, clientCloseCode, nextConnectionOpened };
-  process.stdout.write("PROBE_RESULT=" + JSON.stringify(observation) + "\\n");
-  process.stdout.write("probe-complete\\n");
-  process.exitCode = 0;
-} finally {
-  auth.resolve(false);
-  for (const client of wss.clients) client.terminate();
-  await new Promise((resolve) => wss.close(() => resolve()));
-  await new Promise((resolve) => httpServer.close(() => resolve()));
-}
-`;
-
-function deferred<T>(): {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-  reject: (reason?: unknown) => void;
-} {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-}
-
-function listenOnLoopback(server: http.Server): Promise<AddressInfo> {
-  return new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        reject(new Error("server has no address"));
-        return;
-      }
-      resolve(address);
-    });
-  });
-}
-
-function closeServer(server: http.Server): Promise<void> {
-  return new Promise((resolve, reject) => {
-    server.close((error) => {
-      if (error) reject(error);
-      else resolve();
-    });
-  });
-}
-
-function waitForOpen(ws: WebSocket, timeoutMs = 5_000): Promise<void> {
-  if (ws.readyState === WebSocket.OPEN) return Promise.resolve();
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error("WebSocket open timed out")), timeoutMs);
-    ws.once("open", () => {
-      clearTimeout(timer);
-      resolve();
-    });
-  });
-}
-
-function waitForClose(ws: WebSocket, timeoutMs = 5_000): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error("WebSocket close timed out")), timeoutMs);
-    ws.once("close", (code) => {
-      clearTimeout(timer);
-      resolve(code);
-    });
-  });
-}
-
-function connectClient(port: number): WebSocket {
-  const client = new WebSocket(`ws://127.0.0.1:${port}/ws`);
-  client.on("error", () => {});
-  return client;
-}
-
-function websocketUpgradeRequest(port: number): Buffer {
-  const key = Buffer.from("1234567890abcdef").toString("base64");
-  return Buffer.from(
-    `GET /ws HTTP/1.1\r\n` +
-      `Host: 127.0.0.1:${port}\r\n` +
-      `Upgrade: websocket\r\n` +
-      `Connection: Upgrade\r\n` +
-      `Sec-WebSocket-Key: ${key}\r\n` +
-      `Sec-WebSocket-Version: 13\r\n` +
-      `\r\n`,
-  );
-}
-
-function oversizedMaskedBinaryFrame(payloadLength: number): Buffer {
-  const header = Buffer.alloc(2 + 8 + 4);
-  header[0] = 0x82;
-  header[1] = 0x80 | 127;
-  header.writeBigUInt64BE(BigInt(payloadLength), 2);
-  return Buffer.concat([header, Buffer.alloc(payloadLength)]);
-}
-
-async function waitUntil(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
-  const started = Date.now();
-  while (Date.now() - started < timeoutMs) {
-    if (predicate()) return;
-    await new Promise((resolve) => setTimeout(resolve, 10));
-  }
-  throw new Error("waitUntil timed out");
-}
 
 function waitForExit(
   child: ChildProcess,
@@ -345,20 +94,16 @@ async function runWebsocketProbe(mode: string): Promise<{
     CONFIG_PATH: configPath,
     BACKEND_URL: "http://127.0.0.1:9",
     FRONTEND_BACKEND_API_KEY: DUMMY_API_KEY,
-    FRONTEND_ROOT,
     WEBSOCKET_PROBE_MODE: mode,
+    TSX_TSCONFIG_PATH: path.join(FRONTEND_ROOT, "tsconfig.vite.json"),
   };
 
   try {
-    child = spawn(
-      process.execPath,
-      ["--import", "tsx", "--input-type=module", "--eval", PROBE_SOURCE],
-      {
-        cwd: FRONTEND_ROOT,
-        env: childEnv,
-        stdio: ["ignore", "pipe", "pipe"],
-      },
-    );
+    child = spawn(process.execPath, ["--import", "tsx", PROBE_PATH], {
+      cwd: FRONTEND_ROOT,
+      env: childEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
     child.stdout?.setEncoding("utf8");
     child.stderr?.setEncoding("utf8");
     child.stdout?.on("data", (chunk: string) => {
@@ -483,6 +228,7 @@ describe("oversized pre-auth websocket child probes", () => {
 describe("accepted browser websocket error handling", () => {
   const servers: Array<{ httpServer: http.Server; wss: WebSocketServer }> = [];
   const clients: WebSocket[] = [];
+  const rawSockets: net.Socket[] = [];
 
   beforeEach(() => {
     resetClientErrorLogThrottleForTests();
@@ -490,6 +236,9 @@ describe("accepted browser websocket error handling", () => {
 
   afterEach(async () => {
     resetClientErrorLogThrottleForTests();
+    for (const socket of rawSockets.splice(0)) {
+      socket.destroy();
+    }
     for (const client of clients.splice(0)) {
       client.terminate();
     }
@@ -664,6 +413,7 @@ describe("accepted browser websocket error handling", () => {
     servers.push(started);
 
     const socket = net.connect(started.port, "127.0.0.1");
+    rawSockets.push(socket);
     socket.on("error", () => {});
     await new Promise<void>((resolve, reject) => {
       socket.once("connect", () => resolve());

--- a/frontend/server/websocket.server.errors.test.ts
+++ b/frontend/server/websocket.server.errors.test.ts
@@ -1,0 +1,693 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import http from "node:http";
+import net from "node:net";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import WebSocket, { WebSocketServer } from "ws";
+import { attachWebsocketServerErrorListener } from "./http-server-lifecycle";
+import { resetClientErrorLogThrottleForTests } from "./request-log-throttle";
+import {
+  attachBrowserWebsocketErrorListener,
+  errorCode,
+  MAX_WEBSOCKET_PAYLOAD_BYTES,
+  reportBrowserSocketError,
+} from "./websocket-policy";
+import { initializeWebsocketServer, type WebsocketServerDependencies } from "./websocket.server";
+
+vi.hoisted(() => {
+  process.env["SESSION_KEY"] ??= "1234-in-process-session-key";
+  process.env["FRONTEND_BACKEND_API_KEY"] ??= "1234-dummy-frontend-backend-api-key";
+  process.env["BACKEND_URL"] ??= "http://127.0.0.1:9";
+});
+
+const FRONTEND_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const DUMMY_API_KEY = "1234-dummy-frontend-backend-api-key";
+const DUMMY_SESSION_KEY = "1234-dummy-session-key";
+
+const PROBE_SOURCE = `
+import { register } from "node:module";
+import http from "node:http";
+import net from "node:net";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { WebSocket, WebSocketServer } from "ws";
+
+const frontendRoot = process.env.FRONTEND_ROOT;
+const mode = process.env.WEBSOCKET_PROBE_MODE;
+const appHref = pathToFileURL(path.join(frontendRoot, "app")).href + "/";
+register("data:text/javascript," + encodeURIComponent(\`
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.startsWith("~/")) {
+    return nextResolve(new URL(specifier.slice(2), \${JSON.stringify(appHref)}).href, context);
+  }
+  return nextResolve(specifier, context);
+}
+\`));
+
+const [{ initializeWebsocketServer }, policy, { attachWebsocketServerErrorListener }] = await Promise.all([
+  import(pathToFileURL(path.join(frontendRoot, "server/websocket.server.ts")).href),
+  import(pathToFileURL(path.join(frontendRoot, "server/websocket-policy.ts")).href),
+  import(pathToFileURL(path.join(frontendRoot, "server/http-server-lifecycle.ts")).href),
+]);
+const { MAX_WEBSOCKET_PAYLOAD_BYTES, attachBrowserWebsocketErrorListener, reportBrowserSocketError, errorCode } = policy;
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((res) => { resolve = res; });
+  return { promise, resolve };
+}
+
+function listenOnLoopback(server) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve(server.address()));
+  });
+}
+
+function waitForOpen(ws, timeoutMs = 5000) {
+  if (ws.readyState === WebSocket.OPEN) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("open timeout")), timeoutMs);
+    ws.once("open", () => { clearTimeout(timer); resolve(); });
+  });
+}
+
+function waitForClose(ws, timeoutMs = 5000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("close timeout")), timeoutMs);
+    ws.once("close", (code) => { clearTimeout(timer); resolve(code); });
+  });
+}
+
+function websocketUpgradeRequest(port) {
+  const key = Buffer.from("1234567890abcdef").toString("base64");
+  return Buffer.from(
+    "GET /ws HTTP/1.1\\r\\n" +
+    "Host: 127.0.0.1:" + port + "\\r\\n" +
+    "Upgrade: websocket\\r\\n" +
+    "Connection: Upgrade\\r\\n" +
+    "Sec-WebSocket-Key: " + key + "\\r\\n" +
+    "Sec-WebSocket-Version: 13\\r\\n" +
+    "\\r\\n",
+  );
+}
+
+function oversizedMaskedBinaryFrame(payloadLength) {
+  const header = Buffer.alloc(2 + 8 + 4);
+  header[0] = 0x82;
+  header[1] = 0x80 | 127;
+  header.writeBigUInt64BE(BigInt(payloadLength), 2);
+  return Buffer.concat([header, Buffer.alloc(payloadLength)]);
+}
+
+const auth = deferred();
+let acceptedErrorCode = null;
+let resolveAccepted = () => {};
+const accepted = new Promise((resolve) => { resolveAccepted = resolve; });
+
+function report(error, context) {
+  reportBrowserSocketError(error, context);
+  const code = errorCode(error);
+  process.stdout.write("ACCEPTED_ERROR_CODE=" + code + "\\n");
+  if (acceptedErrorCode == null) {
+    acceptedErrorCode = code;
+    resolveAccepted(code);
+  }
+}
+
+const httpServer = http.createServer();
+const wss = new WebSocketServer({
+  server: httpServer,
+  path: "/ws",
+  maxPayload: MAX_WEBSOCKET_PAYLOAD_BYTES,
+});
+attachWebsocketServerErrorListener(wss, {
+  isOwned: () => false,
+  onUnexpectedError: (error) => {
+    process.stderr.write("WSS_FATAL " + error.message + "\\n");
+    process.exitCode = 1;
+    process.exit(1);
+  },
+});
+initializeWebsocketServer(wss, {
+  authenticate: () => auth.promise,
+  startBackendClient: () => {},
+  reportBrowserSocketError: report,
+  registerBrowserSocketErrorListener: mode === "oversized-pre-auth-listener-removed"
+    ? () => {}
+    : attachBrowserWebsocketErrorListener,
+});
+
+const address = await listenOnLoopback(httpServer);
+const url = "ws://127.0.0.1:" + address.port + "/ws";
+let clientCloseCode = null;
+let nextConnectionOpened = false;
+
+try {
+  if (mode === "pipelined-oversized") {
+    const socket = net.connect(address.port, "127.0.0.1");
+    socket.on("error", () => {});
+    await new Promise((resolve, reject) => {
+      socket.once("connect", resolve);
+      socket.once("error", reject);
+    });
+    socket.write(Buffer.concat([
+      websocketUpgradeRequest(address.port),
+      oversizedMaskedBinaryFrame(MAX_WEBSOCKET_PAYLOAD_BYTES + 1),
+    ]));
+    await Promise.race([
+      accepted,
+      new Promise((_, reject) => setTimeout(() => reject(new Error("accepted error timeout")), 8000)),
+    ]);
+    socket.destroy();
+  } else {
+    const client = new WebSocket(url);
+    client.on("error", () => {});
+    await waitForOpen(client);
+    const closed = waitForClose(client);
+    client.send(Buffer.alloc(MAX_WEBSOCKET_PAYLOAD_BYTES + 1));
+    clientCloseCode = await closed;
+    await Promise.race([
+      accepted,
+      new Promise((_, reject) => setTimeout(() => reject(new Error("accepted error timeout")), 8000)),
+    ]);
+  }
+
+  const healthy = new WebSocket(url);
+  healthy.on("error", () => {});
+  await waitForOpen(healthy);
+  nextConnectionOpened = true;
+  healthy.close();
+  await waitForClose(healthy);
+
+  const observation = { acceptedErrorCode, clientCloseCode, nextConnectionOpened };
+  process.stdout.write("PROBE_RESULT=" + JSON.stringify(observation) + "\\n");
+  process.stdout.write("probe-complete\\n");
+  process.exitCode = 0;
+} finally {
+  auth.resolve(false);
+  for (const client of wss.clients) client.terminate();
+  await new Promise((resolve) => wss.close(() => resolve()));
+  await new Promise((resolve) => httpServer.close(() => resolve()));
+}
+`;
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function listenOnLoopback(server: http.Server): Promise<AddressInfo> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("server has no address"));
+        return;
+      }
+      resolve(address);
+    });
+  });
+}
+
+function closeServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+function waitForOpen(ws: WebSocket, timeoutMs = 5_000): Promise<void> {
+  if (ws.readyState === WebSocket.OPEN) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("WebSocket open timed out")), timeoutMs);
+    ws.once("open", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+function waitForClose(ws: WebSocket, timeoutMs = 5_000): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("WebSocket close timed out")), timeoutMs);
+    ws.once("close", (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+}
+
+function connectClient(port: number): WebSocket {
+  const client = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+  client.on("error", () => {});
+  return client;
+}
+
+function websocketUpgradeRequest(port: number): Buffer {
+  const key = Buffer.from("1234567890abcdef").toString("base64");
+  return Buffer.from(
+    `GET /ws HTTP/1.1\r\n` +
+      `Host: 127.0.0.1:${port}\r\n` +
+      `Upgrade: websocket\r\n` +
+      `Connection: Upgrade\r\n` +
+      `Sec-WebSocket-Key: ${key}\r\n` +
+      `Sec-WebSocket-Version: 13\r\n` +
+      `\r\n`,
+  );
+}
+
+function oversizedMaskedBinaryFrame(payloadLength: number): Buffer {
+  const header = Buffer.alloc(2 + 8 + 4);
+  header[0] = 0x82;
+  header[1] = 0x80 | 127;
+  header.writeBigUInt64BE(BigInt(payloadLength), 2);
+  return Buffer.concat([header, Buffer.alloc(payloadLength)]);
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("waitUntil timed out");
+}
+
+function waitForExit(
+  child: ChildProcess,
+  timeoutMs: number,
+  output: () => string,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(
+        new Error(
+          `websocket probe did not exit within ${timeoutMs}ms\n--- child output ---\n${output()}`,
+        ),
+      );
+    }, timeoutMs);
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal });
+    });
+  });
+}
+
+type ProbeObservation = {
+  acceptedErrorCode?: string | null;
+  clientCloseCode?: number | null;
+  nextConnectionOpened?: boolean;
+};
+
+async function runWebsocketProbe(mode: string): Promise<{
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  observation: ProbeObservation;
+}> {
+  const configPath = await mkdtemp(path.join(tmpdir(), "nzbdav-1234-"));
+  let child: ChildProcess | undefined;
+  let stdout = "";
+  let stderr = "";
+  const output = () => `${stdout}\n${stderr}`;
+
+  const childEnv: NodeJS.ProcessEnv = {
+    PATH: process.env["PATH"],
+    HOME: process.env["HOME"],
+    TMPDIR: process.env["TMPDIR"],
+    NODE_ENV: "test",
+    NO_COLOR: "1",
+    SESSION_KEY: DUMMY_SESSION_KEY,
+    CONFIG_PATH: configPath,
+    BACKEND_URL: "http://127.0.0.1:9",
+    FRONTEND_BACKEND_API_KEY: DUMMY_API_KEY,
+    FRONTEND_ROOT,
+    WEBSOCKET_PROBE_MODE: mode,
+  };
+
+  try {
+    child = spawn(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "--eval", PROBE_SOURCE],
+      {
+        cwd: FRONTEND_ROOT,
+        env: childEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+
+    const result = await waitForExit(child, 25_000, output);
+    const resultLine = stdout.split("\n").find((line) => line.startsWith("PROBE_RESULT="));
+    const observation = resultLine
+      ? (JSON.parse(resultLine.slice("PROBE_RESULT=".length)) as ProbeObservation)
+      : {};
+    return {
+      exitCode: result.code,
+      signal: result.signal,
+      stdout,
+      stderr,
+      observation,
+    };
+  } finally {
+    if (child && child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+      await waitForExit(child, 5_000, output).catch(() => undefined);
+    }
+    child?.stdout?.destroy();
+    child?.stderr?.destroy();
+    await rm(configPath, { recursive: true, force: true });
+  }
+}
+
+function assertNoRepoSessionKey(): void {
+  expect(existsSync(path.join(REPO_ROOT, "session.key"))).toBe(false);
+  expect(existsSync(path.join(FRONTEND_ROOT, "session.key"))).toBe(false);
+  expect(existsSync(path.join(FRONTEND_ROOT, "server", "session.key"))).toBe(false);
+}
+
+async function startTestServer(
+  overrides: Partial<WebsocketServerDependencies> & {
+    authenticate: WebsocketServerDependencies["authenticate"];
+  },
+): Promise<{
+  httpServer: http.Server;
+  wss: WebSocketServer;
+  port: number;
+  reports: unknown[];
+}> {
+  const reports: unknown[] = [];
+  const httpServer = http.createServer();
+  const wss = new WebSocketServer({
+    server: httpServer,
+    path: "/ws",
+    maxPayload: MAX_WEBSOCKET_PAYLOAD_BYTES,
+  });
+  attachWebsocketServerErrorListener(wss, {
+    isOwned: () => false,
+    onUnexpectedError: vi.fn(),
+  });
+  initializeWebsocketServer(wss, {
+    authenticate: overrides.authenticate,
+    startBackendClient: overrides.startBackendClient ?? (() => {}),
+    reportBrowserSocketError:
+      overrides.reportBrowserSocketError ??
+      ((error, context) => {
+        reports.push(error);
+        reportBrowserSocketError(error, context);
+      }),
+    registerBrowserSocketErrorListener:
+      overrides.registerBrowserSocketErrorListener ?? attachBrowserWebsocketErrorListener,
+  });
+  const address = await listenOnLoopback(httpServer);
+  return { httpServer, wss, port: address.port, reports };
+}
+
+async function stopTestServer(httpServer: http.Server, wss: WebSocketServer): Promise<void> {
+  for (const client of wss.clients) {
+    client.terminate();
+  }
+  await new Promise<void>((resolve) => {
+    wss.close(() => resolve());
+  });
+  await closeServer(httpServer);
+}
+
+describe("oversized pre-auth websocket child probes", () => {
+  it("contains an oversized pre-auth frame and accepts a later connection", async () => {
+    const fixed = await runWebsocketProbe("oversized-pre-auth");
+
+    expect(fixed.exitCode).toBe(0);
+    expect(fixed.signal).toBeNull();
+    expect(fixed.stdout).toContain("WS_ERR_UNSUPPORTED_MESSAGE_LENGTH");
+    expect(fixed.stdout).toContain("probe-complete");
+    expect(fixed.observation.nextConnectionOpened).toBe(true);
+    expect(fixed.observation.acceptedErrorCode).toBe("WS_ERR_UNSUPPORTED_MESSAGE_LENGTH");
+    expect(fixed.observation.clientCloseCode).toBe(1009);
+    expect(fixed.stdout).not.toContain(DUMMY_API_KEY);
+    expect(fixed.stdout).not.toContain(DUMMY_SESSION_KEY);
+    assertNoRepoSessionKey();
+  }, 35_000);
+
+  it("exits nonzero when the production accepted-socket listener is removed", async () => {
+    const listenerRemoved = await runWebsocketProbe("oversized-pre-auth-listener-removed");
+
+    expect(listenerRemoved.exitCode).not.toBe(0);
+    expect(listenerRemoved.stdout).not.toContain("probe-complete");
+    assertNoRepoSessionKey();
+  }, 35_000);
+
+  it("contains a pipelined upgrade-head oversized frame", async () => {
+    const pipelined = await runWebsocketProbe("pipelined-oversized");
+
+    expect(pipelined.exitCode).toBe(0);
+    expect(pipelined.signal).toBeNull();
+    expect(pipelined.stdout).toContain("WS_ERR_UNSUPPORTED_MESSAGE_LENGTH");
+    expect(pipelined.stdout).toContain("probe-complete");
+    expect(pipelined.observation.nextConnectionOpened).toBe(true);
+    assertNoRepoSessionKey();
+  }, 35_000);
+});
+
+describe("accepted browser websocket error handling", () => {
+  const servers: Array<{ httpServer: http.Server; wss: WebSocketServer }> = [];
+  const clients: WebSocket[] = [];
+
+  beforeEach(() => {
+    resetClientErrorLogThrottleForTests();
+  });
+
+  afterEach(async () => {
+    resetClientErrorLogThrottleForTests();
+    for (const client of clients.splice(0)) {
+      client.terminate();
+    }
+    for (const server of servers.splice(0)) {
+      await stopTestServer(server.httpServer, server.wss);
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("cleans up an abrupt reset and still accepts a later connection", async () => {
+    const auth = deferred<boolean>();
+    const started = await startTestServer({ authenticate: () => auth.promise });
+    servers.push(started);
+
+    const client = connectClient(started.port);
+    clients.push(client);
+    const closed = waitForClose(client);
+    await waitForOpen(client);
+    client.terminate();
+    await closed;
+    await waitUntil(() => started.wss.clients.size === 0);
+
+    const healthy = connectClient(started.port);
+    clients.push(healthy);
+    await waitForOpen(healthy);
+    expect(healthy.readyState).toBe(WebSocket.OPEN);
+    auth.resolve(false);
+  }, 10_000);
+
+  it("keeps only the newest pre-auth subscription snapshot", async () => {
+    const auth = deferred<boolean>();
+    const captured: string[] = [];
+    const started = await startTestServer({
+      authenticate: () => auth.promise,
+      startBackendClient: (_subscriptions, _lastMessage, forwarder) => {
+        forwarder?.setBackendSocket({
+          readyState: WebSocket.OPEN,
+          send: (data: string) => {
+            captured.push(data);
+          },
+        } as unknown as WebSocket);
+      },
+    });
+    servers.push(started);
+
+    const client = connectClient(started.port);
+    clients.push(client);
+    await waitForOpen(client);
+    client.send(JSON.stringify({ ls: "state" }));
+    client.send(JSON.stringify({ cxs: "state" }));
+    client.send(JSON.stringify({ ls: "state", cxs: "state" }));
+    await waitUntil(() => client.bufferedAmount === 0);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    auth.resolve(true);
+    await waitUntil(() => captured.length > 0);
+
+    expect(captured).toHaveLength(1);
+    const parsed = JSON.parse(captured[0]!) as { sub: string[] };
+    expect(parsed.sub.sort()).toEqual(["cxs", "ls"]);
+  }, 10_000);
+
+  it("releases a pending snapshot if the socket closes before auth", async () => {
+    const auth = deferred<boolean>();
+    const captured: string[] = [];
+    const started = await startTestServer({
+      authenticate: () => auth.promise,
+      startBackendClient: (_subscriptions, _lastMessage, forwarder) => {
+        forwarder?.setBackendSocket({
+          readyState: WebSocket.OPEN,
+          send: (data: string) => {
+            captured.push(data);
+          },
+        } as unknown as WebSocket);
+      },
+    });
+    servers.push(started);
+
+    const client = connectClient(started.port);
+    clients.push(client);
+    await waitForOpen(client);
+    client.send(JSON.stringify({ ls: "state" }));
+    await waitUntil(() => client.bufferedAmount === 0);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const closed = waitForClose(client);
+    client.close();
+    await closed;
+    await waitUntil(() => started.wss.clients.size === 0);
+
+    auth.resolve(true);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(captured).toEqual([]);
+  }, 10_000);
+
+  it("constructs the browser WSS with the shared payload limit", async () => {
+    const auth = deferred<boolean>();
+    const started = await startTestServer({ authenticate: () => auth.promise });
+    servers.push(started);
+    expect(started.wss.options.maxPayload).toBe(MAX_WEBSOCKET_PAYLOAD_BYTES);
+    auth.resolve(false);
+  });
+
+  it("does not treat an exact-limit frame as oversized, but does reject one extra byte", async () => {
+    const auth = deferred<boolean>();
+    const started = await startTestServer({ authenticate: () => auth.promise });
+    servers.push(started);
+
+    const exact = connectClient(started.port);
+    clients.push(exact);
+    await waitForOpen(exact);
+    exact.send(Buffer.alloc(MAX_WEBSOCKET_PAYLOAD_BYTES));
+    await waitUntil(() => clientBufferedOrClosed(exact));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(
+      started.reports.some((error) => errorCode(error) === "WS_ERR_UNSUPPORTED_MESSAGE_LENGTH"),
+    ).toBe(false);
+
+    const oversized = connectClient(started.port);
+    clients.push(oversized);
+    const oversizedClosed = waitForClose(oversized);
+    await waitForOpen(oversized);
+    oversized.send(Buffer.alloc(MAX_WEBSOCKET_PAYLOAD_BYTES + 1));
+    const closeCode = await oversizedClosed;
+    await waitUntil(() =>
+      started.reports.some((error) => errorCode(error) === "WS_ERR_UNSUPPORTED_MESSAGE_LENGTH"),
+    );
+    expect(closeCode).toBe(1009);
+    auth.resolve(false);
+  }, 10_000);
+
+  it("attaches one error listener per accepted socket without growing it", async () => {
+    const auth = deferred<boolean>();
+    const accepted: WebSocket[] = [];
+    const started = await startTestServer({ authenticate: () => auth.promise });
+    servers.push(started);
+    started.wss.on("connection", (socket) => {
+      accepted.push(socket);
+    });
+
+    const client = connectClient(started.port);
+    clients.push(client);
+    await waitForOpen(client);
+    await waitUntil(() => accepted.length === 1);
+    expect(accepted[0]!.listenerCount("error")).toBe(1);
+
+    auth.resolve(true);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    client.send(JSON.stringify({ ls: "state" }));
+    client.send(JSON.stringify({ cxs: "state" }));
+    await waitUntil(() => client.bufferedAmount === 0);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(accepted[0]!.listenerCount("error")).toBe(1);
+
+    const closed = waitForClose(client);
+    client.close();
+    await closed;
+    await waitUntil(() => started.wss.clients.size === 0);
+
+    const next = connectClient(started.port);
+    clients.push(next);
+    await waitForOpen(next);
+    await waitUntil(() => accepted.length === 2);
+    expect(accepted[1]!.listenerCount("error")).toBe(1);
+    expect(accepted[0]!.listenerCount("error")).toBe(1);
+    expect(started.wss.clients.has(accepted[0]!)).toBe(false);
+    expect(started.wss.clients.has(accepted[1]!)).toBe(true);
+  }, 10_000);
+
+  it("contains a pipelined upgrade plus oversized first frame in-process", async () => {
+    const auth = deferred<boolean>();
+    const started = await startTestServer({ authenticate: () => auth.promise });
+    servers.push(started);
+
+    const socket = net.connect(started.port, "127.0.0.1");
+    socket.on("error", () => {});
+    await new Promise<void>((resolve, reject) => {
+      socket.once("connect", () => resolve());
+      socket.once("error", reject);
+    });
+    socket.write(
+      Buffer.concat([
+        websocketUpgradeRequest(started.port),
+        oversizedMaskedBinaryFrame(MAX_WEBSOCKET_PAYLOAD_BYTES + 1),
+      ]),
+    );
+
+    await waitUntil(() =>
+      started.reports.some((error) => errorCode(error) === "WS_ERR_UNSUPPORTED_MESSAGE_LENGTH"),
+    );
+
+    const healthy = connectClient(started.port);
+    clients.push(healthy);
+    await waitForOpen(healthy);
+    socket.destroy();
+    auth.resolve(false);
+  }, 10_000);
+});
+
+function clientBufferedOrClosed(client: WebSocket): boolean {
+  return client.bufferedAmount === 0 || client.readyState === WebSocket.CLOSED;
+}

--- a/frontend/server/websocket.server.ts
+++ b/frontend/server/websocket.server.ts
@@ -3,6 +3,9 @@ import { Buffer } from "node:buffer";
 import { isAuthenticated } from "../app/auth/authentication.server";
 import type { IncomingMessage } from "http";
 import { logger } from "./logger";
+import { attachBrowserWebsocketErrorListener, reportBrowserSocketError } from "./websocket-policy";
+
+export { MAX_WEBSOCKET_PAYLOAD_BYTES } from "./websocket-policy";
 
 // ws types MessageEvent.data as any; decode explicitly.
 function messageEventDataToString(data: unknown): string {
@@ -13,7 +16,6 @@ function messageEventDataToString(data: unknown): string {
   return String(data);
 }
 
-export const MAX_WEBSOCKET_PAYLOAD_BYTES = 64 * 1024;
 export const MAX_TOPICS_PER_SOCKET = 100;
 export const WEBSOCKET_HEARTBEAT_INTERVAL_MS = 30_000;
 export const MAX_CLIENT_BUFFERED_AMOUNT = 1024 * 1024;
@@ -120,7 +122,18 @@ export function nextBackendReconnectDelayMs(
   return Math.floor(random() * (exp + 1));
 }
 
-function initializeWebsocketServer(wss: WebSocketServer) {
+export type WebsocketServerDependencies = {
+  authenticate: typeof isAuthenticated;
+  startBackendClient: typeof initializeWebsocketClient;
+  reportBrowserSocketError: typeof reportBrowserSocketError;
+  registerBrowserSocketErrorListener: typeof attachBrowserWebsocketErrorListener;
+};
+
+export function initializeWebsocketServer(
+  wss: WebSocketServer,
+  dependencies?: WebsocketServerDependencies,
+) {
+  const resolved = dependencies ?? defaultDependencies;
   // keep track of socket subscriptions
   const websockets = new Map<TrackedSocket, Record<string, TopicKind>>();
   const subscriptions = new Map<string, Set<TrackedSocket>>();
@@ -130,7 +143,7 @@ function initializeWebsocketServer(wss: WebSocketServer) {
   // aggregate changes upstream to the backend so it can skip serialization
   // for topics with zero listeners.
   const upstreamSubscriptions = new UpstreamSubscriptionForwarder(subscriptions);
-  initializeWebsocketClient(subscriptions, lastMessage, upstreamSubscriptions);
+  resolved.startBackendClient(subscriptions, lastMessage, upstreamSubscriptions);
 
   const heartbeat = setInterval(() => {
     for (const client of wss.clients) {
@@ -153,7 +166,15 @@ function initializeWebsocketServer(wss: WebSocketServer) {
     let authenticated = false;
     let closed = false;
     const remote = request.socket.remoteAddress ?? "unknown IP";
-    const pendingMessages: WebSocket.MessageEvent[] = [];
+    let pendingMessage: WebSocket.MessageEvent | null = null;
+    resolved.registerBrowserSocketErrorListener(
+      ws,
+      {
+        remote,
+        isAuthenticated: () => authenticated,
+      },
+      resolved.reportBrowserSocketError,
+    );
     ws.isAlive = true;
     ws.on("pong", () => {
       ws.isAlive = true;
@@ -193,7 +214,7 @@ function initializeWebsocketServer(wss: WebSocketServer) {
 
     ws.onmessage = (event: WebSocket.MessageEvent) => {
       if (!authenticated) {
-        pendingMessages.push(event);
+        pendingMessage = event;
         return;
       }
       applySubscription(event);
@@ -201,7 +222,7 @@ function initializeWebsocketServer(wss: WebSocketServer) {
 
     ws.onclose = (event: WebSocket.CloseEvent) => {
       closed = true;
-      pendingMessages.length = 0;
+      pendingMessage = null;
       const topics = websockets.get(ws);
       if (topics) {
         websockets.delete(ws);
@@ -220,20 +241,23 @@ function initializeWebsocketServer(wss: WebSocketServer) {
 
     void (async () => {
       try {
-        if (!(await isAuthenticated(request))) {
+        if (!(await resolved.authenticate(request))) {
           logger.warn(`Rejected unauthenticated websocket connection from ${remote}`);
-          ws.close(1008, "Unauthorized");
+          if (ws.readyState === WebSocket.OPEN) ws.close(1008, "Unauthorized");
           return;
         }
-        if (closed) return;
+        if (closed || ws.readyState !== WebSocket.OPEN) {
+          pendingMessage = null;
+          return;
+        }
         authenticated = true;
         logger.info(`Browser websocket connected from ${remote}`);
-        for (const event of pendingMessages.splice(0)) {
-          applySubscription(event);
-        }
+        const message = pendingMessage;
+        pendingMessage = null;
+        if (message) applySubscription(message);
       } catch (error) {
         logger.error("Error authenticating websocket session", error);
-        ws.close(1011, "Internal server error");
+        if (ws.readyState === WebSocket.OPEN) ws.close(1011, "Internal server error");
       }
     })();
   });
@@ -356,6 +380,13 @@ export function initializeWebsocketClient(
 
   connect();
 }
+
+const defaultDependencies: WebsocketServerDependencies = {
+  authenticate: isAuthenticated,
+  startBackendClient: initializeWebsocketClient,
+  reportBrowserSocketError,
+  registerBrowserSocketErrorListener: attachBrowserWebsocketErrorListener,
+};
 
 /**
  * Forwards the aggregate set of browser-subscribed topics upstream to the backend

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -8,6 +8,7 @@
     "server/compression-filter.ts",
     "server/request-log-throttle.ts",
     "server/startup-grace.ts",
+    "server/websocket-policy.ts",
     "server/websocket-upgrade-guard.ts",
     "server/security-headers.ts",
     "app/utils/url-base.ts",

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "include": [
     "server.ts",
+    "server/http-server-lifecycle.ts",
     "server/logger.ts",
     "server/proxy-path.ts",
     "server/compression-filter.ts",


### PR DESCRIPTION
## Summary
- Fixes #1234: oversized or malformed browser WebSocket frames no longer take down the frontend Node process. Accepted sockets now have an `error` listener, expected peer/transport failures are throttled warnings (no stack), and pre-auth traffic keeps only the latest subscription snapshot.
- Stacked on #1276 (issue 1246, branch `fix/frontend-listen-error-handler`). This PR should not be merged until #1276 is merged; rebase if #1276 changes. It keeps 1246's single WSS `error` listener and does not add a second one.
- Issues 1244 (API key parser) and 1245 (global rejection policy) were intentionally kept out of scope. Tests supply dummy `FRONTEND_BACKEND_API_KEY` / `BACKEND_URL` and a no-op `startBackendClient` seam so probes never start the real backend relay.

## Test plan
- [ ] Oversized pre-auth child probe exits 0, reports `WS_ERR_UNSUPPORTED_MESSAGE_LENGTH`, prints `probe-complete`, and accepts a later healthy connection
- [ ] Negative control with the production accepted-socket listener removed exits nonzero and never prints `probe-complete`
- [ ] Pipelined HTTP upgrade plus oversized first frame is contained; a later connection still opens
- [ ] Abrupt client `terminate()` cleans up once and a later connection succeeds
- [ ] Unowned WSS errors are fatal exactly once; an HTTP-owned Error forwarded by `ws` is not logged or fatalized again
- [ ] Expected oversized/transport logs are warnings without the Error object; unexpected errors pass the Error to `logger.error`
- [ ] Pre-auth retention applies only the newest full subscription snapshot; close before auth applies nothing
- [ ] Confirm 1244/1245 behavior is unchanged (no API-key startup validation, no new process-wide rejection handlers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WebSocket error handling so unexpected failures no longer disrupt healthy connections.
  - Improved cleanup and authentication handling for disconnected or unauthorized connections.
  - Limited pending pre-authentication messages to improve connection stability.
  - Enforced a consistent 64 KiB payload limit for WebSocket messages.
  - Reduced repetitive protocol and transport warnings while preserving useful diagnostics.
  - Prevented sensitive credentials and session information from appearing in error reports.
  - Improved connection recovery after oversized messages and abrupt disconnects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->