### PR TITLE
feat(health): turn on background repairs by default

### DIFF
--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -2159,12 +2159,13 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
 
     /// <summary>
     /// Unset <see cref="ConfigKeys.RepairEnable"/> is on. Only an explicit false disables
-    /// background health checks, PAR2, and damage tolerance.
+    /// background health checks, PAR2, and damage tolerance. Invalid text uses the same
+    /// default-on fallback so a typo cannot throw or disable the stack.
     /// </summary>
     private bool IsBackgroundRepairsMasterEnabled()
     {
         var repairValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairEnable));
-        return repairValue is null || bool.Parse(repairValue);
+        return repairValue is null || !bool.TryParse(repairValue, out var enabled) || enabled;
     }
 
     /// <summary>

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1383,24 +1383,21 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
 
     public bool IsPar2RepairEnabled()
     {
-        var repairValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairEnable));
-        if (repairValue == null || !bool.Parse(repairValue)) return false;
+        if (!IsBackgroundRepairsMasterEnabled()) return false;
         var par2Value = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairPar2Enabled));
         return par2Value == null || bool.Parse(par2Value);
     }
 
     public bool IsDegradedToleranceEnabled()
     {
-        var repairValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairEnable));
-        if (repairValue == null || !bool.Parse(repairValue)) return false;
+        if (!IsBackgroundRepairsMasterEnabled()) return false;
         var toleranceValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairDegradedToleranceEnabled));
         return toleranceValue == null || bool.Parse(toleranceValue);
     }
 
     public bool IsCorruptionTrackingEnabled()
     {
-        var repairValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairEnable));
-        if (repairValue == null || !bool.Parse(repairValue)) return false;
+        if (!IsBackgroundRepairsMasterEnabled()) return false;
         var trackingValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairCorruptionTrackingEnabled));
         return trackingValue == null || bool.Parse(trackingValue);
     }
@@ -2149,9 +2146,7 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
     /// </summary>
     public string? GetRepairDisabledReason()
     {
-        var configValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairEnable));
-        var isRepairJobEnabled = configValue != null && bool.Parse(configValue);
-        return GetRepairDisabledReason(isRepairJobEnabled);
+        return GetRepairDisabledReason(IsBackgroundRepairsMasterEnabled());
     }
 
     internal static string? GetRepairDisabledReason(bool isRepairEnabled)
@@ -2160,6 +2155,16 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
             return "Enable Background Repairs is off";
 
         return null;
+    }
+
+    /// <summary>
+    /// Unset <see cref="ConfigKeys.RepairEnable"/> is on. Only an explicit false disables
+    /// background health checks, PAR2, and damage tolerance.
+    /// </summary>
+    private bool IsBackgroundRepairsMasterEnabled()
+    {
+        var repairValue = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.RepairEnable));
+        return repairValue is null || bool.Parse(repairValue);
     }
 
     /// <summary>

--- a/docs/configuration/repairs.md
+++ b/docs/configuration/repairs.md
@@ -11,7 +11,7 @@ Background health monitoring, PAR2 reconstruction, and replacement of unhealthy 
 
 | Control | Config key | Default | Effect |
 |---------|------------|---------|--------|
-| Enable Background Repairs [since 1.2.5](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.5){ .nzbdav-since } | `repair.enable` | off | Enables health checks, PAR2, and damage tolerance; Library Directory + *Arr are only needed for linked-item replacement |
+| Enable Background Repairs [since 1.2.5](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.5){ .nzbdav-since } | `repair.enable` | on [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since } | Enables health checks, PAR2, and damage tolerance; Library Directory + *Arr are only needed for linked-item replacement. An explicit `false` still disables them. Existing installs that already saved `false` stay off. |
 | Health Check Concurrency [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since } | `repair.healthcheck-concurrency` | `50` | Aggregate NNTP verification-connection limit shared by background checks and queue article validation (1–200, capped by pooled provider capacity) |
 | Health Check Workers [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since } | `repair.healthcheck-workers` | `1` | Library files checked at once (1–8). All workers share Health Check Concurrency; this setting never multiplies it |
 | Health Check Depth | `repair.healthcheck-depth` | `standard` | standard / enhanced / deep / complete |

--- a/docs/guides/stremio.md
+++ b/docs/guides/stremio.md
@@ -46,11 +46,11 @@ Then in **Addons → Marketplace → Usenet → Newznab**, add each indexer (URL
 
 ## Repairs without *Arr [since 1.2.5](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.5){ .nzbdav-since }
 
-Enable **Background Repairs** to run health checks, reconstruct recoverable gaps from PAR2 parity,
-and retain playable files with limited damage. A Library Directory and *Arr are only necessary to
+**Background Repairs** is on by default: health checks, PAR2 reconstruction of recoverable gaps,
+and limited damage tolerance run without a Library Directory or *Arr. Those are only necessary to
 replace linked library items. To auto-remove a broken unlinked item after repeated playback failures,
 set **Repair After Streaming Failures** above `0`; the default (`0`) keeps the item and marks it
-**Action needed**.
+**Action needed**. Turn the toggle off if you do not want idle STAT or PAR2 work.
 
 ## Security and reachability
 

--- a/docs/guides/stremio.md
+++ b/docs/guides/stremio.md
@@ -46,11 +46,11 @@ Then in **Addons → Marketplace → Usenet → Newznab**, add each indexer (URL
 
 ## Repairs without *Arr [since 1.2.5](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.5){ .nzbdav-since }
 
-**Background Repairs** is on by default: health checks, PAR2 reconstruction of recoverable gaps,
+**Background Repairs** is on by default [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since }: health checks, PAR2 reconstruction of recoverable gaps,
 and limited damage tolerance run without a Library Directory or *Arr. Those are only necessary to
 replace linked library items. To auto-remove a broken unlinked item after repeated playback failures,
 set **Repair After Streaming Failures** above `0`; the default (`0`) keeps the item and marks it
-**Action needed**. Turn the toggle off if you do not want idle STAT or PAR2 work.
+**Action needed**. Turn the toggle off if you do not want background health checks, PAR2 work, or limited damage-tolerance handling.
 
 ## Security and reachability
 

--- a/docs/operations/health-repairs.md
+++ b/docs/operations/health-repairs.md
@@ -5,7 +5,8 @@
 **Settings → Repairs** monitors mounted media, reconstructs missing segments from PAR2 parity, and
 can trigger *Arr replacements for unhealthy linked library items.
 
-Requires **Enable Background Repairs**. To automatically replace linked library items, also configure:
+**Enable Background Repairs** is on by default. Turn it off to stop idle health-check STAT traffic
+and PAR2 work. To automatically replace linked library items, also configure:
 
 - **Library Directory** visible inside the container — the organized library root (parent of Arr root folders), never the rclone mount or `/completed-symlinks`
 - At least one configured [Radarr/Sonarr instance](../configuration/arrs.md)

--- a/docs/operations/health-repairs.md
+++ b/docs/operations/health-repairs.md
@@ -5,8 +5,9 @@
 **Settings → Repairs** monitors mounted media, reconstructs missing segments from PAR2 parity, and
 can trigger *Arr replacements for unhealthy linked library items.
 
-**Enable Background Repairs** is on by default. Turn it off to stop idle health-check STAT traffic
-and PAR2 work. To automatically replace linked library items, also configure:
+**Enable Background Repairs** is on by default [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since }. Turn it off to stop
+background health checks, PAR2 work, and limited damage-tolerance handling. To automatically
+replace linked library items, also configure:
 
 - **Library Directory** visible inside the container — the organized library root (parent of Arr root folders), never the rclone mount or `/completed-symlinks`
 - At least one configured [Radarr/Sonarr instance](../configuration/arrs.md)

--- a/docs/operations/plex-readd-diagnosis.md
+++ b/docs/operations/plex-readd-diagnosis.md
@@ -18,7 +18,7 @@ If the mtime is recent or the path changed (new release name, or a `(2)` suffix)
 
 ## 2. Is background repair enabled?
 
-Settings → Health → **Enable Background Repairs**. Default is **off**. If off, health-repair deletion is ruled out.
+Settings → Repairs → **Enable Background Repairs**. Default is **on**. If off, health-repair deletion is ruled out.
 
 ## 3. Look for a server-side deletion
 

--- a/docs/use-cases/streaming-only.md
+++ b/docs/use-cases/streaming-only.md
@@ -18,10 +18,10 @@ Use InfiniDysk without building a traditional *Arr library.
 
 ## Repairs without *Arr [since 1.2.5](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.5){ .nzbdav-since }
 
-**Background Repairs** is on by default: health checks, PAR2 reconstruction of recoverable gaps,
+**Background Repairs** is on by default [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since }: health checks, PAR2 reconstruction of recoverable gaps,
 and limited damage tolerance run without a Library Directory or *Arr. Those are only needed to
 replace linked library items. To automatically remove broken unlinked items after playback failures,
 set **Repair After Streaming Failures** above `0`; its default (`0`) keeps the item and marks it
-**Action needed**. Turn the toggle off if you do not want idle STAT or PAR2 work.
+**Action needed**. Turn the toggle off if you do not want background health checks, PAR2 work, or limited damage-tolerance handling.
 
 Secure the UI and WebDAV the same way as any other deploy — TLS, strong passwords, no open port `3000` on the internet.

--- a/docs/use-cases/streaming-only.md
+++ b/docs/use-cases/streaming-only.md
@@ -18,10 +18,10 @@ Use InfiniDysk without building a traditional *Arr library.
 
 ## Repairs without *Arr [since 1.2.5](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.5){ .nzbdav-since }
 
-Enable **Background Repairs** to run health checks, reconstruct recoverable gaps from PAR2 parity,
-and keep slightly damaged video files playable. A Library Directory and *Arr are only needed to
+**Background Repairs** is on by default: health checks, PAR2 reconstruction of recoverable gaps,
+and limited damage tolerance run without a Library Directory or *Arr. Those are only needed to
 replace linked library items. To automatically remove broken unlinked items after playback failures,
 set **Repair After Streaming Failures** above `0`; its default (`0`) keeps the item and marks it
-**Action needed**.
+**Action needed**. Turn the toggle off if you do not want idle STAT or PAR2 work.
 
 Secure the UI and WebDAV the same way as any other deploy — TLS, strong passwords, no open port `3000` on the internet.

--- a/frontend/app/routes/health/route.test.ts
+++ b/frontend/app/routes/health/route.test.ts
@@ -116,6 +116,26 @@ describe("health route loader", () => {
     await expect(loader(loaderArgs())).resolves.toMatchObject({ isEnabled: false });
   });
 
+  it.each([
+    [" true ", true],
+    ["TRUE", true],
+    [" false ", false],
+    ["bogus", true],
+  ])("parses repair.enable %j as enabled=%s", async (configValue, expected) => {
+    getHealthCheckQueueMock.mockResolvedValue({
+      uncheckedCount: 0,
+      items: [],
+    });
+    getHealthCheckHistoryMock.mockResolvedValue({
+      stats: [],
+      items: [],
+      totalCount: 0,
+    });
+    getConfigMock.mockResolvedValueOnce([{ configName: "repair.enable", configValue }]);
+
+    await expect(loader(loaderArgs())).resolves.toMatchObject({ isEnabled: expected });
+  });
+
   it("uses URL-backed paging and repair-status filters", async () => {
     getHealthCheckQueueMock.mockResolvedValue({ uncheckedCount: 0, items: [] });
     getHealthCheckHistoryMock.mockResolvedValue({ stats: [], items: [], totalCount: 0 });

--- a/frontend/app/routes/health/route.test.ts
+++ b/frontend/app/routes/health/route.test.ts
@@ -86,7 +86,7 @@ describe("health route loader", () => {
     expect(getConfigMock).toHaveBeenCalledWith(["repair.enable"]);
   });
 
-  it("reports health checks disabled when the setting is absent or false", async () => {
+  it("reports health checks enabled when the setting is absent", async () => {
     getHealthCheckQueueMock.mockResolvedValue({
       uncheckedCount: 0,
       items: [],
@@ -96,11 +96,23 @@ describe("health route loader", () => {
       items: [],
       totalCount: 0,
     });
-    getConfigMock
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([{ configName: "repair.enable", configValue: "false" }]);
+    getConfigMock.mockResolvedValueOnce([]);
 
-    await expect(loader(loaderArgs())).resolves.toMatchObject({ isEnabled: false });
+    await expect(loader(loaderArgs())).resolves.toMatchObject({ isEnabled: true });
+  });
+
+  it("reports health checks disabled when the setting is false", async () => {
+    getHealthCheckQueueMock.mockResolvedValue({
+      uncheckedCount: 0,
+      items: [],
+    });
+    getHealthCheckHistoryMock.mockResolvedValue({
+      stats: [],
+      items: [],
+      totalCount: 0,
+    });
+    getConfigMock.mockResolvedValueOnce([{ configName: "repair.enable", configValue: "false" }]);
+
     await expect(loader(loaderArgs())).resolves.toMatchObject({ isEnabled: false });
   });
 

--- a/frontend/app/routes/health/route.tsx
+++ b/frontend/app/routes/health/route.tsx
@@ -55,10 +55,19 @@ function parsePageSize(value: string | null): number {
 function parseHistoryFilter(value: string | null): HealthHistoryFilter {
   return value === "deleted" ||
     value === "repaired" ||
-    value === "degraded" ||
-    value === "action-needed"
+    value === "action-needed" ||
+    value === "degraded"
     ? value
     : "all";
+}
+
+function isBackgroundRepairsEnabled(
+  config: Array<{ configName: string; configValue: string }>,
+  enabledKey: string,
+): boolean {
+  const item = config.find((entry) => entry.configName === enabledKey);
+  if (!item || item.configValue.trim() === "") return true;
+  return item.configValue.toLowerCase() === "true";
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -96,10 +105,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     historyPage,
     historyPageSize,
     historyFilter,
-    isEnabled:
-      config
-        .filter((x) => x.configName === enabledKey)
-        .filter((x) => x.configValue.toLowerCase() === "true").length > 0,
+    isEnabled: isBackgroundRepairsEnabled(config, enabledKey),
     schedule: queueData.schedule ?? null,
   };
 }

--- a/frontend/app/routes/health/route.tsx
+++ b/frontend/app/routes/health/route.tsx
@@ -27,6 +27,7 @@ import {
   updateHealthCheckProgress,
 } from "./health-queue-state";
 import { withUrlBase } from "~/utils/url-base";
+import { parseConfigBoolean } from "~/utils/config-bool";
 
 const topicNames = {
   healthItemStatus: "hs",
@@ -66,8 +67,7 @@ function isBackgroundRepairsEnabled(
   enabledKey: string,
 ): boolean {
   const item = config.find((entry) => entry.configName === enabledKey);
-  if (!item || item.configValue.trim() === "") return true;
-  return item.configValue.toLowerCase() === "true";
+  return parseConfigBoolean(item?.configValue);
 }
 
 export async function loader({ request }: Route.LoaderArgs) {

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -11,6 +11,7 @@ import {
   WeeklyWindowEditor,
   isWeeklyWindowScheduleJsonValid,
 } from "~/components/weekly-window-editor/weekly-window-editor";
+import { parseConfigBoolean } from "~/utils/config-bool";
 import { isPositiveInteger, isPositiveNumber } from "../validation";
 
 type RepairsSettingsProps = {
@@ -51,7 +52,7 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
   ].some((instance) => instance.Enabled !== false);
   const helpText =
     "Continuously monitor mounted media for health, reconstruct missing segments from PAR2 parity, and retain playable files with limited damage. Library Directory and enabled Radarr/Sonarr instances are only needed to replace linked library items.";
-  const isRepairEnabled = config["repair.enable"] === "true";
+  const isRepairEnabled = parseConfigBoolean(config["repair.enable"]);
   const autoRemoveAfter = config["repair.auto-remove-after-failures"] ?? "0";
   const autoRemoveEnabled = isNonNegativeInteger(autoRemoveAfter) && Number(autoRemoveAfter) > 0;
 

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -60,6 +60,7 @@ import { Icon } from "~/components/ui";
 import type { AppOutletContext } from "~/auth/authorization";
 import { isSettingsTabDisabled } from "~/utils/service-provider";
 import { withUrlBase } from "~/utils/url-base";
+import { parseConfigBoolean } from "~/utils/config-bool";
 
 const defaultConfig = {
   "general.base-url": "",
@@ -591,13 +592,13 @@ function Body(props: BodyProps) {
                 {healthQueueResetCount !== null &&
                   ` ${healthQueueResetCount.toLocaleString()} files queued for re-check.`}
                 {healthQueueResetError && ` ${healthQueueResetError}`}
-                {newConfig["repair.enable"] !== "true" &&
+                {!parseConfigBoolean(newConfig["repair.enable"]) &&
                   " Enable Background Repairs to re-check library health."}
               </span>
             </div>
             <div className="flex shrink-0 items-center gap-2">
               {!isReadOnly &&
-                newConfig["repair.enable"] === "true" &&
+                parseConfigBoolean(newConfig["repair.enable"]) &&
                 healthQueueResetCount === null && (
                   <Button
                     variant="ghost"

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -164,7 +164,7 @@ const defaultConfig = {
   "preflight.max-attempts": "20",
   "preflight.ttl-seconds": "120",
   "preflight.indexer-max-wait-seconds": "5",
-  "repair.enable": "false",
+  "repair.enable": "true",
   "repair.healthcheck-concurrency": "50",
   "repair.healthcheck-workers": "1",
   "repair.healthcheck-depth": "standard",

--- a/frontend/app/utils/config-bool.test.ts
+++ b/frontend/app/utils/config-bool.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { parseConfigBoolean } from "./config-bool";
+
+describe("parseConfigBoolean", () => {
+  it.each([
+    [undefined, true],
+    [null, true],
+    ["", true],
+    ["  ", true],
+    ["true", true],
+    ["TRUE", true],
+    [" true ", true],
+    ["false", false],
+    ["FALSE", false],
+    [" false ", false],
+    ["bogus", true],
+    ["1", true],
+    ["0", true],
+  ])("parses %j as %s with default-on fallback", (value, expected) => {
+    expect(parseConfigBoolean(value)).toBe(expected);
+  });
+
+  it("uses an explicit fallback for invalid text", () => {
+    expect(parseConfigBoolean("bogus", false)).toBe(false);
+  });
+});

--- a/frontend/app/utils/config-bool.ts
+++ b/frontend/app/utils/config-bool.ts
@@ -1,0 +1,13 @@
+/**
+ * Parse a stored config flag. Unset, blank, and invalid values use `fallback`.
+ * Matching is trimmed and case-insensitive, same as .NET `bool.TryParse`.
+ */
+export function parseConfigBoolean(value: string | undefined | null, fallback = true): boolean {
+  if (value == null) return fallback;
+  const trimmed = value.trim();
+  if (trimmed === "") return fallback;
+  const normalized = trimmed.toLowerCase();
+  if (normalized === "true") return true;
+  if (normalized === "false") return false;
+  return fallback;
+}

--- a/tests/NzbWebDAV.Tests/Config/DegradedToleranceConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/DegradedToleranceConfigTests.cs
@@ -9,8 +9,15 @@ public sealed class DegradedToleranceConfigTests
     public void ToleranceEnabled_DefaultsToOffWhenRepairsAreOff()
     {
         var config = new ConfigManager();
+        config.UpdateValues([Item(ConfigKeys.RepairEnable, "false")]);
 
         Assert.False(config.IsDegradedToleranceEnabled());
+    }
+
+    [Fact]
+    public void ToleranceEnabled_DefaultsToOnWhenRepairsAreUnset()
+    {
+        Assert.True(new ConfigManager().IsDegradedToleranceEnabled());
     }
 
     [Fact]
@@ -37,7 +44,16 @@ public sealed class DegradedToleranceConfigTests
     [Fact]
     public void CorruptionTracking_DefaultsToOffWhenRepairsAreOff()
     {
-        Assert.False(new ConfigManager().IsCorruptionTrackingEnabled());
+        var config = new ConfigManager();
+        config.UpdateValues([Item(ConfigKeys.RepairEnable, "false")]);
+
+        Assert.False(config.IsCorruptionTrackingEnabled());
+    }
+
+    [Fact]
+    public void CorruptionTracking_DefaultsToOnWhenRepairsAreUnset()
+    {
+        Assert.True(new ConfigManager().IsCorruptionTrackingEnabled());
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -261,10 +261,14 @@ public class ExceptionMiddlewareTests
         var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
         var davItem = Assert.IsType<DavItem>(context.Items["DavItem"]);
         var failureTracker = new StreamingFailureTracker();
-        // Default ConfigManager: repair.enable is off, so repair must be skipped with a reason.
+        var configManager = new ConfigManager();
+        configManager.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "false" },
+        ]);
         var middleware = CreateMiddleware(
             _ => throw new UsenetArticleNotFoundException("missing-segment"),
-            new ConfigManager(),
+            configManager,
             failureTracker);
 
         var events = await CaptureLogsAsync(() => middleware.InvokeAsync(context));
@@ -726,7 +730,7 @@ public class ExceptionMiddlewareTests
         var middleware = CreateMiddleware(
             _ => throw new UsenetCorruptArticleException(
                 segmentId, "provider-a", new InvalidDataException("CRC mismatch")),
-            new ConfigManager(),
+            CreateRepairDisabledConfig(),
             failureTracker);
 
         var events = await CaptureLogsAsync(() => middleware.InvokeAsync(context));
@@ -885,6 +889,30 @@ public class ExceptionMiddlewareTests
     }
 
     [Fact]
+    public void GetRepairDisabledReason_DefaultsToEnabledWhenUnset()
+    {
+        var configManager = new ConfigManager();
+
+        Assert.Null(configManager.GetRepairDisabledReason());
+        Assert.True(configManager.IsRepairJobEnabled());
+        Assert.True(configManager.IsPar2RepairEnabled());
+    }
+
+    [Fact]
+    public void GetRepairDisabledReason_ExplicitFalseDisablesJob()
+    {
+        var configManager = new ConfigManager();
+        configManager.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "false" },
+        ]);
+
+        Assert.Equal("Enable Background Repairs is off", configManager.GetRepairDisabledReason());
+        Assert.False(configManager.IsRepairJobEnabled());
+        Assert.False(configManager.IsPar2RepairEnabled());
+    }
+
+    [Fact]
     public void GetRepairDisabledReason_NamesDisabledToggle()
     {
         Assert.Equal("Enable Background Repairs is off", ConfigManager.GetRepairDisabledReason(false));
@@ -1012,6 +1040,16 @@ public class ExceptionMiddlewareTests
             SubType = DavItem.ItemSubType.MultipartFile,
         };
         return context;
+    }
+
+    private static ConfigManager CreateRepairDisabledConfig()
+    {
+        var configManager = new ConfigManager();
+        configManager.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "false" },
+        ]);
+        return configManager;
     }
 
     private static ConfigManager CreateRepairEnabledConfig()

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -912,6 +912,28 @@ public class ExceptionMiddlewareTests
         Assert.False(configManager.IsPar2RepairEnabled());
     }
 
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("TRUE", true)]
+    [InlineData(" true ", true)]
+    [InlineData("false", false)]
+    [InlineData("FALSE", false)]
+    [InlineData(" false ", false)]
+    [InlineData("bogus", true)]
+    public void GetRepairDisabledReason_ParsesRepairEnableWithoutThrowing(string value, bool enabled)
+    {
+        var configManager = new ConfigManager();
+        configManager.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = value },
+        ]);
+
+        Assert.Equal(enabled, configManager.IsRepairJobEnabled());
+        Assert.Equal(
+            enabled ? null : "Enable Background Repairs is off",
+            configManager.GetRepairDisabledReason());
+    }
+
     [Fact]
     public void GetRepairDisabledReason_NamesDisabledToggle()
     {

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairIntegrationTests.cs
@@ -352,6 +352,10 @@ public sealed class Par2RepairIntegrationTests
         try
         {
             var config = new ConfigManager();
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "false" },
+            ]);
             var store = new RepairPatchStore(dir, 1024 * 1024);
             await store.EnsureCatalogLoadedAsync(CancellationToken.None);
             var service = new Par2RepairService(config, null!, store);

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -115,7 +115,7 @@ public sealed class SupportPackContentsTests : IDisposable
 
         using var environment = JsonDocument.Parse(entries["environment.json"]);
         var tracking = environment.RootElement.GetProperty("par2Repair").GetProperty("corruptionTracking");
-        Assert.False(tracking.GetProperty("enabled").GetBoolean());
+        Assert.True(tracking.GetProperty("enabled").GetBoolean());
         Assert.Equal(0, tracking.GetProperty("filesWithCorruptRecords").GetInt32());
         Assert.Equal(0, tracking.GetProperty("recordedCorruptSegments").GetInt32());
     }


### PR DESCRIPTION
## Summary
- Background repairs (`repair.enable`) are now on when the setting is unset, matching the settings form default.
- Health checks, PAR2, and damage tolerance start without a Library Directory or *Arr; those remain required only to replace linked library items.
- Installs that already saved `false` stay off. Headless `NZBDAV_CONFIG__REPAIR__ENABLE=false` still disables them.

## Test plan
- [ ] Fresh config: Settings → Repairs shows Enable Background Repairs on, and the Health page does not prompt to enable it.
- [ ] Existing install with the toggle saved off still has it off after upgrade.
- [ ] Saving the toggle off stops idle STAT/PAR2 work; saving it on starts checks for history-cleared mounted files.
- [ ] Without a Library Directory, failed files stay mounted as Action needed rather than triggering Arr replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background Repairs are now enabled by default when no setting is configured.
  * Health checks, PAR2 repairs, degraded tolerance, and corruption tracking can operate without a Library Directory or *Arr integration.

* **Bug Fixes**
  * Explicitly disabling Background Repairs now consistently disables related repair processing and reports the correct status.

* **Documentation**
  * Updated repair settings, operational guides, and streaming guidance to reflect the new default and disablement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->