### PR TITLE
fix(health): repair Arr-linked files after SAB history cleanup

### DIFF
--- a/backend/Api/SabControllers/AddFile/AddFileRequest.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileRequest.cs
@@ -34,6 +34,8 @@ public class AddFileRequest()
     public string? IndexerName { get; init; }
     public string? ContentGroupKey { get; init; }
     public CancellationToken CancellationToken { get; init; }
+    internal NzbSubmissionOrigin Origin { get; init; }
+    internal Guid? ArrDownloadId { get; init; }
 
     public static Task<AddFileRequest> New(HttpContext context, ConfigManager configManager)
     {
@@ -66,7 +68,8 @@ public class AddFileRequest()
                        ?? configManager.GetManualUploadCategory(),
             Priority = priority,
             PostProcessing = postProcessing,
-            CancellationToken = context.RequestAborted
+            CancellationToken = context.RequestAborted,
+            Origin = NzbSubmissionOrigin.ExternalSabAdd,
         });
     }
 
@@ -83,6 +86,8 @@ public class AddFileRequest()
         IndexerName = IndexerName,
         ContentGroupKey = ContentGroupKey,
         CancellationToken = CancellationToken,
+        Origin = Origin,
+        ArrDownloadId = ArrDownloadId,
     };
 
     /// <summary>

--- a/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
@@ -4,6 +4,7 @@ using NzbWebDAV.Api.SabControllers.AddFile;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Queue;
 using NzbWebDAV.Services;
 using NzbWebDAV.Utils;
 using System.Net;
@@ -110,6 +111,7 @@ public class AddUrlRequest() : AddFileRequest
             PostProcessing = MapPostProcessingOption(context.GetRequestParam("pp")),
             CancellationToken = fetchDeadline.Token,
             FetchDeadlineSource = fetchDeadline,
+            Origin = NzbSubmissionOrigin.ExternalSabAdd,
         };
     }
 

--- a/backend/Api/SabControllers/RetryHistory/RetryHistoryController.cs
+++ b/backend/Api/SabControllers/RetryHistory/RetryHistoryController.cs
@@ -86,6 +86,8 @@ public class RetryHistoryController(
             IndexerName = historyItem.IndexerName,
             ContentGroupKey = historyItem.ContentGroupKey,
             CancellationToken = ct,
+            Origin = NzbSubmissionOrigin.HistoryRetry,
+            ArrDownloadId = historyItem.ArrDownloadId,
         };
 
         var addFileController = new AddFileController(

--- a/backend/Clients/RadarrSonarr/ArrClient.cs
+++ b/backend/Clients/RadarrSonarr/ArrClient.cs
@@ -37,6 +37,13 @@ public class ArrClient(string host, string apiKey)
         CancellationToken ct = default) =>
         throw new InvalidOperationException();
 
+    public virtual Task<ArrRepairOutcome> RemoveAndBlocklist(
+        ArrMediaFileMatch mediaFile,
+        Guid downloadId,
+        Func<IReadOnlyList<string>, bool>? shouldRequestSearch = null,
+        CancellationToken ct = default) =>
+        throw new InvalidOperationException();
+
     public virtual Task<ArrMediaFileMatch?> FindMediaFileAsync(
         string symlinkOrStrmPath,
         CancellationToken ct = default) =>
@@ -65,6 +72,41 @@ public class ArrClient(string host, string apiKey)
 
     public virtual Task<ArrHistory> GetImportHistoryAsync(int page, int pageSize, CancellationToken ct = default) =>
         Get<ArrHistory>($"/history?eventType=3&page={page}&pageSize={pageSize}&sortKey=date&sortDirection=descending", ct);
+
+    public virtual Task<ArrHistory> GetMediaImportHistoryAsync(
+        ArrMediaFileMatch mediaFile,
+        int page,
+        int pageSize,
+        CancellationToken ct = default) =>
+        throw new InvalidOperationException();
+
+    internal const int MediaImportHistoryPageSize = 50;
+    internal const int MediaImportHistoryMaxPages = 10;
+
+    internal sealed record ArrImportHistoryCollection(
+        IReadOnlyList<ArrHistoryRecord> Records,
+        bool Exhausted);
+
+    internal async Task<ArrImportHistoryCollection> CollectMediaImportHistoryAsync(
+        ArrMediaFileMatch mediaFile,
+        CancellationToken ct = default)
+    {
+        var records = new List<ArrHistoryRecord>();
+        for (var page = 1; page <= MediaImportHistoryMaxPages; page++)
+        {
+            var history = await GetMediaImportHistoryAsync(
+                    mediaFile, page, MediaImportHistoryPageSize, ct)
+                .ConfigureAwait(false);
+            var batch = history.Records;
+            records.AddRange(batch);
+            if (batch.Count < MediaImportHistoryPageSize)
+                return new ArrImportHistoryCollection(records, Exhausted: true);
+            if (history.TotalRecords > 0 && records.Count >= history.TotalRecords)
+                return new ArrImportHistoryCollection(records, Exhausted: true);
+        }
+
+        return new ArrImportHistoryCollection(records, Exhausted: false);
+    }
 
     public async Task<int> GetQueueCountAsync(CancellationToken ct = default) =>
         (await Get<ArrQueue<ArrQueueRecord>>($"/queue?pageSize=1", ct).ConfigureAwait(false)).TotalRecords;

--- a/backend/Clients/RadarrSonarr/ArrClient.cs
+++ b/backend/Clients/RadarrSonarr/ArrClient.cs
@@ -99,10 +99,17 @@ public class ArrClient(string host, string apiKey)
                 .ConfigureAwait(false);
             var batch = history.Records;
             records.AddRange(batch);
-            if (batch.Count < MediaImportHistoryPageSize)
-                return new ArrImportHistoryCollection(records, Exhausted: true);
             if (history.TotalRecords > 0 && records.Count >= history.TotalRecords)
                 return new ArrImportHistoryCollection(records, Exhausted: true);
+            if (batch.Count < MediaImportHistoryPageSize)
+            {
+                // A short page is complete only when Arr did not report a larger total.
+                // Otherwise a truncated page would look exhausted and Unique recovery
+                // could blocklist from an incomplete history set.
+                return new ArrImportHistoryCollection(
+                    records,
+                    Exhausted: history.TotalRecords <= 0);
+            }
         }
 
         return new ArrImportHistoryCollection(records, Exhausted: false);

--- a/backend/Clients/RadarrSonarr/ArrDownloadIdResolver.cs
+++ b/backend/Clients/RadarrSonarr/ArrDownloadIdResolver.cs
@@ -1,0 +1,50 @@
+using System.Globalization;
+using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
+
+namespace NzbWebDAV.Clients.RadarrSonarr;
+
+internal enum ArrDownloadIdResolutionKind
+{
+    NotFound,
+    Unique,
+    Ambiguous,
+}
+
+internal sealed record ArrDownloadIdResolution(
+    ArrDownloadIdResolutionKind Kind,
+    Guid? DownloadId = null);
+
+internal static class ArrDownloadIdResolver
+{
+    public static ArrDownloadIdResolution Resolve(
+        IEnumerable<ArrHistoryRecord> records,
+        ArrMediaFileMatch mediaFile,
+        string organizedPath)
+    {
+        var candidates = records
+            .Select(record => (
+                HasFileId: int.TryParse(
+                    record.Data.FileId,
+                    NumberStyles.None,
+                    CultureInfo.InvariantCulture,
+                    out var fileId),
+                FileId: fileId,
+                HasDownloadId: Guid.TryParse(record.DownloadId, out var downloadId),
+                DownloadId: downloadId,
+                ImportedPath: record.Data.ImportedPath))
+            .Where(record => record.HasFileId
+                && record.FileId == mediaFile.FileId
+                && string.Equals(record.ImportedPath, organizedPath, StringComparison.Ordinal)
+                && record.HasDownloadId)
+            .Select(record => record.DownloadId)
+            .Distinct()
+            .ToArray();
+
+        return candidates.Length switch
+        {
+            1 => new ArrDownloadIdResolution(ArrDownloadIdResolutionKind.Unique, candidates[0]),
+            > 1 => new ArrDownloadIdResolution(ArrDownloadIdResolutionKind.Ambiguous),
+            _ => new ArrDownloadIdResolution(ArrDownloadIdResolutionKind.NotFound),
+        };
+    }
+}

--- a/backend/Clients/RadarrSonarr/ArrDownloadIdResolver.cs
+++ b/backend/Clients/RadarrSonarr/ArrDownloadIdResolver.cs
@@ -24,14 +24,14 @@ internal static class ArrDownloadIdResolver
         var candidates = records
             .Select(record => (
                 HasFileId: int.TryParse(
-                    record.Data.FileId,
+                    record.Data?.FileId,
                     NumberStyles.None,
                     CultureInfo.InvariantCulture,
                     out var fileId),
                 FileId: fileId,
                 HasDownloadId: Guid.TryParse(record.DownloadId, out var downloadId),
                 DownloadId: downloadId,
-                ImportedPath: record.Data.ImportedPath))
+                ImportedPath: record.Data?.ImportedPath))
             .Where(record => record.HasFileId
                 && record.FileId == mediaFile.FileId
                 && string.Equals(record.ImportedPath, organizedPath, StringComparison.Ordinal)

--- a/backend/Clients/RadarrSonarr/BaseModels/ArrHistory.cs
+++ b/backend/Clients/RadarrSonarr/BaseModels/ArrHistory.cs
@@ -31,7 +31,7 @@ public class ArrHistoryRecord
     public string? SourceTitle { get; set; }
 
     [JsonPropertyName("data")]
-    public ArrHistoryData Data { get; set; } = new();
+    public ArrHistoryData? Data { get; set; } = new();
 }
 
 public sealed class ArrHistoryData

--- a/backend/Clients/RadarrSonarr/BaseModels/ArrHistory.cs
+++ b/backend/Clients/RadarrSonarr/BaseModels/ArrHistory.cs
@@ -7,6 +7,9 @@ public class ArrHistory
 {
     [JsonPropertyName("records")]
     public List<ArrHistoryRecord> Records { get; set; } = [];
+
+    [JsonPropertyName("totalRecords")]
+    public int TotalRecords { get; set; }
 }
 
 public class ArrHistoryRecord
@@ -26,6 +29,18 @@ public class ArrHistoryRecord
 
     [JsonPropertyName("sourceTitle")]
     public string? SourceTitle { get; set; }
+
+    [JsonPropertyName("data")]
+    public ArrHistoryData Data { get; set; } = new();
+}
+
+public sealed class ArrHistoryData
+{
+    [JsonPropertyName("fileId")]
+    public string? FileId { get; set; }
+
+    [JsonPropertyName("importedPath")]
+    public string? ImportedPath { get; set; }
 }
 
 public sealed class ArrEventTypeJsonConverter : JsonConverter<int>

--- a/backend/Clients/RadarrSonarr/RadarrClient.cs
+++ b/backend/Clients/RadarrSonarr/RadarrClient.cs
@@ -108,33 +108,47 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
         Func<IReadOnlyList<string>, bool>? shouldRequestSearch = null,
         CancellationToken ct = default)
     {
-        var movieIds = await GetMovieFileIds(symlinkOrStrmPath, ct).ConfigureAwait(false);
-        if (movieIds == null) return ArrRepairOutcome.MediaItemNotFound;
+        var match = await FindMediaFileAsync(symlinkOrStrmPath, ct).ConfigureAwait(false);
+        if (match is null) return ArrRepairOutcome.MediaItemNotFound;
+        return await RemoveAndBlocklist(match, downloadId, shouldRequestSearch, ct)
+            .ConfigureAwait(false);
+    }
+
+    public override async Task<ArrRepairOutcome> RemoveAndBlocklist(
+        ArrMediaFileMatch mediaFile,
+        Guid downloadId,
+        Func<IReadOnlyList<string>, bool>? shouldRequestSearch = null,
+        CancellationToken ct = default)
+    {
+        if (mediaFile.Kind != ArrMediaKind.Movie || mediaFile.MediaIds.Count != 1)
+            throw new ArgumentException("Radarr repair requires one movie match.", nameof(mediaFile));
 
         var historyId = await GetHistoryRecordId(downloadId, ct).ConfigureAwait(false);
         if (historyId == null) return ArrRepairOutcome.DownloadHistoryNotFound;
 
-        if (!Is2xx(await DeleteMovieFile(movieIds.MovieFileId, ct).ConfigureAwait(false)))
-            throw new InvalidOperationException($"Failed to delete movie file `{symlinkOrStrmPath}` from radarr instance `{Host}`.");
+        var movieId = mediaFile.MediaIds[0];
+        if (!Is2xx(await DeleteMovieFile(mediaFile.FileId, ct).ConfigureAwait(false)))
+            throw new InvalidOperationException(
+                $"Failed to delete movie file {mediaFile.FileId} from radarr instance `{Host}`.");
 
         await MarkHistoryFailed(historyId.Value, ct).ConfigureAwait(false);
 
-        if (shouldRequestSearch is not null && !shouldRequestSearch([$"movie:{movieIds.MovieId}"]))
+        if (shouldRequestSearch is not null && !shouldRequestSearch([$"movie:{movieId}"]))
         {
             Log.Warning(
                 "Radarr repair on {Host}: automatic replacement-search limit reached for movie {MovieId}; " +
                 "the file was removed and its download blocklisted without starting another search.",
                 Host,
-                movieIds.MovieId);
+                movieId);
             return ArrRepairOutcome.RemoveAndBlocklistSucceededSearchWithheld;
         }
 
         try
         {
             await ExecuteWithTransientRetryAsync(
-                ct => CommandAsync(
-                    new { name = "MoviesSearch", movieIds = new[] { movieIds.MovieId } },
-                    ct),
+                token => CommandAsync(
+                    new { name = "MoviesSearch", movieIds = new[] { movieId } },
+                    token),
                 ct).ConfigureAwait(false);
         }
         catch (OperationCanceledException) { throw; }
@@ -144,10 +158,25 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
                 ex,
                 "Radarr repair on {Host}: failed to request MoviesSearch for movie {MovieId}",
                 Host,
-                movieIds.MovieId);
+                movieId);
         }
 
         return ArrRepairOutcome.RemoveAndBlocklistSucceeded;
+    }
+
+    public override Task<ArrHistory> GetMediaImportHistoryAsync(
+        ArrMediaFileMatch mediaFile,
+        int page,
+        int pageSize,
+        CancellationToken ct = default)
+    {
+        if (mediaFile.Kind != ArrMediaKind.Movie || mediaFile.MediaIds.Count == 0)
+            return Task.FromResult(new ArrHistory());
+
+        var movieId = mediaFile.MediaIds[0];
+        return Get<ArrHistory>(
+            $"/history?movieId={movieId}&eventType=3&page={page}&pageSize={pageSize}&sortKey=date&sortDirection=descending",
+            ct);
     }
 
     private sealed record MovieFileIds(int MovieFileId, int MovieId);

--- a/backend/Clients/RadarrSonarr/SonarrClient.cs
+++ b/backend/Clients/RadarrSonarr/SonarrClient.cs
@@ -130,32 +130,29 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
         Func<IReadOnlyList<string>, bool>? shouldRequestSearch = null,
         CancellationToken ct = default)
     {
-        var episodeFileId = await GetEpisodeFileId(symlinkOrStrmPath, ct).ConfigureAwait(false);
-        if (episodeFileId == null) return ArrRepairOutcome.MediaItemNotFound;
+        var match = await FindMediaFileAsync(symlinkOrStrmPath, ct).ConfigureAwait(false);
+        if (match is null) return ArrRepairOutcome.MediaItemNotFound;
+        return await RemoveAndBlocklist(match, downloadId, shouldRequestSearch, ct)
+            .ConfigureAwait(false);
+    }
+
+    public override async Task<ArrRepairOutcome> RemoveAndBlocklist(
+        ArrMediaFileMatch mediaFile,
+        Guid downloadId,
+        Func<IReadOnlyList<string>, bool>? shouldRequestSearch = null,
+        CancellationToken ct = default)
+    {
+        if (mediaFile.Kind != ArrMediaKind.Episode)
+            throw new ArgumentException("Sonarr repair requires an episode match.", nameof(mediaFile));
 
         var historyId = await GetHistoryRecordId(downloadId, ct).ConfigureAwait(false);
         if (historyId == null) return ArrRepairOutcome.DownloadHistoryNotFound;
 
-        List<int> episodeIds;
-        try
-        {
-            episodeIds = (await GetEpisodesFromEpisodeFileId(episodeFileId.Value, ct).ConfigureAwait(false))
-                .Select(episode => episode.Id)
-                .ToList();
-        }
-        catch (OperationCanceledException) { throw; }
-        catch (Exception ex)
-        {
-            Log.Warning(
-                ex,
-                "Sonarr repair on {Host}: could not resolve episodes for episode file {EpisodeFileId}; repair will continue without explicit search",
-                Host,
-                episodeFileId.Value);
-            episodeIds = [];
-        }
+        var episodeIds = mediaFile.MediaIds.ToList();
 
-        if (!Is2xx(await DeleteEpisodeFile(episodeFileId.Value, ct).ConfigureAwait(false)))
-            throw new InvalidOperationException($"Failed to delete episode file `{symlinkOrStrmPath}` from sonarr instance `{Host}`.");
+        if (!Is2xx(await DeleteEpisodeFile(mediaFile.FileId, ct).ConfigureAwait(false)))
+            throw new InvalidOperationException(
+                $"Failed to delete episode file {mediaFile.FileId} from sonarr instance `{Host}`.");
 
         await MarkHistoryFailed(historyId.Value, ct).ConfigureAwait(false);
 
@@ -166,7 +163,7 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
                 Log.Warning(
                     "Sonarr repair on {Host}: no episodes linked to episode file {EpisodeFileId}; skipping EpisodeSearch",
                     Host,
-                    episodeFileId.Value);
+                    mediaFile.FileId);
             }
             else if (shouldRequestSearch is not null &&
                      !shouldRequestSearch(episodeIds.Select(id => $"episode:{id}").ToArray()))
@@ -175,13 +172,13 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
                     "Sonarr repair on {Host}: automatic replacement-search limit reached for episode file {EpisodeFileId}; " +
                     "the file was removed and its download blocklisted without starting another search.",
                     Host,
-                    episodeFileId.Value);
+                    mediaFile.FileId);
                 return ArrRepairOutcome.RemoveAndBlocklistSucceededSearchWithheld;
             }
             else
             {
                 await ExecuteWithTransientRetryAsync(
-                    ct => CommandAsync(new { name = "EpisodeSearch", episodeIds }, ct),
+                    token => CommandAsync(new { name = "EpisodeSearch", episodeIds }, token),
                     ct).ConfigureAwait(false);
             }
         }
@@ -192,10 +189,25 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
                 ex,
                 "Sonarr repair on {Host}: failed to request EpisodeSearch for episode file {EpisodeFileId}",
                 Host,
-                episodeFileId.Value);
+                mediaFile.FileId);
         }
 
         return ArrRepairOutcome.RemoveAndBlocklistSucceeded;
+    }
+
+    public override Task<ArrHistory> GetMediaImportHistoryAsync(
+        ArrMediaFileMatch mediaFile,
+        int page,
+        int pageSize,
+        CancellationToken ct = default)
+    {
+        if (mediaFile.Kind != ArrMediaKind.Episode || mediaFile.MediaIds.Count == 0)
+            return Task.FromResult(new ArrHistory());
+
+        var episodeId = mediaFile.MediaIds[0];
+        return Get<ArrHistory>(
+            $"/history?episodeId={episodeId}&eventType=3&page={page}&pageSize={pageSize}&sortKey=date&sortDirection=descending",
+            ct);
     }
 
     private async Task<int?> GetEpisodeFileId(string symlinkOrStrmPath, CancellationToken ct)

--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -359,6 +359,10 @@ public class DavDatabaseContext : DbContext
                 .ValueGeneratedNever()
                 .IsRequired(false);
 
+            e.Property(i => i.ArrDownloadId)
+                .ValueGeneratedNever()
+                .IsRequired(false);
+
             e.HasIndex(i => new { i.ParentId, i.Name })
                 .IsUnique();
 
@@ -518,6 +522,10 @@ public class DavDatabaseContext : DbContext
 
             e.HasIndex(i => i.ContentGroupKey)
                 .IsUnique(false);
+
+            e.Property(i => i.ArrDownloadId)
+                .ValueGeneratedNever()
+                .IsRequired(false);
         });
 
         // HistoryItem
@@ -559,6 +567,9 @@ public class DavDatabaseContext : DbContext
                 .IsRequired(false);
 
             e.Property(i => i.NzbBlobId)
+                .IsRequired(false);
+
+            e.Property(i => i.ArrDownloadId)
                 .IsRequired(false);
 
             e.Property(i => i.IndexerName)

--- a/backend/Database/MigrationHelpers/GuidTextCasingSql.cs
+++ b/backend/Database/MigrationHelpers/GuidTextCasingSql.cs
@@ -15,8 +15,10 @@ internal static class GuidTextCasingSql
     internal const string MigrationId = "20260820160000_Normalize-Guid-Text-Casing";
 
     /// <summary>
-    /// Every Guid-typed TEXT column on the SQLite <c>DavDatabaseContext</c> snapshot.
-    /// 18 tables / 27 columns. PostgreSQL uses native uuid and must not run this rewrite.
+    /// Guid-typed TEXT columns present on the SQLite <c>DavDatabaseContext</c> snapshot
+    /// at the <c>Normalize-Guid-Text-Casing</c> migration, not the current schema.
+    /// 18 tables / 27 columns. Do not append later columns: that historical migration
+    /// runs before they exist. PostgreSQL uses native uuid and must not run this rewrite.
     /// </summary>
     internal static readonly (string Table, string[] Columns)[] GuidColumns =
     [

--- a/backend/Database/Migrations/20260830120000_Add-Arr-Download-Provenance.cs
+++ b/backend/Database/Migrations/20260830120000_Add-Arr-Download-Provenance.cs
@@ -1,0 +1,52 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.Migrations;
+
+/// <summary>
+/// Durable Arr grab provenance independent of SAB history rows and NZB blob keys.
+/// Additive and nullable; existing rows stay null. Back up /config before upgrading.
+/// </summary>
+[DbContext(typeof(DavDatabaseContext))]
+[Migration("20260830120000_Add-Arr-Download-Provenance")]
+public partial class AddArrDownloadProvenance : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<Guid>(
+            name: "ArrDownloadId",
+            table: "QueueItems",
+            type: "TEXT",
+            nullable: true);
+
+        migrationBuilder.AddColumn<Guid>(
+            name: "ArrDownloadId",
+            table: "HistoryItems",
+            type: "TEXT",
+            nullable: true);
+
+        migrationBuilder.AddColumn<Guid>(
+            name: "ArrDownloadId",
+            table: "DavItems",
+            type: "TEXT",
+            nullable: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "ArrDownloadId",
+            table: "DavItems");
+
+        migrationBuilder.DropColumn(
+            name: "ArrDownloadId",
+            table: "HistoryItems");
+
+        migrationBuilder.DropColumn(
+            name: "ArrDownloadId",
+            table: "QueueItems");
+    }
+}

--- a/backend/Database/Migrations/DavDatabaseContextModelSnapshot.cs
+++ b/backend/Database/Migrations/DavDatabaseContextModelSnapshot.cs
@@ -83,6 +83,9 @@ namespace NzbWebDAV.Database.Migrations
                     b.Property<Guid>("Id")
                         .HasColumnType("TEXT");
 
+                    b.Property<Guid?>("ArrDownloadId")
+                        .HasColumnType("TEXT");
+
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("TEXT");
 
@@ -300,6 +303,9 @@ namespace NzbWebDAV.Database.Migrations
             modelBuilder.Entity("NzbWebDAV.Database.Models.HistoryItem", b =>
                 {
                     b.Property<Guid>("Id")
+                        .HasColumnType("TEXT");
+
+                    b.Property<Guid?>("ArrDownloadId")
                         .HasColumnType("TEXT");
 
                     b.Property<string>("Category")
@@ -554,6 +560,9 @@ namespace NzbWebDAV.Database.Migrations
             modelBuilder.Entity("NzbWebDAV.Database.Models.QueueItem", b =>
                 {
                     b.Property<Guid>("Id")
+                        .HasColumnType("TEXT");
+
+                    b.Property<Guid?>("ArrDownloadId")
                         .HasColumnType("TEXT");
 
                     b.Property<string>("Category")

--- a/backend/Database/Models/DavItem.cs
+++ b/backend/Database/Models/DavItem.cs
@@ -23,6 +23,14 @@ public class DavItem
     public Guid? HistoryItemId { get; set; }
     public Guid? FileBlobId { get; set; }
     public Guid? NzbBlobId { get; set; }
+
+    /// <summary>
+    /// The SAB <c>nzo_id</c> known to represent this release in an external Arr instance.
+    /// This is provenance used for validated Arr history lookup. It is not a blob key,
+    /// a foreign key to InfiniDysk history, or proof by itself that an Arr instance
+    /// still owns the media.
+    /// </summary>
+    public Guid? ArrDownloadId { get; set; }
     public string? GeneratedStrmOutputRoot { get; set; }
     public string? GeneratedStrmPath { get; set; }
     public string? GeneratedStrmTarget { get; set; }
@@ -44,7 +52,8 @@ public class DavItem
         DateTimeOffset? lastHealthCheck,
         Guid? historyItemId,
         Guid? fileBlobId,
-        Guid? nzbBlobId = null
+        Guid? nzbBlobId = null,
+        Guid? arrDownloadId = null
     )
     {
         return new DavItem()
@@ -65,7 +74,8 @@ public class DavItem
                 : null,
             HistoryItemId = historyItemId,
             FileBlobId = fileBlobId,
-            NzbBlobId = nzbBlobId
+            NzbBlobId = nzbBlobId,
+            ArrDownloadId = arrDownloadId
         };
     }
 

--- a/backend/Database/Models/HistoryItem.cs
+++ b/backend/Database/Models/HistoryItem.cs
@@ -17,6 +17,14 @@ public class HistoryItem
     public string? ContentGroupKey { get; set; }
     public DateTimeOffset? LastPlayedAt { get; set; }
 
+    /// <summary>
+    /// The SAB <c>nzo_id</c> known to represent this release in an external Arr instance.
+    /// This is provenance used for validated Arr history lookup. It is not a blob key,
+    /// a foreign key to InfiniDysk history, or proof by itself that an Arr instance
+    /// still owns the media.
+    /// </summary>
+    public Guid? ArrDownloadId { get; set; }
+
     public enum DownloadStatusOption
     {
         Completed = 1,

--- a/backend/Database/Models/QueueItem.cs
+++ b/backend/Database/Models/QueueItem.cs
@@ -19,6 +19,14 @@ public class QueueItem
     public string? IndexerName { get; set; }
     public string? ContentGroupKey { get; set; }
 
+    /// <summary>
+    /// The SAB <c>nzo_id</c> known to represent this release in an external Arr instance.
+    /// This is provenance used for validated Arr history lookup. It is not a blob key,
+    /// a foreign key to InfiniDysk history, or proof by itself that an Arr instance
+    /// still owns the media.
+    /// </summary>
+    public Guid? ArrDownloadId { get; set; }
+
     public enum PriorityOption
     {
         Default = -100,

--- a/backend/Database/PostgresMigrations/20260830120000_Add-Arr-Download-Provenance.cs
+++ b/backend/Database/PostgresMigrations/20260830120000_Add-Arr-Download-Provenance.cs
@@ -1,0 +1,54 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.PostgresMigrations;
+
+/// <summary>
+/// Durable Arr grab provenance independent of SAB history rows and NZB blob keys.
+/// Additive and nullable; existing rows stay null. Back up /config before upgrading.
+/// </summary>
+[DbContext(typeof(PostgresDavDatabaseContext))]
+[Migration("20260830120000_Add-Arr-Download-Provenance")]
+public partial class AddArrDownloadProvenance : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<Guid>(
+            name: "ArrDownloadId",
+            table: "QueueItems",
+            type: "uuid",
+            nullable: true);
+
+        migrationBuilder.AddColumn<Guid>(
+            name: "ArrDownloadId",
+            table: "HistoryItems",
+            type: "uuid",
+            nullable: true);
+
+        migrationBuilder.AddColumn<Guid>(
+            name: "ArrDownloadId",
+            table: "DavItems",
+            type: "uuid",
+            nullable: true);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "ArrDownloadId",
+            table: "DavItems");
+
+        migrationBuilder.DropColumn(
+            name: "ArrDownloadId",
+            table: "HistoryItems");
+
+        migrationBuilder.DropColumn(
+            name: "ArrDownloadId",
+            table: "QueueItems");
+    }
+}

--- a/backend/Database/PostgresMigrations/PostgresDavDatabaseContextModelSnapshot.cs
+++ b/backend/Database/PostgresMigrations/PostgresDavDatabaseContextModelSnapshot.cs
@@ -103,6 +103,9 @@ namespace NzbWebDAV.Database.PostgresMigrations
                     b.Property<Guid>("Id")
                         .HasColumnType("uuid");
 
+                    b.Property<Guid?>("ArrDownloadId")
+                        .HasColumnType("uuid");
+
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("timestamp without time zone");
 
@@ -320,6 +323,9 @@ namespace NzbWebDAV.Database.PostgresMigrations
             modelBuilder.Entity("NzbWebDAV.Database.Models.HistoryItem", b =>
                 {
                     b.Property<Guid>("Id")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid?>("ArrDownloadId")
                         .HasColumnType("uuid");
 
                     b.Property<string>("Category")
@@ -561,6 +567,9 @@ namespace NzbWebDAV.Database.PostgresMigrations
             modelBuilder.Entity("NzbWebDAV.Database.Models.QueueItem", b =>
                 {
                     b.Property<Guid>("Id")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid?>("ArrDownloadId")
                         .HasColumnType("uuid");
 
                     b.Property<string>("Category")

--- a/backend/Queue/FileAggregators/BaseAggregator.cs
+++ b/backend/Queue/FileAggregators/BaseAggregator.cs
@@ -55,7 +55,8 @@ public abstract class BaseAggregator
             releaseDate: null,
             lastHealthCheck: null,
             historyItemId: MountDirectory.HistoryItemId,
-            fileBlobId: null
+            fileBlobId: null,
+            arrDownloadId: MountDirectory.ArrDownloadId
         );
         _directoryCache.Add(pathKey, directory);
         DBClient.Ctx.Items.Add(directory);

--- a/backend/Queue/FileAggregators/FileAggregator.cs
+++ b/backend/Queue/FileAggregators/FileAggregator.cs
@@ -83,7 +83,8 @@ public class FileAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, 
                 lastHealthCheck: checkedFullHealth ? DateTimeOffset.UtcNow : null,
                 historyItemId: MountDirectory.HistoryItemId,
                 fileBlobId: davNzbFile.Id,
-                nzbBlobId: MountDirectory.HistoryItemId
+                nzbBlobId: MountDirectory.HistoryItemId,
+                arrDownloadId: MountDirectory.ArrDownloadId
             );
 
             dbClient.Ctx.Items.Add(davItem);

--- a/backend/Queue/FileAggregators/MultipartMkvAggregator.cs
+++ b/backend/Queue/FileAggregators/MultipartMkvAggregator.cs
@@ -50,7 +50,8 @@ public class MultipartMkvAggregator(
                 lastHealthCheck: checkedFullHealth ? DateTimeOffset.UtcNow : null,
                 historyItemId: MountDirectory.HistoryItemId,
                 fileBlobId: davMultipartFile.Id,
-                nzbBlobId: MountDirectory.HistoryItemId
+                nzbBlobId: MountDirectory.HistoryItemId,
+                arrDownloadId: MountDirectory.ArrDownloadId
             );
 
             dbClient.Ctx.Items.Add(davItem);

--- a/backend/Queue/FileAggregators/RarAggregator.cs
+++ b/backend/Queue/FileAggregators/RarAggregator.cs
@@ -66,7 +66,8 @@ public class RarAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, b
             lastHealthCheck: null,
             historyItemId: MountDirectory.HistoryItemId,
             fileBlobId: davMultipartFile.Id,
-            nzbBlobId: MountDirectory.HistoryItemId
+            nzbBlobId: MountDirectory.HistoryItemId,
+            arrDownloadId: MountDirectory.ArrDownloadId
         );
 
         dbClient.Ctx.Items.Add(davItem);
@@ -131,7 +132,8 @@ public class RarAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, b
                 lastHealthCheck: checkedFullHealth ? DateTimeOffset.UtcNow : null,
                 historyItemId: MountDirectory.HistoryItemId,
                 fileBlobId: davMultipartFile.Id,
-                nzbBlobId: MountDirectory.HistoryItemId
+                nzbBlobId: MountDirectory.HistoryItemId,
+                arrDownloadId: MountDirectory.ArrDownloadId
             );
 
             dbClient.Ctx.Items.Add(davItem);

--- a/backend/Queue/FileAggregators/SevenZipAggregator.cs
+++ b/backend/Queue/FileAggregators/SevenZipAggregator.cs
@@ -55,7 +55,8 @@ public class SevenZipAggregator(
                 lastHealthCheck: checkedFullHealth ? DateTimeOffset.UtcNow : null,
                 historyItemId: MountDirectory.HistoryItemId,
                 fileBlobId: davMultipartFile.Id,
-                nzbBlobId: MountDirectory.HistoryItemId
+                nzbBlobId: MountDirectory.HistoryItemId,
+                arrDownloadId: MountDirectory.ArrDownloadId
             );
 
             dbClient.Ctx.Items.Add(davItem);

--- a/backend/Queue/NzbSubmissionRequest.cs
+++ b/backend/Queue/NzbSubmissionRequest.cs
@@ -3,6 +3,17 @@ using NzbWebDAV.Database.Models;
 namespace NzbWebDAV.Queue;
 
 /// <summary>
+/// Distinguishes how an NZB entered the queue so Arr download provenance is
+/// captured only for external SAB adds, never inferred from optional fields.
+/// </summary>
+internal enum NzbSubmissionOrigin
+{
+    Internal,
+    ExternalSabAdd,
+    HistoryRetry,
+}
+
+/// <summary>
 /// Transport-neutral NZB enqueue request. SAB and WebDAV adapters map into this
 /// before calling <see cref="NzbSubmissionService"/>.
 /// </summary>
@@ -19,6 +30,8 @@ public sealed class NzbSubmissionRequest
     public string? IndexerName { get; init; }
     public string? ContentGroupKey { get; init; }
     public CancellationToken CancellationToken { get; init; }
+    internal NzbSubmissionOrigin Origin { get; init; }
+    internal Guid? ArrDownloadId { get; init; }
 }
 
 public sealed class NzbSubmissionResult

--- a/backend/Queue/NzbSubmissionService.cs
+++ b/backend/Queue/NzbSubmissionService.cs
@@ -38,6 +38,12 @@ public class NzbSubmissionService(
     {
         await using var sourceStream = request.NzbFileStream;
         var id = request.NzoId ?? Guid.NewGuid();
+        var arrDownloadId = request.Origin switch
+        {
+            NzbSubmissionOrigin.ExternalSabAdd => id,
+            NzbSubmissionOrigin.HistoryRetry => request.ArrDownloadId,
+            _ => null,
+        };
         var category = StringUtil.EmptyToNull(request.Category)
                        ?? configManager.GetManualUploadCategory();
 
@@ -160,6 +166,7 @@ public class NzbSubmissionService(
                 PauseUntil = request.PauseUntil,
                 IndexerName = request.IndexerName,
                 ContentGroupKey = request.ContentGroupKey,
+                ArrDownloadId = arrDownloadId,
             };
 
             // record the original NZB filename so it can be served at download time

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -910,7 +910,8 @@ public class QueueItemProcessor(
             releaseDate: null,
             lastHealthCheck: null,
             historyItemId: queueItem.Id,
-            fileBlobId: null
+            fileBlobId: null,
+            arrDownloadId: queueItem.ArrDownloadId
         );
         dbClient.Ctx.Items.Add(mountFolder);
         return Task.FromResult(mountFolder);
@@ -935,7 +936,8 @@ public class QueueItemProcessor(
                 releaseDate: null,
                 lastHealthCheck: null,
                 historyItemId: queueItem.Id,
-                fileBlobId: null
+                fileBlobId: null,
+                arrDownloadId: queueItem.ArrDownloadId
             );
             dbClient.Ctx.Items.Add(mountFolder);
             return mountFolder;
@@ -963,6 +965,7 @@ public class QueueItemProcessor(
             NzbBlobId = queueItem.Id,
             IndexerName = queueItem.IndexerName,
             ContentGroupKey = queueItem.ContentGroupKey,
+            ArrDownloadId = queueItem.ArrDownloadId,
         };
     }
 

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -2513,7 +2513,9 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             }
         }
 
-        var recovered = recoveredConflict ? null : recoveredDownloadId;
+        var recovered = recoveredConflict || sawAmbiguousIdentity
+            ? null
+            : recoveredDownloadId;
         if (anInstanceFailed)
         {
             return new ArrLinkedRepairResult(

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -2883,7 +2883,7 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 return;
             }
 
-            if (arrDecision == ArrLinkedRepairDecision.DeferMissingDownloadIdentity)
+            async Task DeferMissingProvenanceAsync(string reason, string messageTail)
             {
                 var utcNow = DateTimeOffset.UtcNow;
                 davItem.LastHealthCheck = utcNow;
@@ -2891,7 +2891,7 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 Log.Warning(
                     "Health-check repair deferred for {Path}: no unique Arr download provenance could be proven. Reason: {Reason}",
                     davItem.Path,
-                    "exact Arr media item found, but no unique original download ID could be proven");
+                    reason);
                 await RecordHealthResult(
                     dbClient, davItem,
                     HealthCheckResult.HealthResult.Unhealthy,
@@ -2899,53 +2899,37 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                     string.Join(" ", [
                         "File failed health validation.",
                         $"Corresponding {linkType} and Arr media item found,",
-                        "but no unique original Arr download ID could be proven.",
-                        "Leaving the file in place rather than searching again without blocklisting the failed release."
+                        messageTail,
                     ]), ct).ConfigureAwait(false);
+            }
+
+            if (arrDecision == ArrLinkedRepairDecision.DeferMissingDownloadIdentity)
+            {
+                await DeferMissingProvenanceAsync(
+                    "exact Arr media item found, but no unique original download ID could be proven",
+                    "but no unique original Arr download ID could be proven. " +
+                    "Leaving the file in place rather than searching again without blocklisting the failed release.")
+                    .ConfigureAwait(false);
                 return;
             }
 
             if (arrDecision == ArrLinkedRepairDecision.DeferAmbiguousDownloadIdentity)
             {
-                var utcNow = DateTimeOffset.UtcNow;
-                davItem.LastHealthCheck = utcNow;
-                davItem.NextHealthCheck = utcNow + TimeSpan.FromDays(1);
-                Log.Warning(
-                    "Health-check repair deferred for {Path}: no unique Arr download provenance could be proven. Reason: {Reason}",
-                    davItem.Path,
-                    "multiple import-history download IDs matched");
-                await RecordHealthResult(
-                    dbClient, davItem,
-                    HealthCheckResult.HealthResult.Unhealthy,
-                    HealthCheckResult.RepairAction.ActionNeeded,
-                    string.Join(" ", [
-                        "File failed health validation.",
-                        $"Corresponding {linkType} and Arr media item found,",
-                        "but multiple Arr import-history download IDs matched.",
-                        "Leaving the file in place rather than guessing which release to blocklist."
-                    ]), ct).ConfigureAwait(false);
+                await DeferMissingProvenanceAsync(
+                    "multiple import-history download IDs matched",
+                    "but multiple Arr import-history download IDs matched. " +
+                    "Leaving the file in place rather than guessing which release to blocklist.")
+                    .ConfigureAwait(false);
                 return;
             }
 
             if (arrDecision == ArrLinkedRepairDecision.DeferMissingDownloadHistory)
             {
-                var utcNow = DateTimeOffset.UtcNow;
-                davItem.LastHealthCheck = utcNow;
-                davItem.NextHealthCheck = utcNow + TimeSpan.FromDays(1);
-                Log.Warning(
-                    "Health-check repair deferred for {Path}: no unique Arr download provenance could be proven. Reason: {Reason}",
-                    davItem.Path,
-                    "exact media item and download ID found, but no grabbed history record exists to blocklist");
-                await RecordHealthResult(
-                    dbClient, davItem,
-                    HealthCheckResult.HealthResult.Unhealthy,
-                    HealthCheckResult.RepairAction.ActionNeeded,
-                    string.Join(" ", [
-                        "File failed health validation.",
-                        $"Corresponding {linkType} and Arr media item found,",
-                        "but the original Arr download history could not be identified.",
-                        "Leaving the file in place rather than searching again without blocklisting the failed release."
-                    ]), ct).ConfigureAwait(false);
+                await DeferMissingProvenanceAsync(
+                    "exact media item and download ID found, but no grabbed history record exists to blocklist",
+                    "but the original Arr download history could not be identified. " +
+                    "Leaving the file in place rather than searching again without blocklisting the failed release.")
+                    .ConfigureAwait(false);
                 return;
             }
 

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -2261,8 +2261,16 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
         /// </summary>
         DeferUnreachable,
         /// <summary>
-        /// The Arr media item exists, but its original download history cannot be identified.
-        /// Leave it in place rather than searching again without blocklisting the failed release.
+        /// An exact Arr media item was found, but no unique original download ID could be proven.
+        /// </summary>
+        DeferMissingDownloadIdentity,
+        /// <summary>
+        /// Multiple import-history download IDs matched the exact media file and path.
+        /// </summary>
+        DeferAmbiguousDownloadIdentity,
+        /// <summary>
+        /// The Arr media item exists and a specific download ID is known, but Arr has no grabbed
+        /// history for that ID. Leave it in place rather than searching again without blocklisting.
         /// </summary>
         DeferMissingDownloadHistory,
         /// <summary>
@@ -2276,6 +2284,11 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
         /// </summary>
         DeferRootPathMismatch,
     }
+
+    internal sealed record ArrLinkedRepairResult(
+        ArrLinkedRepairDecision Decision,
+        Guid? RecoveredDownloadId = null,
+        string? RecoveryHost = null);
 
     /// <summary>
     /// True when <paramref name="candidatePath"/> is the same as <paramref name="rootPath"/> or a
@@ -2314,7 +2327,7 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
     /// remove-and-blocklist or be deferred when ownership cannot be confirmed safely.
     /// Extracted so the unreachable-instance fail-safe can be unit-tested without a full Repair harness.
     /// </summary>
-    internal static async Task<ArrLinkedRepairDecision> DecideArrLinkedRepairAsync(
+    internal static async Task<ArrLinkedRepairResult> DecideArrLinkedRepairAsync(
         IEnumerable<ArrClient> arrClients,
         string symlinkOrStrmPath,
         Guid? downloadId,
@@ -2325,6 +2338,12 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
         var anInstanceFailed = false;
         var sawConfiguredClient = false;
         var matchedArrRootFolder = false;
+        var sawAmbiguousIdentity = false;
+        var sawMissingIdentity = false;
+        var sawMissingDownloadHistory = false;
+        Guid? recoveredDownloadId = null;
+        string? recoveryHost = null;
+        var recoveredConflict = false;
 
         foreach (var arrClient in arrClients)
         {
@@ -2377,15 +2396,86 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
 
             matchedArrRootFolder = true;
 
-            if (downloadId == null)
-                return ArrLinkedRepairDecision.DeferMissingDownloadHistory;
+            ArrMediaFileMatch? mediaFile;
+            try
+            {
+                mediaFile = await arrClient.FindMediaFileAsync(symlinkOrStrmPath, ct)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception e) when (e is HttpRequestException or TaskCanceledException or InvalidOperationException)
+            {
+                anInstanceFailed = true;
+                LogArrRepairFailure(
+                    e,
+                    "Health-check repair: could not look up the Arr media file on {Host}",
+                    arrClient.Host);
+                continue;
+            }
+
+            if (mediaFile is null)
+                continue;
+
+            var effectiveId = downloadId;
+            if (effectiveId is null)
+            {
+                ArrClient.ArrImportHistoryCollection collected;
+                try
+                {
+                    collected = await arrClient.CollectMediaImportHistoryAsync(mediaFile, ct)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception e) when (e is HttpRequestException or TaskCanceledException or InvalidOperationException)
+                {
+                    anInstanceFailed = true;
+                    LogArrRepairFailure(
+                        e,
+                        "Health-check repair: could not query Arr import history on {Host}",
+                        arrClient.Host);
+                    continue;
+                }
+
+                var resolution = ArrDownloadIdResolver.Resolve(
+                    collected.Records, mediaFile, symlinkOrStrmPath);
+                if (resolution.Kind == ArrDownloadIdResolutionKind.Unique && !collected.Exhausted)
+                    resolution = new ArrDownloadIdResolution(ArrDownloadIdResolutionKind.NotFound);
+
+                if (resolution.Kind == ArrDownloadIdResolutionKind.Unique)
+                {
+                    effectiveId = resolution.DownloadId;
+                    if (recoveredDownloadId is null)
+                    {
+                        recoveredDownloadId = effectiveId;
+                        recoveryHost = arrClient.Host;
+                    }
+                    else if (recoveredDownloadId != effectiveId)
+                    {
+                        recoveredConflict = true;
+                    }
+                }
+                else if (resolution.Kind == ArrDownloadIdResolutionKind.Ambiguous)
+                {
+                    sawAmbiguousIdentity = true;
+                    continue;
+                }
+                else
+                {
+                    sawMissingIdentity = true;
+                    continue;
+                }
+            }
+
+            if (effectiveId is null)
+            {
+                sawMissingIdentity = true;
+                continue;
+            }
 
             ArrRepairOutcome repairOutcome;
             try
             {
                 repairOutcome = await arrClient.RemoveAndBlocklist(
-                    symlinkOrStrmPath,
-                    downloadId.Value,
+                    mediaFile,
+                    effectiveId.Value,
                     shouldRequestSearch is null ? null : identity => shouldRequestSearch(arrClient, identity),
                     ct).ConfigureAwait(false);
             }
@@ -2399,27 +2489,59 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 continue;
             }
 
+            var persistedRecovery = recoveredConflict ? null : recoveredDownloadId;
             if (repairOutcome == ArrRepairOutcome.RemoveAndBlocklistSucceeded)
-                return ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded;
+            {
+                return new ArrLinkedRepairResult(
+                    ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded,
+                    persistedRecovery,
+                    recoveryHost);
+            }
 
             if (repairOutcome == ArrRepairOutcome.RemoveAndBlocklistSucceededSearchWithheld)
-                return ArrLinkedRepairDecision.RemoveAndBlocklistSucceededSearchWithheld;
+            {
+                return new ArrLinkedRepairResult(
+                    ArrLinkedRepairDecision.RemoveAndBlocklistSucceededSearchWithheld,
+                    persistedRecovery,
+                    recoveryHost);
+            }
 
             if (repairOutcome == ArrRepairOutcome.DownloadHistoryNotFound)
-                return ArrLinkedRepairDecision.DeferMissingDownloadHistory;
-
-            // A root-folder match with no exact media-item match may be caused by path
-            // normalization, stale Arr data, or a transient partial response. Keep checking
-            // other configured instances, but never use this miss to authorize deletion.
+            {
+                sawMissingDownloadHistory = true;
+                continue;
+            }
         }
 
+        var recovered = recoveredConflict ? null : recoveredDownloadId;
         if (anInstanceFailed)
-            return ArrLinkedRepairDecision.DeferUnreachable;
+        {
+            return new ArrLinkedRepairResult(
+                ArrLinkedRepairDecision.DeferUnreachable, recovered, recoveryHost);
+        }
+
+        if (sawAmbiguousIdentity)
+        {
+            return new ArrLinkedRepairResult(
+                ArrLinkedRepairDecision.DeferAmbiguousDownloadIdentity, recovered, recoveryHost);
+        }
+
+        if (sawMissingIdentity)
+        {
+            return new ArrLinkedRepairResult(
+                ArrLinkedRepairDecision.DeferMissingDownloadIdentity, recovered, recoveryHost);
+        }
+
+        if (sawMissingDownloadHistory)
+        {
+            return new ArrLinkedRepairResult(
+                ArrLinkedRepairDecision.DeferMissingDownloadHistory, recovered, recoveryHost);
+        }
 
         if (sawConfiguredClient && !matchedArrRootFolder)
-            return ArrLinkedRepairDecision.DeferRootPathMismatch;
+            return new ArrLinkedRepairResult(ArrLinkedRepairDecision.DeferRootPathMismatch);
 
-        return ArrLinkedRepairDecision.DeferNoMatchingMediaItem;
+        return new ArrLinkedRepairResult(ArrLinkedRepairDecision.DeferNoMatchingMediaItem);
     }
 
     private static void LogArrRepairFailure(Exception exception, string messageTemplate, string host)
@@ -2710,10 +2832,10 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                     ]), ct).ConfigureAwait(false);
                 return;
             }
-            var arrDecision = await DecideArrLinkedRepairAsync(
+            var arrResult = await DecideArrLinkedRepairAsync(
                 arrClients,
                 linkedPath,
-                davItem.HistoryItemId ?? davItem.NzbBlobId,
+                davItem.ArrDownloadId,
                 ct,
                 (arrClient, mediaIdentities) => _replacementSearchBudget.TryReserveAll(
                     mediaIdentities
@@ -2722,6 +2844,17 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                     arrConfig.EffectiveQueueReplacementSearchLimit(),
                     arrConfig.EffectiveQueueReplacementSearchWindow()),
                 _arrBackoff).ConfigureAwait(false);
+
+            if (davItem.ArrDownloadId is null && arrResult.RecoveredDownloadId is { } recovered)
+            {
+                davItem.ArrDownloadId = recovered;
+                Log.Information(
+                    "Recovered Arr download provenance for {Path} from exact import history on {Host}.",
+                    davItem.Path,
+                    arrResult.RecoveryHost);
+            }
+
+            var arrDecision = arrResult.Decision;
 
             if (arrDecision is ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded
                 or ArrLinkedRepairDecision.RemoveAndBlocklistSucceededSearchWithheld)
@@ -2750,11 +2883,59 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 return;
             }
 
+            if (arrDecision == ArrLinkedRepairDecision.DeferMissingDownloadIdentity)
+            {
+                var utcNow = DateTimeOffset.UtcNow;
+                davItem.LastHealthCheck = utcNow;
+                davItem.NextHealthCheck = utcNow + TimeSpan.FromDays(1);
+                Log.Warning(
+                    "Health-check repair deferred for {Path}: no unique Arr download provenance could be proven. Reason: {Reason}",
+                    davItem.Path,
+                    "exact Arr media item found, but no unique original download ID could be proven");
+                await RecordHealthResult(
+                    dbClient, davItem,
+                    HealthCheckResult.HealthResult.Unhealthy,
+                    HealthCheckResult.RepairAction.ActionNeeded,
+                    string.Join(" ", [
+                        "File failed health validation.",
+                        $"Corresponding {linkType} and Arr media item found,",
+                        "but no unique original Arr download ID could be proven.",
+                        "Leaving the file in place rather than searching again without blocklisting the failed release."
+                    ]), ct).ConfigureAwait(false);
+                return;
+            }
+
+            if (arrDecision == ArrLinkedRepairDecision.DeferAmbiguousDownloadIdentity)
+            {
+                var utcNow = DateTimeOffset.UtcNow;
+                davItem.LastHealthCheck = utcNow;
+                davItem.NextHealthCheck = utcNow + TimeSpan.FromDays(1);
+                Log.Warning(
+                    "Health-check repair deferred for {Path}: no unique Arr download provenance could be proven. Reason: {Reason}",
+                    davItem.Path,
+                    "multiple import-history download IDs matched");
+                await RecordHealthResult(
+                    dbClient, davItem,
+                    HealthCheckResult.HealthResult.Unhealthy,
+                    HealthCheckResult.RepairAction.ActionNeeded,
+                    string.Join(" ", [
+                        "File failed health validation.",
+                        $"Corresponding {linkType} and Arr media item found,",
+                        "but multiple Arr import-history download IDs matched.",
+                        "Leaving the file in place rather than guessing which release to blocklist."
+                    ]), ct).ConfigureAwait(false);
+                return;
+            }
+
             if (arrDecision == ArrLinkedRepairDecision.DeferMissingDownloadHistory)
             {
                 var utcNow = DateTimeOffset.UtcNow;
                 davItem.LastHealthCheck = utcNow;
                 davItem.NextHealthCheck = utcNow + TimeSpan.FromDays(1);
+                Log.Warning(
+                    "Health-check repair deferred for {Path}: no unique Arr download provenance could be proven. Reason: {Reason}",
+                    davItem.Path,
+                    "exact media item and download ID found, but no grabbed history record exists to blocklist");
                 await RecordHealthResult(
                     dbClient, davItem,
                     HealthCheckResult.HealthResult.Unhealthy,

--- a/tests/NzbWebDAV.Tests/Api/AddFileDuplicateReplaceTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AddFileDuplicateReplaceTests.cs
@@ -225,6 +225,18 @@ public sealed class AddFileDuplicateReplaceTests : IAsyncLifetime
 
         Assert.Equal(assignedId.ToString(), Assert.Single(response.NzoIds));
         Assert.True(await _context.QueueItems.AsNoTracking().AnyAsync(q => q.Id == assignedId));
+        Assert.Null((await _context.QueueItems.AsNoTracking().SingleAsync(q => q.Id == assignedId)).ArrDownloadId);
+    }
+
+    [Fact]
+    public async Task AddFileAsync_ExternalSabAdd_PersistsReturnedNzoIdAsArrDownloadId()
+    {
+        var response = await CreateController().AddFileAsync(
+            CreateRequest("Arr.Grab.nzb", "tv", origin: NzbSubmissionOrigin.ExternalSabAdd));
+
+        var nzoId = Guid.Parse(Assert.Single(response.NzoIds));
+        var queued = await _context.QueueItems.AsNoTracking().SingleAsync(q => q.Id == nzoId);
+        Assert.Equal(nzoId, queued.ArrDownloadId);
     }
 
     [Fact]
@@ -356,7 +368,8 @@ public sealed class AddFileDuplicateReplaceTests : IAsyncLifetime
         string fileName,
         string category,
         Guid? nzoId = null,
-        bool replaceExisting = true)
+        bool replaceExisting = true,
+        NzbSubmissionOrigin origin = NzbSubmissionOrigin.Internal)
     {
         var nzb = """
             <?xml version="1.0" encoding="utf-8"?>
@@ -380,6 +393,7 @@ public sealed class AddFileDuplicateReplaceTests : IAsyncLifetime
             Priority = QueueItem.PriorityOption.Normal,
             PostProcessing = QueueItem.PostProcessingOption.None,
             CancellationToken = CancellationToken.None,
+            Origin = origin,
         };
     }
 }

--- a/tests/NzbWebDAV.Tests/Api/NzbSubmissionIngestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/NzbSubmissionIngestTests.cs
@@ -177,6 +177,7 @@ public sealed class NzbSubmissionIngestTests : IAsyncLifetime
             new MemoryStream(Encoding.UTF8.GetBytes(ValidNzb))));
 
         Assert.True(response.Status);
+        Assert.Null((await _context.QueueItems.AsNoTracking().SingleAsync()).ArrDownloadId);
         var backupFile = Assert.Single(
             Directory.EnumerateFiles(backupRoot, "*.nzb", SearchOption.AllDirectories));
         Assert.Equal(ValidNzb, await File.ReadAllTextAsync(backupFile));

--- a/tests/NzbWebDAV.Tests/Api/RetryHistoryControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/RetryHistoryControllerTests.cs
@@ -114,6 +114,74 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task RetryHistoryAsync_PreservesOriginalArrDownloadIdOnNewQueueItem()
+    {
+        var originalArrDownloadId = Guid.NewGuid();
+        await SeedFailedHistoryAsync(
+            originalArrDownloadId, "Show.S01E01.nzb", "tv", writeBlob: true, originalArrDownloadId);
+
+        var response = await CreateController().RetryHistoryAsync(await CreateRequest(originalArrDownloadId));
+        var retryId = Guid.Parse(response.NzoId!);
+        var queued = await _context.QueueItems.AsNoTracking().SingleAsync(x => x.Id == retryId);
+
+        Assert.NotEqual(originalArrDownloadId, retryId);
+        Assert.Equal(originalArrDownloadId, queued.ArrDownloadId);
+        var original = await _context.HistoryItems.AsNoTracking().SingleAsync(x => x.Id == originalArrDownloadId);
+        Assert.Equal(originalArrDownloadId, original.ArrDownloadId);
+    }
+
+    [Fact]
+    public async Task RetryHistoryAsync_RetryChainPreservesOriginalArrDownloadId()
+    {
+        var originalArrDownloadId = Guid.NewGuid();
+        await SeedFailedHistoryAsync(
+            originalArrDownloadId, "Show.S01E01.nzb", "tv", writeBlob: true, originalArrDownloadId);
+
+        var first = await CreateController().RetryHistoryAsync(await CreateRequest(originalArrDownloadId));
+        var firstId = Guid.Parse(first.NzoId!);
+        _context.QueueItems.Remove(await _context.QueueItems.SingleAsync(x => x.Id == firstId));
+        _context.HistoryItems.Add(new HistoryItem
+        {
+            Id = firstId,
+            CreatedAt = DateTime.UtcNow,
+            FileName = "Show.S01E01.nzb",
+            JobName = "Show.S01E01",
+            Category = "tv",
+            DownloadStatus = HistoryItem.DownloadStatusOption.Failed,
+            TotalSegmentBytes = 100,
+            DownloadTimeSeconds = 1,
+            FailMessage = "failed again",
+            NzbBlobId = firstId,
+            ArrDownloadId = originalArrDownloadId,
+            IndexerName = "test-indexer",
+            ContentGroupKey = "group-key",
+        });
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var second = await CreateController().RetryHistoryAsync(await CreateRequest(firstId));
+        var secondId = Guid.Parse(second.NzoId!);
+        var queued = await _context.QueueItems.AsNoTracking().SingleAsync(x => x.Id == secondId);
+
+        Assert.NotEqual(originalArrDownloadId, secondId);
+        Assert.NotEqual(firstId, secondId);
+        Assert.Equal(originalArrDownloadId, queued.ArrDownloadId);
+    }
+
+    [Fact]
+    public async Task RetryHistoryAsync_LegacyNullProvenance_StaysNull()
+    {
+        var historyId = Guid.NewGuid();
+        await SeedFailedHistoryAsync(historyId, "Legacy.nzb", "tv", writeBlob: true, arrDownloadId: null);
+
+        var response = await CreateController().RetryHistoryAsync(await CreateRequest(historyId));
+        var retryId = Guid.Parse(response.NzoId!);
+        var queued = await _context.QueueItems.AsNoTracking().SingleAsync(x => x.Id == retryId);
+
+        Assert.Null(queued.ArrDownloadId);
+    }
+
+    [Fact]
     public async Task RetryHistoryAsync_MissingBlob_ThrowsBadRequest()
     {
         var historyId = Guid.NewGuid();
@@ -180,9 +248,11 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
         const string fileName = "Already.Queued.nzb";
         const string category = "tv";
         var historyId = Guid.NewGuid();
-        await SeedFailedHistoryAsync(historyId, fileName, category, writeBlob: true);
+        var originalArrDownloadId = Guid.NewGuid();
+        await SeedFailedHistoryAsync(historyId, fileName, category, writeBlob: true, originalArrDownloadId);
 
         var existingQueueId = Guid.NewGuid();
+        var unrelatedProvenance = Guid.NewGuid();
         _context.QueueItems.Add(new QueueItem
         {
             Id = existingQueueId,
@@ -194,6 +264,7 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
             Category = category,
             Priority = QueueItem.PriorityOption.Normal,
             PostProcessing = QueueItem.PostProcessingOption.None,
+            ArrDownloadId = unrelatedProvenance,
         });
         _context.NzbNames.Add(new NzbName { Id = existingQueueId, FileName = fileName });
         await _context.SaveChangesAsync();
@@ -210,6 +281,10 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
             .SingleAsync(q => q.Category == category && q.FileName == fileName)).Id);
         Assert.NotNull(await _context.HistoryItems.AsNoTracking()
             .SingleOrDefaultAsync(h => h.Id == historyId));
+        Assert.Equal(
+            originalArrDownloadId,
+            (await _context.QueueItems.AsNoTracking().SingleAsync(q => q.Id == newId)).ArrDownloadId);
+        Assert.NotEqual(unrelatedProvenance, originalArrDownloadId);
     }
 
 
@@ -218,7 +293,7 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
     {
         var okId = Guid.NewGuid();
         var badId = Guid.NewGuid();
-        await SeedFailedHistoryAsync(okId, "Ok.nzb", "tv", writeBlob: true);
+        await SeedFailedHistoryAsync(okId, "Ok.nzb", "tv", writeBlob: true, okId);
 
         var context = new DefaultHttpContext();
         context.Request.QueryString = new QueryString($"?value={okId}&value={badId}");
@@ -231,6 +306,7 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
         Assert.Single(response.NzoIds!);
         Assert.NotNull(response.Failed);
         Assert.Single(response.Failed!);
+        Assert.Equal(okId, (await _context.QueueItems.AsNoTracking().SingleAsync()).ArrDownloadId);
     }
 
     private RetryHistoryController CreateController() =>
@@ -249,15 +325,21 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
         return await RetryHistoryRequest.New(context);
     }
 
-    private Task SeedFailedHistoryAsync(Guid id, string fileName, string category, bool writeBlob) =>
-        SeedHistoryAsync(id, fileName, category, HistoryItem.DownloadStatusOption.Failed, writeBlob);
+    private Task SeedFailedHistoryAsync(
+        Guid id,
+        string fileName,
+        string category,
+        bool writeBlob,
+        Guid? arrDownloadId = null) =>
+        SeedHistoryAsync(id, fileName, category, HistoryItem.DownloadStatusOption.Failed, writeBlob, arrDownloadId);
 
     private async Task SeedHistoryAsync(
         Guid id,
         string fileName,
         string category,
         HistoryItem.DownloadStatusOption status,
-        bool writeBlob)
+        bool writeBlob,
+        Guid? arrDownloadId = null)
     {
         if (writeBlob)
         {
@@ -290,6 +372,7 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
                 ? "Timeout reading from NNTP stream."
                 : null,
             NzbBlobId = id,
+            ArrDownloadId = arrDownloadId,
             IndexerName = "test-indexer",
             ContentGroupKey = "group-key",
         });

--- a/tests/NzbWebDAV.Tests/Api/SabFailedDownloadIdentityTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabFailedDownloadIdentityTests.cs
@@ -104,6 +104,9 @@ public sealed class SabFailedDownloadIdentityTests : IAsyncLifetime
         var addResponse = await CreateAddFileController().AddFileAsync(CreateRequest(fileName, category));
         Assert.True(addResponse.Status);
         var nzoId = Assert.Single(addResponse.NzoIds);
+        var queued = await _context.QueueItems.AsNoTracking().SingleAsync();
+        Assert.Equal(Guid.Parse(nzoId), queued.Id);
+        Assert.Equal(Guid.Parse(nzoId), queued.ArrDownloadId);
 
         // 2. Processing fails non-retryably: the important file's first segment is
         //    missing on every provider (empty fake = DMCA'd/expired content).
@@ -118,6 +121,8 @@ public sealed class SabFailedDownloadIdentityTests : IAsyncLifetime
         Assert.Equal(category, slot.Category);
         Assert.Equal(HistoryItem.DownloadStatusOption.Failed, slot.Status);
         Assert.False(string.IsNullOrWhiteSpace(slot.FailMessage));
+        var history = await _context.HistoryItems.AsNoTracking().SingleAsync();
+        Assert.Equal(Guid.Parse(nzoId), history.ArrDownloadId);
     }
 
     [Fact]
@@ -200,6 +205,7 @@ public sealed class SabFailedDownloadIdentityTests : IAsyncLifetime
             Priority = QueueItem.PriorityOption.Normal,
             PostProcessing = QueueItem.PostProcessingOption.None,
             CancellationToken = CancellationToken.None,
+            Origin = NzbSubmissionOrigin.ExternalSabAdd,
         };
     }
 }

--- a/tests/NzbWebDAV.Tests/Clients/ArrDownloadIdResolverTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/ArrDownloadIdResolverTests.cs
@@ -1,0 +1,124 @@
+using NzbWebDAV.Clients.RadarrSonarr;
+using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
+
+namespace NzbWebDAV.Tests.Clients;
+
+public class ArrDownloadIdResolverTests
+{
+    private static readonly ArrMediaFileMatch Movie =
+        new(ArrMediaKind.Movie, FileId: 201, MediaIds: [101]);
+    private const string Path = "/library/movies/Title/Title.mkv";
+
+    [Fact]
+    public void UniqueExactFileIdAndPath_Resolves()
+    {
+        var downloadId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var resolution = ArrDownloadIdResolver.Resolve(
+            [
+                Record(downloadId.ToString(), "201", Path),
+            ],
+            Movie,
+            Path);
+
+        Assert.Equal(ArrDownloadIdResolutionKind.Unique, resolution.Kind);
+        Assert.Equal(downloadId, resolution.DownloadId);
+    }
+
+    [Fact]
+    public void DuplicateRowsWithSameDownloadId_DeduplicateToUnique()
+    {
+        var downloadId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        var resolution = ArrDownloadIdResolver.Resolve(
+            [
+                Record(downloadId.ToString(), "201", Path),
+                Record(downloadId.ToString(), "201", Path),
+            ],
+            Movie,
+            Path);
+
+        Assert.Equal(ArrDownloadIdResolutionKind.Unique, resolution.Kind);
+        Assert.Equal(downloadId, resolution.DownloadId);
+    }
+
+    [Fact]
+    public void TwoDistinctDownloadIds_AreAmbiguous()
+    {
+        var resolution = ArrDownloadIdResolver.Resolve(
+            [
+                Record("11111111-1111-1111-1111-111111111111", "201", Path),
+                Record("22222222-2222-2222-2222-222222222222", "201", Path),
+            ],
+            Movie,
+            Path);
+
+        Assert.Equal(ArrDownloadIdResolutionKind.Ambiguous, resolution.Kind);
+        Assert.Null(resolution.DownloadId);
+    }
+
+    [Fact]
+    public void PathWithoutMatchingFileId_IsIgnored()
+    {
+        var resolution = ArrDownloadIdResolver.Resolve(
+            [Record(Guid.NewGuid().ToString(), "999", Path)],
+            Movie,
+            Path);
+
+        Assert.Equal(ArrDownloadIdResolutionKind.NotFound, resolution.Kind);
+    }
+
+    [Fact]
+    public void FileIdWithoutMatchingPath_IsIgnored()
+    {
+        var resolution = ArrDownloadIdResolver.Resolve(
+            [Record(Guid.NewGuid().ToString(), "201", "/other/path.mkv")],
+            Movie,
+            Path);
+
+        Assert.Equal(ArrDownloadIdResolutionKind.NotFound, resolution.Kind);
+    }
+
+    [Fact]
+    public void MalformedFileId_IsIgnored()
+    {
+        var resolution = ArrDownloadIdResolver.Resolve(
+            [Record(Guid.NewGuid().ToString(), "not-an-int", Path)],
+            Movie,
+            Path);
+
+        Assert.Equal(ArrDownloadIdResolutionKind.NotFound, resolution.Kind);
+    }
+
+    [Fact]
+    public void NonGuidDownloadId_IsIgnored()
+    {
+        var resolution = ArrDownloadIdResolver.Resolve(
+            [Record("not-a-guid", "201", Path)],
+            Movie,
+            Path);
+
+        Assert.Equal(ArrDownloadIdResolutionKind.NotFound, resolution.Kind);
+    }
+
+    [Fact]
+    public void PathComparison_IsOrdinal()
+    {
+        var resolution = ArrDownloadIdResolver.Resolve(
+            [Record(Guid.NewGuid().ToString(), "201", "/Library/movies/Title/Title.mkv")],
+            Movie,
+            Path);
+
+        Assert.Equal(ArrDownloadIdResolutionKind.NotFound, resolution.Kind);
+    }
+
+    private static ArrHistoryRecord Record(string downloadId, string fileId, string importedPath) =>
+        new()
+        {
+            DownloadId = downloadId,
+            EventType = 3,
+            Data = new ArrHistoryData
+            {
+                FileId = fileId,
+                ImportedPath = importedPath,
+            },
+        };
+}

--- a/tests/NzbWebDAV.Tests/Clients/ArrDownloadIdResolverTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/ArrDownloadIdResolverTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using NzbWebDAV.Clients.RadarrSonarr;
 using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
 
@@ -104,6 +105,29 @@ public class ArrDownloadIdResolverTests
     {
         var resolution = ArrDownloadIdResolver.Resolve(
             [Record(Guid.NewGuid().ToString(), "201", "/Library/movies/Title/Title.mkv")],
+            Movie,
+            Path);
+
+        Assert.Equal(ArrDownloadIdResolutionKind.NotFound, resolution.Kind);
+    }
+
+    [Fact]
+    public void ExplicitJsonNullData_IsIgnoredWithoutThrowing()
+    {
+        var record = JsonSerializer.Deserialize<ArrHistoryRecord>(
+            """{"downloadId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","data":null}""")!;
+
+        Assert.Null(record.Data);
+        var resolution = ArrDownloadIdResolver.Resolve([record], Movie, Path);
+
+        Assert.Equal(ArrDownloadIdResolutionKind.NotFound, resolution.Kind);
+    }
+
+    [Fact]
+    public void NullDataObject_IsIgnoredWithoutThrowing()
+    {
+        var resolution = ArrDownloadIdResolver.Resolve(
+            [new ArrHistoryRecord { DownloadId = Guid.NewGuid().ToString(), EventType = 3, Data = null }],
             Movie,
             Path);
 

--- a/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
@@ -567,6 +567,51 @@ public class RadarrSonarrClientTests
     }
 
     [Fact]
+    public async Task CollectMediaImportHistoryAsync_ShortPageWithLargerTotal_IsNotExhausted()
+    {
+        var match = new ArrMediaFileMatch(ArrMediaKind.Movie, FileId: 201, MediaIds: [101]);
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/history?movieId=101&eventType=3&page=1&pageSize=50&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[{"downloadId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}],"totalRecords":100}"""))));
+        var client = new TestRadarrClient(httpClient);
+
+        var collected = await client.CollectMediaImportHistoryAsync(match);
+
+        Assert.False(collected.Exhausted);
+        Assert.Single(collected.Records);
+    }
+
+    [Fact]
+    public async Task CollectMediaImportHistoryAsync_ShortPageWithoutTotal_IsExhausted()
+    {
+        var match = new ArrMediaFileMatch(ArrMediaKind.Movie, FileId: 201, MediaIds: [101]);
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/history?movieId=101&eventType=3&page=1&pageSize=50&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[{"downloadId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}]}"""))));
+        var client = new TestRadarrClient(httpClient);
+
+        var collected = await client.CollectMediaImportHistoryAsync(match);
+
+        Assert.True(collected.Exhausted);
+        Assert.Single(collected.Records);
+    }
+
+    [Fact]
+    public async Task CollectMediaImportHistoryAsync_ShortPageMatchingTotal_IsExhausted()
+    {
+        var match = new ArrMediaFileMatch(ArrMediaKind.Movie, FileId: 201, MediaIds: [101]);
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/history?movieId=101&eventType=3&page=1&pageSize=50&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[{"downloadId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}],"totalRecords":1}"""))));
+        var client = new TestRadarrClient(httpClient);
+
+        var collected = await client.CollectMediaImportHistoryAsync(match);
+
+        Assert.True(collected.Exhausted);
+        Assert.Single(collected.Records);
+    }
+
+    [Fact]
     public async Task SonarrRepair_LooksUpMediaBeforeGrabbedHistory()
     {
         const string seriesPath = "/library/tv/Order Show";

--- a/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
@@ -131,6 +131,7 @@ public class RadarrSonarrClientTests
             ("GET /api/v3/series", JsonResponse($"[{{\"id\":102,\"path\":\"{seriesPath}\"}}]")),
             ("GET /api/v3/episodefile?seriesId=102",
                 JsonResponse($"[{{\"id\":202,\"seriesId\":102,\"path\":\"{filePath}\"}}]")),
+            ("GET /api/v3/episode?episodeFileId=202", JsonResponse("""[{"id":302,"seriesId":102}]""")),
             ($"GET /api/v3/history?downloadId={downloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
                 JsonResponse("""{"records":[]}"""))));
         var client = new TestSonarrClient(httpClient);
@@ -522,6 +523,80 @@ public class RadarrSonarrClientTests
         var record = Assert.Single((await client.GetQueueAsync()).Records);
 
         Assert.Equal("episode:99", record.GetMediaIdentity());
+    }
+
+    [Fact]
+    public async Task SonarrImportHistory_IsScopedToEpisodeAndImportEventType()
+    {
+        var match = new ArrMediaFileMatch(ArrMediaKind.Episode, FileId: 201, MediaIds: [301]);
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/history?episodeId=301&eventType=3&page=1&pageSize=50&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[],"totalRecords":0}"""))));
+        var client = new TestSonarrClient(httpClient);
+
+        var history = await client.GetMediaImportHistoryAsync(match, page: 1, pageSize: 50);
+
+        Assert.Empty(history.Records);
+    }
+
+    [Fact]
+    public async Task RadarrImportHistory_IsScopedToMovieAndImportEventType()
+    {
+        var match = new ArrMediaFileMatch(ArrMediaKind.Movie, FileId: 201, MediaIds: [101]);
+        using var httpClient = new HttpClient(CreateHandler(
+            ("GET /api/v3/history?movieId=101&eventType=3&page=1&pageSize=50&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[],"totalRecords":0}"""))));
+        var client = new TestRadarrClient(httpClient);
+
+        var history = await client.GetMediaImportHistoryAsync(match, page: 1, pageSize: 50);
+
+        Assert.Empty(history.Records);
+    }
+
+    [Fact]
+    public async Task CollectMediaImportHistoryAsync_HonorsCancellationToken()
+    {
+        using var httpClient = new HttpClient(new HangUntilCancelledHandler());
+        var client = new TestRadarrClient(httpClient);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        var match = new ArrMediaFileMatch(ArrMediaKind.Movie, FileId: 1, MediaIds: [1]);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => client.CollectMediaImportHistoryAsync(match, cts.Token));
+    }
+
+    [Fact]
+    public async Task SonarrRepair_LooksUpMediaBeforeGrabbedHistory()
+    {
+        const string seriesPath = "/library/tv/Order Show";
+        const string filePath = seriesPath + "/Order Show S01E01.mkv";
+        var downloadId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+        var handler = CreateHandler(
+            ("GET /api/v3/series", JsonResponse($"[{{\"id\":109,\"path\":\"{seriesPath}\"}}]")),
+            ("GET /api/v3/episodefile?seriesId=109",
+                JsonResponse($"[{{\"id\":209,\"seriesId\":109,\"path\":\"{filePath}\"}}]")),
+            ("GET /api/v3/episode?episodeFileId=209", JsonResponse("""[{"id":309,"seriesId":109}]""")),
+            ($"GET /api/v3/history?downloadId={downloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending",
+                JsonResponse("""{"records":[{"id":409}]}""")),
+            ("DELETE /api/v3/episodefile/209", Status(HttpStatusCode.OK)),
+            ("POST /api/v3/history/failed/409", JsonResponse("{}")),
+            ("POST /api/v3/command", JsonResponse("{}")));
+        using var httpClient = new HttpClient(handler);
+        var client = new TestSonarrClient(httpClient);
+
+        Assert.Equal(
+            ArrRepairOutcome.RemoveAndBlocklistSucceeded,
+            await client.RemoveAndBlocklist(filePath, downloadId));
+
+        var mediaIndex = handler.Requests.FindIndex(request =>
+            request.StartsWith("GET /api/v3/episode?episodeFileId=209", StringComparison.Ordinal));
+        var historyIndex = handler.Requests.FindIndex(request =>
+            request.Contains("eventType=1", StringComparison.Ordinal));
+        var deleteIndex = handler.Requests.FindIndex(request =>
+            request.StartsWith("DELETE ", StringComparison.Ordinal));
+        Assert.InRange(mediaIndex, 0, historyIndex - 1);
+        Assert.InRange(historyIndex, mediaIndex + 1, deleteIndex - 1);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Database/ArrDownloadProvenanceMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/ArrDownloadProvenanceMigrationTests.cs
@@ -1,0 +1,170 @@
+using System.Data;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Database;
+
+public sealed class ArrDownloadProvenanceMigrationTests
+{
+    private const string PriorMigration = "20260824160000_Add-Health-Repair-Pending";
+    private const string ProvenanceMigration = "20260830120000_Add-Arr-Download-Provenance";
+
+    [Fact]
+    public async Task Upgrade_AddsNullableColumnsWithoutBackfillOrIndexes()
+    {
+        await using var harness = await MigrationHarness.CreateAsync();
+        var ctx = harness.Context;
+
+        var queueId = Guid.Parse("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeee0001");
+        var historyId = Guid.Parse("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeee0002");
+        var davId = Guid.Parse("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeee0003");
+        await InsertLegacyRowsAsync(ctx, queueId, historyId, davId);
+
+        Assert.Contains(ProvenanceMigration, await ctx.Database.GetPendingMigrationsAsync());
+        await ctx.Database.MigrateAsync();
+        Assert.Empty(await ctx.Database.GetPendingMigrationsAsync());
+
+        Assert.True(await ColumnIsNullableAsync(ctx, "QueueItems"));
+        Assert.True(await ColumnIsNullableAsync(ctx, "HistoryItems"));
+        Assert.True(await ColumnIsNullableAsync(ctx, "DavItems"));
+        Assert.False(await IndexExistsAsync(ctx, "ArrDownloadId"));
+
+        Assert.Equal(queueId, (await ctx.QueueItems.AsNoTracking().SingleAsync()).Id);
+        Assert.Equal(historyId, (await ctx.HistoryItems.AsNoTracking().SingleAsync()).Id);
+        Assert.Equal(davId, (await ctx.Items.AsNoTracking().SingleAsync(x => x.Id == davId)).Id);
+        Assert.Null((await ctx.QueueItems.AsNoTracking().SingleAsync()).ArrDownloadId);
+        Assert.Null((await ctx.HistoryItems.AsNoTracking().SingleAsync()).ArrDownloadId);
+        Assert.Null((await ctx.Items.AsNoTracking().SingleAsync(x => x.Id == davId)).ArrDownloadId);
+
+        var mixed = Guid.Parse("AbCdEf01-2345-4aBc-8DeF-0123456789Ab");
+        var written = await ctx.QueueItems.SingleAsync();
+        written.ArrDownloadId = mixed;
+        await ctx.SaveChangesAsync();
+        ctx.ChangeTracker.Clear();
+
+        var reread = await ctx.QueueItems.AsNoTracking().SingleAsync();
+        Assert.Equal(mixed, reread.ArrDownloadId);
+        Assert.Equal(mixed.ToString("D").ToUpperInvariant(), await ReadTextAsync(ctx, queueId));
+    }
+
+    private static async Task InsertLegacyRowsAsync(
+        DavDatabaseContext ctx, Guid queueId, Guid historyId, Guid davId)
+    {
+        await ctx.Database.ExecuteSqlRawAsync(
+            """
+            INSERT INTO QueueItems (Id, CreatedAt, SortOrder, FileName, JobName, NzbFileSize, TotalSegmentBytes, Category, Priority, PostProcessing)
+            VALUES ({0}, {1}, 0, 'legacy.nzb', 'legacy', 1, 1, 'tv', 0, 0);
+            """,
+            queueId.ToString("D").ToUpperInvariant(),
+            DateTime.UtcNow);
+
+        await ctx.Database.ExecuteSqlRawAsync(
+            """
+            INSERT INTO HistoryItems (Id, CreatedAt, FileName, JobName, Category, DownloadStatus, TotalSegmentBytes, DownloadTimeSeconds, NzbBlobId)
+            VALUES ({0}, {1}, 'legacy.nzb', 'legacy', 'tv', 1, 1, 1, {2});
+            """,
+            historyId.ToString("D").ToUpperInvariant(),
+            DateTime.UtcNow,
+            historyId.ToString("D").ToUpperInvariant());
+
+        await ctx.Database.ExecuteSqlRawAsync(
+            """
+            INSERT INTO DavItems (Id, IdPrefix, CreatedAt, ParentId, Name, FileSize, Type, SubType, Path, HistoryItemId, NzbBlobId, HealthRepairPending)
+            VALUES ({0}, {1}, {2}, {3}, 'legacy.mkv', 1, 2, 201, '/content/legacy.mkv', {4}, {5}, 0);
+            """,
+            davId.ToString("D").ToUpperInvariant(),
+            davId.ToString("N")[..DavItem.IdPrefixLength],
+            DateTime.UtcNow,
+            DavItem.ContentFolder.Id.ToString("D").ToUpperInvariant(),
+            historyId.ToString("D").ToUpperInvariant(),
+            historyId.ToString("D").ToUpperInvariant());
+    }
+
+    private static async Task<bool> ColumnIsNullableAsync(DavDatabaseContext ctx, string table)
+    {
+        var connection = (SqliteConnection)ctx.Database.GetDbConnection();
+        if (connection.State != ConnectionState.Open)
+            await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"SELECT \"notnull\" FROM pragma_table_info('{table}') WHERE name = 'ArrDownloadId';";
+        var value = await command.ExecuteScalarAsync();
+        return Convert.ToInt32(value) == 0;
+    }
+
+    private static async Task<bool> IndexExistsAsync(DavDatabaseContext ctx, string columnName)
+    {
+        var connection = (SqliteConnection)ctx.Database.GetDbConnection();
+        if (connection.State != ConnectionState.Open)
+            await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            """
+            SELECT 1 FROM sqlite_master
+            WHERE type = 'index' AND sql LIKE '%' || $column || '%'
+            LIMIT 1;
+            """;
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "$column";
+        parameter.Value = columnName;
+        command.Parameters.Add(parameter);
+        return await command.ExecuteScalarAsync() is not null and not DBNull;
+    }
+
+    private static async Task<string> ReadTextAsync(DavDatabaseContext ctx, Guid queueId)
+    {
+        var connection = (SqliteConnection)ctx.Database.GetDbConnection();
+        if (connection.State != ConnectionState.Open)
+            await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT ArrDownloadId FROM QueueItems WHERE Id = $id;";
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "$id";
+        parameter.Value = queueId.ToString("D").ToUpperInvariant();
+        command.Parameters.Add(parameter);
+        return Assert.IsType<string>(await command.ExecuteScalarAsync());
+    }
+
+    private sealed class MigrationHarness : IAsyncDisposable
+    {
+        private readonly string _databasePath;
+
+        private MigrationHarness(string databasePath, DavDatabaseContext context)
+        {
+            _databasePath = databasePath;
+            Context = context;
+        }
+
+        public DavDatabaseContext Context { get; }
+
+        public static async Task<MigrationHarness> CreateAsync()
+        {
+            var databasePath = Path.Join(
+                Path.GetTempPath(),
+                $"nzbdav-arr-download-id-{Guid.NewGuid():N}.sqlite");
+            var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite($"Data Source={databasePath};Pooling=False")
+                .AddInterceptors(new SqliteForeignKeyEnabler())
+                .ReplaceService<
+                    IMigrationsSqlGenerator,
+                    SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            var context = new DavDatabaseContext(options);
+            await context.Database.MigrateAsync(PriorMigration);
+            return new MigrationHarness(databasePath, context);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.DisposeAsync();
+            File.Delete(_databasePath);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Database/FixEmptyCategoriesMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/FixEmptyCategoriesMigrationTests.cs
@@ -48,29 +48,32 @@ public sealed class FixEmptyCategoriesMigrationTests
             ctx,
             [uncategorizedFolder, emptyFolder, mount, collisionMount, existingMount]);
 
-        ctx.HistoryItems.AddRange(
-            new HistoryItem
-            {
-                Id = emptyHistoryId,
-                CreatedAt = DateTime.UtcNow,
-                FileName = "hist-empty.nzb",
-                JobName = "hist-empty",
-                Category = "",
-                DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
-                TotalSegmentBytes = 20,
-                DownloadTimeSeconds = 1,
-            },
-            new HistoryItem
-            {
-                Id = whitespaceHistoryId,
-                CreatedAt = DateTime.UtcNow,
-                FileName = "hist-ws.nzb",
-                JobName = "hist-ws",
-                Category = "   ",
-                DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
-                TotalSegmentBytes = 20,
-                DownloadTimeSeconds = 1,
-            });
+        await HistoricalDavItemSeeder.SeedHistoryItemsAsync(
+            ctx,
+            [
+                new HistoryItem
+                {
+                    Id = emptyHistoryId,
+                    CreatedAt = DateTime.UtcNow,
+                    FileName = "hist-empty.nzb",
+                    JobName = "hist-empty",
+                    Category = "",
+                    DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+                    TotalSegmentBytes = 20,
+                    DownloadTimeSeconds = 1,
+                },
+                new HistoryItem
+                {
+                    Id = whitespaceHistoryId,
+                    CreatedAt = DateTime.UtcNow,
+                    FileName = "hist-ws.nzb",
+                    JobName = "hist-ws",
+                    Category = "   ",
+                    DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+                    TotalSegmentBytes = 20,
+                    DownloadTimeSeconds = 1,
+                },
+            ]);
 
         await ctx.SaveChangesAsync();
         var createdAt = DateTime.UtcNow;
@@ -148,17 +151,19 @@ public sealed class FixEmptyCategoriesMigrationTests
         mount.Path = "/content//Orphan Release";
 
         await HistoricalDavItemSeeder.SeedAsync(ctx, [emptyFolder, mount]);
-        ctx.HistoryItems.Add(new HistoryItem
-        {
-            Id = Guid.NewGuid(),
-            CreatedAt = DateTime.UtcNow,
-            FileName = "orphan.nzb",
-            JobName = "orphan",
-            Category = "",
-            DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
-            TotalSegmentBytes = 20,
-            DownloadTimeSeconds = 1,
-        });
+        await HistoricalDavItemSeeder.SeedHistoryItemsAsync(ctx, [
+            new HistoryItem
+            {
+                Id = Guid.NewGuid(),
+                CreatedAt = DateTime.UtcNow,
+                FileName = "orphan.nzb",
+                JobName = "orphan",
+                Category = "",
+                DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+                TotalSegmentBytes = 20,
+                DownloadTimeSeconds = 1,
+            },
+        ]);
         await ctx.SaveChangesAsync();
         ctx.ChangeTracker.Clear();
 

--- a/tests/NzbWebDAV.Tests/Database/HistoricalDavItemSeeder.cs
+++ b/tests/NzbWebDAV.Tests/Database/HistoricalDavItemSeeder.cs
@@ -50,6 +50,89 @@ internal static class HistoricalDavItemSeeder
         await transaction.CommitAsync();
     }
 
+    public static async Task SeedHistoryItemsAsync(DavDatabaseContext context, IEnumerable<HistoryItem> items)
+    {
+        var connection = (SqliteConnection)context.Database.GetDbConnection();
+        if (connection.State != ConnectionState.Open)
+            await connection.OpenAsync();
+
+        await using var transaction = await connection.BeginTransactionAsync();
+        await using var command = connection.CreateCommand();
+        command.Transaction = (SqliteTransaction)transaction;
+        command.CommandText = """
+            INSERT INTO HistoryItems (
+                Id, CreatedAt, FileName, JobName, Category, DownloadStatus, TotalSegmentBytes,
+                DownloadTimeSeconds, FailMessage, DownloadDirId, NzbBlobId, IndexerName,
+                ContentGroupKey, LastPlayedAt)
+            VALUES (
+                $id, $createdAt, $fileName, $jobName, $category, $downloadStatus, $totalSegmentBytes,
+                $downloadTimeSeconds, $failMessage, $downloadDirId, $nzbBlobId, $indexerName,
+                $contentGroupKey, $lastPlayedAt);
+            """;
+
+        foreach (var item in items)
+        {
+            command.Parameters.Clear();
+            Add(command, "$id", GuidText(item.Id));
+            Add(command, "$createdAt", item.CreatedAt);
+            Add(command, "$fileName", item.FileName);
+            Add(command, "$jobName", item.JobName);
+            Add(command, "$category", item.Category);
+            Add(command, "$downloadStatus", (int)item.DownloadStatus);
+            Add(command, "$totalSegmentBytes", item.TotalSegmentBytes);
+            Add(command, "$downloadTimeSeconds", item.DownloadTimeSeconds);
+            Add(command, "$failMessage", item.FailMessage);
+            Add(command, "$downloadDirId", item.DownloadDirId is { } downloadDirId ? GuidText(downloadDirId) : null);
+            Add(command, "$nzbBlobId", item.NzbBlobId is { } nzbBlobId ? GuidText(nzbBlobId) : null);
+            Add(command, "$indexerName", item.IndexerName);
+            Add(command, "$contentGroupKey", item.ContentGroupKey);
+            Add(command, "$lastPlayedAt", item.LastPlayedAt?.ToUnixTimeSeconds());
+            await command.ExecuteNonQueryAsync();
+        }
+
+        await transaction.CommitAsync();
+    }
+
+    public static async Task SeedQueueItemsAsync(DavDatabaseContext context, IEnumerable<QueueItem> items)
+    {
+        var connection = (SqliteConnection)context.Database.GetDbConnection();
+        if (connection.State != ConnectionState.Open)
+            await connection.OpenAsync();
+
+        await using var transaction = await connection.BeginTransactionAsync();
+        await using var command = connection.CreateCommand();
+        command.Transaction = (SqliteTransaction)transaction;
+        command.CommandText = """
+            INSERT INTO QueueItems (
+                Id, CreatedAt, SortOrder, FileName, JobName, NzbFileSize, TotalSegmentBytes,
+                Category, Priority, PostProcessing, PauseUntil, IndexerName, ContentGroupKey)
+            VALUES (
+                $id, $createdAt, $sortOrder, $fileName, $jobName, $nzbFileSize, $totalSegmentBytes,
+                $category, $priority, $postProcessing, $pauseUntil, $indexerName, $contentGroupKey);
+            """;
+
+        foreach (var item in items)
+        {
+            command.Parameters.Clear();
+            Add(command, "$id", GuidText(item.Id));
+            Add(command, "$createdAt", item.CreatedAt);
+            Add(command, "$sortOrder", item.SortOrder);
+            Add(command, "$fileName", item.FileName);
+            Add(command, "$jobName", item.JobName);
+            Add(command, "$nzbFileSize", item.NzbFileSize);
+            Add(command, "$totalSegmentBytes", item.TotalSegmentBytes);
+            Add(command, "$category", item.Category);
+            Add(command, "$priority", (int)item.Priority);
+            Add(command, "$postProcessing", (int)item.PostProcessing);
+            Add(command, "$pauseUntil", item.PauseUntil);
+            Add(command, "$indexerName", item.IndexerName);
+            Add(command, "$contentGroupKey", item.ContentGroupKey);
+            await command.ExecuteNonQueryAsync();
+        }
+
+        await transaction.CommitAsync();
+    }
+
     private static void Add(SqliteCommand command, string name, object? value) =>
         command.Parameters.AddWithValue(name, value ?? DBNull.Value);
 

--- a/tests/NzbWebDAV.Tests/Database/NormalizeGuidTextCasingMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/NormalizeGuidTextCasingMigrationTests.cs
@@ -16,7 +16,7 @@ public sealed class NormalizeGuidTextCasingMigrationTests
     private const string PriorMigration = "20260818220000_Add-Par2-Repair-Jobs";
 
     [Fact]
-    public void Inventory_CoversTwentySevenGuidColumnsAcrossEighteenTables()
+    public void Inventory_CoversGuidColumnsPresentAtNormalizationMigration()
     {
         Assert.Equal(18, GuidTextCasingSql.GuidColumns.Length);
         Assert.Equal(27, GuidTextCasingSql.GuidColumns.Sum(entry => entry.Columns.Length));
@@ -82,32 +82,36 @@ public sealed class NormalizeGuidTextCasingMigrationTests
         ctx.NzbFiles.Add(new DavNzbFile { Id = nzbId, SegmentIds = ["seg"] });
         ctx.RarFiles.Add(new DavRarFile { Id = rarId, RarParts = [] });
         ctx.MultipartFiles.Add(new DavMultipartFile { Id = multiId, Metadata = new DavMultipartFile.Meta() });
-        ctx.HistoryItems.Add(new HistoryItem
-        {
-            Id = historyId,
-            CreatedAt = DateTime.UtcNow,
-            FileName = "hist.nzb",
-            JobName = "hist",
-            Category = "tv",
-            DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
-            TotalSegmentBytes = 20,
-            DownloadTimeSeconds = 1,
-            DownloadDirId = dirId,
-            NzbBlobId = nzbBlobId,
-        });
-        ctx.QueueItems.Add(new QueueItem
-        {
-            Id = queueId,
-            CreatedAt = DateTime.UtcNow,
-            SortOrder = QueueItem.SortOrderStride,
-            FileName = "queue.nzb",
-            JobName = "queue",
-            NzbFileSize = 10,
-            TotalSegmentBytes = 20,
-            Category = "tv",
-            Priority = QueueItem.PriorityOption.Normal,
-            PostProcessing = QueueItem.PostProcessingOption.None,
-        });
+        await HistoricalDavItemSeeder.SeedHistoryItemsAsync(ctx, [
+            new HistoryItem
+            {
+                Id = historyId,
+                CreatedAt = DateTime.UtcNow,
+                FileName = "hist.nzb",
+                JobName = "hist",
+                Category = "tv",
+                DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+                TotalSegmentBytes = 20,
+                DownloadTimeSeconds = 1,
+                DownloadDirId = dirId,
+                NzbBlobId = nzbBlobId,
+            },
+        ]);
+        await HistoricalDavItemSeeder.SeedQueueItemsAsync(ctx, [
+            new QueueItem
+            {
+                Id = queueId,
+                CreatedAt = DateTime.UtcNow,
+                SortOrder = QueueItem.SortOrderStride,
+                FileName = "queue.nzb",
+                JobName = "queue",
+                NzbFileSize = 10,
+                TotalSegmentBytes = 20,
+                Category = "tv",
+                Priority = QueueItem.PriorityOption.Normal,
+                PostProcessing = QueueItem.PostProcessingOption.None,
+            },
+        ]);
         ctx.QueueNzbContents.Add(new QueueNzbContents { Id = queueId, NzbContents = "<nzb />" });
         ctx.HealthCheckResults.Add(new HealthCheckResult
         {

--- a/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using System.Data.Common;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
@@ -56,6 +57,34 @@ public sealed class PostgresMigrationTests
             Assert.Empty(await context.Database.GetPendingMigrationsAsync());
             Assert.True(await DatabaseStartupGuards.ConfigItemsTableExistsAsync(context));
             Assert.Equal(5, await context.Items.CountAsync());
+
+            Assert.Equal("uuid", await GetColumnTypeAsync(context, "DavItems", "ArrDownloadId"));
+            Assert.Equal("YES", await GetIsNullableAsync(context, "DavItems", "ArrDownloadId"));
+            Assert.Equal("uuid", await GetColumnTypeAsync(context, "HistoryItems", "ArrDownloadId"));
+            Assert.Equal("YES", await GetIsNullableAsync(context, "HistoryItems", "ArrDownloadId"));
+            Assert.Equal("uuid", await GetColumnTypeAsync(context, "QueueItems", "ArrDownloadId"));
+            Assert.Equal("YES", await GetIsNullableAsync(context, "QueueItems", "ArrDownloadId"));
+
+            var id = Guid.Parse("AbCdEf01-2345-4aBc-8DeF-0123456789Ab");
+            context.QueueItems.Add(new QueueItem
+            {
+                Id = Guid.NewGuid(),
+                CreatedAt = DateTime.UtcNow,
+                FileName = "pg-provenance.nzb",
+                JobName = "pg-provenance",
+                NzbFileSize = 1,
+                TotalSegmentBytes = 1,
+                Category = "tv",
+                Priority = QueueItem.PriorityOption.Normal,
+                PostProcessing = QueueItem.PostProcessingOption.None,
+                ArrDownloadId = id,
+            });
+            await context.SaveChangesAsync();
+            context.ChangeTracker.Clear();
+            Assert.Equal(
+                id,
+                (await context.QueueItems.AsNoTracking().SingleAsync(x => x.FileName == "pg-provenance.nzb"))
+                    .ArrDownloadId);
         }
         finally
         {
@@ -361,6 +390,52 @@ public sealed class PostgresMigrationTests
             IndexerName = indexerName,
             DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
         };
+
+    private static async Task<string> GetColumnTypeAsync(
+        PostgresDavDatabaseContext context, string table, string column)
+    {
+        await using var command = context.Database.GetDbConnection().CreateCommand();
+        if (command.Connection!.State != ConnectionState.Open)
+            await command.Connection.OpenAsync();
+        command.CommandText =
+            """
+            SELECT data_type
+            FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND table_name = $table
+              AND column_name = $column;
+            """;
+        AddParameter(command, "$table", table);
+        AddParameter(command, "$column", column);
+        return Assert.IsType<string>(await command.ExecuteScalarAsync());
+    }
+
+    private static async Task<string> GetIsNullableAsync(
+        PostgresDavDatabaseContext context, string table, string column)
+    {
+        await using var command = context.Database.GetDbConnection().CreateCommand();
+        if (command.Connection!.State != ConnectionState.Open)
+            await command.Connection.OpenAsync();
+        command.CommandText =
+            """
+            SELECT is_nullable
+            FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND table_name = $table
+              AND column_name = $column;
+            """;
+        AddParameter(command, "$table", table);
+        AddParameter(command, "$column", column);
+        return Assert.IsType<string>(await command.ExecuteScalarAsync());
+    }
+
+    private static void AddParameter(DbCommand command, string name, string value)
+    {
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = name;
+        parameter.Value = value;
+        command.Parameters.Add(parameter);
+    }
 
     private static async Task ExecuteAsync(NpgsqlConnection connection, string commandText)
     {

--- a/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
@@ -402,11 +402,11 @@ public sealed class PostgresMigrationTests
             SELECT data_type
             FROM information_schema.columns
             WHERE table_schema = current_schema()
-              AND table_name = $table
-              AND column_name = $column;
+              AND table_name = @table
+              AND column_name = @column;
             """;
-        AddParameter(command, "$table", table);
-        AddParameter(command, "$column", column);
+        AddParameter(command, "@table", table);
+        AddParameter(command, "@column", column);
         return Assert.IsType<string>(await command.ExecuteScalarAsync());
     }
 
@@ -421,11 +421,11 @@ public sealed class PostgresMigrationTests
             SELECT is_nullable
             FROM information_schema.columns
             WHERE table_schema = current_schema()
-              AND table_name = $table
-              AND column_name = $column;
+              AND table_name = @table
+              AND column_name = @column;
             """;
-        AddParameter(command, "$table", table);
-        AddParameter(command, "$column", column);
+        AddParameter(command, "@table", table);
+        AddParameter(command, "@column", column);
         return Assert.IsType<string>(await command.ExecuteScalarAsync());
     }
 

--- a/tests/NzbWebDAV.Tests/Queue/FileAggregatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/FileAggregatorTests.cs
@@ -1,0 +1,76 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Queue.FileAggregators;
+using NzbWebDAV.Queue.FileProcessors;
+
+namespace NzbWebDAV.Tests.Queue;
+
+public class FileAggregatorTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly DavDatabaseContext _context;
+    private readonly DavDatabaseClient _dbClient;
+
+    public FileAggregatorTests()
+    {
+        _dbPath = Path.Join(Path.GetTempPath(), $"file-agg-{Guid.NewGuid():N}.sqlite");
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={_dbPath}")
+            .Options;
+        _context = new DavDatabaseContext(options);
+        _context.Database.EnsureCreated();
+        _dbClient = new DavDatabaseClient(_context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        try { File.Delete(_dbPath); } catch (IOException) { /* ignore */ }
+    }
+
+    [Fact]
+    public void UpdateDatabase_PropagatesArrDownloadIdToNestedDirectoryAndLeaf()
+    {
+        var historyItemId = Guid.NewGuid();
+        var arrDownloadId = Guid.NewGuid();
+        var mount = DavItem.New(
+            Guid.NewGuid(),
+            DavItem.ContentFolder,
+            "release",
+            null,
+            DavItem.ItemType.Directory,
+            DavItem.ItemSubType.Directory,
+            null,
+            null,
+            historyItemId,
+            null,
+            arrDownloadId: arrDownloadId);
+        _context.Items.Add(mount);
+
+        new FileAggregator(_dbClient, mount, checkedFullHealth: false).UpdateDatabase(
+        [
+            new FileProcessor.Result
+            {
+                NzbFile = new NzbFile
+                {
+                    Subject = "\"nested/video.mkv\" yEnc",
+                    Segments = { new NzbSegment { MessageId = "seg@test", Bytes = 10 } },
+                },
+                FileName = "nested/video.mkv",
+                FileSize = 10,
+                ReleaseDate = DateTimeOffset.UnixEpoch,
+            },
+        ]);
+
+        var directory = Assert.Single(_context.Items.Local, i =>
+            i.ParentId == mount.Id && i.Type == DavItem.ItemType.Directory);
+        var leaf = Assert.Single(_context.Items.Local, i =>
+            i.Type == DavItem.ItemType.UsenetFile);
+        Assert.Equal(arrDownloadId, directory.ArrDownloadId);
+        Assert.Equal(arrDownloadId, leaf.ArrDownloadId);
+        Assert.Equal(historyItemId, leaf.NzbBlobId);
+        Assert.NotEqual(leaf.NzbBlobId, leaf.ArrDownloadId);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Queue/MultipartMkvAggregatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/MultipartMkvAggregatorTests.cs
@@ -34,6 +34,7 @@ public class MultipartMkvAggregatorTests : IDisposable
     public void UpdateDatabase_CreatesOneDavItemPerProcessorResult()
     {
         var historyItemId = Guid.NewGuid();
+        var arrDownloadId = Guid.NewGuid();
         var mount = DavItem.New(
             Guid.NewGuid(),
             DavItem.ContentFolder,
@@ -44,7 +45,9 @@ public class MultipartMkvAggregatorTests : IDisposable
             null,
             null,
             historyItemId,
-            null);
+            null,
+            nzbBlobId: null,
+            arrDownloadId: arrDownloadId);
         _context.Items.Add(mount);
 
         new MultipartMkvAggregator(_dbClient, mount, checkedFullHealth: false).UpdateDatabase(
@@ -61,6 +64,9 @@ public class MultipartMkvAggregatorTests : IDisposable
         Assert.All(items, i => Assert.Equal(DavItem.ItemSubType.MultipartFile, i.SubType));
         Assert.Equal([10L, 20L], items.Select(i => i.FileSize).ToArray());
         Assert.Equal(2, _context.BlobMultipartFiles.Count);
+        Assert.All(items, i => Assert.Equal(arrDownloadId, i.ArrDownloadId));
+        Assert.All(items, i => Assert.Equal(historyItemId, i.NzbBlobId));
+        Assert.Equal(arrDownloadId, mount.ArrDownloadId);
     }
 
     private static MultipartMkvProcessor.Result Result(string filename, long size) => new()

--- a/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
@@ -539,6 +539,107 @@ public class ArrLinkedRepairDecisionTests
     }
 
     [Fact]
+    public async Task UniqueRecoveryThenAmbiguousInstance_DoesNotReturnRecoveredId()
+    {
+        var recovered = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        var other = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://radarr-unique",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, id) =>
+                {
+                    Assert.Equal(recovered, id);
+                    return Task.FromResult(ArrRepairOutcome.DownloadHistoryNotFound);
+                },
+                importHistory: (_, _, _) => Task.FromResult(new ArrHistory
+                {
+                    TotalRecords = 1,
+                    Records =
+                    [
+                        new ArrHistoryRecord
+                        {
+                            DownloadId = recovered.ToString(),
+                            EventType = 3,
+                            Data = new ArrHistoryData { FileId = "1", ImportedPath = LibraryPath },
+                        },
+                    ],
+                })),
+            new ScriptedArrClient(
+                host: "http://radarr-ambiguous",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, _) => throw new InvalidOperationException("must not mutate"),
+                importHistory: (_, _, _) => Task.FromResult(new ArrHistory
+                {
+                    TotalRecords = 2,
+                    Records =
+                    [
+                        new ArrHistoryRecord
+                        {
+                            DownloadId = recovered.ToString(),
+                            EventType = 3,
+                            Data = new ArrHistoryData { FileId = "1", ImportedPath = LibraryPath },
+                        },
+                        new ArrHistoryRecord
+                        {
+                            DownloadId = other.ToString(),
+                            EventType = 3,
+                            Data = new ArrHistoryData { FileId = "1", ImportedPath = LibraryPath },
+                        },
+                    ],
+                })),
+        };
+
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, null, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferAmbiguousDownloadIdentity, result.Decision);
+        Assert.Null(result.RecoveredDownloadId);
+    }
+
+    [Fact]
+    public async Task TruncatedImportHistoryPage_DoesNotTreatUniqueMatchAsProven()
+    {
+        var recovered = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, _) => throw new InvalidOperationException("must not mutate"),
+                importHistory: (_, _, _) => Task.FromResult(new ArrHistory
+                {
+                    TotalRecords = 100,
+                    Records =
+                    [
+                        new ArrHistoryRecord
+                        {
+                            DownloadId = recovered.ToString(),
+                            EventType = 3,
+                            Data = new ArrHistoryData { FileId = "1", ImportedPath = LibraryPath },
+                        },
+                    ],
+                })),
+        };
+
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, null, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferMissingDownloadIdentity, result.Decision);
+        Assert.Null(result.RecoveredDownloadId);
+    }
+
+    [Fact]
     public async Task FirstInstanceMissingHistory_DoesNotPreventLaterInstanceSuccess()
     {
         var downloadId = DownloadId;

--- a/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
@@ -20,10 +20,10 @@ public class ArrLinkedRepairDecisionTests
                 removeAndBlocklist: (_, _) => Task.FromResult(ArrRepairOutcome.MediaItemNotFound)),
         };
 
-        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
             clients, LibraryPath, DownloadId, CancellationToken.None);
 
-        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, decision);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, result.Decision);
     }
 
     [Fact]
@@ -40,10 +40,10 @@ public class ArrLinkedRepairDecisionTests
                 removeAndBlocklist: (_, _) => throw new HttpRequestException("timeout")),
         };
 
-        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
             clients, LibraryPath, DownloadId, CancellationToken.None);
 
-        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, decision);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, result.Decision);
     }
 
     [Fact]
@@ -60,10 +60,10 @@ public class ArrLinkedRepairDecisionTests
                 removeAndBlocklist: (_, _) => Task.FromResult(ArrRepairOutcome.MediaItemNotFound)),
         };
 
-        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
             clients, LibraryPath, DownloadId, CancellationToken.None);
 
-        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, decision);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, result.Decision);
     }
 
     [Fact]
@@ -84,10 +84,10 @@ public class ArrLinkedRepairDecisionTests
                 removeAndBlocklist: (_, _) => Task.FromResult(ArrRepairOutcome.MediaItemNotFound)),
         };
 
-        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
             clients, LibraryPath, DownloadId, CancellationToken.None);
 
-        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, decision);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, result.Decision);
     }
 
     [Fact]
@@ -105,10 +105,10 @@ public class ArrLinkedRepairDecisionTests
                     Task.FromResult(ArrRepairOutcome.RemoveAndBlocklistSucceeded)),
         };
 
-        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
             clients, LibraryPath, DownloadId, CancellationToken.None);
 
-        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded, decision);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded, result.Decision);
     }
 
     [Fact]
@@ -126,12 +126,12 @@ public class ArrLinkedRepairDecisionTests
                     Task.FromResult(ArrRepairOutcome.RemoveAndBlocklistSucceededSearchWithheld)),
         };
 
-        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
             clients, LibraryPath, DownloadId, CancellationToken.None);
 
         Assert.Equal(
             HealthCheckService.ArrLinkedRepairDecision.RemoveAndBlocklistSucceededSearchWithheld,
-            decision);
+            result.Decision);
     }
 
     [Fact]
@@ -148,10 +148,10 @@ public class ArrLinkedRepairDecisionTests
                 removeAndBlocklist: (_, _) => throw new InvalidOperationException("should not be called")),
         };
 
-        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
             clients, LibraryPath, null, CancellationToken.None);
 
-        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferMissingDownloadHistory, decision);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferMissingDownloadIdentity, result.Decision);
     }
 
     [Fact]
@@ -169,10 +169,10 @@ public class ArrLinkedRepairDecisionTests
                     Task.FromResult(ArrRepairOutcome.DownloadHistoryNotFound)),
         };
 
-        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
             clients, LibraryPath, DownloadId, CancellationToken.None);
 
-        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferMissingDownloadHistory, decision);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferMissingDownloadHistory, result.Decision);
     }
 
     [Fact]
@@ -190,10 +190,10 @@ public class ArrLinkedRepairDecisionTests
                 removeAndBlocklist: (_, _) => throw new InvalidOperationException("should not be called")),
         };
 
-        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
             clients, localPath, DownloadId, CancellationToken.None);
 
-        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferRootPathMismatch, decision);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferRootPathMismatch, result.Decision);
     }
 
     [Fact]
@@ -218,10 +218,10 @@ public class ArrLinkedRepairDecisionTests
                 removeAndBlocklist: (_, _) => throw new InvalidOperationException("should not be called")),
         };
 
-        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
             clients, localPath, DownloadId, CancellationToken.None);
 
-        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferRootPathMismatch, decision);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferRootPathMismatch, result.Decision);
     }
 
     [Fact]
@@ -243,11 +243,11 @@ public class ArrLinkedRepairDecisionTests
                 }),
         };
 
-        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
             clients, LibraryPath, DownloadId, CancellationToken.None);
 
         Assert.Equal(1, removeCalls);
-        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferNoMatchingMediaItem, decision);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferNoMatchingMediaItem, result.Decision);
     }
 
     [Fact]
@@ -276,11 +276,11 @@ public class ArrLinkedRepairDecisionTests
                 }),
         };
 
-        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
             clients, LibraryPath, DownloadId, CancellationToken.None);
 
         Assert.Equal(1, movieRemoveCalls);
-        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferNoMatchingMediaItem, decision);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferNoMatchingMediaItem, result.Decision);
     }
 
     [Fact]
@@ -301,10 +301,10 @@ public class ArrLinkedRepairDecisionTests
                 removeAndBlocklist: (_, _) => throw new InvalidOperationException("should not be called")),
         };
 
-        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
             clients, LibraryPath, DownloadId, CancellationToken.None);
 
-        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, decision);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, result.Decision);
     }
 
     [Fact]
@@ -322,10 +322,10 @@ public class ArrLinkedRepairDecisionTests
                 removeAndBlocklist: (_, _) => throw new InvalidOperationException("should not be called")),
         };
 
-        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
             clients, LibraryPath, DownloadId, CancellationToken.None);
 
-        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, decision);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, result.Decision);
     }
 
     [Fact]
@@ -368,19 +368,19 @@ public class ArrLinkedRepairDecisionTests
                     Task.FromResult(ArrRepairOutcome.RemoveAndBlocklistSucceeded)),
         };
 
-        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
             clients, LibraryPath, DownloadId, CancellationToken.None);
 
-        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded, decision);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded, result.Decision);
     }
 
     [Fact]
     public async Task NoArrInstances_DefersWithoutDelete()
     {
-        var decision = await HealthCheckService.DecideArrLinkedRepairAsync(
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
             [], LibraryPath, DownloadId, CancellationToken.None);
 
-        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferNoMatchingMediaItem, decision);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferNoMatchingMediaItem, result.Decision);
     }
 
     [Theory]
@@ -400,18 +400,271 @@ public class ArrLinkedRepairDecisionTests
         Assert.Equal(expected, HealthCheckService.IsPathWithinRoot(candidate, root));
     }
 
+    [Fact]
+    public async Task StoredArrDownloadId_IsPassedInsteadOfLocalBlobId()
+    {
+        var observed = new List<Guid>();
+        var arrDownloadId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, downloadId) =>
+                {
+                    observed.Add(downloadId);
+                    return Task.FromResult(ArrRepairOutcome.RemoveAndBlocklistSucceeded);
+                }),
+        };
+
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, arrDownloadId, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded, result.Decision);
+        Assert.Equal([arrDownloadId], observed);
+        Assert.Null(result.RecoveredDownloadId);
+    }
+
+    [Fact]
+    public async Task NullProvenance_NeverFallsBackToLocalIds()
+    {
+        var nzbBlobId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, _) => throw new InvalidOperationException("must not use NzbBlobId"),
+                importHistory: (_, _, _) => Task.FromResult(new ArrHistory())),
+        };
+
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, null, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferMissingDownloadIdentity, result.Decision);
+        Assert.Null(result.RecoveredDownloadId);
+        _ = nzbBlobId;
+    }
+
+    [Fact]
+    public async Task UniqueExactLegacyRecovery_IsUsedAndReturned()
+    {
+        var recovered = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://radarr.test",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, downloadId) =>
+                {
+                    Assert.Equal(recovered, downloadId);
+                    return Task.FromResult(ArrRepairOutcome.RemoveAndBlocklistSucceeded);
+                },
+                importHistory: (_, _, _) => Task.FromResult(new ArrHistory
+                {
+                    TotalRecords = 1,
+                    Records =
+                    [
+                        new ArrHistoryRecord
+                        {
+                            DownloadId = recovered.ToString(),
+                            EventType = 3,
+                            Data = new ArrHistoryData
+                            {
+                                FileId = "1",
+                                ImportedPath = LibraryPath,
+                            },
+                        },
+                    ],
+                })),
+        };
+
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, null, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded, result.Decision);
+        Assert.Equal(recovered, result.RecoveredDownloadId);
+        Assert.Equal("http://radarr.test", result.RecoveryHost);
+    }
+
+    [Fact]
+    public async Task AmbiguousLegacyEvidence_DefersWithoutMutation()
+    {
+        var first = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var second = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, _) => throw new InvalidOperationException("must not mutate"),
+                importHistory: (_, _, _) => Task.FromResult(new ArrHistory
+                {
+                    TotalRecords = 2,
+                    Records =
+                    [
+                        new ArrHistoryRecord
+                        {
+                            DownloadId = first.ToString(),
+                            EventType = 3,
+                            Data = new ArrHistoryData { FileId = "1", ImportedPath = LibraryPath },
+                        },
+                        new ArrHistoryRecord
+                        {
+                            DownloadId = second.ToString(),
+                            EventType = 3,
+                            Data = new ArrHistoryData { FileId = "1", ImportedPath = LibraryPath },
+                        },
+                    ],
+                })),
+        };
+
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, null, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferAmbiguousDownloadIdentity, result.Decision);
+        Assert.Null(result.RecoveredDownloadId);
+    }
+
+    [Fact]
+    public async Task FirstInstanceMissingHistory_DoesNotPreventLaterInstanceSuccess()
+    {
+        var downloadId = DownloadId;
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://first-radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, _) => Task.FromResult(ArrRepairOutcome.DownloadHistoryNotFound)),
+            new ScriptedArrClient(
+                host: "http://second-radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, id) =>
+                {
+                    Assert.Equal(downloadId, id);
+                    return Task.FromResult(ArrRepairOutcome.RemoveAndBlocklistSucceeded);
+                }),
+        };
+
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, downloadId, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded, result.Decision);
+    }
+
+    [Fact]
+    public async Task UnreachableOwnerPlusHistoryMiss_ReturnsDeferUnreachable()
+    {
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://unreachable",
+                rootFolders: () => throw new HttpRequestException("down"),
+                removeAndBlocklist: (_, _) => throw new InvalidOperationException("should not be called")),
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, _) => Task.FromResult(ArrRepairOutcome.DownloadHistoryNotFound)),
+        };
+
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, DownloadId, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, result.Decision);
+    }
+
+    [Fact]
+    public async Task RootMatchWithoutExactMedia_DoesNotClaimMediaOwnership()
+    {
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, _) => throw new InvalidOperationException("should not mutate"),
+                findMediaFile: _ => Task.FromResult<ArrMediaFileMatch?>(null)),
+        };
+
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients, LibraryPath, DownloadId, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferNoMatchingMediaItem, result.Decision);
+    }
+
+    private static readonly ArrMediaFileMatch DummyMediaFile =
+        new(ArrMediaKind.Movie, FileId: 1, MediaIds: [1]);
+
     private sealed class ScriptedArrClient(
         string host,
         Func<Task<List<ArrRootFolder>>> rootFolders,
-        Func<string, Guid, Task<ArrRepairOutcome>> removeAndBlocklist) : ArrClient(host, "test-key")
+        Func<string, Guid, Task<ArrRepairOutcome>> removeAndBlocklist,
+        Func<string, Task<ArrMediaFileMatch?>>? findMediaFile = null,
+        Func<ArrMediaFileMatch, int, int, Task<ArrHistory>>? importHistory = null,
+        Func<ArrMediaFileMatch, Guid, Task<ArrRepairOutcome>>? removeAndBlocklistMatch = null)
+        : ArrClient(host, "test-key")
     {
+        public List<Guid> BlocklistDownloadIds { get; } = [];
+
         public override Task<List<ArrRootFolder>> GetRootFolders(CancellationToken ct) => rootFolders();
+
+        public override Task<ArrMediaFileMatch?> FindMediaFileAsync(
+            string symlinkOrStrmPath,
+            CancellationToken ct = default) =>
+            findMediaFile?.Invoke(symlinkOrStrmPath)
+            ?? Task.FromResult<ArrMediaFileMatch?>(DummyMediaFile);
+
+        public override Task<ArrHistory> GetMediaImportHistoryAsync(
+            ArrMediaFileMatch mediaFile,
+            int page,
+            int pageSize,
+            CancellationToken ct = default) =>
+            importHistory?.Invoke(mediaFile, page, pageSize)
+            ?? Task.FromResult(new ArrHistory());
 
         public override Task<ArrRepairOutcome> RemoveAndBlocklist(
             string symlinkOrStrmPath,
             Guid downloadId,
             Func<IReadOnlyList<string>, bool>? shouldRequestSearch = null,
-            CancellationToken ct = default) =>
-            removeAndBlocklist(symlinkOrStrmPath, downloadId);
+            CancellationToken ct = default)
+        {
+            BlocklistDownloadIds.Add(downloadId);
+            return removeAndBlocklist(symlinkOrStrmPath, downloadId);
+        }
+
+        public override Task<ArrRepairOutcome> RemoveAndBlocklist(
+            ArrMediaFileMatch mediaFile,
+            Guid downloadId,
+            Func<IReadOnlyList<string>, bool>? shouldRequestSearch = null,
+            CancellationToken ct = default)
+        {
+            BlocklistDownloadIds.Add(downloadId);
+            return removeAndBlocklistMatch is not null
+                ? removeAndBlocklistMatch(mediaFile, downloadId)
+                : removeAndBlocklist(LibraryPath, downloadId);
+        }
     }
 }

--- a/tests/NzbWebDAV.Tests/Services/HistoryCleanupServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HistoryCleanupServiceTests.cs
@@ -95,6 +95,37 @@ public sealed class HistoryCleanupServiceTests : IDisposable
         Assert.False(await _context.HistoryCleanupItems.AsNoTracking().AnyAsync(x => x.Id == historyItemId));
     }
 
+    [Fact]
+    public async Task ProcessNextItemAsync_KeepMountedFilesPreservesArrDownloadId()
+    {
+        var arrDownloadId = Guid.NewGuid();
+        var currentJobId = Guid.NewGuid();
+        var video = NewVideo(currentJobId, "movies/Movie/movie.mkv");
+        video.NzbBlobId = currentJobId;
+        video.ArrDownloadId = arrDownloadId;
+        _context.Items.Add(video);
+        _context.HistoryCleanupItems.Add(new HistoryCleanupItem
+        {
+            Id = currentJobId,
+            DeleteMountedFiles = false,
+        });
+        await _context.SaveChangesAsync();
+
+        await CreateStrmFilesPostProcessor.WriteStrmFileAsync(_config, video, forceRewrite: false);
+        await _context.SaveChangesAsync();
+        var strmPath = CreateStrmFilesPostProcessor.GetStrmFilePath(_config, video);
+
+        var processed = await HistoryCleanupService.ProcessNextItemAsync(_context);
+
+        Assert.True(processed);
+        Assert.True(File.Exists(strmPath));
+        var retained = await _context.Items.AsNoTracking().SingleAsync(x => x.Id == video.Id);
+        Assert.Null(retained.HistoryItemId);
+        Assert.Equal(currentJobId, retained.NzbBlobId);
+        Assert.Equal(arrDownloadId, retained.ArrDownloadId);
+        Assert.False(await _context.HistoryCleanupItems.AsNoTracking().AnyAsync(x => x.Id == currentJobId));
+    }
+
     private static DavItem NewVideo(Guid historyItemId, string relativePath)
     {
         var id = Guid.NewGuid();

--- a/tests/NzbWebDAV.Tests/Services/HistoryRetentionServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HistoryRetentionServiceTests.cs
@@ -69,7 +69,7 @@ public sealed class HistoryRetentionServiceTests : IAsyncLifetime
         var davItem = DavItem.New(
             davItemId, DavItem.Root, "old.mkv", 100,
             DavItem.ItemType.UsenetFile, DavItem.ItemSubType.NzbFile,
-            null, null, oldHistoryId, null);
+            null, null, oldHistoryId, null, nzbBlobId: oldHistoryId, arrDownloadId: oldHistoryId);
         _context.Items.Add(davItem);
         await _context.SaveChangesAsync();
         _context.ChangeTracker.Clear();
@@ -96,6 +96,8 @@ public sealed class HistoryRetentionServiceTests : IAsyncLifetime
         var preserved = await _context.Items.AsNoTracking().SingleAsync(x => x.Id == davItemId);
         Assert.Null(preserved.HistoryItemId);
         Assert.Equal("old.mkv", preserved.Name);
+        Assert.Equal(oldHistoryId, preserved.ArrDownloadId);
+        Assert.Equal(oldHistoryId, preserved.NzbBlobId);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Health repair no longer treats `HistoryItemId` or `NzbBlobId` as the Arr grab ID. External SAB `addfile`/`addurl` persist the returned `nzo_id` as nullable `ArrDownloadId`; retries keep a new queue/blob ID but retain the original provenance; keep-files history cleanup still only clears `HistoryItemId`.
- When provenance is missing, repair recovers it only from an exact unique Arr import-history match (current file ID + imported path + one GUID `downloadId`). Ambiguous or incomplete evidence stays fail-closed. Later Arr instances are still checked when one matching instance lacks grabbed history.
- Additive nullable SQLite `TEXT` / PostgreSQL `uuid` columns with no backfill or index.

Closes #1266

**Back up `/config` before upgrading; the database migration applies automatically at startup.**

## Test plan
- [ ] External SAB add stores the returned `nzo_id` as `ArrDownloadId` on queue, history, and mounted files
- [ ] Retry (including a second retry) gets a new queue/blob ID and keeps the original `ArrDownloadId`
- [ ] Keep-files history cleanup clears `HistoryItemId` and leaves `ArrDownloadId` and `NzbBlobId` unchanged
- [ ] Health repair queries Arr with `ArrDownloadId` only — never `NzbBlobId` fallback
- [ ] Exact unique import-history recovery repairs using the original grab ID; ambiguous/missing evidence does not delete
- [ ] A non-owning Arr instance that lacks grabbed history does not block a later owning instance
- [ ] SQLite and PostgreSQL migrations apply cleanly; existing rows stay null; GUID casing upgrade still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved automatic repair handling for downloads linked to media libraries.
  * Download identity is preserved across queueing, retries, history, and mounted files.
  * Download information can be recovered from media import history when available.
  * Improved Radarr and Sonarr media matching and import-history processing.
  * External download additions retain their identity throughout processing.
  * Added download-identity tracking for SQLite and PostgreSQL databases.

* **Bug Fixes**
  * Repairs are deferred when download identity is missing, ambiguous, or conflicting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->