### PR TITLE
fix(queue): restart instead of serving a dead queue after processor failure

### DIFF
--- a/backend.Benchmarks/SabApiReport.cs
+++ b/backend.Benchmarks/SabApiReport.cs
@@ -84,8 +84,7 @@ internal static class SabApiReport
                 new ProviderUsageTracker(),
                 new WatchdogLog(),
                 new QueueItemSourceTracker(),
-                new BenchmarkGate(),
-                startLoop: false);
+                new BenchmarkGate());
 
             SeedCorpus(dbContext);
             await dbContext.SaveChangesAsync().ConfigureAwait(false);

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -239,7 +239,8 @@ public sealed partial class Program
             builder.Services.AddHealthChecks()
                 .AddCheck<StreamingReadinessCheck>(
                     "streaming_readiness",
-                    tags: ["ready"]);
+                    tags: ["ready"])
+                .AddCheck<QueueCoordinatorHealthCheck>("queue_coordinator");
             builder.Services.Configure<ForwardedHeadersOptions>(options =>
             {
                 options.ForwardedHeaders = ForwardedHeaders.XForwardedFor
@@ -337,6 +338,12 @@ public sealed partial class Program
                     sp.GetRequiredService<ConfigManager>()))
                 .AddSingleton<QueueManager>()
                 .AddSingleton<IQueueCoordinator>(sp => sp.GetRequiredService<QueueManager>())
+                .AddSingleton<QueueCoordinatorHostedService>()
+                .AddSingleton<IQueueCoordinatorLiveness>(sp =>
+                    sp.GetRequiredService<QueueCoordinatorHostedService>())
+                .AddHostedService(sp =>
+                    sp.GetRequiredService<QueueCoordinatorHostedService>())
+                .AddSingleton<QueueCoordinatorHealthCheck>()
                 .AddSingleton(sp => new NzbResolutionCache(
                     () => sp.GetRequiredService<IDbContextFactory<DavDatabaseContext>>().CreateDbContext()))
                 .AddSingleton<PreferredOrderStore>()
@@ -531,10 +538,6 @@ public sealed partial class Program
                 UsenetProviderIdentity.RemapHostKeyedMetricsAsync(
                     configManager.GetUsenetProviderConfig(),
                     SigtermUtil.GetCancellationToken())));
-            // Start the queue only after Kestrel is serving so /health can answer
-            // before the first BODY decode (which can crash on a bad native lib).
-            app.Lifetime.ApplicationStarted.Register(() =>
-                app.Services.GetRequiredService<QueueManager>().StartProcessing());
             await RunHostAndSetExitCodeAsync(app).ConfigureAwait(false);
         }
         catch (ConfigPathAccessException exception)

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -27,7 +27,8 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
     private readonly ConcurrentDictionary<Guid, int> _stallAttempts = new();
 
     private readonly UsenetStreamingClient _usenetClient;
-    private readonly CancellationTokenSource? _cancellationTokenSource;
+    private CancellationTokenSource? _cancellationTokenSource;
+    private readonly Lock _startLock = new();
     private readonly SemaphoreSlim _stateLock = new(1, 1);
     private readonly SemaphoreSlim _finalizeLock = new(1, 1);
     private readonly Lock _admissionLock = new();
@@ -43,7 +44,6 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
 
     private CancellationTokenSource _sleepingQueueToken = new();
     private readonly Lock _sleepingQueueLock = new();
-    private int _loopStarted;
     private Task? _coordinatorTask;
     private Guid? _primaryId;
     private int _pendingAdmissions;
@@ -93,7 +93,7 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
         IDbContextFactory<DavDatabaseContext> dbContextFactory
     ) : this(
         usenetClient, configManager, websocketManager, providerUsageTracker,
-        watchdogLog, sourceTracker, benchmarkGate, startLoop: false,
+        watchdogLog, sourceTracker, benchmarkGate,
         healthCheckConnectionGate, ownsHealthCheckConnectionGate: false,
         dbContextFactory: dbContextFactory)
     {
@@ -106,8 +106,7 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
         ProviderUsageTracker providerUsageTracker,
         WatchdogLog watchdogLog,
         QueueItemSourceTracker sourceTracker,
-        BenchmarkGate benchmarkGate,
-        bool startLoop
+        BenchmarkGate benchmarkGate
     ) : this(
         usenetClient,
         configManager,
@@ -116,7 +115,6 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
         watchdogLog,
         sourceTracker,
         benchmarkGate,
-        startLoop,
         new HealthCheckConnectionGate(configManager),
         ownsHealthCheckConnectionGate: true,
         dbContextFactory: null)
@@ -131,7 +129,6 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
         WatchdogLog watchdogLog,
         QueueItemSourceTracker sourceTracker,
         BenchmarkGate benchmarkGate,
-        bool startLoop,
         HealthCheckConnectionGate? healthCheckConnectionGate = null,
         IDbContextFactory<DavDatabaseContext>? dbContextFactory = null
     )
@@ -145,7 +142,6 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
             watchdogLog,
             sourceTracker,
             benchmarkGate,
-            startLoop,
             gate,
             ownsHealthCheckConnectionGate: healthCheckConnectionGate is null,
             dbContextFactory: dbContextFactory);
@@ -159,7 +155,6 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
         WatchdogLog watchdogLog,
         QueueItemSourceTracker sourceTracker,
         BenchmarkGate benchmarkGate,
-        bool startLoop,
         HealthCheckConnectionGate healthCheckConnectionGate,
         bool ownsHealthCheckConnectionGate,
         IDbContextFactory<DavDatabaseContext>? dbContextFactory)
@@ -174,11 +169,7 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
         _dbContextFactory = dbContextFactory;
         _healthCheckConnectionGate = healthCheckConnectionGate;
         _ownsHealthCheckConnectionGate = ownsHealthCheckConnectionGate;
-        _cancellationTokenSource = CancellationTokenSource
-            .CreateLinkedTokenSource(SigtermUtil.GetCancellationToken());
         _configChangeSubscription = _configManager.Subscribe(OnConfigChanged);
-        if (startLoop)
-            StartProcessing();
     }
 
     private void OnConfigChanged(object? sender, ConfigManager.ConfigEventArgs args)
@@ -192,14 +183,24 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
         _benchmarkGate.IsPaused || _configManager.IsQueueEffectivelyPaused();
 
     /// <summary>
-    /// Starts the background queue loop. Safe to call more than once; only the
-    /// first call starts processing. DI construction leaves the loop stopped so
-    /// Kestrel can bind before the first BODY decode.
+    /// Starts the queue loop once and returns the task that the hosted service
+    /// must observe. Repeated calls return the same task.
     /// </summary>
-    public void StartProcessing()
+    internal Task StartProcessing(CancellationToken stoppingToken)
     {
-        if (Interlocked.Exchange(ref _loopStarted, 1) == 1) return;
-        _coordinatorTask = ProcessQueueAsync(_cancellationTokenSource!.Token);
+        lock (_startLock)
+        {
+            ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+
+            if (_coordinatorTask is not null)
+                return _coordinatorTask;
+
+            _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+                stoppingToken,
+                SigtermUtil.GetCancellationToken());
+            _coordinatorTask = ProcessQueueAsync(_cancellationTokenSource.Token);
+            return _coordinatorTask;
+        }
     }
 
     /// <summary>True while any NZB queue item is actively processing.</summary>
@@ -1421,13 +1422,24 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
 
-        _cancellationTokenSource?.Cancel();
+        Task? coordinatorTask;
+        CancellationTokenSource? cancellationTokenSource;
+        lock (_startLock)
+        {
+            coordinatorTask = _coordinatorTask;
+            cancellationTokenSource = _cancellationTokenSource;
+        }
+
+        cancellationTokenSource?.Cancel();
         try
         {
-            _coordinatorTask?.GetAwaiter().GetResult();
+            coordinatorTask?.GetAwaiter().GetResult();
         }
-        catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
+        catch (Exception e)
         {
+            // StartProcessing is internal and its exact task is directly awaited
+            // by QueueCoordinatorHostedService. Disposal only performs the second,
+            // teardown-time observation.
             Log.Debug(e, "Queue coordinator exited with error during dispose");
         }
 

--- a/backend/Services/IQueueCoordinatorLiveness.cs
+++ b/backend/Services/IQueueCoordinatorLiveness.cs
@@ -1,0 +1,18 @@
+namespace NzbWebDAV.Services;
+
+public enum QueueCoordinatorState
+{
+    NotStarted,
+    Running,
+    Stopped,
+    Faulted,
+}
+
+/// <summary>
+/// Exposes only queue-coordinator lifecycle state to health reporting.
+/// Queue mutations remain on IQueueCoordinator.
+/// </summary>
+public interface IQueueCoordinatorLiveness
+{
+    QueueCoordinatorState GetState();
+}

--- a/backend/Services/QueueCoordinatorHealthCheck.cs
+++ b/backend/Services/QueueCoordinatorHealthCheck.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+
+namespace NzbWebDAV.Services;
+
+public sealed class QueueCoordinatorHealthCheck(
+    IQueueCoordinatorLiveness liveness,
+    IHostApplicationLifetime lifetime) : IHealthCheck
+{
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var state = liveness.GetState();
+        var result = state switch
+        {
+            QueueCoordinatorState.NotStarted
+                when !lifetime.ApplicationStarted.IsCancellationRequested =>
+                HealthCheckResult.Healthy("Queue coordinator is waiting for application startup."),
+
+            QueueCoordinatorState.NotStarted =>
+                HealthCheckResult.Unhealthy(
+                    "Queue coordinator did not start after application startup."),
+
+            QueueCoordinatorState.Running =>
+                HealthCheckResult.Healthy(),
+
+            QueueCoordinatorState.Stopped
+                when lifetime.ApplicationStopping.IsCancellationRequested =>
+                HealthCheckResult.Healthy("Queue coordinator is stopping."),
+
+            QueueCoordinatorState.Stopped =>
+                HealthCheckResult.Unhealthy(
+                    "Queue coordinator stopped while the host is still running."),
+
+            QueueCoordinatorState.Faulted =>
+                HealthCheckResult.Unhealthy(
+                    "Queue coordinator terminated unexpectedly; process restart is required."),
+
+            _ => HealthCheckResult.Unhealthy("Queue coordinator state is invalid."),
+        };
+
+        return Task.FromResult(result);
+    }
+}

--- a/backend/Services/QueueCoordinatorHostedService.cs
+++ b/backend/Services/QueueCoordinatorHostedService.cs
@@ -1,0 +1,123 @@
+using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Queue;
+using Serilog;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Owns the queue coordinator for the process lifetime. Any unexpected
+/// termination faults this BackgroundService so the host exits nonzero.
+/// </summary>
+public sealed class QueueCoordinatorHostedService : BackgroundService, IQueueCoordinatorLiveness
+{
+    private readonly Func<CancellationToken, Task> _runCoordinator;
+    private readonly IHostApplicationLifetime _lifetime;
+    private int _state = (int)QueueCoordinatorState.NotStarted;
+
+    public QueueCoordinatorHostedService(
+        QueueManager queueManager,
+        IHostApplicationLifetime lifetime)
+        : this(queueManager.StartProcessing, lifetime)
+    {
+    }
+
+    // Allows lifecycle tests to supply a deterministic coordinator task.
+    internal QueueCoordinatorHostedService(
+        Func<CancellationToken, Task> runCoordinator,
+        IHostApplicationLifetime lifetime)
+    {
+        _runCoordinator = runCoordinator;
+        _lifetime = lifetime;
+    }
+
+    public QueueCoordinatorState GetState() =>
+        (QueueCoordinatorState)Volatile.Read(ref _state);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!await WaitForApplicationStartedAsync(stoppingToken).ConfigureAwait(false))
+        {
+            SetState(QueueCoordinatorState.Stopped);
+            return;
+        }
+
+        SetState(QueueCoordinatorState.Running);
+
+        try
+        {
+            // Directly await the coordinator. WaitAsync(stoppingToken) would let
+            // shutdown cancellation mask a concurrent coordinator fault.
+            await _runCoordinator(stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (IsHostStopping(stoppingToken))
+        {
+            SetState(QueueCoordinatorState.Stopped);
+            return;
+        }
+        catch (OperationCanceledException exception)
+        {
+            var fault = new InvalidOperationException(
+                "Queue coordinator canceled without a host shutdown request.",
+                exception);
+            SetState(QueueCoordinatorState.Faulted);
+            Log.Fatal(
+                fault,
+                "Queue coordinator canceled unexpectedly; stopping the backend");
+            throw fault;
+        }
+        catch (Exception exception)
+        {
+            // Deliberately includes OutOfMemoryException. OOM is the confirmed
+            // incident class and must reach the BackgroundService fault boundary.
+            SetState(QueueCoordinatorState.Faulted);
+            Log.Fatal(
+                exception,
+                "Queue coordinator faulted; stopping the backend instead of serving a dead queue");
+            throw;
+        }
+
+        if (IsHostStopping(stoppingToken))
+        {
+            SetState(QueueCoordinatorState.Stopped);
+            return;
+        }
+
+        var unexpectedExit = new InvalidOperationException(
+            "Queue coordinator exited while the host was still running.");
+        SetState(QueueCoordinatorState.Faulted);
+        Log.Fatal(
+            unexpectedExit,
+            "Queue coordinator exited unexpectedly; stopping the backend");
+        throw unexpectedExit;
+    }
+
+    private void SetState(QueueCoordinatorState state) =>
+        Volatile.Write(ref _state, (int)state);
+
+    private bool IsHostStopping(CancellationToken stoppingToken) =>
+        stoppingToken.IsCancellationRequested ||
+        _lifetime.ApplicationStopping.IsCancellationRequested;
+
+    private async Task<bool> WaitForApplicationStartedAsync(
+        CancellationToken stoppingToken)
+    {
+        if (_lifetime.ApplicationStarted.IsCancellationRequested)
+            return true;
+
+        var started = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var registration = _lifetime.ApplicationStarted.Register(
+            static state => ((TaskCompletionSource)state!).TrySetResult(),
+            started);
+
+        try
+        {
+            await started.Task.WaitAsync(stoppingToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            return false;
+        }
+    }
+}

--- a/backend/Services/QueueCoordinatorHostedService.cs
+++ b/backend/Services/QueueCoordinatorHostedService.cs
@@ -102,13 +102,20 @@ public sealed class QueueCoordinatorHostedService : BackgroundService, IQueueCoo
         CancellationToken stoppingToken)
     {
         if (_lifetime.ApplicationStarted.IsCancellationRequested)
+        {
+            TryTransition(QueueCoordinatorState.NotStarted, QueueCoordinatorState.Running);
             return true;
+        }
 
         var started = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        using var registration = _lifetime.ApplicationStarted.Register(
-            static state => ((TaskCompletionSource)state!).TrySetResult(),
-            started);
+        using var registration = _lifetime.ApplicationStarted.Register(() =>
+        {
+            // Set Running on the ApplicationStarted thread so /health cannot
+            // observe NotStarted after the host has already started serving.
+            TryTransition(QueueCoordinatorState.NotStarted, QueueCoordinatorState.Running);
+            started.TrySetResult();
+        });
 
         try
         {
@@ -120,4 +127,7 @@ public sealed class QueueCoordinatorHostedService : BackgroundService, IQueueCoo
             return false;
         }
     }
+
+    private bool TryTransition(QueueCoordinatorState from, QueueCoordinatorState to) =>
+        Interlocked.CompareExchange(ref _state, (int)to, (int)from) == (int)from;
 }

--- a/backend/Services/Repair/RepairPatchStore.cs
+++ b/backend/Services/Repair/RepairPatchStore.cs
@@ -219,6 +219,7 @@ public sealed class RepairPatchStore
             return Task.CompletedTask;
 
         Task load;
+        bool isOwner;
         lock (_catalogLoadSync)
         {
             if (IsCatalogReady)
@@ -227,18 +228,20 @@ public sealed class RepairPatchStore
             if (_catalogLoadInFlight is { IsCompleted: false } inflight)
             {
                 load = inflight;
+                isOwner = false;
             }
             else
             {
                 load = LoadCatalogOnceAsync(ct);
                 _catalogLoadInFlight = load;
+                isOwner = true;
             }
         }
 
-        return AwaitCatalogLoadAsync(load, ct);
+        return AwaitCatalogLoadAsync(load, isOwner, ct);
     }
 
-    private async Task AwaitCatalogLoadAsync(Task load, CancellationToken ct)
+    private async Task AwaitCatalogLoadAsync(Task load, bool isOwner, CancellationToken ct)
     {
         try
         {
@@ -248,11 +251,11 @@ public sealed class RepairPatchStore
         {
             lock (_catalogLoadSync)
             {
-                // Drop the shared slot when this waiter cancelled, even if the
-                // scan is still unwinding. Otherwise a retry joins a load bound
-                // to the cancelled token and fails immediately.
+                // Drop the slot when the load finished, or when its owner
+                // cancelled so a retry can start a new scan. A cancelled
+                // secondary waiter must not clear an in-flight owner scan.
                 if (ReferenceEquals(_catalogLoadInFlight, load)
-                    && (load.IsCompleted || ct.IsCancellationRequested))
+                    && (load.IsCompleted || (isOwner && ct.IsCancellationRequested)))
                     _catalogLoadInFlight = null;
             }
 

--- a/backend/Services/Repair/RepairPatchStore.cs
+++ b/backend/Services/Repair/RepairPatchStore.cs
@@ -248,7 +248,11 @@ public sealed class RepairPatchStore
         {
             lock (_catalogLoadSync)
             {
-                if (ReferenceEquals(_catalogLoadInFlight, load) && load.IsCompleted)
+                // Drop the shared slot when this waiter cancelled, even if the
+                // scan is still unwinding. Otherwise a retry joins a load bound
+                // to the cancelled token and fails immediately.
+                if (ReferenceEquals(_catalogLoadInFlight, load)
+                    && (load.IsCompleted || ct.IsCancellationRequested))
                     _catalogLoadInFlight = null;
             }
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -63,6 +63,17 @@ healthcheck:
 Use `/ready` as a restart trigger only if restarting a streaming-wedged container is the intended
 policy. This check detects a stuck in-flight article budget; it does not test provider connectivity.
 
+## Queue coordinator liveness (`/health`) [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since }
+
+The backend `/health` endpoint reports `503 Service Unavailable` if the queue coordinator fails or
+exits unexpectedly. The backend also exits with a nonzero code, allowing the documented Compose
+`restart: unless-stopped` policy to restart the container automatically. Previously, the SAB API and
+health endpoint could continue responding while queued items no longer progressed.
+
+`/ready` continues to report streaming admission readiness. The default frontend `/healthz` remains
+a lightweight process endpoint; queue-coordinator recovery does not depend on a healthcheck watcher
+because the backend process exits on failure.
+
 ## WebDAV or playback fails
 
 - Confirm WebDAV username/password.

--- a/tests/NzbWebDAV.Tests/Api/AddFileDuplicateReplaceTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AddFileDuplicateReplaceTests.cs
@@ -75,8 +75,7 @@ public sealed class AddFileDuplicateReplaceTests : IAsyncLifetime
             new ProviderUsageTracker(),
             new WatchdogLog(),
             new QueueItemSourceTracker(),
-            new BenchmarkGate(),
-            startLoop: false);
+            new BenchmarkGate());
     }
 
     public async Task DisposeAsync()

--- a/tests/NzbWebDAV.Tests/Api/AddUrlDeadlineTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/AddUrlDeadlineTests.cs
@@ -87,8 +87,7 @@ public sealed class AddUrlDeadlineTests : IAsyncLifetime
             new ProviderUsageTracker(),
             new WatchdogLog(),
             new QueueItemSourceTracker(),
-            new BenchmarkGate(),
-            startLoop: false);
+            new BenchmarkGate());
     }
 
     public async Task DisposeAsync()

--- a/tests/NzbWebDAV.Tests/Api/DeleteWebdavItemControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/DeleteWebdavItemControllerTests.cs
@@ -92,8 +92,7 @@ public sealed class DeleteWebdavItemControllerTests : IAsyncLifetime
             new ProviderUsageTracker(),
             new WatchdogLog(),
             new QueueItemSourceTracker(),
-            new BenchmarkGate(),
-            startLoop: false);
+            new BenchmarkGate());
     }
 
     public async Task DisposeAsync()

--- a/tests/NzbWebDAV.Tests/Api/HttpPipelineIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/HttpPipelineIntegrationTests.cs
@@ -1,7 +1,5 @@
 using System.Net;
 using System.Text.Json;
-using Microsoft.Extensions.DependencyInjection;
-using NzbWebDAV.Services;
 using NzbWebDAV.Tests.TestUtils;
 
 namespace NzbWebDAV.Tests.Api;
@@ -66,19 +64,6 @@ public sealed class HttpPipelineIntegrationTests(NzbDavWebApplicationFactory fac
     [Fact]
     public async Task HealthEndpoint_IsAvailableWithoutAuthentication()
     {
-        var coordinator = factory.Services.GetRequiredService<QueueCoordinatorHostedService>();
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
-        while (coordinator.GetState() != QueueCoordinatorState.Running)
-        {
-            if (DateTime.UtcNow >= deadline)
-            {
-                throw new TimeoutException(
-                    $"Queue coordinator state was {coordinator.GetState()}, expected Running.");
-            }
-
-            await Task.Delay(10);
-        }
-
         using var client = factory.CreateClient();
 
         using var response = await client.GetAsync("/health");

--- a/tests/NzbWebDAV.Tests/Api/HttpPipelineIntegrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/HttpPipelineIntegrationTests.cs
@@ -1,5 +1,7 @@
 using System.Net;
 using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using NzbWebDAV.Services;
 using NzbWebDAV.Tests.TestUtils;
 
 namespace NzbWebDAV.Tests.Api;
@@ -64,6 +66,19 @@ public sealed class HttpPipelineIntegrationTests(NzbDavWebApplicationFactory fac
     [Fact]
     public async Task HealthEndpoint_IsAvailableWithoutAuthentication()
     {
+        var coordinator = factory.Services.GetRequiredService<QueueCoordinatorHostedService>();
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (coordinator.GetState() != QueueCoordinatorState.Running)
+        {
+            if (DateTime.UtcNow >= deadline)
+            {
+                throw new TimeoutException(
+                    $"Queue coordinator state was {coordinator.GetState()}, expected Running.");
+            }
+
+            await Task.Delay(10);
+        }
+
         using var client = factory.CreateClient();
 
         using var response = await client.GetAsync("/health");

--- a/tests/NzbWebDAV.Tests/Api/NzbSubmissionIngestTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/NzbSubmissionIngestTests.cs
@@ -83,8 +83,7 @@ public sealed class NzbSubmissionIngestTests : IAsyncLifetime
             new ProviderUsageTracker(),
             new WatchdogLog(),
             new QueueItemSourceTracker(),
-            new BenchmarkGate(),
-            startLoop: false);
+            new BenchmarkGate());
     }
 
     public async Task DisposeAsync()

--- a/tests/NzbWebDAV.Tests/Api/RetryHistoryControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/RetryHistoryControllerTests.cs
@@ -76,8 +76,7 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
             new ProviderUsageTracker(),
             new WatchdogLog(),
             new QueueItemSourceTracker(),
-            new BenchmarkGate(),
-            startLoop: false);
+            new BenchmarkGate());
     }
 
     public async Task DisposeAsync()

--- a/tests/NzbWebDAV.Tests/Api/SabApiResponseShapeTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabApiResponseShapeTests.cs
@@ -94,8 +94,7 @@ public sealed class SabApiResponseShapeTests : IAsyncLifetime
                 new ProviderUsageTracker(),
                 new WatchdogLog(),
                 new QueueItemSourceTracker(),
-                new BenchmarkGate(),
-                startLoop: false);
+                new BenchmarkGate());
 
             SeedCorpus(HistoryCount, QueueCount);
             await _context.SaveChangesAsync();

--- a/tests/NzbWebDAV.Tests/Api/SabFailedDownloadIdentityTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabFailedDownloadIdentityTests.cs
@@ -82,8 +82,7 @@ public sealed class SabFailedDownloadIdentityTests : IAsyncLifetime
             new ProviderUsageTracker(),
             new WatchdogLog(),
             new QueueItemSourceTracker(),
-            new BenchmarkGate(),
-            startLoop: false);
+            new BenchmarkGate());
     }
 
     public async Task DisposeAsync()

--- a/tests/NzbWebDAV.Tests/Api/SabLimitZeroTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabLimitZeroTests.cs
@@ -74,8 +74,7 @@ public sealed class SabLimitZeroTests : IAsyncLifetime
             new ProviderUsageTracker(),
             new WatchdogLog(),
             new QueueItemSourceTracker(),
-            new BenchmarkGate(),
-            startLoop: false);
+            new BenchmarkGate());
     }
 
     public async Task DisposeAsync()

--- a/tests/NzbWebDAV.Tests/Api/SabPauseResumeTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SabPauseResumeTests.cs
@@ -85,8 +85,7 @@ public sealed class SabPauseResumeTests : IAsyncLifetime
             new ProviderUsageTracker(),
             new WatchdogLog(),
             new QueueItemSourceTracker(),
-            new BenchmarkGate(),
-            startLoop: false);
+            new BenchmarkGate());
     }
 
     public async Task DisposeAsync()

--- a/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
@@ -538,7 +538,7 @@ public sealed class PostgresMigrationTests
                         configManager, websocketManager, new ProviderUsageTracker(), new MetricsWriter(),
                         new ProviderBytesTracker(), new StreamTraceBuffer(100), new ActiveReadRegistry()),
                     configManager, websocketManager, new ProviderUsageTracker(), new WatchdogLog(),
-                    new QueueItemSourceTracker(), new BenchmarkGate(), startLoop: false);
+                    new QueueItemSourceTracker(), new BenchmarkGate());
                 return new SabControllerFixture(schema, adminConnection, context, queueManager,
                     configManager, new DavDatabaseClient(context), interceptor);
             }

--- a/tests/NzbWebDAV.Tests/Hosting/QueueCoordinatorHealthEndpointTests.cs
+++ b/tests/NzbWebDAV.Tests/Hosting/QueueCoordinatorHealthEndpointTests.cs
@@ -27,7 +27,7 @@ public sealed class QueueCoordinatorHealthEndpointTests(NzbDavWebApplicationFact
     public async Task HealthEndpoint_ReturnsOkOnceCoordinatorIsRunning()
     {
         var hosted = factory.Services.GetRequiredService<QueueCoordinatorHostedService>();
-        await WaitUntilStateAsync(hosted, QueueCoordinatorState.Running);
+        Assert.Equal(QueueCoordinatorState.Running, hosted.GetState());
 
         using var client = factory.CreateClient();
         using var response = await client.GetAsync("/health");
@@ -57,23 +57,6 @@ public sealed class QueueCoordinatorHealthEndpointTests(NzbDavWebApplicationFact
         Assert.Equal("Unhealthy", await health.Content.ReadAsStringAsync());
         Assert.Equal(HttpStatusCode.OK, ready.StatusCode);
         Assert.Equal("Healthy", await ready.Content.ReadAsStringAsync());
-    }
-
-    private static async Task WaitUntilStateAsync(
-        QueueCoordinatorHostedService service,
-        QueueCoordinatorState expected)
-    {
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
-        while (service.GetState() != expected)
-        {
-            if (DateTime.UtcNow >= deadline)
-            {
-                throw new TimeoutException(
-                    $"Queue coordinator state was {service.GetState()}, expected {expected}.");
-            }
-
-            await Task.Delay(10);
-        }
     }
 
     private sealed class FaultedLiveness : IQueueCoordinatorLiveness

--- a/tests/NzbWebDAV.Tests/Hosting/QueueCoordinatorHealthEndpointTests.cs
+++ b/tests/NzbWebDAV.Tests/Hosting/QueueCoordinatorHealthEndpointTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Services;
+using NzbWebDAV.Tests.TestUtils;
+
+namespace NzbWebDAV.Tests.Hosting;
+
+[Collection(nameof(HttpIntegrationCollection))]
+public sealed class QueueCoordinatorHealthEndpointTests(NzbDavWebApplicationFactory factory)
+{
+    [Fact]
+    public void LivenessAliases_ResolveToTheSameHostedServiceInstance()
+    {
+        var hosted = factory.Services.GetRequiredService<QueueCoordinatorHostedService>();
+        var liveness = factory.Services.GetRequiredService<IQueueCoordinatorLiveness>();
+        var hostedServices = factory.Services.GetRequiredService<IEnumerable<IHostedService>>();
+
+        Assert.Same(hosted, liveness);
+        Assert.Contains(hostedServices, service => ReferenceEquals(service, hosted));
+    }
+
+    [Fact]
+    public async Task HealthEndpoint_ReturnsOkOnceCoordinatorIsRunning()
+    {
+        var hosted = factory.Services.GetRequiredService<QueueCoordinatorHostedService>();
+        await WaitUntilStateAsync(hosted, QueueCoordinatorState.Running);
+
+        using var client = factory.CreateClient();
+        using var response = await client.GetAsync("/health");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("Healthy", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task HealthEndpoint_Returns503WhenCoordinatorIsFaulted_WhileReadyStaysHealthy()
+    {
+        await using var isolated = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<IQueueCoordinatorLiveness>();
+                services.AddSingleton<IQueueCoordinatorLiveness>(new FaultedLiveness());
+            });
+        });
+
+        using var client = isolated.CreateClient();
+
+        using var health = await client.GetAsync("/health");
+        using var ready = await client.GetAsync("/ready");
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, health.StatusCode);
+        Assert.Equal("Unhealthy", await health.Content.ReadAsStringAsync());
+        Assert.Equal(HttpStatusCode.OK, ready.StatusCode);
+        Assert.Equal("Healthy", await ready.Content.ReadAsStringAsync());
+    }
+
+    private static async Task WaitUntilStateAsync(
+        QueueCoordinatorHostedService service,
+        QueueCoordinatorState expected)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (service.GetState() != expected)
+        {
+            if (DateTime.UtcNow >= deadline)
+            {
+                throw new TimeoutException(
+                    $"Queue coordinator state was {service.GetState()}, expected {expected}.");
+            }
+
+            await Task.Delay(10);
+        }
+    }
+
+    private sealed class FaultedLiveness : IQueueCoordinatorLiveness
+    {
+        public QueueCoordinatorState GetState() => QueueCoordinatorState.Faulted;
+    }
+}

--- a/tests/NzbWebDAV.Tests/Hosting/QueueCoordinatorHostedServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Hosting/QueueCoordinatorHostedServiceTests.cs
@@ -226,8 +226,8 @@ public sealed class QueueCoordinatorHostedServiceTests
         Assert.False(invoked.Task.IsCompleted);
 
         lifetime.SignalStarted();
-        await invoked.Task.WaitAsync(GateTimeout);
         Assert.Equal(QueueCoordinatorState.Running, service.GetState());
+        await invoked.Task.WaitAsync(GateTimeout);
 
         await service.StopAsync(CancellationToken.None);
         Assert.Equal(QueueCoordinatorState.Stopped, service.GetState());
@@ -303,12 +303,11 @@ public sealed class QueueCoordinatorHostedServiceTests
         {
             await runTask.WaitAsync(GateTimeout);
         }
-        catch (OperationCanceledException)
-        {
-        }
-        catch (InvalidOperationException)
+        catch (Exception exception) when (
+            exception is OperationCanceledException or InvalidOperationException)
         {
             // Teardown only: the test body already observed success or failure.
+            _ = exception;
         }
     }
 

--- a/tests/NzbWebDAV.Tests/Hosting/QueueCoordinatorHostedServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Hosting/QueueCoordinatorHostedServiceTests.cs
@@ -1,0 +1,354 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NzbWebDAV;
+using NzbWebDAV.Services;
+using NzbWebDAV.Tests.TestUtils;
+
+namespace NzbWebDAV.Tests.Hosting;
+
+[Collection(nameof(HttpIntegrationCollection))]
+public sealed class QueueCoordinatorHostedServiceTests
+{
+    private static readonly TimeSpan GateTimeout = TimeSpan.FromSeconds(5);
+
+    [Fact]
+    public async Task OutOfMemoryException_FaultsHostAndSetsExitCodeOne()
+    {
+        await AssertFaultStopsHostAsync(
+            coordinator => coordinator.Fault(new OutOfMemoryException("deterministic coordinator OOM")));
+    }
+
+    [Fact]
+    public async Task SynchronousStartupException_FaultsHostAndSetsExitCodeOne()
+    {
+        var priorExitCode = Environment.ExitCode;
+        IHostApplicationLifetime? lifetime = null;
+        Task? runTask = null;
+        try
+        {
+            Environment.ExitCode = 0;
+            var host = CreateHost(
+                _ => throw new InvalidOperationException("deterministic coordinator startup failure"),
+                out var service,
+                out lifetime);
+
+            runTask = Program.RunHostAndSetExitCodeAsync(host);
+            var thrown = await Record.ExceptionAsync(() => runTask.WaitAsync(GateTimeout));
+
+            Assert.Null(thrown);
+            Assert.True(lifetime.ApplicationStopping.IsCancellationRequested);
+            Assert.True(service.ExecuteTask!.IsFaulted);
+            Assert.Equal(QueueCoordinatorState.Faulted, service.GetState());
+            Assert.Equal(1, Environment.ExitCode);
+        }
+        finally
+        {
+            if (runTask is not null && lifetime is not null)
+                await StopIfRunningAsync(runTask, lifetime);
+            Environment.ExitCode = priorExitCode;
+        }
+    }
+
+    [Fact]
+    public async Task AsynchronousException_FaultsHostAndSetsExitCodeOne()
+    {
+        await AssertFaultStopsHostAsync(
+            coordinator => coordinator.Fault(
+                new InvalidOperationException("deterministic coordinator fault")));
+    }
+
+    [Fact]
+    public async Task UnexpectedCancellation_IsConvertedToFaultAndSetsExitCodeOne()
+    {
+        var priorExitCode = Environment.ExitCode;
+        IHostApplicationLifetime? lifetime = null;
+        Task? runTask = null;
+        try
+        {
+            Environment.ExitCode = 0;
+            var coordinator = new ControlledCoordinator();
+            var host = CreateHost(coordinator.RunAsync, out var service, out lifetime);
+
+            runTask = Program.RunHostAndSetExitCodeAsync(host);
+            await coordinator.Started.Task.WaitAsync(GateTimeout);
+            coordinator.Cancel();
+
+            var thrown = await Record.ExceptionAsync(() => runTask.WaitAsync(GateTimeout));
+            Assert.Null(thrown);
+            Assert.True(lifetime.ApplicationStopping.IsCancellationRequested);
+            Assert.True(service.ExecuteTask!.IsFaulted);
+            Assert.False(service.ExecuteTask.IsCanceled);
+            Assert.Equal(QueueCoordinatorState.Faulted, service.GetState());
+            Assert.Equal(1, Environment.ExitCode);
+        }
+        finally
+        {
+            if (runTask is not null && lifetime is not null)
+                await StopIfRunningAsync(runTask, lifetime);
+            Environment.ExitCode = priorExitCode;
+        }
+    }
+
+    [Fact]
+    public async Task UnexpectedCleanCompletion_FaultsHostAndSetsExitCodeOne()
+    {
+        await AssertFaultStopsHostAsync(coordinator => coordinator.Complete());
+    }
+
+    [Fact]
+    public async Task GracefulHostStop_RecordsStoppedAndLeavesExitCodeZero()
+    {
+        var priorExitCode = Environment.ExitCode;
+        IHostApplicationLifetime? lifetime = null;
+        Task? runTask = null;
+        try
+        {
+            Environment.ExitCode = 0;
+            var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            async Task RunUntilStoppedAsync(CancellationToken stoppingToken)
+            {
+                started.TrySetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, stoppingToken);
+            }
+
+            var host = CreateHost(RunUntilStoppedAsync, out var service, out lifetime);
+
+            runTask = Program.RunHostAndSetExitCodeAsync(host);
+            await started.Task.WaitAsync(GateTimeout);
+            lifetime.StopApplication();
+
+            var thrown = await Record.ExceptionAsync(() => runTask.WaitAsync(GateTimeout));
+            Assert.Null(thrown);
+            Assert.False(service.ExecuteTask!.IsFaulted);
+            Assert.Equal(QueueCoordinatorState.Stopped, service.GetState());
+            Assert.Equal(0, Environment.ExitCode);
+        }
+        finally
+        {
+            if (runTask is not null && lifetime is not null)
+                await StopIfRunningAsync(runTask, lifetime);
+            Environment.ExitCode = priorExitCode;
+        }
+    }
+
+    [Fact]
+    public async Task ApplicationStopping_BeforeHostedServiceToken_IsGraceful()
+    {
+        var priorExitCode = Environment.ExitCode;
+        IHostApplicationLifetime? lifetime = null;
+        Task? runTask = null;
+        try
+        {
+            Environment.ExitCode = 0;
+            IHostApplicationLifetime? capturedLifetime = null;
+            var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            async Task RunUntilApplicationStoppingAsync(CancellationToken _)
+            {
+                started.TrySetResult();
+                var completion = new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                using var registration = capturedLifetime!.ApplicationStopping.Register(
+                    () => completion.TrySetResult());
+                await completion.Task;
+            }
+
+            var host = CreateHost(RunUntilApplicationStoppingAsync, out var service, out lifetime);
+            capturedLifetime = lifetime;
+
+            runTask = Program.RunHostAndSetExitCodeAsync(host);
+            await started.Task.WaitAsync(GateTimeout);
+            lifetime.StopApplication();
+
+            var thrown = await Record.ExceptionAsync(() => runTask.WaitAsync(GateTimeout));
+            Assert.Null(thrown);
+            Assert.False(service.ExecuteTask!.IsFaulted);
+            Assert.Equal(QueueCoordinatorState.Stopped, service.GetState());
+            Assert.Equal(0, Environment.ExitCode);
+        }
+        finally
+        {
+            if (runTask is not null && lifetime is not null)
+                await StopIfRunningAsync(runTask, lifetime);
+            Environment.ExitCode = priorExitCode;
+        }
+    }
+
+    [Fact]
+    public async Task HostStopRacingWithFault_StillRecordsFaultedAndExitsOne()
+    {
+        var priorExitCode = Environment.ExitCode;
+        IHostApplicationLifetime? lifetime = null;
+        Task? runTask = null;
+        try
+        {
+            Environment.ExitCode = 0;
+            var coordinator = new ControlledCoordinator();
+            var host = CreateHost(coordinator.RunAsync, out var service, out lifetime);
+
+            runTask = Program.RunHostAndSetExitCodeAsync(host);
+            await coordinator.Started.Task.WaitAsync(GateTimeout);
+            lifetime.StopApplication();
+            coordinator.Fault(new InvalidOperationException("shutdown race fault"));
+
+            var thrown = await Record.ExceptionAsync(() => runTask.WaitAsync(GateTimeout));
+            Assert.Null(thrown);
+            Assert.True(service.ExecuteTask!.IsFaulted);
+            Assert.Equal(QueueCoordinatorState.Faulted, service.GetState());
+            Assert.Equal(1, Environment.ExitCode);
+        }
+        finally
+        {
+            if (runTask is not null && lifetime is not null)
+                await StopIfRunningAsync(runTask, lifetime);
+            Environment.ExitCode = priorExitCode;
+        }
+    }
+
+    [Fact]
+    public async Task Coordinator_IsNotInvokedUntilApplicationStarted()
+    {
+        using var lifetime = new TestHostApplicationLifetime();
+        var invoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task RunAsync(CancellationToken stoppingToken)
+        {
+            invoked.TrySetResult();
+            return Task.Delay(Timeout.InfiniteTimeSpan, stoppingToken);
+        }
+
+        using var service = new QueueCoordinatorHostedService(RunAsync, lifetime);
+        await service.StartAsync(CancellationToken.None);
+
+        Assert.Equal(QueueCoordinatorState.NotStarted, service.GetState());
+        Assert.False(invoked.Task.IsCompleted);
+
+        lifetime.SignalStarted();
+        await invoked.Task.WaitAsync(GateTimeout);
+        Assert.Equal(QueueCoordinatorState.Running, service.GetState());
+
+        await service.StopAsync(CancellationToken.None);
+        Assert.Equal(QueueCoordinatorState.Stopped, service.GetState());
+        Assert.False(service.ExecuteTask!.IsFaulted);
+    }
+
+    private static async Task AssertFaultStopsHostAsync(Action<ControlledCoordinator> terminate)
+    {
+        var priorExitCode = Environment.ExitCode;
+        IHostApplicationLifetime? lifetime = null;
+        Task? runTask = null;
+        try
+        {
+            Environment.ExitCode = 0;
+            var coordinator = new ControlledCoordinator();
+            var host = CreateHost(coordinator.RunAsync, out var service, out lifetime);
+
+            runTask = Program.RunHostAndSetExitCodeAsync(host);
+            await coordinator.Started.Task.WaitAsync(GateTimeout);
+            terminate(coordinator);
+
+            var thrown = await Record.ExceptionAsync(() => runTask.WaitAsync(GateTimeout));
+            Assert.Null(thrown);
+            Assert.True(lifetime.ApplicationStopping.IsCancellationRequested);
+            Assert.True(service.ExecuteTask!.IsFaulted);
+            Assert.Equal(QueueCoordinatorState.Faulted, service.GetState());
+            Assert.Equal(1, Environment.ExitCode);
+        }
+        finally
+        {
+            if (runTask is not null && lifetime is not null)
+                await StopIfRunningAsync(runTask, lifetime);
+            Environment.ExitCode = priorExitCode;
+        }
+    }
+
+    private static IHost CreateHost(
+        Func<CancellationToken, Task> runCoordinator,
+        out QueueCoordinatorHostedService service,
+        out IHostApplicationLifetime lifetime)
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.Logging.ClearProviders();
+        builder.Services.Configure<HostOptions>(options =>
+        {
+            options.ShutdownTimeout = TimeSpan.FromSeconds(5);
+            options.BackgroundServiceExceptionBehavior =
+                BackgroundServiceExceptionBehavior.StopHost;
+        });
+        builder.Services.AddSingleton<ProcessExitCoordinator>();
+        builder.Services.AddSingleton(sp => new QueueCoordinatorHostedService(
+            runCoordinator,
+            sp.GetRequiredService<IHostApplicationLifetime>()));
+        builder.Services.AddSingleton<IQueueCoordinatorLiveness>(sp =>
+            sp.GetRequiredService<QueueCoordinatorHostedService>());
+        builder.Services.AddHostedService(sp =>
+            sp.GetRequiredService<QueueCoordinatorHostedService>());
+
+        var host = builder.Build();
+        service = host.Services.GetRequiredService<QueueCoordinatorHostedService>();
+        lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+        return host;
+    }
+
+    private static async Task StopIfRunningAsync(
+        Task runTask,
+        IHostApplicationLifetime lifetime)
+    {
+        if (!runTask.IsCompleted)
+            lifetime.StopApplication();
+
+        try
+        {
+            await runTask.WaitAsync(GateTimeout);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (InvalidOperationException)
+        {
+            // Teardown only: the test body already observed success or failure.
+        }
+    }
+
+    private sealed class ControlledCoordinator
+    {
+        private readonly TaskCompletionSource _completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Started { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task RunAsync(CancellationToken _)
+        {
+            Started.TrySetResult();
+            return _completion.Task;
+        }
+
+        public void Complete() => _completion.TrySetResult();
+        public void Cancel() => _completion.TrySetCanceled();
+        public void Fault(Exception exception) => _completion.TrySetException(exception);
+    }
+
+    private sealed class TestHostApplicationLifetime : IHostApplicationLifetime, IDisposable
+    {
+        private readonly CancellationTokenSource _started = new();
+        private readonly CancellationTokenSource _stopping = new();
+        private readonly CancellationTokenSource _stopped = new();
+
+        public CancellationToken ApplicationStarted => _started.Token;
+        public CancellationToken ApplicationStopping => _stopping.Token;
+        public CancellationToken ApplicationStopped => _stopped.Token;
+
+        public void SignalStarted() => _started.Cancel();
+        public void StopApplication() => _stopping.Cancel();
+
+        public void Dispose()
+        {
+            _started.Dispose();
+            _stopping.Dispose();
+            _stopped.Dispose();
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Queue/ConcurrentQueueManagerTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/ConcurrentQueueManagerTests.cs
@@ -87,8 +87,7 @@ public sealed class ConcurrentQueueManagerTests : IAsyncLifetime
             new ProviderUsageTracker(),
             new WatchdogLog(),
             new QueueItemSourceTracker(),
-            new BenchmarkGate(),
-            startLoop: false);
+            new BenchmarkGate());
         _queueManager.CreateDbContextOverride = () => new DavDatabaseContext(_options);
     }
 

--- a/tests/NzbWebDAV.Tests/Queue/QueueManagerLoopTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueManagerLoopTests.cs
@@ -237,6 +237,50 @@ public class QueueManagerLoopTests
         Assert.True(Volatile.Read(ref polls) >= 1, "Expected dequeue attempt after resume + awaken");
     }
 
+    [Fact]
+    public async Task StartProcessing_ReturnsSameObservedTask()
+    {
+        using var manager = CreateManager();
+        manager.IdleDelay = TimeSpan.FromMilliseconds(50);
+        manager.GetTopQueueItemOverride = (_, _) =>
+            Task.FromResult<(QueueItem? queueItem, Stream? queueNzbStream)>((null, null));
+
+        using var cts = new CancellationTokenSource();
+        var first = manager.StartProcessing(cts.Token);
+        var second = manager.StartProcessing(cts.Token);
+        Assert.Same(first, second);
+
+        await cts.CancelAsync();
+        await first.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task Dispose_AfterObservedCoordinatorFault_DoesNotRethrow()
+    {
+        using var manager = CreateManager();
+        manager.GetTopQueueItemOverride = (_, _) =>
+            throw new OutOfMemoryException("deterministic coordinator OOM");
+
+        using var cts = new CancellationTokenSource();
+        var coordinator = manager.StartProcessing(cts.Token);
+        var observed = await Record.ExceptionAsync(() => coordinator.WaitAsync(TimeSpan.FromSeconds(5)));
+
+        Assert.IsType<OutOfMemoryException>(observed);
+        Assert.Null(Record.Exception(manager.Dispose));
+    }
+
+    [Fact]
+    public void StartProcessing_AfterDispose_ThrowsObjectDisposedException()
+    {
+        var manager = CreateManager();
+        manager.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() =>
+        {
+            _ = manager.StartProcessing(CancellationToken.None);
+        });
+    }
+
     private static QueueManager CreateManager(ConfigManager? config = null)
     {
         config ??= CreateDefaultConfig();
@@ -257,8 +301,7 @@ public class QueueManagerLoopTests
             new ProviderUsageTracker(),
             new WatchdogLog(),
             new QueueItemSourceTracker(),
-            new BenchmarkGate(),
-            startLoop: false);
+            new BenchmarkGate());
     }
 
     private static ConfigManager CreateDefaultConfig()

--- a/tests/NzbWebDAV.Tests/Queue/QueueManagerPauseResumeTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueManagerPauseResumeTests.cs
@@ -59,8 +59,7 @@ public sealed class QueueManagerPauseResumeTests : IAsyncLifetime
             new ProviderUsageTracker(),
             new WatchdogLog(),
             new QueueItemSourceTracker(),
-            new BenchmarkGate(),
-            startLoop: false);
+            new BenchmarkGate());
     }
 
     public async Task DisposeAsync()

--- a/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
@@ -93,8 +93,7 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
             _queueManagerUsageTracker,
             new WatchdogLog(),
             new QueueItemSourceTracker(),
-            new BenchmarkGate(),
-            startLoop: false);
+            new BenchmarkGate());
         _queueManager.CreateDbContextOverride = () => new DavDatabaseContext(_options);
         _queueManager.StuckItemCheckInterval = TimeSpan.FromMilliseconds(50);
         _queueManager.StuckItemThreshold = TimeSpan.FromMilliseconds(250);

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckCoordinatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckCoordinatorTests.cs
@@ -800,7 +800,6 @@ public sealed class HealthCheckCoordinatorTests
                 new WatchdogLog(),
                 new QueueItemSourceTracker(),
                 BenchmarkGate,
-                startLoop: false,
                 healthCheckConnectionGate: _gate);
             Service = new HealthCheckService(
                 Config,

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
@@ -103,7 +103,6 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
             new WatchdogLog(),
             new QueueItemSourceTracker(),
             new BenchmarkGate(),
-            startLoop: false,
             healthCheckConnectionGate: _healthCheckConnectionGate);
     }
 

--- a/tests/NzbWebDAV.Tests/Services/QueueCoordinatorHealthCheckTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/QueueCoordinatorHealthCheckTests.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Tests.Services;
+
+public sealed class QueueCoordinatorHealthCheckTests
+{
+    [Theory]
+    [InlineData(QueueCoordinatorState.NotStarted, false, false, HealthStatus.Healthy)]
+    [InlineData(QueueCoordinatorState.NotStarted, true, false, HealthStatus.Unhealthy)]
+    [InlineData(QueueCoordinatorState.Running, true, false, HealthStatus.Healthy)]
+    [InlineData(QueueCoordinatorState.Stopped, true, true, HealthStatus.Healthy)]
+    [InlineData(QueueCoordinatorState.Stopped, true, false, HealthStatus.Unhealthy)]
+    [InlineData(QueueCoordinatorState.Faulted, true, false, HealthStatus.Unhealthy)]
+    [InlineData(QueueCoordinatorState.Faulted, true, true, HealthStatus.Unhealthy)]
+    public async Task CheckHealthAsync_MatchesLifecycleTruthTable(
+        QueueCoordinatorState state,
+        bool applicationStarted,
+        bool applicationStopping,
+        HealthStatus expected)
+    {
+        using var lifetime = new TestHostApplicationLifetime();
+        if (applicationStarted)
+            lifetime.SignalStarted();
+        if (applicationStopping)
+            lifetime.StopApplication();
+
+        var check = new QueueCoordinatorHealthCheck(new FakeLiveness(state), lifetime);
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(expected, result.Status);
+        if (expected == HealthStatus.Unhealthy)
+            Assert.DoesNotContain("Exception", result.Description ?? "", StringComparison.Ordinal);
+    }
+
+    private sealed class FakeLiveness(QueueCoordinatorState state) : IQueueCoordinatorLiveness
+    {
+        public QueueCoordinatorState GetState() => state;
+    }
+
+    private sealed class TestHostApplicationLifetime : IHostApplicationLifetime, IDisposable
+    {
+        private readonly CancellationTokenSource _started = new();
+        private readonly CancellationTokenSource _stopping = new();
+        private readonly CancellationTokenSource _stopped = new();
+
+        public CancellationToken ApplicationStarted => _started.Token;
+        public CancellationToken ApplicationStopping => _stopping.Token;
+        public CancellationToken ApplicationStopped => _stopped.Token;
+
+        public void SignalStarted() => _started.Cancel();
+        public void StopApplication() => _stopping.Cancel();
+
+        public void Dispose()
+        {
+            _started.Dispose();
+            _stopping.Dispose();
+            _stopped.Dispose();
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Repair/RepairPatchStoreTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/RepairPatchStoreTests.cs
@@ -259,6 +259,54 @@ public sealed class RepairPatchStoreTests
     }
 
     [Fact]
+    public async Task CancelledSecondaryWaiter_DoesNotStartDuplicateScan()
+    {
+        var dir = NewTempDir("catalog-secondary-cancel");
+        var scanEntered = NewTcs();
+        var allowScan = NewTcs();
+        var starts = 0;
+        var content = "secondary-cancel-blob"u8.ToArray();
+        var blob = WriteBlob(dir, "secondary-cancel@test", content);
+
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024, ct =>
+            {
+                Interlocked.Increment(ref starts);
+                scanEntered.TrySetResult();
+                allowScan.Task.Wait(ct);
+                return new[] { blob };
+            });
+
+            var owner = store.EnsureCatalogLoadedAsync(CancellationToken.None);
+            await scanEntered.Task.WaitAsync(Timeout);
+
+            using var secondaryCts = new CancellationTokenSource();
+            var secondary = store.EnsureCatalogLoadedAsync(secondaryCts.Token);
+            secondaryCts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => secondary);
+
+            var later = store.EnsureCatalogLoadedAsync(CancellationToken.None);
+            Assert.Equal(1, Volatile.Read(ref starts));
+            Assert.False(owner.IsCompleted);
+            Assert.False(later.IsCompleted);
+
+            allowScan.TrySetResult();
+            await Task.WhenAll(owner, later).WaitAsync(Timeout);
+
+            Assert.Equal(1, Volatile.Read(ref starts));
+            Assert.True(store.IsCatalogReady);
+            Assert.Equal(1, store.EntryCount);
+            Assert.Equal(content.Length, store.CurrentBytes);
+        }
+        finally
+        {
+            allowScan.TrySetResult();
+            DeleteDir(dir);
+        }
+    }
+
+    [Fact]
     public async Task ConcurrentCommit_NewHashSurvivesPublication()
     {
         var dir = NewTempDir("catalog-live-unique");

--- a/tests/NzbWebDAV.Tests/UsenetMigration/Step6LifecycleTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/Step6LifecycleTests.cs
@@ -511,7 +511,6 @@ public sealed class Step6LifecycleTests
             new ProviderUsageTracker(),
             new WatchdogLog(),
             new QueueItemSourceTracker(),
-            new BenchmarkGate(),
-            startLoop: false);
+            new BenchmarkGate());
     }
 }

--- a/tests/NzbWebDAV.Tests/UsenetMigration/SubmissionWorkerPoolTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/SubmissionWorkerPoolTests.cs
@@ -503,7 +503,6 @@ public sealed class SubmissionWorkerPoolTests
             new ProviderUsageTracker(),
             new WatchdogLog(),
             new QueueItemSourceTracker(),
-            new BenchmarkGate(),
-            startLoop: false);
+            new BenchmarkGate());
     }
 }

--- a/tests/NzbWebDAV.Tests/UsenetMigration/UsenetMigrationControllerAuthTests.cs
+++ b/tests/NzbWebDAV.Tests/UsenetMigration/UsenetMigrationControllerAuthTests.cs
@@ -386,7 +386,6 @@ public sealed class UsenetMigrationControllerAuthTests
             new ProviderUsageTracker(),
             new WatchdogLog(),
             new QueueItemSourceTracker(),
-            new BenchmarkGate(),
-            startLoop: false);
+            new BenchmarkGate());
     }
 }


### PR DESCRIPTION
## Summary
- A queue processor `OutOfMemoryException` could fault `ProcessQueueAsync` with no host-owned observer, so `/health` and the SAB API kept returning 200 while the queue was dead (confirmed #1236 incident: 78 minutes of unobserved coordinator death).
- The queue coordinator is now started and directly awaited by `QueueCoordinatorHostedService` after `ApplicationStarted`. Faults, unexpected cancellation, and unexpected clean completion reuse the existing hosted-service `StopHost` / `RunHostAndSetExitCodeAsync` rail and exit 1 so Compose `restart: unless-stopped` can recover the container.
- `/health` reports sticky queue-coordinator lifecycle state (`NotStarted` / `Running` / `Stopped` / `Faulted`). `/ready` is unchanged. No fixed heartbeat is added: claim I/O and worker cleanup still have no proven upper bound (#1186 / #1238). `QueueManager.Dispose` swallows a second observation of the already-awaited coordinator task so teardown cannot hide the established exit-code path. Shutdown drain duration is unchanged (#1251).

## Test plan
- [x] Coordinator OOM, sync startup throw, and async fault: `ExecuteTask.IsFaulted`, host stop, exit code 1
- [x] Unexpected cancellation is wrapped as a non-cancellation fault (not `IsCanceled`) and exits 1
- [x] Unexpected clean completion exits 1
- [x] Host stop racing a non-cancellation fault still records sticky `Faulted` and exits 1 (guards `WaitAsync(stoppingToken)`)
- [x] Graceful stop via hosted-service token and via `ApplicationStopping` before that token: `Stopped`, exit 0
- [x] Coordinator is not invoked until `ApplicationStarted`
- [x] `StartProcessing` is idempotent; dispose after an observed OOM does not rethrow; start after dispose throws `ObjectDisposedException`
- [x] Health-check truth table, including `Faulted` remaining unhealthy after `ApplicationStopping`
- [x] DI aliases resolve to one instance; `/health` is 200 while running; `/health` is 503 when liveness is `Faulted` while `/ready` stays 200

Fixes #1236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added queue coordinator lifecycle monitoring and health reporting.
  - The `/health` endpoint now returns HTTP 503 when queue processing fails.
  - Queue processing now starts and stops with the application lifecycle.
  - Coordinator failures are surfaced for automatic process recovery.

- **Bug Fixes**
  - Fixed cancelled catalog loads blocking subsequent repair retries.

- **Documentation**
  - Clarified the roles of `/health`, `/ready`, and frontend health endpoints.

- **Tests**
  - Added coverage for lifecycle, failure handling, health responses, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->