### PR TITLE
fix(ui): Last Import tooltip no longer spills off the Overview dashboard

### DIFF
--- a/frontend/app/components/ui/feedback.tsx
+++ b/frontend/app/components/ui/feedback.tsx
@@ -48,11 +48,13 @@ export function Tooltip({
   children,
   placement = "top",
   className = "",
+  contentClassName = "",
 }: {
   content: string;
   children: ReactNode;
   placement?: TooltipPlacement;
   className?: string;
+  contentClassName?: string;
 }) {
   const tooltipId = useId();
   const [hovered, setHovered] = useState(false);
@@ -95,7 +97,12 @@ export function Tooltip({
         id={tooltipId}
         role="tooltip"
         aria-hidden={!open}
-        className="tooltip-content z-50 w-72 max-w-[calc(100vw-2rem)] whitespace-normal text-left text-xs leading-relaxed"
+        className={[
+          "tooltip-content z-50 w-72 max-w-[calc(100vw-2rem)] whitespace-normal text-left text-xs leading-relaxed",
+          contentClassName,
+        ]
+          .filter(Boolean)
+          .join(" ")}
       >
         {content}
       </span>

--- a/frontend/app/routes/overview/components/arr-health/arr-health.test.tsx
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.test.tsx
@@ -127,6 +127,8 @@ describe("ArrHealth", () => {
     expect(markup).toMatch(/max-sm:!inline-block[^>]*>queue</);
     expect(markup).toMatch(/max-sm:!inline-block[^>]*>pending</);
     expect(markup).toMatch(/max-sm:!inline-block[^>]*>schedule</);
+    expect(markup).toContain("tooltip-end");
+    expect(markup).toContain("max-sm:w-52!");
     expect(markup).toContain("max-sm:sr-only");
     expect(markup).not.toContain("overflow-x-auto");
     expect(markup).not.toContain("min-w-[640px]");

--- a/frontend/app/routes/overview/components/arr-health/arr-health.tsx
+++ b/frontend/app/routes/overview/components/arr-health/arr-health.tsx
@@ -98,6 +98,8 @@ export function ArrHealth({ data, window }: ArrHealthProps) {
                     icon="schedule"
                     tooltip="When this instance last completed an import."
                     className="max-sm:w-[25%] max-sm:px-1"
+                    tooltipClassName="tooltip-end"
+                    tooltipContentClassName="max-sm:w-52!"
                   />
                 </tr>
               </thead>
@@ -190,15 +192,23 @@ function MetricHeader({
   icon,
   tooltip,
   className = "",
+  tooltipClassName = "",
+  tooltipContentClassName = "",
 }: {
   label: string;
   icon: string;
   tooltip: string;
   className?: string;
+  tooltipClassName?: string;
+  tooltipContentClassName?: string;
 }) {
   return (
     <th className={className}>
-      <Tooltip content={tooltip}>
+      <Tooltip
+        content={tooltip}
+        className={tooltipClassName}
+        contentClassName={tooltipContentClassName}
+      >
         <span className="inline-flex cursor-help items-center">
           <Icon
             name={icon}


### PR DESCRIPTION
## Summary
- The Arr Health **Last import** help bubble was centered over the rightmost column and forced to 18rem, so on a narrow Overview it ran past the dashboard edge (`overflow-x-hidden` on the main pane clipped it).
- Align that tooltip to the trigger's end (`tooltip-end`) and cap its width on small screens so the full sentence stays inside the card.

## Test plan
- [ ] Open Overview on a ~390px-wide viewport (or phone) with Arr Health visible
- [ ] Hover/tap the clock icon in the instance table header
- [ ] Confirm the “When this instance last completed an import.” bubble is fully readable and does not extend past the Arr Health card
- [ ] Check the same tooltip on a desktop-width Overview still sits above **Last import** without covering the page edge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tooltip customization to support responsive sizing and positioning.
  * Enhanced the “Last import” metric tooltip for better display on mobile devices.

* **Tests**
  * Added coverage verifying tooltip positioning and mobile layout styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->