### PR TITLE
feat(usenet): measure production pipelined cache bypass before the warm-read fix

### DIFF
--- a/backend.Benchmarks/Baselines/streaming-baseline.json
+++ b/backend.Benchmarks/Baselines/streaming-baseline.json
@@ -209,6 +209,78 @@
           "policy": "warn"
         }
       }
+    },
+    "pipelined-cold-read": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 12,
+        "transportBytes": 3145728,
+        "transportBatchRequests": 3,
+        "cacheHits": 0,
+        "cacheMisses": 1,
+        "cacheBytesServed": 0,
+        "cacheBatchBypassRequests": 3,
+        "cacheBatchBypassArticles": 11,
+        "cacheWriteCommits": 1
+      },
+      "timing": {
+        "firstByteMs": {
+          "baseline": 0.222,
+          "envelope": 15.222,
+          "policy": "fail"
+        },
+        "elapsedMs": {
+          "baseline": 1.256,
+          "envelope": 16.256,
+          "policy": "fail"
+        },
+        "throughputMiBs": {
+          "baseline": 2388.535,
+          "floor": 796.178,
+          "policy": "fail"
+        },
+        "cpuSeconds": {
+          "baseline": 0.001,
+          "envelope": 0.251,
+          "policy": "warn"
+        }
+      }
+    },
+    "pipelined-warm-reread": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 11,
+        "transportBytes": 2883584,
+        "transportBatchRequests": 3,
+        "cacheHits": 1,
+        "cacheMisses": 0,
+        "cacheBytesServed": 262144,
+        "cacheBatchBypassRequests": 3,
+        "cacheBatchBypassArticles": 11,
+        "cacheWriteCommits": 0
+      },
+      "timing": {
+        "firstByteMs": {
+          "baseline": 0.129,
+          "envelope": 15.129,
+          "policy": "fail"
+        },
+        "elapsedMs": {
+          "baseline": 0.55,
+          "envelope": 15.55,
+          "policy": "fail"
+        },
+        "throughputMiBs": {
+          "baseline": 5458.515,
+          "floor": 1819.505,
+          "policy": "fail"
+        },
+        "cpuSeconds": {
+          "baseline": 0.001,
+          "envelope": 0.251,
+          "policy": "warn"
+        }
+      }
     }
   }
 }

--- a/backend.Benchmarks/Program.cs
+++ b/backend.Benchmarks/Program.cs
@@ -336,9 +336,11 @@ namespace NzbWebDAV.Benchmarks
         IReadOnlyDictionary<string, LongRange>? segmentRanges = null) : NntpClient
     {
         private int _bodyRequestCount;
+        private int _batchRequestCount;
         private long _bodyBytesRequested;
 
         public int BodyRequestCount => Volatile.Read(ref _bodyRequestCount);
+        public int BatchRequestCount => Volatile.Read(ref _batchRequestCount);
         public long BodyBytesRequested => Interlocked.Read(ref _bodyBytesRequested);
         public HashSet<string> RequestedSegmentIds { get; } = new(StringComparer.Ordinal);
 
@@ -387,6 +389,7 @@ namespace NzbWebDAV.Benchmarks
             ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken)
         {
+            Interlocked.Increment(ref _batchRequestCount);
             var responses = segmentIds
                 .Select(segmentId => DecodedBodyAsync(segmentId, cancellationToken))
                 .ToArray();

--- a/backend.Benchmarks/RepeatableStreamingReport.cs
+++ b/backend.Benchmarks/RepeatableStreamingReport.cs
@@ -10,6 +10,8 @@ internal static class RepeatableStreamingReport
     private const int SegmentSize = 256 * 1024;
     private const int SegmentCount = 12;
     private const int ProbeSize = 64 * 1024;
+    private const int ProductionArticleBufferSize = 40;
+    private const int ProductionBodyBatchWidth = 4;
     private const string ReportName = "streaming";
 
     public static async Task RunAsync(string? jsonPath = null)
@@ -26,6 +28,9 @@ internal static class RepeatableStreamingReport
     {
         var fixture = CreateFixture();
         var cacheDir = Path.Join(Path.GetTempPath(), "nzbdav-repeatable-streaming-" + Guid.NewGuid().ToString("N"));
+        var pipelinedCacheDir = Path.Join(
+            Path.GetTempPath(),
+            "nzbdav-repeatable-streaming-pipelined-" + Guid.NewGuid().ToString("N"));
         var scenarios = new Dictionary<string, ScenarioSnapshot>(StringComparer.Ordinal);
 
         try
@@ -97,11 +102,45 @@ internal static class RepeatableStreamingReport
                     dead.Snapshot,
                     extra: $"zero_filled_bytes={dead.Snapshot.Deterministic["bytes"]}");
             }
+
+            var pipelinedStatistics = new SegmentCacheStatistics();
+            using var pipelinedTransport = fixture.CreateTransport();
+            using var pipelinedCache = new SegmentCacheNntpClient(
+                pipelinedTransport,
+                pipelinedCacheDir,
+                maxBytes: fixture.Source.Length * 2L,
+                usageTracker: null,
+                metricsWriter: null,
+                enumerateCacheFiles: null,
+                pipelinedStatistics);
+            await WaitForCatalogAsync(pipelinedCache).ConfigureAwait(false);
+
+            await RecordPipelinedAsync(
+                scenarios,
+                print,
+                pipelinedTransport,
+                pipelinedStatistics,
+                "pipelined-cold-read",
+                () => ReadAllVerifiedAsync(
+                    fixture.CreateProductionShapedStream(pipelinedCache),
+                    fixture.Source)).ConfigureAwait(false);
+
+            await RecordPipelinedAsync(
+                scenarios,
+                print,
+                pipelinedTransport,
+                pipelinedStatistics,
+                "pipelined-warm-reread",
+                () => ReadAllVerifiedAsync(
+                    fixture.CreateProductionShapedStream(pipelinedCache),
+                    fixture.Source)).ConfigureAwait(false);
         }
         finally
         {
             if (Directory.Exists(cacheDir))
                 Directory.Delete(cacheDir, recursive: true);
+            if (Directory.Exists(pipelinedCacheDir))
+                Directory.Delete(pipelinedCacheDir, recursive: true);
         }
 
         return scenarios;
@@ -132,6 +171,38 @@ internal static class RepeatableStreamingReport
         scenarios[name] = snapshot;
         if (print)
             Print(name, snapshot, extra: extra?.Invoke(snapshot));
+    }
+
+    private static async Task RecordPipelinedAsync(
+        Dictionary<string, ScenarioSnapshot> scenarios,
+        bool print,
+        BenchmarkNntpClient transport,
+        SegmentCacheStatistics statistics,
+        string name,
+        Func<Task<StreamingMetrics>> action)
+    {
+        var requestsBefore = transport.BodyRequestCount;
+        var bytesBefore = transport.BodyBytesRequested;
+        var batchesBefore = transport.BatchRequestCount;
+        var cacheBefore = statistics.GetSnapshot();
+        var process = Process.GetCurrentProcess();
+        process.Refresh();
+        var cpuBefore = process.TotalProcessorTime;
+        var metrics = await action().ConfigureAwait(false);
+        process.Refresh();
+        var cpuSeconds = (process.TotalProcessorTime - cpuBefore).TotalSeconds;
+        var cacheAfter = statistics.GetSnapshot();
+        var snapshot = ToPipelinedSnapshot(
+            metrics,
+            transport.BodyRequestCount - requestsBefore,
+            transport.BodyBytesRequested - bytesBefore,
+            transport.BatchRequestCount - batchesBefore,
+            cacheBefore,
+            cacheAfter,
+            cpuSeconds);
+        scenarios[name] = snapshot;
+        if (print)
+            Print(name, snapshot);
     }
 
     private static async Task<DeadArticleCapture> MeasureDeadArticleAsync(Fixture fixture)
@@ -188,6 +259,38 @@ internal static class RepeatableStreamingReport
                 cpuSeconds));
     }
 
+    private static ScenarioSnapshot ToPipelinedSnapshot(
+        StreamingMetrics metrics,
+        int transportRequests,
+        long transportBytes,
+        int transportBatchRequests,
+        SegmentCacheSnapshot cacheBefore,
+        SegmentCacheSnapshot cacheAfter,
+        double cpuSeconds)
+    {
+        var seconds = Math.Max(metrics.Elapsed.TotalSeconds, double.Epsilon);
+        var throughput = metrics.BytesRead / 1024d / 1024d / seconds;
+        return new ScenarioSnapshot(
+            new Dictionary<string, long>(StringComparer.Ordinal)
+            {
+                ["bytes"] = metrics.BytesRead,
+                ["transportRequests"] = transportRequests,
+                ["transportBytes"] = transportBytes,
+                ["transportBatchRequests"] = transportBatchRequests,
+                ["cacheHits"] = cacheAfter.Hits - cacheBefore.Hits,
+                ["cacheMisses"] = cacheAfter.Misses - cacheBefore.Misses,
+                ["cacheBytesServed"] = cacheAfter.BytesServed - cacheBefore.BytesServed,
+                ["cacheBatchBypassRequests"] = cacheAfter.BatchBypassRequests - cacheBefore.BatchBypassRequests,
+                ["cacheBatchBypassArticles"] = cacheAfter.BatchBypassArticles - cacheBefore.BatchBypassArticles,
+                ["cacheWriteCommits"] = cacheAfter.WriteCommits - cacheBefore.WriteCommits,
+            },
+            PerformanceReportJson.StreamingTiming(
+                metrics.FirstByte.TotalMilliseconds,
+                metrics.Elapsed.TotalMilliseconds,
+                throughput,
+                cpuSeconds));
+    }
+
     private static async Task<StreamingMetrics> ReadAllAsync(INntpClient client, Fixture fixture)
     {
         await using var stream = fixture.CreateStream(client);
@@ -198,6 +301,33 @@ internal static class RepeatableStreamingReport
         await stream.CopyToAsync(Stream.Null).ConfigureAwait(false);
         stopwatch.Stop();
         return new StreamingMetrics(stopwatch.Elapsed, firstByte, read, OperationCount: 1);
+    }
+
+    private static async Task<StreamingMetrics> ReadAllVerifiedAsync(NzbFileStream stream, byte[] expected)
+    {
+        await using (stream)
+        {
+            var output = new byte[expected.Length];
+            var stopwatch = Stopwatch.StartNew();
+            var firstCount = Math.Min(ProbeSize, output.Length);
+            var firstRead = await stream.ReadAtLeastAsync(output.AsMemory(0, firstCount), firstCount, throwOnEndOfStream: true)
+                .ConfigureAwait(false);
+            var firstByte = stopwatch.Elapsed;
+            var total = firstRead;
+            while (total < output.Length)
+            {
+                var read = await stream.ReadAsync(output.AsMemory(total)).ConfigureAwait(false);
+                if (read == 0) break;
+                total += read;
+            }
+
+            stopwatch.Stop();
+            if (total != expected.Length)
+                throw new InvalidOperationException(
+                    $"Pipelined streaming read length {total} did not match fixture length {expected.Length}.");
+            Verify(expected, output, "pipelined-read");
+            return new StreamingMetrics(stopwatch.Elapsed, firstByte, total, OperationCount: 1);
+        }
     }
 
     private static async Task<StreamingMetrics> PrimeCacheAsync(SegmentCacheNntpClient client, Fixture fixture)
@@ -322,6 +452,17 @@ internal static class RepeatableStreamingReport
         public NzbFileStream CreateStream(INntpClient client) =>
             new(SegmentIds, Source.Length, client, articleBufferSize: 0, segmentByteRanges: Ranges,
                 usePipelinedBodyRequests: false, fileName: "repeatable-streaming-benchmark.bin");
+
+        public NzbFileStream CreateProductionShapedStream(INntpClient client) =>
+            new(
+                SegmentIds,
+                Source.Length,
+                client,
+                articleBufferSize: ProductionArticleBufferSize,
+                segmentByteRanges: Ranges,
+                usePipelinedBodyRequests: true,
+                fileName: "repeatable-streaming-pipelined-benchmark.bin",
+                streamingBodyBatchWidth: ProductionBodyBatchWidth);
     }
 
     private readonly record struct StreamingMetrics(

--- a/backend/Clients/Usenet/SegmentCacheNntpClient.cs
+++ b/backend/Clients/Usenet/SegmentCacheNntpClient.cs
@@ -18,16 +18,20 @@ namespace NzbWebDAV.Clients.Usenet;
 public sealed class SegmentCacheNntpClient : WrappingNntpClient
 {
     public const string CacheProviderName = "segment-cache";
+    internal const string DefaultCachePath = "/config/segment-cache";
 
     private readonly string _dir;
     private readonly long _maxBytes;
     private readonly ProviderUsageTracker? _usageTracker;
     private readonly MetricsWriter? _metricsWriter;
+    private readonly SegmentCacheStatistics _statistics;
+    private readonly SegmentCacheGeneration _generation;
     private readonly ConcurrentDictionary<string, CacheEntry> _index = new();
     private readonly object _evictLock = new();
     private readonly Func<IEnumerable<string>> _enumerateCacheFiles;
     private long _currentBytes;
     private int _catalogReady;
+    private int _catalogDegraded;
 
     private static readonly JsonSerializerOptions HeaderJsonOptions = new() { IncludeFields = true };
 
@@ -37,7 +41,7 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         long maxBytes,
         ProviderUsageTracker? usageTracker = null,
         MetricsWriter? metricsWriter = null)
-        : this(inner, cacheDir, maxBytes, usageTracker, metricsWriter, enumerateCacheFiles: null)
+        : this(inner, cacheDir, maxBytes, usageTracker, metricsWriter, enumerateCacheFiles: null, statistics: null)
     {
     }
 
@@ -47,12 +51,15 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         long maxBytes,
         ProviderUsageTracker? usageTracker,
         MetricsWriter? metricsWriter,
-        Func<IEnumerable<string>>? enumerateCacheFiles) : base(inner)
+        Func<IEnumerable<string>>? enumerateCacheFiles,
+        SegmentCacheStatistics? statistics = null) : base(inner)
     {
         _dir = cacheDir;
         _maxBytes = maxBytes;
         _usageTracker = usageTracker;
         _metricsWriter = metricsWriter;
+        _statistics = statistics ?? new SegmentCacheStatistics();
+        _generation = _statistics.BeginGeneration(enabled: true, maxBytes);
         Directory.CreateDirectory(_dir);
         _enumerateCacheFiles = enumerateCacheFiles
                                ?? (() => Directory.EnumerateFiles(_dir, "*", SearchOption.AllDirectories));
@@ -62,6 +69,11 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
     public bool IsCatalogReady => Volatile.Read(ref _catalogReady) != 0;
     internal Task CatalogLoadTask { get; }
     internal long CurrentBytes => Interlocked.Read(ref _currentBytes);
+
+    internal static string ClassifyCachePath(string path) =>
+        string.Equals(path, DefaultCachePath, StringComparison.Ordinal)
+            ? "[CONFIG_PATH]/segment-cache"
+            : "[CUSTOM_PATH]";
 
     public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(SegmentId segmentId, CancellationToken ct)
     {
@@ -75,13 +87,16 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
             return await base.DecodedBodyAsync(segmentId, onConnectionReadyAgain, ct).ConfigureAwait(false);
 
         string id = segmentId;
-        if (TryServeFromCache(id, out var cached))
+        var lookup = TryServeFromCache(id, out var cached, out var servedBytes);
+        if (lookup == CacheLookupResult.Hit)
         {
+            _statistics.RecordHit(servedBytes);
             RecordCacheHit();
             ArticleBodyCompletion.InvokeContained(onConnectionReadyAgain, ArticleBodyResult.Retrieved);
             return cached!;
         }
 
+        RecordLookup(lookup);
         var response = await base.DecodedBodyAsync(segmentId, onConnectionReadyAgain, ct).ConfigureAwait(false);
         return await WrapForCachingAsync(id, response, ct).ConfigureAwait(false);
     }
@@ -89,11 +104,17 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
     public override async Task<UsenetDecodedBodyResponse?> TryGetLocalDecodedBodyAsync(
         SegmentId segmentId, CancellationToken ct)
     {
-        if (MultiProviderNntpClient.AttributionContext.Value == null
-            && TryServeFromCache(segmentId.ToString(), out var cached))
+        if (MultiProviderNntpClient.AttributionContext.Value == null)
         {
-            RecordCacheHit();
-            return cached;
+            var lookup = TryServeFromCache(segmentId.ToString(), out var cached, out var servedBytes);
+            if (lookup == CacheLookupResult.Hit)
+            {
+                _statistics.RecordHit(servedBytes);
+                RecordCacheHit();
+                return cached;
+            }
+
+            RecordLookup(lookup);
         }
 
         return await base.TryGetLocalDecodedBodyAsync(segmentId, ct).ConfigureAwait(false);
@@ -116,16 +137,37 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
             return await base.DecodedBodyAsync(segmentId, exclusiveConnection, ct).ConfigureAwait(false);
 
         string id = segmentId;
-        if (TryServeFromCache(id, out var cached))
+        var lookup = TryServeFromCache(id, out var cached, out var servedBytes);
+        if (lookup == CacheLookupResult.Hit)
         {
+            _statistics.RecordHit(servedBytes);
             RecordCacheHit();
             ArticleBodyCompletion.InvokeContained(
                 exclusiveConnection.OnConnectionReadyAgain, ArticleBodyResult.Retrieved);
             return cached!;
         }
 
+        RecordLookup(lookup);
         var response = await base.DecodedBodyAsync(segmentId, exclusiveConnection, ct).ConfigureAwait(false);
         return await WrapForCachingAsync(id, response, ct).ConfigureAwait(false);
+    }
+
+    public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+        IReadOnlyList<SegmentId> segmentIds,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
+        CancellationToken cancellationToken)
+    {
+        _statistics.RecordBatchBypass(segmentIds.Count);
+        return base.DecodedBodiesAsync(segmentIds, onConnectionReadyAgain, cancellationToken);
+    }
+
+    public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+        IReadOnlyList<SegmentId> segmentIds,
+        UsenetExclusiveConnection exclusiveConnection,
+        CancellationToken cancellationToken)
+    {
+        _statistics.RecordBatchBypass(segmentIds.Count);
+        return base.DecodedBodiesAsync(segmentIds, exclusiveConnection, cancellationToken);
     }
 
     private async Task<UsenetDecodedBodyResponse> WrapForCachingAsync(
@@ -147,16 +189,21 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         }
 
         if (header == null) return response;
-        return response with { Stream = new WriteThroughStream(source, header, BlobPath(Hash(id)), OnFinalized) };
+        var attempt = _statistics.BeginWriteAttempt();
+        return response with
+        {
+            Stream = new WriteThroughStream(source, header, BlobPath(Hash(id)), OnCommitted, attempt),
+        };
     }
 
-    private bool TryServeFromCache(string id, out UsenetDecodedBodyResponse? response)
+    private CacheLookupResult TryServeFromCache(string id, out UsenetDecodedBodyResponse? response, out long servedBytes)
     {
         response = null;
-        if (!IsCatalogReady) return false;
+        servedBytes = 0;
+        if (!IsCatalogReady) return CacheLookupResult.NotReady;
 
         var hash = Hash(id);
-        if (!_index.TryGetValue(hash, out var entry)) return false;
+        if (!_index.TryGetValue(hash, out var entry)) return CacheLookupResult.Miss;
 
         var blobPath = BlobPath(hash);
         try
@@ -165,13 +212,14 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
                 File.ReadAllText(blobPath + ".h"), HeaderJsonOptions);
             if (header == null || header.PartSize != entry.Size)
             {
-                Drop(hash);
-                return false;
+                RecordReadFailureAndDrop(hash);
+                return CacheLookupResult.ReadFailure;
             }
 
             var fileStream = new FileStream(blobPath, FileMode.Open, FileAccess.Read,
                 FileShare.Read | FileShare.Delete, bufferSize: 81920, useAsync: true);
             entry.LastAccessTicks = DateTime.UtcNow.Ticks;
+            servedBytes = header.PartSize;
             response = new UsenetDecodedBodyResponse
             {
                 SegmentId = id,
@@ -179,13 +227,33 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
                 ResponseMessage = "222 - Article retrieved from segment cache",
                 Stream = new CachedYencStream(header, fileStream),
             };
-            return true;
+            return CacheLookupResult.Hit;
         }
         catch
         {
-            Drop(hash);
-            return false;
+            RecordReadFailureAndDrop(hash);
+            return CacheLookupResult.ReadFailure;
         }
+    }
+
+    private void RecordLookup(CacheLookupResult lookup)
+    {
+        switch (lookup)
+        {
+            case CacheLookupResult.NotReady:
+                _statistics.RecordLookupUnavailable();
+                break;
+            case CacheLookupResult.Miss:
+                _statistics.RecordMiss();
+                break;
+        }
+    }
+
+    private void RecordReadFailureAndDrop(string hash)
+    {
+        _statistics.RecordReadFailure();
+        Drop(hash);
+        PublishIndexGauges();
     }
 
     private void RecordCacheHit()
@@ -204,16 +272,21 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         });
     }
 
-    private void OnFinalized(string hash, long size)
+    private void OnCommitted(string hash, long size)
     {
+        long evictedEntries = 0;
+        long evictedBytes = 0;
         lock (_evictLock)
         {
             if (_index.TryGetValue(hash, out var existing)) _currentBytes -= existing.Size;
             _index[hash] = new CacheEntry { Size = size, LastAccessTicks = DateTime.UtcNow.Ticks };
             _currentBytes += size;
+            EvictWhileLocked(ref evictedEntries, ref evictedBytes);
         }
 
-        EvictIfNeeded();
+        if (evictedEntries > 0)
+            _statistics.RecordEviction(evictedEntries, evictedBytes);
+        PublishIndexGauges();
     }
 
     private void Drop(string hash)
@@ -223,37 +296,60 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
             if (_index.TryRemove(hash, out var entry)) _currentBytes -= entry.Size;
         }
 
-        SafeDelete(BlobPath(hash));
-        SafeDelete(BlobPath(hash) + ".h");
+        TryDelete(BlobPath(hash));
+        TryDelete(BlobPath(hash) + ".h");
     }
 
     private void EvictIfNeeded()
     {
         if (Interlocked.Read(ref _currentBytes) <= _maxBytes) return;
+        long evictedEntries = 0;
+        long evictedBytes = 0;
         lock (_evictLock)
         {
             if (_currentBytes <= _maxBytes) return;
-            foreach (var kv in _index.OrderBy(x => x.Value.LastAccessTicks).ToList())
-            {
-                if (_currentBytes <= _maxBytes) break;
-                if (!_index.TryRemove(kv.Key, out var entry)) continue;
-                _currentBytes -= entry.Size;
-                SafeDelete(BlobPath(kv.Key));
-                SafeDelete(BlobPath(kv.Key) + ".h");
-            }
+            EvictWhileLocked(ref evictedEntries, ref evictedBytes);
+        }
+
+        if (evictedEntries > 0)
+            _statistics.RecordEviction(evictedEntries, evictedBytes);
+        PublishIndexGauges();
+    }
+
+    private void EvictWhileLocked(ref long evictedEntries, ref long evictedBytes)
+    {
+        if (_currentBytes <= _maxBytes) return;
+        foreach (var kv in _index.OrderBy(x => x.Value.LastAccessTicks).ToList())
+        {
+            if (_currentBytes <= _maxBytes) break;
+            if (!_index.TryRemove(kv.Key, out var entry)) continue;
+            _currentBytes -= entry.Size;
+            evictedEntries++;
+            evictedBytes += entry.Size;
+            TryDelete(BlobPath(kv.Key));
+            TryDelete(BlobPath(kv.Key) + ".h");
         }
     }
+
+    private void PublishIndexGauges() =>
+        _generation.SetIndex(_index.Count, Interlocked.Read(ref _currentBytes));
 
     private void LoadIndex()
     {
         var stopwatch = Stopwatch.StartNew();
+        var cleaned = 0;
         try
         {
             foreach (var file in _enumerateCacheFiles())
             {
                 if (file.EndsWith(".tmp", StringComparison.Ordinal))
                 {
-                    SafeDelete(file);
+                    if (TryDelete(file))
+                    {
+                        cleaned++;
+                        _statistics.RecordTemporaryFileCleaned();
+                    }
+
                     continue;
                 }
 
@@ -275,7 +371,9 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         }
         catch (Exception e) when (e is IOException or UnauthorizedAccessException)
         {
-            Log.Warning(e, "Segment cache: failed to scan {Dir}; starting empty.", _dir);
+            Volatile.Write(ref _catalogDegraded, 1);
+            Log.Warning("Segment cache catalog scan failed; starting empty.");
+            Log.Debug(e, "Segment cache catalog scan failure stack");
         }
         finally
         {
@@ -287,9 +385,21 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
             {
                 Volatile.Write(ref _catalogReady, 1);
                 stopwatch.Stop();
+                var entries = _index.Count;
+                var bytes = Interlocked.Read(ref _currentBytes);
+                _generation.SetCatalogReady(stopwatch.ElapsedMilliseconds, entries, bytes);
                 Log.Information(
-                    "Segment cache catalog loaded: {Count} entries, {Size} bytes in {Elapsed}ms.",
-                    _index.Count, Interlocked.Read(ref _currentBytes), stopwatch.ElapsedMilliseconds);
+                    "Segment cache catalog ready. Enabled: {Enabled}. Path: {PathClass}. MaxBytes: {MaxBytes}. " +
+                    "Entries: {Count}. Bytes: {Size}. DurationMs: {Elapsed}. TemporaryFilesCleaned: {Cleaned}. " +
+                    "Degraded: {Degraded}.",
+                    true,
+                    ClassifyCachePath(_dir),
+                    _maxBytes,
+                    entries,
+                    bytes,
+                    stopwatch.ElapsedMilliseconds,
+                    cleaned,
+                    Volatile.Read(ref _catalogDegraded) != 0);
             }
         }
     }
@@ -299,16 +409,26 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
     private static string Hash(string id)
         => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(id)));
 
-    private static void SafeDelete(string path)
+    private static bool TryDelete(string path)
     {
         try
         {
-            if (File.Exists(path)) File.Delete(path);
+            if (!File.Exists(path)) return false;
+            File.Delete(path);
+            return true;
         }
         catch
         {
-            // ignore
+            return false;
         }
+    }
+
+    private enum CacheLookupResult
+    {
+        NotReady,
+        Miss,
+        ReadFailure,
+        Hit,
     }
 
     private sealed class CacheEntry
@@ -323,20 +443,26 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         private readonly UsenetYencHeader _header;
         private readonly string _blobPath;
         private readonly string _tempPath;
-        private readonly Action<string, long> _onFinalized;
+        private readonly Action<string, long> _onCommitted;
+        private readonly SegmentCacheWriteAttempt _attempt;
         private FileStream? _temp;
         private long _written;
         private bool _eof;
         private bool _writeFailed;
 
-        public WriteThroughStream(YencStream source, UsenetYencHeader header, string blobPath,
-            Action<string, long> onFinalized) : base(Null)
+        public WriteThroughStream(
+            YencStream source,
+            UsenetYencHeader header,
+            string blobPath,
+            Action<string, long> onCommitted,
+            SegmentCacheWriteAttempt attempt) : base(Null)
         {
             _source = source;
             _header = header;
             _blobPath = blobPath;
             _tempPath = blobPath + "." + Guid.NewGuid().ToString("N") + ".tmp";
-            _onFinalized = onFinalized;
+            _onCommitted = onCommitted;
+            _attempt = attempt;
         }
 
         public override ValueTask<UsenetYencHeader?> GetYencHeadersAsync(CancellationToken cancellationToken = default)
@@ -396,17 +522,22 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
                     {
                         File.WriteAllText(_blobPath + ".h", JsonSerializer.Serialize(_header, HeaderJsonOptions));
                         File.Move(_tempPath, _blobPath, overwrite: true);
-                        _onFinalized(Path.GetFileName(_blobPath), _written);
+                        _onCommitted(Path.GetFileName(_blobPath), _written);
+                        _attempt.Complete(SegmentCacheWriteOutcome.Committed, _written);
                     }
                     else
                     {
-                        SafeDelete(_tempPath);
+                        TryDelete(_tempPath);
+                        _attempt.Complete(
+                            _writeFailed ? SegmentCacheWriteOutcome.Failed : SegmentCacheWriteOutcome.Skipped,
+                            _written);
                     }
                 }
                 catch
                 {
-                    SafeDelete(_tempPath);
-                    SafeDelete(_blobPath + ".h");
+                    TryDelete(_tempPath);
+                    TryDelete(_blobPath + ".h");
+                    _attempt.Complete(SegmentCacheWriteOutcome.Failed, _written);
                 }
             }
 

--- a/backend/Clients/Usenet/SegmentCacheStatistics.cs
+++ b/backend/Clients/Usenet/SegmentCacheStatistics.cs
@@ -1,0 +1,239 @@
+namespace NzbWebDAV.Clients.Usenet;
+
+/// <summary>
+/// Process-lifetime segment-cache counters and the active wrapper generation's gauges.
+/// Cache code records domain events; Prometheus and support-pack code read snapshots.
+/// </summary>
+public sealed class SegmentCacheStatistics
+{
+    private long _hits;
+    private long _misses;
+    private long _lookupUnavailable;
+    private long _bytesServed;
+    private long _batchBypassRequests;
+    private long _batchBypassArticles;
+    private long _writeAttempts;
+    private long _writeCommits;
+    private long _writeSkipped;
+    private long _writeFailures;
+    private long _readFailures;
+    private long _evictions;
+    private long _bytesEvicted;
+    private long _temporaryFilesCleaned;
+    private long _nextGenerationId;
+
+    private readonly Lock _gaugeLock = new();
+    private GaugeState _gauges;
+
+    internal SegmentCacheGeneration BeginGeneration(bool enabled, long maxBytes)
+    {
+        var id = Interlocked.Increment(ref _nextGenerationId);
+        var effectiveMax = enabled ? maxBytes : 0L;
+        var generation = new SegmentCacheGeneration(this, id, enabled, effectiveMax);
+        lock (_gaugeLock)
+        {
+            _gauges = new GaugeState(
+                id,
+                enabled,
+                CatalogReady: false,
+                CatalogLoadDurationMs: null,
+                Entries: 0,
+                CurrentBytes: 0,
+                MaxBytes: effectiveMax);
+        }
+
+        return generation;
+    }
+
+    public void RecordHit(long bytes)
+    {
+        Interlocked.Increment(ref _hits);
+        Interlocked.Add(ref _bytesServed, bytes);
+    }
+
+    public void RecordMiss() => Interlocked.Increment(ref _misses);
+
+    public void RecordLookupUnavailable() => Interlocked.Increment(ref _lookupUnavailable);
+
+    public void RecordBatchBypass(int articleCount)
+    {
+        Interlocked.Increment(ref _batchBypassRequests);
+        Interlocked.Add(ref _batchBypassArticles, articleCount);
+    }
+
+    public void RecordReadFailure() => Interlocked.Increment(ref _readFailures);
+
+    public void RecordEviction(long entries, long bytes)
+    {
+        Interlocked.Add(ref _evictions, entries);
+        Interlocked.Add(ref _bytesEvicted, bytes);
+    }
+
+    public void RecordTemporaryFileCleaned() => Interlocked.Increment(ref _temporaryFilesCleaned);
+
+    internal SegmentCacheWriteAttempt BeginWriteAttempt()
+    {
+        Interlocked.Increment(ref _writeAttempts);
+        return new SegmentCacheWriteAttempt(CompleteWrite);
+    }
+
+    public SegmentCacheSnapshot GetSnapshot()
+    {
+        var hits = Interlocked.Read(ref _hits);
+        var misses = Interlocked.Read(ref _misses);
+        var lookupUnavailable = Interlocked.Read(ref _lookupUnavailable);
+        var bytesServed = Interlocked.Read(ref _bytesServed);
+        var batchBypassRequests = Interlocked.Read(ref _batchBypassRequests);
+        var batchBypassArticles = Interlocked.Read(ref _batchBypassArticles);
+        var writeAttempts = Interlocked.Read(ref _writeAttempts);
+        var writeCommits = Interlocked.Read(ref _writeCommits);
+        var writeSkipped = Interlocked.Read(ref _writeSkipped);
+        var writeFailures = Interlocked.Read(ref _writeFailures);
+        var readFailures = Interlocked.Read(ref _readFailures);
+        var evictions = Interlocked.Read(ref _evictions);
+        var bytesEvicted = Interlocked.Read(ref _bytesEvicted);
+        var temporaryFilesCleaned = Interlocked.Read(ref _temporaryFilesCleaned);
+
+        GaugeState gauges;
+        lock (_gaugeLock)
+            gauges = _gauges;
+
+        return new SegmentCacheSnapshot(
+            gauges.Enabled,
+            gauges.CatalogReady,
+            gauges.CatalogLoadDurationMs,
+            gauges.Entries,
+            gauges.CurrentBytes,
+            gauges.MaxBytes,
+            hits,
+            misses,
+            lookupUnavailable,
+            bytesServed,
+            batchBypassRequests,
+            batchBypassArticles,
+            writeAttempts,
+            writeCommits,
+            writeSkipped,
+            writeFailures,
+            readFailures,
+            evictions,
+            bytesEvicted,
+            temporaryFilesCleaned,
+            QueuedWriteBytes: null,
+            PeakQueuedWriteBytes: null);
+    }
+
+    internal void SetCatalog(long generationId, bool ready, long? durationMs, long entries, long currentBytes)
+    {
+        lock (_gaugeLock)
+        {
+            if (_gauges.GenerationId != generationId) return;
+            _gauges = _gauges with
+            {
+                CatalogReady = ready,
+                CatalogLoadDurationMs = durationMs,
+                Entries = entries,
+                CurrentBytes = currentBytes,
+            };
+        }
+    }
+
+    internal void SetIndex(long generationId, long entries, long currentBytes)
+    {
+        lock (_gaugeLock)
+        {
+            if (_gauges.GenerationId != generationId) return;
+            _gauges = _gauges with { Entries = entries, CurrentBytes = currentBytes };
+        }
+    }
+
+    private void CompleteWrite(SegmentCacheWriteOutcome outcome, long _)
+    {
+        switch (outcome)
+        {
+            case SegmentCacheWriteOutcome.Committed:
+                Interlocked.Increment(ref _writeCommits);
+                break;
+            case SegmentCacheWriteOutcome.Skipped:
+                Interlocked.Increment(ref _writeSkipped);
+                break;
+            case SegmentCacheWriteOutcome.Failed:
+                Interlocked.Increment(ref _writeFailures);
+                break;
+        }
+    }
+
+    private readonly record struct GaugeState(
+        long GenerationId,
+        bool Enabled,
+        bool CatalogReady,
+        long? CatalogLoadDurationMs,
+        long Entries,
+        long CurrentBytes,
+        long MaxBytes);
+}
+
+public sealed record SegmentCacheSnapshot(
+    bool Enabled,
+    bool CatalogReady,
+    long? CatalogLoadDurationMs,
+    long Entries,
+    long CurrentBytes,
+    long MaxBytes,
+    long Hits,
+    long Misses,
+    long LookupUnavailable,
+    long BytesServed,
+    long BatchBypassRequests,
+    long BatchBypassArticles,
+    long WriteAttempts,
+    long WriteCommits,
+    long WriteSkipped,
+    long WriteFailures,
+    long ReadFailures,
+    long Evictions,
+    long BytesEvicted,
+    long TemporaryFilesCleaned,
+    long? QueuedWriteBytes,
+    long? PeakQueuedWriteBytes);
+
+internal sealed class SegmentCacheGeneration
+{
+    private readonly SegmentCacheStatistics _owner;
+
+    internal SegmentCacheGeneration(SegmentCacheStatistics owner, long id, bool enabled, long maxBytes)
+    {
+        _owner = owner;
+        Id = id;
+        Enabled = enabled;
+        MaxBytes = maxBytes;
+    }
+
+    internal long Id { get; }
+    internal bool Enabled { get; }
+    internal long MaxBytes { get; }
+
+    internal void SetCatalogReady(long durationMs, long entries, long currentBytes) =>
+        _owner.SetCatalog(Id, ready: true, durationMs, entries, currentBytes);
+
+    internal void SetIndex(long entries, long currentBytes) =>
+        _owner.SetIndex(Id, entries, currentBytes);
+}
+
+internal enum SegmentCacheWriteOutcome
+{
+    Committed,
+    Skipped,
+    Failed,
+}
+
+internal sealed class SegmentCacheWriteAttempt(Action<SegmentCacheWriteOutcome, long> complete)
+{
+    private int _completed;
+
+    public void Complete(SegmentCacheWriteOutcome outcome, long bytes)
+    {
+        if (Interlocked.Exchange(ref _completed, 1) == 0)
+            complete(outcome, bytes);
+    }
+}

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -22,6 +22,7 @@ public class UsenetStreamingClient : WrappingNntpClient
 {
     private readonly Lock _configChangeLock = new();
     private readonly RepairPatchStore? _repairPatchStore;
+    private readonly SegmentCacheStatistics? _segmentCacheStatistics;
 
     public UsenetStreamingClient(
         ConfigManager configManager,
@@ -34,15 +35,17 @@ public class UsenetStreamingClient : WrappingNntpClient
         ArticleMissNegativeCache? articleMissCache = null,
         ProviderLatencyTracker? latencyTracker = null,
         ConcurrentReadTracker? concurrentReadTracker = null,
-        RepairPatchStore? repairPatchStore = null)
+        RepairPatchStore? repairPatchStore = null,
+        SegmentCacheStatistics? segmentCacheStatistics = null)
 #pragma warning disable CA2000 // the client chain transfers to the base class and is disposed with this instance
         : base(CreateDownloadingNntpClient(
 #pragma warning restore CA2000
             configManager, websocketManager, usageTracker, metricsWriter, bytesTracker,
             streamTrace, activeReadRegistry, articleMissCache, latencyTracker, concurrentReadTracker,
-            repairPatchStore))
+            repairPatchStore, segmentCacheStatistics))
     {
         _repairPatchStore = repairPatchStore;
+        _segmentCacheStatistics = segmentCacheStatistics;
         // when config changes, create a new MultiProviderClient to use instead.
         configManager.OnConfigChanged += (_, configEventArgs) =>
         {
@@ -65,7 +68,7 @@ public class UsenetStreamingClient : WrappingNntpClient
                         var newUsenetClient = CreateDownloadingNntpClient(
                             configManager, websocketManager, usageTracker, metricsWriter, bytesTracker,
                             streamTrace, activeReadRegistry, articleMissCache, latencyTracker,
-                            concurrentReadTracker, _repairPatchStore);
+                            concurrentReadTracker, _repairPatchStore, _segmentCacheStatistics);
                         ReplaceUnderlyingClient(newUsenetClient);
                         return;
                     }
@@ -106,7 +109,8 @@ public class UsenetStreamingClient : WrappingNntpClient
         ArticleMissNegativeCache? articleMissCache,
         ProviderLatencyTracker? latencyTracker,
         ConcurrentReadTracker? concurrentReadTracker,
-        RepairPatchStore? repairPatchStore
+        RepairPatchStore? repairPatchStore,
+        SegmentCacheStatistics? segmentCacheStatistics
     )
     {
 #pragma warning disable CA2000 // wrapped by DownloadingNntpClient below; the returned client chain is disposed with this instance
@@ -129,14 +133,23 @@ public class UsenetStreamingClient : WrappingNntpClient
                     configManager.GetSegmentCachePath(),
                     configManager.GetSegmentCacheMaxBytes(),
                     usageTracker,
-                    metricsWriter
+                    metricsWriter,
+                    enumerateCacheFiles: null,
+                    segmentCacheStatistics
                 );
             }
             catch (Exception e) when (e is IOException or UnauthorizedAccessException or ArgumentException)
             {
-                Log.Warning(e, "Segment cache disabled: failed to initialise at {Path}.",
-                    configManager.GetSegmentCachePath());
+                segmentCacheStatistics?.BeginGeneration(enabled: false, maxBytes: 0);
+                Log.Warning(
+                    "Segment cache disabled: failed to initialise at {PathClass}.",
+                    SegmentCacheNntpClient.ClassifyCachePath(configManager.GetSegmentCachePath()));
+                Log.Debug(e, "Segment cache initialisation failure");
             }
+        }
+        else
+        {
+            segmentCacheStatistics?.BeginGeneration(enabled: false, maxBytes: 0);
         }
 
         if (repairPatchStore != null)

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -141,6 +141,34 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
             ? GetAliasedConfigValue(configName)
             : GetConfigValue(configName);
 
+    /// <summary>
+    /// Bounded origin of the raw value backing an allowlisted setting.
+    /// Empty persisted/environment values count as unset so the typed getter's default applies.
+    /// </summary>
+    internal EffectiveConfigSource GetEffectiveSource(string key)
+    {
+        lock (_config)
+        {
+            if (_environmentOverlay.TryGetValue(key, out var envValue)
+                && StringUtil.EmptyToNull(envValue) is not null)
+                return EffectiveConfigSource.Environment;
+            if (_config.TryGetValue(key, out var persisted)
+                && StringUtil.EmptyToNull(persisted) is not null)
+                return EffectiveConfigSource.Sqlite;
+            if (LegacyConfigKeyAliases.TryGetValue(key, out var legacyKey))
+            {
+                if (_environmentOverlay.TryGetValue(legacyKey, out var legacyEnv)
+                    && StringUtil.EmptyToNull(legacyEnv) is not null)
+                    return EffectiveConfigSource.Environment;
+                if (_config.TryGetValue(legacyKey, out var legacyPersisted)
+                    && StringUtil.EmptyToNull(legacyPersisted) is not null)
+                    return EffectiveConfigSource.Sqlite;
+            }
+
+            return EffectiveConfigSource.Default;
+        }
+    }
+
     /// <summary>Persisted SQLite value only (ignores ENV overlay). Used when normalizing provider IDs.</summary>
     public string? GetPersistedConfigValue(string configName)
     {

--- a/backend/Config/EffectiveStreamingConfigManifest.cs
+++ b/backend/Config/EffectiveStreamingConfigManifest.cs
@@ -1,0 +1,230 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NzbWebDAV.Models;
+
+namespace NzbWebDAV.Config;
+
+internal enum EffectiveConfigSource
+{
+    Default,
+    Sqlite,
+    Environment,
+}
+
+/// <summary>
+/// Safe-by-construction effective streaming settings for support packs and public
+/// benchmark extraction. Built only from typed <see cref="ConfigManager"/> getters.
+/// </summary>
+internal static class EffectiveStreamingConfigManifest
+{
+    internal const int SchemaVersion = 1;
+
+    internal static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase, allowIntegerValues: false) },
+    };
+
+    public static EffectiveStreamingConfigDocument Create(ConfigManager configManager)
+    {
+        ArgumentNullException.ThrowIfNull(configManager);
+        var providers = configManager.GetUsenetProviderConfig().Providers;
+        var providerEntries = new List<EffectiveProviderSettings>(providers.Count);
+        for (var i = 0; i < providers.Count; i++)
+        {
+            var provider = providers[i];
+            providerEntries.Add(new EffectiveProviderSettings(
+                Alias: $"provider{i + 1}",
+                Type: ProviderTypeName(provider.Type),
+                MaxConnections: provider.MaxConnections,
+                TlsEnabled: provider.UseSsl,
+                TlsVerification: !provider.SkipTlsVerification,
+                WarmConnectionFloor: configManager.GetWarmConnectionsFloor(provider.MaxConnections)));
+        }
+
+        return new EffectiveStreamingConfigDocument(
+            SchemaVersion,
+            new EffectiveStreamingSettings(
+                configManager.GetArticleBufferSize(),
+                configManager.IsPipelinedBodyRequestsEnabled(),
+                configManager.GetStreamingBodyBatchWidth(),
+                configManager.IsContainerAwareFillEnabled(),
+                configManager.GetUsenetBandwidthLimitBytesPerSecond(),
+                configManager.GetStreamingPriority().HighPriorityOdds,
+                configManager.GetStreamingSegmentRetries(),
+                (int)configManager.GetStreamingReadTimeout().TotalSeconds,
+                (int)configManager.GetStreamingWriteTimeout().TotalSeconds,
+                (int)configManager.GetStreamingSegmentTimeout().TotalSeconds),
+            new EffectiveConnectionSettings(
+                configManager.GetMaxDownloadConnections(),
+                configManager.IsMaxDownloadConnectionsPerStream(),
+                configManager.GetMaxDownloadConnectionsPerStreamCount(),
+                configManager.IsWarmConnectionsEnabled(),
+                providers.Count(provider => provider.Type == ProviderType.Pooled),
+                configManager.GetUsenetProviderConfig().TotalPooledConnections),
+            new EffectiveMemorySettings(
+                configManager.GetInFlightArticleBudgetBytes(),
+                configManager.IsSharedStreamsEnabled(),
+                configManager.GetSharedStreamsRingBytes(),
+                configManager.GetSharedStreamsMaxEntries(),
+                configManager.GetSharedStreamsMaxEntriesPerFile(),
+                configManager.GetSharedStreamsGraceSeconds(),
+                configManager.GetSharedStreamsSmallRangeMaxBytes()),
+            new EffectiveSegmentCacheSettings(
+                configManager.IsSegmentCacheEnabled(),
+                configManager.GetSegmentCacheMaxBytes()),
+            new EffectiveRepairSettings(
+                configManager.IsRepairJobEnabled(),
+                configManager.IsPar2RepairEnabled(),
+                configManager.IsDegradedToleranceEnabled(),
+                configManager.IsCorruptionTrackingEnabled()),
+            providerEntries,
+            new EffectiveStreamingSources(
+                new EffectiveStreamingSettingSources(
+                    Source(configManager, ConfigKeys.UsenetArticleBufferSize),
+                    Source(configManager, ConfigKeys.UsenetPipelinedBodyRequests),
+                    Source(configManager, ConfigKeys.UsenetStreamingBodyBatchWidth),
+                    Source(configManager, ConfigKeys.UsenetContainerAwareFill),
+                    Source(configManager, ConfigKeys.UsenetBandwidthLimitMbps),
+                    Source(configManager, ConfigKeys.UsenetStreamingPriority),
+                    Source(configManager, ConfigKeys.UsenetStreamingSegmentRetries),
+                    Source(configManager, ConfigKeys.UsenetStreamingReadTimeoutSeconds),
+                    Source(configManager, ConfigKeys.UsenetStreamingWriteTimeoutSeconds),
+                    Source(configManager, ConfigKeys.UsenetStreamingSegmentTimeoutSeconds)),
+                new EffectiveConnectionSettingSources(
+                    Source(configManager, ConfigKeys.UsenetMaxDownloadConnections),
+                    Source(configManager, ConfigKeys.UsenetMaxDownloadConnectionsPerStream),
+                    Source(configManager, ConfigKeys.UsenetWarmConnectionsEnabled)),
+                new EffectiveMemorySettingSources(
+                    Source(configManager, ConfigKeys.UsenetInFlightArticleBudgetMb),
+                    Source(configManager, ConfigKeys.UsenetSharedStreamsEnabled),
+                    Source(configManager, ConfigKeys.UsenetSharedStreamsRingMb),
+                    Source(configManager, ConfigKeys.UsenetSharedStreamsMaxEntries),
+                    Source(configManager, ConfigKeys.UsenetSharedStreamsMaxEntriesPerFile),
+                    Source(configManager, ConfigKeys.UsenetSharedStreamsGraceSeconds),
+                    Source(configManager, ConfigKeys.UsenetSharedStreamsSmallRangeMaxMb)),
+                new EffectiveSegmentCacheSettingSources(
+                    Source(configManager, ConfigKeys.UsenetSegmentCacheEnabled),
+                    Source(configManager, ConfigKeys.UsenetSegmentCacheMaxGb)),
+                new EffectiveRepairSettingSources(
+                    Source(configManager, ConfigKeys.RepairEnable),
+                    Source(configManager, ConfigKeys.RepairPar2Enabled),
+                    Source(configManager, ConfigKeys.RepairDegradedToleranceEnabled),
+                    Source(configManager, ConfigKeys.RepairCorruptionTrackingEnabled)),
+                Source(configManager, ConfigKeys.UsenetProviders)));
+    }
+
+    private static EffectiveConfigSource Source(ConfigManager configManager, string key) =>
+        configManager.GetEffectiveSource(key);
+
+    private static string ProviderTypeName(ProviderType type) => type switch
+    {
+        ProviderType.Pooled => "pooled",
+        ProviderType.BackupAndStats => "backupandstats",
+        ProviderType.BackupOnly => "backuponly",
+        _ => "disabled",
+    };
+}
+
+internal sealed record EffectiveStreamingConfigDocument(
+    int SchemaVersion,
+    EffectiveStreamingSettings Streaming,
+    EffectiveConnectionSettings Connections,
+    EffectiveMemorySettings Memory,
+    EffectiveSegmentCacheSettings SegmentCache,
+    EffectiveRepairSettings Repair,
+    IReadOnlyList<EffectiveProviderSettings> Providers,
+    EffectiveStreamingSources Source);
+
+internal sealed record EffectiveStreamingSettings(
+    int ArticleBufferSize,
+    bool PipelinedBodyRequests,
+    int BodyBatchWidth,
+    bool ContainerAwareFill,
+    long BandwidthLimitBytesPerSecond,
+    int StreamingPriority,
+    int SegmentRetryCount,
+    int ReadTimeoutSeconds,
+    int WriteTimeoutSeconds,
+    int SegmentTimeoutSeconds);
+
+internal sealed record EffectiveConnectionSettings(
+    int EffectiveTotalDownloadLimit,
+    bool PerStreamModeEnabled,
+    int EffectivePerStreamCount,
+    bool WarmConnectionsEnabled,
+    int PooledProviderCount,
+    int TotalPooledConnectionCount);
+
+internal sealed record EffectiveMemorySettings(
+    long InFlightArticleBudgetBytes,
+    bool SharedStreamsEnabled,
+    long SharedStreamRingBytes,
+    int SharedStreamMaxEntries,
+    int MaxEntriesPerFile,
+    int GraceSeconds,
+    long SmallRangeMaximumBytes);
+
+internal sealed record EffectiveSegmentCacheSettings(
+    bool Enabled,
+    long MaxBytes);
+
+internal sealed record EffectiveRepairSettings(
+    bool BackgroundEnabled,
+    bool Par2Enabled,
+    bool DegradedToleranceEnabled,
+    bool CorruptionTrackingEnabled);
+
+internal sealed record EffectiveProviderSettings(
+    string Alias,
+    string Type,
+    int MaxConnections,
+    bool TlsEnabled,
+    bool TlsVerification,
+    int WarmConnectionFloor);
+
+internal sealed record EffectiveStreamingSources(
+    EffectiveStreamingSettingSources Streaming,
+    EffectiveConnectionSettingSources Connections,
+    EffectiveMemorySettingSources Memory,
+    EffectiveSegmentCacheSettingSources SegmentCache,
+    EffectiveRepairSettingSources Repair,
+    EffectiveConfigSource Providers);
+
+internal sealed record EffectiveStreamingSettingSources(
+    EffectiveConfigSource ArticleBufferSize,
+    EffectiveConfigSource PipelinedBodyRequests,
+    EffectiveConfigSource BodyBatchWidth,
+    EffectiveConfigSource ContainerAwareFill,
+    EffectiveConfigSource BandwidthLimitBytesPerSecond,
+    EffectiveConfigSource StreamingPriority,
+    EffectiveConfigSource SegmentRetryCount,
+    EffectiveConfigSource ReadTimeoutSeconds,
+    EffectiveConfigSource WriteTimeoutSeconds,
+    EffectiveConfigSource SegmentTimeoutSeconds);
+
+internal sealed record EffectiveConnectionSettingSources(
+    EffectiveConfigSource EffectiveTotalDownloadLimit,
+    EffectiveConfigSource PerStreamModeEnabled,
+    EffectiveConfigSource WarmConnectionsEnabled);
+
+internal sealed record EffectiveMemorySettingSources(
+    EffectiveConfigSource InFlightArticleBudgetBytes,
+    EffectiveConfigSource SharedStreamsEnabled,
+    EffectiveConfigSource SharedStreamRingBytes,
+    EffectiveConfigSource SharedStreamMaxEntries,
+    EffectiveConfigSource MaxEntriesPerFile,
+    EffectiveConfigSource GraceSeconds,
+    EffectiveConfigSource SmallRangeMaximumBytes);
+
+internal sealed record EffectiveSegmentCacheSettingSources(
+    EffectiveConfigSource Enabled,
+    EffectiveConfigSource MaxBytes);
+
+internal sealed record EffectiveRepairSettingSources(
+    EffectiveConfigSource BackgroundEnabled,
+    EffectiveConfigSource Par2Enabled,
+    EffectiveConfigSource DegradedToleranceEnabled,
+    EffectiveConfigSource CorruptionTrackingEnabled);

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -328,6 +328,7 @@ public sealed partial class Program
                 .AddSingleton<QueueItemSourceTracker>()
                 .AddSingleton<StreamingFailureTracker>()
                 .AddSingleton<HealthCheckConnectionGate>()
+                .AddSingleton<SegmentCacheStatistics>()
                 .AddSingleton<UsenetStreamingClient>()
                 .AddHostedService<ProviderRecoveryProbeService>()
                 // LazyRarResolver takes INntpClient (for testability) but must

--- a/backend/Services/Observability/PrometheusMetrics.cs
+++ b/backend/Services/Observability/PrometheusMetrics.cs
@@ -62,6 +62,26 @@ public sealed class PrometheusMetrics
     private readonly Counter _sharedStreamReadersServed;
     private readonly Counter _privateFallbacks;
     private readonly Counter _streamingCorruptSegments;
+    private readonly Gauge _segmentCacheEnabled;
+    private readonly Gauge _segmentCacheCatalogReady;
+    private readonly Gauge _segmentCacheCatalogLoadDurationSeconds;
+    private readonly Gauge _segmentCacheEntries;
+    private readonly Gauge _segmentCacheBytes;
+    private readonly Gauge _segmentCacheMaxBytes;
+    private readonly Counter _segmentCacheHits;
+    private readonly Counter _segmentCacheMisses;
+    private readonly Counter _segmentCacheLookupUnavailable;
+    private readonly Counter _segmentCacheBytesServed;
+    private readonly Counter _segmentCacheBatchBypassRequests;
+    private readonly Counter _segmentCacheBatchBypassArticles;
+    private readonly Counter _segmentCacheWriteAttempts;
+    private readonly Counter _segmentCacheWriteCommits;
+    private readonly Counter _segmentCacheWriteSkipped;
+    private readonly Counter _segmentCacheWriteFailures;
+    private readonly Counter _segmentCacheReadFailures;
+    private readonly Counter _segmentCacheEvictions;
+    private readonly Counter _segmentCacheEvictedBytes;
+    private readonly Counter _segmentCacheTemporaryFilesCleaned;
     private readonly HashSet<string> _providerKeys = new(StringComparer.Ordinal);
 
     public PrometheusMetrics(CollectorRegistry registry)
@@ -179,6 +199,66 @@ public sealed class PrometheusMetrics
         _streamingCorruptSegments = metrics.CreateCounter(
             "nzbdav_streaming_corrupt_segments_total",
             "Streaming-confirmed corrupt Usenet articles.");
+        _segmentCacheEnabled = metrics.CreateGauge(
+            "nzbdav_segment_cache_enabled",
+            "Whether the active NNTP client generation has a segment-cache wrapper.");
+        _segmentCacheCatalogReady = metrics.CreateGauge(
+            "nzbdav_segment_cache_catalog_ready",
+            "Whether the active segment-cache generation finished its catalog scan.");
+        _segmentCacheCatalogLoadDurationSeconds = metrics.CreateGauge(
+            "nzbdav_segment_cache_catalog_load_duration_seconds",
+            "Duration of the active generation's completed catalog scan.");
+        _segmentCacheEntries = metrics.CreateGauge(
+            "nzbdav_segment_cache_entries",
+            "Indexed segment-cache entries in the active generation.");
+        _segmentCacheBytes = metrics.CreateGauge(
+            "nzbdav_segment_cache_bytes",
+            "Indexed segment-cache body bytes in the active generation.");
+        _segmentCacheMaxBytes = metrics.CreateGauge(
+            "nzbdav_segment_cache_max_bytes",
+            "Effective segment-cache byte limit.");
+        _segmentCacheHits = metrics.CreateCounter(
+            "nzbdav_segment_cache_hits_total",
+            "Eligible article lookups served by a validated local cache entry.");
+        _segmentCacheMisses = metrics.CreateCounter(
+            "nzbdav_segment_cache_misses_total",
+            "Eligible lookups attempted after catalog readiness that were not served.");
+        _segmentCacheLookupUnavailable = metrics.CreateCounter(
+            "nzbdav_segment_cache_lookup_unavailable_total",
+            "Lookups skipped because catalog hydration was incomplete.");
+        _segmentCacheBytesServed = metrics.CreateCounter(
+            "nzbdav_segment_cache_bytes_served_total",
+            "Decoded body bytes represented by segment-cache hits.");
+        _segmentCacheBatchBypassRequests = metrics.CreateCounter(
+            "nzbdav_segment_cache_batch_bypass_requests_total",
+            "DecodedBodiesAsync calls forwarded without per-article cache lookup.");
+        _segmentCacheBatchBypassArticles = metrics.CreateCounter(
+            "nzbdav_segment_cache_batch_bypass_articles_total",
+            "Articles in DecodedBodiesAsync calls forwarded without per-article cache lookup.");
+        _segmentCacheWriteAttempts = metrics.CreateCounter(
+            "nzbdav_segment_cache_write_attempts_total",
+            "Valid remote BODY responses wrapped for possible cache population.");
+        _segmentCacheWriteCommits = metrics.CreateCounter(
+            "nzbdav_segment_cache_write_commits_total",
+            "Complete validated bodies atomically committed to the segment cache.");
+        _segmentCacheWriteSkipped = metrics.CreateCounter(
+            "nzbdav_segment_cache_write_skipped_total",
+            "Cache write attempts ended without commit because of partial read, early dispose, or size validation.");
+        _segmentCacheWriteFailures = metrics.CreateCounter(
+            "nzbdav_segment_cache_write_failures_total",
+            "Cache I/O or serialization failures that prevented commit while playback continued.");
+        _segmentCacheReadFailures = metrics.CreateCounter(
+            "nzbdav_segment_cache_read_failures_total",
+            "Indexed cache entries that could not be validated or opened and were dropped.");
+        _segmentCacheEvictions = metrics.CreateCounter(
+            "nzbdav_segment_cache_evictions_total",
+            "Segment-cache entries removed for capacity.");
+        _segmentCacheEvictedBytes = metrics.CreateCounter(
+            "nzbdav_segment_cache_evicted_bytes_total",
+            "Body bytes removed from the segment cache for capacity.");
+        _segmentCacheTemporaryFilesCleaned = metrics.CreateCounter(
+            "nzbdav_segment_cache_temporary_files_cleaned_total",
+            "Stale cache .tmp files removed during catalog scan.");
     }
 
     public static PrometheusMetrics? Current { get; set; }
@@ -215,6 +295,31 @@ public sealed class PrometheusMetrics
     public void RecordPar2PatchEviction() => _par2PatchEvictions.Inc();
 
     public void RecordStreamingCorruptSegment() => _streamingCorruptSegments.Inc();
+
+    public void SetSegmentCache(SegmentCacheSnapshot snapshot)
+    {
+        _segmentCacheEnabled.Set(snapshot.Enabled ? 1 : 0);
+        _segmentCacheCatalogReady.Set(snapshot.CatalogReady ? 1 : 0);
+        _segmentCacheCatalogLoadDurationSeconds.Set(
+            snapshot.CatalogLoadDurationMs is { } ms ? ms / 1000.0 : 0);
+        _segmentCacheEntries.Set(snapshot.Entries);
+        _segmentCacheBytes.Set(snapshot.CurrentBytes);
+        _segmentCacheMaxBytes.Set(snapshot.MaxBytes);
+        _segmentCacheHits.IncTo(snapshot.Hits);
+        _segmentCacheMisses.IncTo(snapshot.Misses);
+        _segmentCacheLookupUnavailable.IncTo(snapshot.LookupUnavailable);
+        _segmentCacheBytesServed.IncTo(snapshot.BytesServed);
+        _segmentCacheBatchBypassRequests.IncTo(snapshot.BatchBypassRequests);
+        _segmentCacheBatchBypassArticles.IncTo(snapshot.BatchBypassArticles);
+        _segmentCacheWriteAttempts.IncTo(snapshot.WriteAttempts);
+        _segmentCacheWriteCommits.IncTo(snapshot.WriteCommits);
+        _segmentCacheWriteSkipped.IncTo(snapshot.WriteSkipped);
+        _segmentCacheWriteFailures.IncTo(snapshot.WriteFailures);
+        _segmentCacheReadFailures.IncTo(snapshot.ReadFailures);
+        _segmentCacheEvictions.IncTo(snapshot.Evictions);
+        _segmentCacheEvictedBytes.IncTo(snapshot.BytesEvicted);
+        _segmentCacheTemporaryFilesCleaned.IncTo(snapshot.TemporaryFilesCleaned);
+    }
 
     public void Refresh(
         ActiveReadRegistry activeReads,

--- a/backend/Services/Observability/PrometheusMetricsCollector.cs
+++ b/backend/Services/Observability/PrometheusMetricsCollector.cs
@@ -14,7 +14,8 @@ public sealed class PrometheusMetricsCollector(
     MetricsWriter metricsWriter,
     UsenetStreamingClient usenetClient,
     RepairPatchStore repairPatchStore,
-    HealthCheckConnectionGate healthCheckConnectionGate) : BackgroundService
+    HealthCheckConnectionGate healthCheckConnectionGate,
+    SegmentCacheStatistics segmentCacheStatistics) : BackgroundService
 {
     private static readonly TimeSpan Interval = TimeSpan.FromSeconds(5);
 
@@ -32,6 +33,7 @@ public sealed class PrometheusMetricsCollector(
                         metrics.SetPar2PatchStoreBytes(repairPatchStore.CurrentBytes);
                     }
                     metrics.SetHealthCheckGate(healthCheckConnectionGate.GetSnapshot());
+                    metrics.SetSegmentCache(segmentCacheStatistics.GetSnapshot());
                 }
                 catch (Exception ex) when (ex is not OutOfMemoryException)
                 {

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -161,7 +161,7 @@ public sealed class SupportPackService(
                 cancellationToken).ConfigureAwait(false);
             sectionStatus["configurationEffectiveStreaming"] = "included";
         }
-        catch
+        catch (Exception e) when (e is not OutOfMemoryException and not OperationCanceledException)
         {
             sectionStatus["configurationEffectiveStreaming"] = "unavailable";
         }
@@ -177,7 +177,7 @@ public sealed class SupportPackService(
                 cancellationToken).ConfigureAwait(false);
             sectionStatus["segmentCache"] = "included";
         }
-        catch
+        catch (Exception e) when (e is not OutOfMemoryException and not OperationCanceledException)
         {
             sectionStatus["segmentCache"] = "unavailable";
         }

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -38,7 +38,8 @@ public sealed class SupportPackService(
     Repair.RepairPatchStore repairPatchStore,
     HealthCheckConnectionGate healthCheckConnectionGate,
     ConcurrentReadTracker? concurrentReadTracker = null,
-    IQueueCoordinator? queueCoordinator = null)
+    IQueueCoordinator? queueCoordinator = null,
+    SegmentCacheStatistics? segmentCacheStatistics = null)
 {
     private const long MinuteMs = 60_000;
     private const long HourMs = 60 * MinuteMs;
@@ -148,6 +149,38 @@ public sealed class SupportPackService(
             await BuildEnvironmentAsync(generatedAt, cancellationToken).ConfigureAwait(false),
             redactor,
             cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await WriteTextAsync(
+                archive,
+                "configuration-effective-streaming.json",
+                redactor.RedactText(JsonSerializer.Serialize(
+                    EffectiveStreamingConfigManifest.Create(configManager),
+                    EffectiveStreamingConfigManifest.SerializerOptions)),
+                cancellationToken).ConfigureAwait(false);
+            sectionStatus["configurationEffectiveStreaming"] = "included";
+        }
+        catch
+        {
+            sectionStatus["configurationEffectiveStreaming"] = "unavailable";
+        }
+
+        try
+        {
+            var cache = (segmentCacheStatistics ?? new SegmentCacheStatistics()).GetSnapshot();
+            await WriteJsonAsync(
+                archive,
+                "metrics/segment-cache.json",
+                BuildSegmentCacheMetrics(generatedAt, cache),
+                redactor,
+                cancellationToken).ConfigureAwait(false);
+            sectionStatus["segmentCache"] = "included";
+        }
+        catch
+        {
+            sectionStatus["segmentCache"] = "unavailable";
+        }
 
         try
         {
@@ -318,6 +351,14 @@ public sealed class SupportPackService(
         File names, filesystem paths, account usernames, DNS hostnames, and
         non-secret URL paths can remain for troubleshooting. Share this archive only
         with trusted NzbDAV support.
+
+        configuration-effective-streaming.json is the only configuration document
+        designed for public benchmark extraction. It contains resolved, allowlisted
+        streaming settings and no credentials, hostnames, paths, or provider
+        identities. metrics/segment-cache.json is likewise a public-safe cache
+        snapshot. The rest of this archive, including configuration.json, logs, and
+        environment.json, remains a private trusted-support artifact and must not be
+        published with benchmark results.
         """;
 
     private static object BuildConfiguration(
@@ -332,6 +373,14 @@ public sealed class SupportPackService(
                 source = item.Source,
                 environmentVariable = item.EnvironmentVariableName,
             }),
+        };
+
+    private static object BuildSegmentCacheMetrics(DateTimeOffset generatedAt, SegmentCacheSnapshot cache) =>
+        new
+        {
+            schemaVersion = 1,
+            capturedAtUtc = generatedAt,
+            cache,
         };
 
     private async Task<object> BuildEnvironmentAsync(

--- a/scripts/fixtures/performance-gate-expanded-baseline.json
+++ b/scripts/fixtures/performance-gate-expanded-baseline.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "report": "streaming",
+  "meta": { "commit": "test", "generatedAt": "2026-01-01T00:00:00+00:00", "os": "test", "dotnet": "test" },
+  "scenarios": {
+    "cold-sequential": {
+      "deterministic": { "bytes": 100, "transportRequests": 2, "transportBytes": 100 },
+      "timing": {
+        "firstByteMs": { "baseline": 10.0, "envelope": 30.0, "policy": "fail" },
+        "elapsedMs": { "baseline": 20.0, "envelope": 60.0, "policy": "fail" },
+        "throughputMiBs": { "baseline": 90.0, "floor": 30.0, "policy": "fail" },
+        "cpuSeconds": { "baseline": 0.1, "envelope": 0.35, "policy": "warn" }
+      }
+    },
+    "pipelined-cold-read": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 12,
+        "transportBytes": 3145728,
+        "transportBatchRequests": 3,
+        "cacheHits": 0,
+        "cacheMisses": 1,
+        "cacheBytesServed": 0,
+        "cacheBatchBypassRequests": 3,
+        "cacheBatchBypassArticles": 11,
+        "cacheWriteCommits": 1
+      },
+      "timing": {
+        "firstByteMs": { "baseline": 1.0, "envelope": 16.0, "policy": "fail" },
+        "elapsedMs": { "baseline": 2.0, "envelope": 17.0, "policy": "fail" },
+        "throughputMiBs": { "baseline": 30.0, "floor": 10.0, "policy": "fail" },
+        "cpuSeconds": { "baseline": 0.01, "envelope": 0.26, "policy": "warn" }
+      }
+    },
+    "pipelined-warm-reread": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 11,
+        "transportBytes": 2883584,
+        "transportBatchRequests": 3,
+        "cacheHits": 1,
+        "cacheMisses": 0,
+        "cacheBytesServed": 262144,
+        "cacheBatchBypassRequests": 3,
+        "cacheBatchBypassArticles": 11,
+        "cacheWriteCommits": 0
+      },
+      "timing": {
+        "firstByteMs": { "baseline": 1.0, "envelope": 16.0, "policy": "fail" },
+        "elapsedMs": { "baseline": 2.0, "envelope": 17.0, "policy": "fail" },
+        "throughputMiBs": { "baseline": 40.0, "floor": 13.333, "policy": "fail" },
+        "cpuSeconds": { "baseline": 0.01, "envelope": 0.26, "policy": "warn" }
+      }
+    }
+  }
+}

--- a/scripts/fixtures/performance-gate-expanded-candidate.json
+++ b/scripts/fixtures/performance-gate-expanded-candidate.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": 1,
+  "report": "streaming",
+  "meta": { "commit": "test", "generatedAt": "2026-01-01T00:00:00+00:00", "os": "test", "dotnet": "test" },
+  "scenarios": {
+    "cold-sequential": {
+      "deterministic": { "bytes": 100, "transportRequests": 2, "transportBytes": 100 },
+      "timing": { "firstByteMs": 10.0, "elapsedMs": 20.0, "throughputMiBs": 90.0, "cpuSeconds": 0.1 }
+    },
+    "pipelined-cold-read": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 12,
+        "transportBytes": 3145728,
+        "transportBatchRequests": 3,
+        "cacheHits": 0,
+        "cacheMisses": 1,
+        "cacheBytesServed": 0,
+        "cacheBatchBypassRequests": 3,
+        "cacheBatchBypassArticles": 11,
+        "cacheWriteCommits": 1
+      },
+      "timing": { "firstByteMs": 1.0, "elapsedMs": 2.0, "throughputMiBs": 30.0, "cpuSeconds": 0.01 }
+    },
+    "pipelined-warm-reread": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 11,
+        "transportBytes": 2883584,
+        "transportBatchRequests": 3,
+        "cacheHits": 1,
+        "cacheMisses": 0,
+        "cacheBytesServed": 262144,
+        "cacheBatchBypassRequests": 3,
+        "cacheBatchBypassArticles": 11,
+        "cacheWriteCommits": 0
+      },
+      "timing": { "firstByteMs": 1.0, "elapsedMs": 2.0, "throughputMiBs": 40.0, "cpuSeconds": 0.01 }
+    }
+  }
+}

--- a/scripts/fixtures/performance-gate-expanded-missing-cold.json
+++ b/scripts/fixtures/performance-gate-expanded-missing-cold.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "report": "streaming",
+  "meta": {
+    "commit": "test",
+    "generatedAt": "2026-01-01T00:00:00+00:00",
+    "os": "test",
+    "dotnet": "test"
+  },
+  "scenarios": {
+    "cold-sequential": {
+      "deterministic": {
+        "bytes": 100,
+        "transportRequests": 2,
+        "transportBytes": 100
+      },
+      "timing": {
+        "firstByteMs": 10.0,
+        "elapsedMs": 20.0,
+        "throughputMiBs": 90.0,
+        "cpuSeconds": 0.1
+      }
+    },
+    "pipelined-warm-reread": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 11,
+        "transportBytes": 2883584,
+        "transportBatchRequests": 3,
+        "cacheHits": 1,
+        "cacheMisses": 0,
+        "cacheBytesServed": 262144,
+        "cacheBatchBypassRequests": 3,
+        "cacheBatchBypassArticles": 11,
+        "cacheWriteCommits": 0
+      },
+      "timing": {
+        "firstByteMs": 1.0,
+        "elapsedMs": 2.0,
+        "throughputMiBs": 40.0,
+        "cpuSeconds": 0.01
+      }
+    }
+  }
+}

--- a/scripts/fixtures/performance-gate-expanded-missing-warm.json
+++ b/scripts/fixtures/performance-gate-expanded-missing-warm.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "report": "streaming",
+  "meta": {
+    "commit": "test",
+    "generatedAt": "2026-01-01T00:00:00+00:00",
+    "os": "test",
+    "dotnet": "test"
+  },
+  "scenarios": {
+    "cold-sequential": {
+      "deterministic": {
+        "bytes": 100,
+        "transportRequests": 2,
+        "transportBytes": 100
+      },
+      "timing": {
+        "firstByteMs": 10.0,
+        "elapsedMs": 20.0,
+        "throughputMiBs": 90.0,
+        "cpuSeconds": 0.1
+      }
+    },
+    "pipelined-cold-read": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 12,
+        "transportBytes": 3145728,
+        "transportBatchRequests": 3,
+        "cacheHits": 0,
+        "cacheMisses": 1,
+        "cacheBytesServed": 0,
+        "cacheBatchBypassRequests": 3,
+        "cacheBatchBypassArticles": 11,
+        "cacheWriteCommits": 1
+      },
+      "timing": {
+        "firstByteMs": 1.0,
+        "elapsedMs": 2.0,
+        "throughputMiBs": 30.0,
+        "cpuSeconds": 0.01
+      }
+    }
+  }
+}

--- a/scripts/fixtures/performance-gate-expanded-timing.json
+++ b/scripts/fixtures/performance-gate-expanded-timing.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "report": "streaming",
+  "meta": {
+    "commit": "test",
+    "generatedAt": "2026-01-01T00:00:00+00:00",
+    "os": "test",
+    "dotnet": "test"
+  },
+  "scenarios": {
+    "cold-sequential": {
+      "deterministic": {
+        "bytes": 100,
+        "transportRequests": 2,
+        "transportBytes": 100
+      },
+      "timing": {
+        "firstByteMs": 10.0,
+        "elapsedMs": 20.0,
+        "throughputMiBs": 90.0,
+        "cpuSeconds": 0.1
+      }
+    },
+    "pipelined-cold-read": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 12,
+        "transportBytes": 3145728,
+        "transportBatchRequests": 3,
+        "cacheHits": 0,
+        "cacheMisses": 1,
+        "cacheBytesServed": 0,
+        "cacheBatchBypassRequests": 3,
+        "cacheBatchBypassArticles": 11,
+        "cacheWriteCommits": 1
+      },
+      "timing": {
+        "firstByteMs": 1.0,
+        "elapsedMs": 2.0,
+        "throughputMiBs": 30.0,
+        "cpuSeconds": 0.01
+      }
+    },
+    "pipelined-warm-reread": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 11,
+        "transportBytes": 2883584,
+        "transportBatchRequests": 3,
+        "cacheHits": 1,
+        "cacheMisses": 0,
+        "cacheBytesServed": 262144,
+        "cacheBatchBypassRequests": 3,
+        "cacheBatchBypassArticles": 11,
+        "cacheWriteCommits": 0
+      },
+      "timing": {
+        "firstByteMs": 1.0,
+        "elapsedMs": 999.0,
+        "throughputMiBs": 40.0,
+        "cpuSeconds": 0.01
+      }
+    }
+  }
+}

--- a/scripts/fixtures/performance-gate-expanded-warm-transport.json
+++ b/scripts/fixtures/performance-gate-expanded-warm-transport.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "report": "streaming",
+  "meta": {
+    "commit": "test",
+    "generatedAt": "2026-01-01T00:00:00+00:00",
+    "os": "test",
+    "dotnet": "test"
+  },
+  "scenarios": {
+    "cold-sequential": {
+      "deterministic": {
+        "bytes": 100,
+        "transportRequests": 2,
+        "transportBytes": 100
+      },
+      "timing": {
+        "firstByteMs": 10.0,
+        "elapsedMs": 20.0,
+        "throughputMiBs": 90.0,
+        "cpuSeconds": 0.1
+      }
+    },
+    "pipelined-cold-read": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 12,
+        "transportBytes": 3145728,
+        "transportBatchRequests": 3,
+        "cacheHits": 0,
+        "cacheMisses": 1,
+        "cacheBytesServed": 0,
+        "cacheBatchBypassRequests": 3,
+        "cacheBatchBypassArticles": 11,
+        "cacheWriteCommits": 1
+      },
+      "timing": {
+        "firstByteMs": 1.0,
+        "elapsedMs": 2.0,
+        "throughputMiBs": 30.0,
+        "cpuSeconds": 0.01
+      }
+    },
+    "pipelined-warm-reread": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 0,
+        "transportBytes": 0,
+        "transportBatchRequests": 3,
+        "cacheHits": 1,
+        "cacheMisses": 0,
+        "cacheBytesServed": 262144,
+        "cacheBatchBypassRequests": 3,
+        "cacheBatchBypassArticles": 11,
+        "cacheWriteCommits": 0
+      },
+      "timing": {
+        "firstByteMs": 1.0,
+        "elapsedMs": 2.0,
+        "throughputMiBs": 40.0,
+        "cpuSeconds": 0.01
+      }
+    }
+  }
+}

--- a/scripts/fixtures/performance-gate-expanded-write-1.json
+++ b/scripts/fixtures/performance-gate-expanded-write-1.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "report": "streaming",
+  "meta": {
+    "commit": "test",
+    "generatedAt": "2026-01-01T00:00:00+00:00",
+    "os": "test",
+    "dotnet": "test"
+  },
+  "scenarios": {
+    "cold-sequential": {
+      "deterministic": {
+        "bytes": 100,
+        "transportRequests": 2,
+        "transportBytes": 100
+      },
+      "timing": {
+        "firstByteMs": 10.0,
+        "elapsedMs": 20.0,
+        "throughputMiBs": 90.0,
+        "cpuSeconds": 0.1
+      }
+    },
+    "pipelined-cold-read": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 12,
+        "transportBytes": 3145728,
+        "transportBatchRequests": 3,
+        "cacheHits": 0,
+        "cacheMisses": 1,
+        "cacheBytesServed": 0,
+        "cacheBatchBypassRequests": 3,
+        "cacheBatchBypassArticles": 11,
+        "cacheWriteCommits": 1
+      },
+      "timing": {
+        "firstByteMs": 1.0,
+        "elapsedMs": 2.0,
+        "throughputMiBs": 30.0,
+        "cpuSeconds": 0.01
+      }
+    },
+    "pipelined-warm-reread": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 11,
+        "transportBytes": 2883584,
+        "transportBatchRequests": 3,
+        "cacheHits": 1,
+        "cacheMisses": 0,
+        "cacheBytesServed": 262144,
+        "cacheBatchBypassRequests": 3,
+        "cacheBatchBypassArticles": 11,
+        "cacheWriteCommits": 0
+      },
+      "timing": {
+        "firstByteMs": 1.0,
+        "elapsedMs": 2.0,
+        "throughputMiBs": 40.0,
+        "cpuSeconds": 0.01
+      }
+    }
+  }
+}

--- a/scripts/fixtures/performance-gate-expanded-write-2.json
+++ b/scripts/fixtures/performance-gate-expanded-write-2.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "report": "streaming",
+  "meta": {
+    "commit": "test",
+    "generatedAt": "2026-01-01T00:00:00+00:00",
+    "os": "test",
+    "dotnet": "test"
+  },
+  "scenarios": {
+    "cold-sequential": {
+      "deterministic": {
+        "bytes": 100,
+        "transportRequests": 2,
+        "transportBytes": 100
+      },
+      "timing": {
+        "firstByteMs": 10.0,
+        "elapsedMs": 20.0,
+        "throughputMiBs": 90.0,
+        "cpuSeconds": 0.1
+      }
+    },
+    "pipelined-cold-read": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 12,
+        "transportBytes": 3145728,
+        "transportBatchRequests": 3,
+        "cacheHits": 0,
+        "cacheMisses": 1,
+        "cacheBytesServed": 0,
+        "cacheBatchBypassRequests": 3,
+        "cacheBatchBypassArticles": 11,
+        "cacheWriteCommits": 1
+      },
+      "timing": {
+        "firstByteMs": 1.0,
+        "elapsedMs": 2.1,
+        "throughputMiBs": 30.0,
+        "cpuSeconds": 0.01
+      }
+    },
+    "pipelined-warm-reread": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 11,
+        "transportBytes": 2883584,
+        "transportBatchRequests": 3,
+        "cacheHits": 1,
+        "cacheMisses": 0,
+        "cacheBytesServed": 262144,
+        "cacheBatchBypassRequests": 3,
+        "cacheBatchBypassArticles": 11,
+        "cacheWriteCommits": 0
+      },
+      "timing": {
+        "firstByteMs": 1.0,
+        "elapsedMs": 2.0,
+        "throughputMiBs": 40.0,
+        "cpuSeconds": 0.01
+      }
+    }
+  }
+}

--- a/scripts/fixtures/performance-gate-expanded-write-3.json
+++ b/scripts/fixtures/performance-gate-expanded-write-3.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "report": "streaming",
+  "meta": {
+    "commit": "test",
+    "generatedAt": "2026-01-01T00:00:00+00:00",
+    "os": "test",
+    "dotnet": "test"
+  },
+  "scenarios": {
+    "cold-sequential": {
+      "deterministic": {
+        "bytes": 100,
+        "transportRequests": 2,
+        "transportBytes": 100
+      },
+      "timing": {
+        "firstByteMs": 10.0,
+        "elapsedMs": 20.0,
+        "throughputMiBs": 90.0,
+        "cpuSeconds": 0.1
+      }
+    },
+    "pipelined-cold-read": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 12,
+        "transportBytes": 3145728,
+        "transportBatchRequests": 3,
+        "cacheHits": 0,
+        "cacheMisses": 1,
+        "cacheBytesServed": 0,
+        "cacheBatchBypassRequests": 3,
+        "cacheBatchBypassArticles": 11,
+        "cacheWriteCommits": 1
+      },
+      "timing": {
+        "firstByteMs": 1.0,
+        "elapsedMs": 1.9,
+        "throughputMiBs": 30.0,
+        "cpuSeconds": 0.01
+      }
+    },
+    "pipelined-warm-reread": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 11,
+        "transportBytes": 2883584,
+        "transportBatchRequests": 3,
+        "cacheHits": 1,
+        "cacheMisses": 0,
+        "cacheBytesServed": 262144,
+        "cacheBatchBypassRequests": 3,
+        "cacheBatchBypassArticles": 11,
+        "cacheWriteCommits": 0
+      },
+      "timing": {
+        "firstByteMs": 1.0,
+        "elapsedMs": 2.0,
+        "throughputMiBs": 40.0,
+        "cpuSeconds": 0.01
+      }
+    }
+  }
+}

--- a/scripts/fixtures/performance-gate-schema-v2.json
+++ b/scripts/fixtures/performance-gate-schema-v2.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 2,
+  "report": "streaming",
+  "meta": {
+    "commit": "test",
+    "generatedAt": "2026-01-01T00:00:00+00:00",
+    "os": "test",
+    "dotnet": "test"
+  },
+  "scenarios": {
+    "cold-sequential": {
+      "deterministic": {
+        "bytes": 100,
+        "transportRequests": 2,
+        "transportBytes": 100
+      },
+      "timing": {
+        "firstByteMs": 10.0,
+        "elapsedMs": 20.0,
+        "throughputMiBs": 90.0,
+        "cpuSeconds": 0.1
+      }
+    },
+    "pipelined-cold-read": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 12,
+        "transportBytes": 3145728,
+        "transportBatchRequests": 3,
+        "cacheHits": 0,
+        "cacheMisses": 1,
+        "cacheBytesServed": 0,
+        "cacheBatchBypassRequests": 3,
+        "cacheBatchBypassArticles": 11,
+        "cacheWriteCommits": 1
+      },
+      "timing": {
+        "firstByteMs": 1.0,
+        "elapsedMs": 2.0,
+        "throughputMiBs": 30.0,
+        "cpuSeconds": 0.01
+      }
+    },
+    "pipelined-warm-reread": {
+      "deterministic": {
+        "bytes": 3145728,
+        "transportRequests": 11,
+        "transportBytes": 2883584,
+        "transportBatchRequests": 3,
+        "cacheHits": 1,
+        "cacheMisses": 0,
+        "cacheBytesServed": 262144,
+        "cacheBatchBypassRequests": 3,
+        "cacheBatchBypassArticles": 11,
+        "cacheWriteCommits": 0
+      },
+      "timing": {
+        "firstByteMs": 1.0,
+        "elapsedMs": 2.0,
+        "throughputMiBs": 40.0,
+        "cpuSeconds": 0.01
+      }
+    }
+  }
+}

--- a/scripts/test-performance-baseline-gate.sh
+++ b/scripts/test-performance-baseline-gate.sh
@@ -154,4 +154,85 @@ run_gate 0 \
     "${FIXTURES}/performance-gate-clean-b.json" \
     "${FIXTURES}/performance-gate-clean-c.json" >/dev/null
 
+EXPANDED_BASELINE="${FIXTURES}/performance-gate-expanded-baseline.json"
+run_gate 0 \
+  --baseline "${EXPANDED_BASELINE}" \
+  --candidates "${FIXTURES}/performance-gate-expanded-candidate.json" >/dev/null
+
+output="$(run_gate 2 \
+  --baseline "${EXPANDED_BASELINE}" \
+  --candidates "${FIXTURES}/performance-gate-expanded-missing-cold.json")"
+if ! grep -q 'pipelined-cold-read' <<<"${output}"; then
+  echo "missing pipelined-cold-read did not fail schema comparison" >&2
+  echo "${output}" >&2
+  exit 1
+fi
+
+output="$(run_gate 2 \
+  --baseline "${EXPANDED_BASELINE}" \
+  --candidates "${FIXTURES}/performance-gate-expanded-missing-warm.json")"
+if ! grep -q 'pipelined-warm-reread' <<<"${output}"; then
+  echo "missing pipelined-warm-reread did not fail schema comparison" >&2
+  echo "${output}" >&2
+  exit 1
+fi
+
+output="$(run_gate 2 \
+  --baseline "${EXPANDED_BASELINE}" \
+  --candidates "${FIXTURES}/performance-gate-expanded-warm-transport.json" \
+  --deterministic-only)"
+if ! grep -q 'transportRequests' <<<"${output}"; then
+  echo "warm transport regression did not fail deterministic comparison" >&2
+  echo "${output}" >&2
+  exit 1
+fi
+
+run_gate 0 \
+  --baseline "${EXPANDED_BASELINE}" \
+  --candidates "${FIXTURES}/performance-gate-expanded-timing.json" \
+  --deterministic-only >/dev/null
+
+output="$(run_gate 1 \
+  --baseline "${EXPANDED_BASELINE}" \
+  --candidates "${FIXTURES}/performance-gate-expanded-timing.json")"
+if ! grep -q 'elapsedMs' <<<"${output}"; then
+  echo "timing-only change did not fail envelope comparison" >&2
+  echo "${output}" >&2
+  exit 1
+fi
+
+output="$(run_gate 2 \
+  --baseline "${EXPANDED_BASELINE}" \
+  --candidates "${FIXTURES}/performance-gate-schema-v2.json")"
+if ! grep -q 'schemaVersion' <<<"${output}"; then
+  echo "schema version 2 did not fail" >&2
+  echo "${output}" >&2
+  exit 1
+fi
+
+expanded_written="${tmpdir}/expanded-written-baseline.json"
+run_gate 0 \
+  --candidates \
+    "${FIXTURES}/performance-gate-expanded-write-1.json" \
+    "${FIXTURES}/performance-gate-expanded-write-2.json" \
+    "${FIXTURES}/performance-gate-expanded-write-3.json" \
+  --write-baseline "${expanded_written}" >/dev/null
+
+python3 - "${expanded_written}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+baseline = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+cold = baseline["scenarios"]["pipelined-cold-read"]["deterministic"]
+if cold["bytes"] != 3145728 or cold["transportBatchRequests"] != 3 or cold["cacheWriteCommits"] != 1:
+    raise SystemExit(f"write-baseline lost integer deterministic values: {cold}")
+warm = baseline["scenarios"]["pipelined-warm-reread"]["deterministic"]
+if warm["transportRequests"] != 11 or warm["cacheHits"] != 1:
+    raise SystemExit(f"write-baseline lost warm integers: {warm}")
+timing = baseline["scenarios"]["pipelined-cold-read"]["timing"]["elapsedMs"]
+if "baseline" not in timing or "envelope" not in timing or timing["policy"] != "fail":
+    raise SystemExit(f"write-baseline missing new-scenario timing policy: {timing}")
+PY
+
 echo "Performance baseline gate fixtures passed."

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
@@ -291,8 +291,8 @@ public sealed class SegmentCacheNntpClientTests
     public async Task LookupDuringBlockedCatalog_IncrementsUnavailableNotMiss()
     {
         var cacheDir = NewCacheDir();
-        var loadStarted = new ManualResetEventSlim();
-        var allowLoad = new ManualResetEventSlim();
+        using var loadStarted = new ManualResetEventSlim();
+        using var allowLoad = new ManualResetEventSlim();
         const string segmentId = "blocked-catalog";
         byte[] content = "blocked-catalog-bytes"u8.ToArray();
         var statistics = new SegmentCacheStatistics();
@@ -329,8 +329,6 @@ public sealed class SegmentCacheNntpClientTests
         {
             allowLoad.Set();
             DeleteCacheDir(cacheDir);
-            loadStarted.Dispose();
-            allowLoad.Dispose();
         }
     }
 
@@ -416,6 +414,9 @@ public sealed class SegmentCacheNntpClientTests
             using var client = CreateClient(inner, cacheDir, statistics);
             await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
             SetUnixMode(cacheDir, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+            Skip.IfNot(
+                DirectoryWriteEnforced(cacheDir),
+                "Test is running as root; file modes are not enforced.");
 
             var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
             await using var output = new MemoryStream();
@@ -509,6 +510,9 @@ public sealed class SegmentCacheNntpClientTests
             var tmpPath = Path.Join(lockedDir, "stale.tmp");
             File.WriteAllText(tmpPath, "tmp");
             SetUnixMode(lockedDir, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+            Skip.IfNot(
+                FileDeleteEnforced(tmpPath),
+                "Test is running as root; file modes are not enforced.");
             var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
             using var client = new SegmentCacheNntpClient(
                 inner,
@@ -530,9 +534,13 @@ public sealed class SegmentCacheNntpClientTests
             {
                 SetUnixMode(lockedDir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
             }
-            catch
+            catch (IOException)
             {
-                // ignore
+                // Best-effort restore before recursive delete.
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Best-effort restore before recursive delete.
             }
 
             DeleteCacheDir(cacheDir);
@@ -633,6 +641,38 @@ public sealed class SegmentCacheNntpClientTests
     {
         if (OperatingSystem.IsWindows()) return;
         File.SetUnixFileMode(path, mode);
+    }
+
+    private static bool DirectoryWriteEnforced(string directory)
+    {
+        var probe = Path.Join(directory, $".probe-{Guid.NewGuid():N}");
+        try
+        {
+            File.WriteAllBytes(probe, []);
+            File.Delete(probe);
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return true;
+        }
+    }
+
+    private static bool FileDeleteEnforced(string path)
+    {
+        try
+        {
+            File.Delete(path);
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return true;
+        }
+        catch (IOException)
+        {
+            return true;
+        }
     }
 
     private static async Task ReadFullyAsync(SegmentCacheNntpClient client, string segmentId)

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
@@ -227,6 +227,420 @@ public sealed class SegmentCacheNntpClientTests
         }
     }
 
+    [Fact]
+    public async Task ReadyHit_IncrementsHitAndBytesServedOnce()
+    {
+        var cacheDir = NewCacheDir();
+        const string segmentId = "hit-counter";
+        byte[] content = "hit-counter-bytes"u8.ToArray();
+        var statistics = new SegmentCacheStatistics();
+
+        try
+        {
+            WriteCacheEntry(cacheDir, segmentId, content);
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
+            using var client = CreateClient(inner, cacheDir, statistics);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            await ReadAndDisposeAsync(response.Stream!);
+
+            var snapshot = statistics.GetSnapshot();
+            Assert.Equal(1, snapshot.Hits);
+            Assert.Equal(content.Length, snapshot.BytesServed);
+            Assert.Equal(0, snapshot.Misses);
+            Assert.Equal(0, inner.BodyRequestCount);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
+    public async Task ReadyMiss_IncrementsMissOnce()
+    {
+        var cacheDir = NewCacheDir();
+        const string segmentId = "miss-counter";
+        byte[] content = "provider-miss-bytes"u8.ToArray();
+        var statistics = new SegmentCacheStatistics();
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]> { [segmentId] = content }, useCachedYencStreams: true);
+            using var client = CreateClient(inner, cacheDir, statistics);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            await ReadAndDisposeAsync(response.Stream!);
+
+            var snapshot = statistics.GetSnapshot();
+            Assert.Equal(1, snapshot.Misses);
+            Assert.Equal(0, snapshot.Hits);
+            Assert.Equal(1, snapshot.WriteAttempts);
+            Assert.Equal(1, snapshot.WriteCommits);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
+    public async Task LookupDuringBlockedCatalog_IncrementsUnavailableNotMiss()
+    {
+        var cacheDir = NewCacheDir();
+        var loadStarted = new ManualResetEventSlim();
+        var allowLoad = new ManualResetEventSlim();
+        const string segmentId = "blocked-catalog";
+        byte[] content = "blocked-catalog-bytes"u8.ToArray();
+        var statistics = new SegmentCacheStatistics();
+
+        try
+        {
+            WriteCacheEntry(cacheDir, segmentId, content);
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]> { [segmentId] = content }, useCachedYencStreams: true);
+            using var client = new SegmentCacheNntpClient(
+                inner,
+                cacheDir,
+                maxBytes: 1024 * 1024,
+                usageTracker: null,
+                metricsWriter: null,
+                enumerateCacheFiles: () =>
+                {
+                    loadStarted.Set();
+                    allowLoad.Wait();
+                    return Directory.EnumerateFiles(cacheDir, "*", SearchOption.AllDirectories);
+                },
+                statistics);
+
+            Assert.True(loadStarted.Wait(TimeSpan.FromSeconds(5)));
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            await ReadAndDisposeAsync(response.Stream!);
+
+            var snapshot = statistics.GetSnapshot();
+            Assert.Equal(1, snapshot.LookupUnavailable);
+            Assert.Equal(0, snapshot.Misses);
+            Assert.Equal(0, snapshot.Hits);
+            Assert.Equal(1, inner.BodyRequestCount);
+        }
+        finally
+        {
+            allowLoad.Set();
+            DeleteCacheDir(cacheDir);
+            loadStarted.Dispose();
+            allowLoad.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task CorruptCacheFile_IncrementsReadFailureAndDropsEntry()
+    {
+        var cacheDir = NewCacheDir();
+        const string segmentId = "corrupt-entry";
+        byte[] content = "corrupt-entry-bytes"u8.ToArray();
+        var statistics = new SegmentCacheStatistics();
+
+        try
+        {
+            WriteCacheEntry(cacheDir, segmentId, content);
+            var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(segmentId)));
+            File.WriteAllText(Path.Join(cacheDir, hash[..2], hash) + ".h", "{not-json");
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]> { [segmentId] = content }, useCachedYencStreams: true);
+            using var client = CreateClient(inner, cacheDir, statistics);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(content.Length, client.CurrentBytes);
+
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            response.Stream!.Dispose();
+
+            var snapshot = statistics.GetSnapshot();
+            Assert.Equal(1, snapshot.ReadFailures);
+            Assert.Equal(0, snapshot.Hits);
+            Assert.Equal(0, client.CurrentBytes);
+            Assert.Equal(0, snapshot.Entries);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
+    public async Task PartialRead_RecordsOneAttemptAndOneSkip()
+    {
+        var cacheDir = NewCacheDir();
+        const string segmentId = "partial-skip";
+        byte[] content = Enumerable.Repeat((byte)7, 1024).ToArray();
+        var statistics = new SegmentCacheStatistics();
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]> { [segmentId] = content }, useCachedYencStreams: true);
+            using var client = CreateClient(inner, cacheDir, statistics);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            Assert.NotNull(response.Stream);
+            var buffer = new byte[16];
+            Assert.Equal(16, await response.Stream.ReadAsync(buffer));
+            response.Stream.Dispose();
+
+            var snapshot = statistics.GetSnapshot();
+            Assert.Equal(1, snapshot.WriteAttempts);
+            Assert.Equal(1, snapshot.WriteSkipped);
+            Assert.Equal(0, snapshot.WriteCommits);
+            Assert.Equal(0, snapshot.WriteFailures);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [SkippableFact]
+    public async Task WriteOpenFailure_RecordsOneFailureWithoutFailingPlayback()
+    {
+        Skip.If(OperatingSystem.IsWindows(), "Unix file modes are not enforced on Windows.");
+        var cacheDir = NewCacheDir();
+        const string segmentId = "write-fail";
+        byte[] content = "write-fail-bytes"u8.ToArray();
+        var statistics = new SegmentCacheStatistics();
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]> { [segmentId] = content }, useCachedYencStreams: true);
+            using var client = CreateClient(inner, cacheDir, statistics);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+            SetUnixMode(cacheDir, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            await using var output = new MemoryStream();
+            await response.Stream!.CopyToAsync(output);
+            response.Stream.Dispose();
+
+            Assert.Equal(content, output.ToArray());
+            var snapshot = statistics.GetSnapshot();
+            Assert.Equal(1, snapshot.WriteAttempts);
+            Assert.Equal(1, snapshot.WriteFailures);
+            Assert.Equal(0, snapshot.WriteCommits);
+        }
+        finally
+        {
+            SetUnixMode(cacheDir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
+    public async Task CapacityEviction_RecordsExactEntryAndByteCounts()
+    {
+        var cacheDir = NewCacheDir();
+        byte[] first = "first-cache-entry"u8.ToArray();
+        byte[] second = "second-cache-entry!!"u8.ToArray();
+        var statistics = new SegmentCacheStatistics();
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            var inner = new FakeNntpClient(
+                new Dictionary<string, byte[]>
+                {
+                    ["first"] = first,
+                    ["second"] = second,
+                },
+                useCachedYencStreams: true);
+            using var client = CreateClient(inner, cacheDir, statistics, maxBytes: second.Length);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await ReadFullyAsync(client, "first");
+            Assert.Equal(first.Length, client.CurrentBytes);
+            await ReadFullyAsync(client, "second");
+
+            var snapshot = statistics.GetSnapshot();
+            Assert.Equal(1, snapshot.Evictions);
+            Assert.Equal(first.Length, snapshot.BytesEvicted);
+            Assert.Equal(second.Length, client.CurrentBytes);
+            Assert.Equal(1, snapshot.Entries);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
+    public async Task SuccessfulStaleTmpDeletion_IncrementsCleanup()
+    {
+        var cacheDir = NewCacheDir();
+        var statistics = new SegmentCacheStatistics();
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            File.WriteAllText(Path.Join(cacheDir, "stale.tmp"), "tmp");
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
+            using var client = CreateClient(inner, cacheDir, statistics);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(1, statistics.GetSnapshot().TemporaryFilesCleaned);
+            Assert.False(File.Exists(Path.Join(cacheDir, "stale.tmp")));
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [SkippableFact]
+    public async Task FailedStaleTmpDeletion_DoesNotIncrementCleanup()
+    {
+        Skip.If(OperatingSystem.IsWindows(), "Unix file modes are not enforced on Windows.");
+        var cacheDir = NewCacheDir();
+        var lockedDir = Path.Join(cacheDir, "locked");
+        var statistics = new SegmentCacheStatistics();
+
+        try
+        {
+            Directory.CreateDirectory(lockedDir);
+            var tmpPath = Path.Join(lockedDir, "stale.tmp");
+            File.WriteAllText(tmpPath, "tmp");
+            SetUnixMode(lockedDir, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
+            using var client = new SegmentCacheNntpClient(
+                inner,
+                cacheDir,
+                maxBytes: 1024,
+                usageTracker: null,
+                metricsWriter: null,
+                enumerateCacheFiles: () => [tmpPath],
+                statistics);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(0, statistics.GetSnapshot().TemporaryFilesCleaned);
+            SetUnixMode(lockedDir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            Assert.True(File.Exists(tmpPath));
+        }
+        finally
+        {
+            try
+            {
+                SetUnixMode(lockedDir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            }
+            catch
+            {
+                // ignore
+            }
+
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
+    public async Task OrdinaryBatch_IncrementsBypassOnceAndForwards()
+    {
+        await AssertBatchBypassAsync(exclusive: false);
+    }
+
+    [Fact]
+    public async Task ExclusiveBatch_IncrementsBypassOnceAndForwards()
+    {
+        await AssertBatchBypassAsync(exclusive: true);
+    }
+
+    [Fact]
+    public async Task BatchSetupFailure_PropagatesUnchanged()
+    {
+        var cacheDir = NewCacheDir();
+        var statistics = new SegmentCacheStatistics();
+        var inner = new ThrowingBatchNntpClient();
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            using var client = CreateClient(inner, cacheDir, statistics);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var error = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => client.DecodedBodiesAsync(["a", "b"], onConnectionReadyAgain: null, CancellationToken.None));
+            Assert.Equal("batch-setup", error.Message);
+            Assert.Equal(1, statistics.GetSnapshot().BatchBypassRequests);
+            Assert.Equal(2, statistics.GetSnapshot().BatchBypassArticles);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    private static async Task AssertBatchBypassAsync(bool exclusive)
+    {
+        var cacheDir = NewCacheDir();
+        var statistics = new SegmentCacheStatistics();
+        var segments = new Dictionary<string, byte[]>
+        {
+            ["a"] = "aaa"u8.ToArray(),
+            ["b"] = "bbb"u8.ToArray(),
+            ["c"] = "ccc"u8.ToArray(),
+        };
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            var inner = new FakeNntpClient(segments, useCachedYencStreams: true);
+            using var client = CreateClient(inner, cacheDir, statistics);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var ids = new SegmentId[] { "a", "b", "c" };
+            var batch = exclusive
+                ? await client.DecodedBodiesAsync(ids, new UsenetExclusiveConnection(null), CancellationToken.None)
+                : await client.DecodedBodiesAsync(ids, onConnectionReadyAgain: null, CancellationToken.None);
+
+            Assert.Equal(3, batch.Responses.Count);
+            Assert.Equal(1, inner.BatchRequestCount);
+            Assert.Equal(3, inner.BodyRequestCount);
+            var snapshot = statistics.GetSnapshot();
+            Assert.Equal(1, snapshot.BatchBypassRequests);
+            Assert.Equal(3, snapshot.BatchBypassArticles);
+            Assert.Equal(0, snapshot.Hits);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    private static SegmentCacheNntpClient CreateClient(
+        INntpClient inner,
+        string cacheDir,
+        SegmentCacheStatistics statistics,
+        long maxBytes = 1024 * 1024) =>
+        new(inner, cacheDir, maxBytes, usageTracker: null, metricsWriter: null, enumerateCacheFiles: null, statistics);
+
+    private static string NewCacheDir() =>
+        Path.Join(Path.GetTempPath(), "nzbdav-segment-cache-" + Guid.NewGuid().ToString("N"));
+
+    private static void DeleteCacheDir(string cacheDir)
+    {
+        if (Directory.Exists(cacheDir))
+            Directory.Delete(cacheDir, recursive: true);
+    }
+
+    private static void SetUnixMode(string path, UnixFileMode mode)
+    {
+        if (OperatingSystem.IsWindows()) return;
+        File.SetUnixFileMode(path, mode);
+    }
+
+    private static async Task ReadFullyAsync(SegmentCacheNntpClient client, string segmentId)
+    {
+        var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+        await ReadAndDisposeAsync(response.Stream!);
+    }
+
     private static async Task ReadAndDisposeAsync(Stream stream)
     {
         await using (stream)
@@ -339,5 +753,56 @@ public sealed class SegmentCacheNntpClientTests
                     PartSize = bytes.Length,
                 },
                 new MemoryStream(bytes, writable: false));
+    }
+
+    private sealed class ThrowingBatchNntpClient : NntpClient
+    {
+        public override Task ConnectAsync(string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("batch-setup");
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
     }
 }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheStatisticsTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheStatisticsTests.cs
@@ -1,0 +1,135 @@
+using NzbWebDAV.Clients.Usenet;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public sealed class SegmentCacheStatisticsTests
+{
+    [Fact]
+    public async Task ConcurrentHits_RecordExactTotals()
+    {
+        var statistics = new SegmentCacheStatistics();
+        const int tasks = 32;
+        const int hitsPerTask = 1_000;
+        const long bytesPerHit = 64;
+
+        await Task.WhenAll(Enumerable.Range(0, tasks).Select(_ => Task.Run(() =>
+        {
+            for (var i = 0; i < hitsPerTask; i++)
+                statistics.RecordHit(bytesPerHit);
+        })));
+
+        var snapshot = statistics.GetSnapshot();
+        Assert.Equal(tasks * hitsPerTask, snapshot.Hits);
+        Assert.Equal(tasks * hitsPerTask * bytesPerHit, snapshot.BytesServed);
+        Assert.Null(snapshot.QueuedWriteBytes);
+        Assert.Null(snapshot.PeakQueuedWriteBytes);
+    }
+
+    [Fact]
+    public async Task SnapshotsDuringUpdates_NeverDecreaseProcessLifetimeCounters()
+    {
+        var statistics = new SegmentCacheStatistics();
+        var decreasing = 0;
+        using var cts = new CancellationTokenSource();
+        var reader = Task.Run(async () =>
+        {
+            var previousHits = 0L;
+            var previousBytes = 0L;
+            while (!cts.IsCancellationRequested)
+            {
+                var snapshot = statistics.GetSnapshot();
+                if (snapshot.Hits < previousHits || snapshot.BytesServed < previousBytes)
+                    Interlocked.Increment(ref decreasing);
+                previousHits = snapshot.Hits;
+                previousBytes = snapshot.BytesServed;
+                await Task.Yield();
+            }
+        });
+
+        await Task.WhenAll(Enumerable.Range(0, 16).Select(_ => Task.Run(() =>
+        {
+            for (var i = 0; i < 500; i++)
+                statistics.RecordHit(8);
+        })));
+
+        cts.Cancel();
+        await reader;
+        Assert.Equal(0, decreasing);
+        Assert.Equal(16 * 500, statistics.GetSnapshot().Hits);
+    }
+
+    [Fact]
+    public void LaterGeneration_SupersedesGauges_AndIgnoresStaleUpdates()
+    {
+        var statistics = new SegmentCacheStatistics();
+        var generationA = statistics.BeginGeneration(enabled: true, maxBytes: 100);
+        generationA.SetCatalogReady(12, entries: 3, currentBytes: 30);
+        generationA.SetIndex(3, 30);
+
+        var generationB = statistics.BeginGeneration(enabled: true, maxBytes: 200);
+        generationB.SetCatalogReady(8, entries: 1, currentBytes: 10);
+
+        generationA.SetIndex(99, 999);
+        generationA.SetCatalogReady(50, 99, 999);
+
+        var snapshot = statistics.GetSnapshot();
+        Assert.True(snapshot.Enabled);
+        Assert.True(snapshot.CatalogReady);
+        Assert.Equal(8, snapshot.CatalogLoadDurationMs);
+        Assert.Equal(1, snapshot.Entries);
+        Assert.Equal(10, snapshot.CurrentBytes);
+        Assert.Equal(200, snapshot.MaxBytes);
+    }
+
+    [Fact]
+    public void LateRetiredGeneration_StillContributesOutcomeCounters()
+    {
+        var statistics = new SegmentCacheStatistics();
+        statistics.BeginGeneration(enabled: true, maxBytes: 100);
+        statistics.RecordHit(16);
+        statistics.BeginGeneration(enabled: true, maxBytes: 200);
+        statistics.RecordHit(32);
+        statistics.RecordMiss();
+
+        var snapshot = statistics.GetSnapshot();
+        Assert.Equal(2, snapshot.Hits);
+        Assert.Equal(48, snapshot.BytesServed);
+        Assert.Equal(1, snapshot.Misses);
+        Assert.Equal(200, snapshot.MaxBytes);
+    }
+
+    [Fact]
+    public void DisabledGeneration_HasZeroActiveGauges_AndPreservesCounters()
+    {
+        var statistics = new SegmentCacheStatistics();
+        statistics.BeginGeneration(enabled: true, maxBytes: 50);
+        statistics.RecordHit(8);
+        statistics.BeginGeneration(enabled: false, maxBytes: 50);
+
+        var snapshot = statistics.GetSnapshot();
+        Assert.False(snapshot.Enabled);
+        Assert.False(snapshot.CatalogReady);
+        Assert.Null(snapshot.CatalogLoadDurationMs);
+        Assert.Equal(0, snapshot.Entries);
+        Assert.Equal(0, snapshot.CurrentBytes);
+        Assert.Equal(0, snapshot.MaxBytes);
+        Assert.Equal(1, snapshot.Hits);
+        Assert.Equal(8, snapshot.BytesServed);
+        Assert.Null(snapshot.QueuedWriteBytes);
+        Assert.Null(snapshot.PeakQueuedWriteBytes);
+    }
+
+    [Fact]
+    public void WriteAttempt_CompletesOnce()
+    {
+        var statistics = new SegmentCacheStatistics();
+        var attempt = statistics.BeginWriteAttempt();
+        attempt.Complete(SegmentCacheWriteOutcome.Committed, 10);
+        attempt.Complete(SegmentCacheWriteOutcome.Failed, 10);
+
+        var snapshot = statistics.GetSnapshot();
+        Assert.Equal(1, snapshot.WriteAttempts);
+        Assert.Equal(1, snapshot.WriteCommits);
+        Assert.Equal(0, snapshot.WriteFailures);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Config/EffectiveStreamingConfigManifestTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/EffectiveStreamingConfigManifestTests.cs
@@ -1,0 +1,211 @@
+using System.Collections;
+using System.Reflection;
+using System.Text.Json;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+public sealed class EffectiveStreamingConfigManifestTests
+{
+    [Fact]
+    public void Defaults_MatchCurrentTypedGetters()
+    {
+        var config = new ConfigManager();
+        var document = EffectiveStreamingConfigManifest.Create(config);
+
+        Assert.Equal(1, document.SchemaVersion);
+        Assert.Equal(40, document.Streaming.ArticleBufferSize);
+        Assert.True(document.Streaming.PipelinedBodyRequests);
+        Assert.Equal(4, document.Streaming.BodyBatchWidth);
+        Assert.True(document.Streaming.ContainerAwareFill);
+        Assert.Equal(0, document.Streaming.BandwidthLimitBytesPerSecond);
+        Assert.Equal(80, document.Streaming.StreamingPriority);
+        Assert.Equal(3, document.Streaming.SegmentRetryCount);
+        Assert.Equal(30, document.Streaming.ReadTimeoutSeconds);
+        Assert.Equal(60, document.Streaming.WriteTimeoutSeconds);
+        Assert.Equal(8, document.Streaming.SegmentTimeoutSeconds);
+        Assert.Equal(config.GetMaxDownloadConnections(), document.Connections.EffectiveTotalDownloadLimit);
+        Assert.False(document.Connections.PerStreamModeEnabled);
+        Assert.True(document.Connections.WarmConnectionsEnabled);
+        Assert.Equal(config.GetInFlightArticleBudgetBytes(), document.Memory.InFlightArticleBudgetBytes);
+        Assert.True(document.Memory.SharedStreamsEnabled);
+        Assert.True(document.SegmentCache.Enabled);
+        Assert.Equal(10L * 1024 * 1024 * 1024, document.SegmentCache.MaxBytes);
+        Assert.True(document.Repair.BackgroundEnabled);
+        Assert.True(document.Repair.Par2Enabled);
+        Assert.True(document.Repair.DegradedToleranceEnabled);
+        Assert.True(document.Repair.CorruptionTrackingEnabled);
+        Assert.Empty(document.Providers);
+        Assert.Equal(EffectiveConfigSource.Default, document.Source.Streaming.ArticleBufferSize);
+    }
+
+    [Fact]
+    public void SqliteAndEnvironmentOverrides_AreEffectiveValues()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.UsenetArticleBufferSize, ConfigValue = "12" },
+            new ConfigItem { ConfigName = ConfigKeys.UsenetStreamingBodyBatchWidth, ConfigValue = "99" },
+            new ConfigItem { ConfigName = ConfigKeys.UsenetSegmentCacheMaxGb, ConfigValue = "2" },
+            new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "false" },
+        ]);
+        config.ApplyEnvironmentOverlay(ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+        {
+            ["NZBDAV_CONFIG__USENET__PIPELINED_BODY_REQUESTS"] = "false",
+            ["NZBDAV_CONFIG__USENET__ARTICLE_BUFFER_SIZE"] = "7",
+        }));
+
+        var document = EffectiveStreamingConfigManifest.Create(config);
+        Assert.Equal(7, document.Streaming.ArticleBufferSize);
+        Assert.False(document.Streaming.PipelinedBodyRequests);
+        Assert.Equal(8, document.Streaming.BodyBatchWidth);
+        Assert.Equal(2L * 1024 * 1024 * 1024, document.SegmentCache.MaxBytes);
+        Assert.False(document.Repair.BackgroundEnabled);
+        Assert.False(document.Repair.Par2Enabled);
+        Assert.Equal(EffectiveConfigSource.Environment, document.Source.Streaming.ArticleBufferSize);
+        Assert.Equal(EffectiveConfigSource.Environment, document.Source.Streaming.PipelinedBodyRequests);
+        Assert.Equal(EffectiveConfigSource.Sqlite, document.Source.Streaming.BodyBatchWidth);
+        Assert.Equal(EffectiveConfigSource.Sqlite, document.Source.Repair.BackgroundEnabled);
+    }
+
+    [Fact]
+    public void Providers_AreAliasedWithoutSecretsOrPaths()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig
+                {
+                    Providers =
+                    [
+                        new UsenetProviderConfig.ConnectionDetails
+                        {
+                            ProviderId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+                            Type = ProviderType.Pooled,
+                            Host = "news.secret.example",
+                            Port = 563,
+                            UseSsl = true,
+                            SkipTlsVerification = false,
+                            User = "sentinel-user",
+                            Pass = "sentinel-pass",
+                            MaxConnections = 20,
+                            StorageGroup = "secret-group",
+                        },
+                    ],
+                }),
+            },
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetSegmentCachePath,
+                ConfigValue = "/secret/cache-path",
+            },
+            new ConfigItem { ConfigName = ConfigKeys.ApiKey, ConfigValue = "sentinel-api-key" },
+            new ConfigItem { ConfigName = ConfigKeys.WebdavPass, ConfigValue = "sentinel-webdav-pass" },
+            new ConfigItem { ConfigName = ConfigKeys.ApiStrmKey, ConfigValue = "sentinel-strm-key" },
+        ]);
+
+        var document = EffectiveStreamingConfigManifest.Create(config);
+        var json = JsonSerializer.Serialize(document, EffectiveStreamingConfigManifest.SerializerOptions);
+
+        Assert.Single(document.Providers);
+        Assert.Equal("provider1", document.Providers[0].Alias);
+        Assert.Equal("pooled", document.Providers[0].Type);
+        Assert.Equal(20, document.Providers[0].MaxConnections);
+        Assert.True(document.Providers[0].TlsEnabled);
+        Assert.True(document.Providers[0].TlsVerification);
+        Assert.DoesNotContain("news.secret.example", json);
+        Assert.DoesNotContain("sentinel-user", json);
+        Assert.DoesNotContain("sentinel-pass", json);
+        Assert.DoesNotContain("11111111-1111-1111-1111-111111111111", json);
+        Assert.DoesNotContain("secret-group", json);
+        Assert.DoesNotContain("/secret/cache-path", json);
+        Assert.DoesNotContain("sentinel-api-key", json);
+        Assert.DoesNotContain("sentinel-webdav-pass", json);
+        Assert.DoesNotContain("sentinel-strm-key", json);
+        Assert.DoesNotContain("NZBDAV_CONFIG", json);
+        Assert.DoesNotContain("usenet.segment-cache.path", json);
+    }
+
+    [Fact]
+    public void SerializedOutput_IsCamelCaseSchemaVersion1_AndAllowlisted()
+    {
+        var config = new ConfigManager();
+        var document = EffectiveStreamingConfigManifest.Create(config);
+        var json = JsonSerializer.Serialize(document, EffectiveStreamingConfigManifest.SerializerOptions);
+        using var parsed = JsonDocument.Parse(json);
+
+        Assert.Equal(1, parsed.RootElement.GetProperty("schemaVersion").GetInt32());
+        var offenders = new List<string>();
+        CollectJsonNames(parsed.RootElement, "", offenders);
+        Assert.True(offenders.Count == 0, string.Join(", ", offenders));
+        Assert.DoesNotContain("path", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("password", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("providerId", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReflectionAllowlist_RejectsUnknownDocumentProperties()
+    {
+        var names = CollectPropertyNames(typeof(EffectiveStreamingConfigDocument));
+        foreach (var name in names)
+        {
+            Assert.True(
+                char.IsUpper(name[0]) && name.All(char.IsLetterOrDigit),
+                $"document property {name} is not a stable identifier");
+        }
+
+        Assert.DoesNotContain("Path", names);
+        Assert.DoesNotContain("Host", names);
+        Assert.DoesNotContain("User", names);
+        Assert.DoesNotContain("Pass", names);
+        Assert.DoesNotContain("Password", names);
+        Assert.DoesNotContain("ProviderId", names);
+        Assert.DoesNotContain("StorageGroup", names);
+        Assert.DoesNotContain("ApiKey", names);
+    }
+
+    private static void CollectJsonNames(JsonElement element, string path, List<string> offenders)
+    {
+        if (element.ValueKind != JsonValueKind.Object) return;
+        foreach (var property in element.EnumerateObject())
+        {
+            if (property.Name.Length == 0 || !char.IsLower(property.Name[0]) || !property.Name.All(char.IsLetterOrDigit))
+                offenders.Add($"{path}/{property.Name}");
+            if (property.Value.ValueKind == JsonValueKind.Object)
+                CollectJsonNames(property.Value, $"{path}/{property.Name}", offenders);
+            else if (property.Value.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in property.Value.EnumerateArray())
+                    CollectJsonNames(item, path, offenders);
+            }
+        }
+    }
+
+    private static IEnumerable<string> CollectPropertyNames(Type type)
+    {
+        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            yield return property.Name;
+            var propertyType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+            if (propertyType.IsGenericType
+                && propertyType.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
+            {
+                foreach (var nested in CollectPropertyNames(propertyType.GetGenericArguments()[0]))
+                    yield return nested;
+            }
+            else if (propertyType.Namespace == typeof(EffectiveStreamingConfigDocument).Namespace
+                     && propertyType.IsClass
+                     && propertyType != typeof(string))
+            {
+                foreach (var nested in CollectPropertyNames(propertyType))
+                    yield return nested;
+            }
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Config/EffectiveStreamingConfigManifestTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/EffectiveStreamingConfigManifestTests.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using System.Reflection;
 using System.Text.Json;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
@@ -150,25 +149,139 @@ public sealed class EffectiveStreamingConfigManifestTests
     }
 
     [Fact]
-    public void ReflectionAllowlist_RejectsUnknownDocumentProperties()
+    public void SerializedPropertyPaths_MatchExplicitPublicAllowlist()
     {
-        var names = CollectPropertyNames(typeof(EffectiveStreamingConfigDocument));
-        foreach (var name in names)
-        {
-            Assert.True(
-                char.IsUpper(name[0]) && name.All(char.IsLetterOrDigit),
-                $"document property {name} is not a stable identifier");
-        }
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig
+                {
+                    Providers =
+                    [
+                        new UsenetProviderConfig.ConnectionDetails
+                        {
+                            Type = ProviderType.Pooled,
+                            Host = "news.secret.example",
+                            Port = 563,
+                            UseSsl = true,
+                            User = "sentinel-user",
+                            Pass = "sentinel-pass",
+                            MaxConnections = 8,
+                        },
+                    ],
+                }),
+            },
+        ]);
 
-        Assert.DoesNotContain("Path", names);
-        Assert.DoesNotContain("Host", names);
-        Assert.DoesNotContain("User", names);
-        Assert.DoesNotContain("Pass", names);
-        Assert.DoesNotContain("Password", names);
-        Assert.DoesNotContain("ProviderId", names);
-        Assert.DoesNotContain("StorageGroup", names);
-        Assert.DoesNotContain("ApiKey", names);
+        var json = JsonSerializer.Serialize(
+            EffectiveStreamingConfigManifest.Create(config),
+            EffectiveStreamingConfigManifest.SerializerOptions);
+        using var parsed = JsonDocument.Parse(json);
+        var actual = CollectJsonPaths(parsed.RootElement);
+
+        var unexpected = actual.Except(AllowedJsonPaths, StringComparer.Ordinal).Order().ToArray();
+        var missing = AllowedJsonPaths.Except(actual, StringComparer.Ordinal).Order().ToArray();
+        Assert.True(
+            unexpected.Length == 0 && missing.Length == 0,
+            "unexpected: " + string.Join(", ", unexpected) + "; missing: " + string.Join(", ", missing));
+        Assert.DoesNotContain(
+            actual,
+            static path => ForbiddenJsonPathSegments.Contains(path.Split('.')[^1]));
     }
+
+    private static readonly HashSet<string> AllowedJsonPaths =
+    [
+        "schemaVersion",
+        "streaming",
+        "streaming.articleBufferSize",
+        "streaming.pipelinedBodyRequests",
+        "streaming.bodyBatchWidth",
+        "streaming.containerAwareFill",
+        "streaming.bandwidthLimitBytesPerSecond",
+        "streaming.streamingPriority",
+        "streaming.segmentRetryCount",
+        "streaming.readTimeoutSeconds",
+        "streaming.writeTimeoutSeconds",
+        "streaming.segmentTimeoutSeconds",
+        "connections",
+        "connections.effectiveTotalDownloadLimit",
+        "connections.perStreamModeEnabled",
+        "connections.effectivePerStreamCount",
+        "connections.warmConnectionsEnabled",
+        "connections.pooledProviderCount",
+        "connections.totalPooledConnectionCount",
+        "memory",
+        "memory.inFlightArticleBudgetBytes",
+        "memory.sharedStreamsEnabled",
+        "memory.sharedStreamRingBytes",
+        "memory.sharedStreamMaxEntries",
+        "memory.maxEntriesPerFile",
+        "memory.graceSeconds",
+        "memory.smallRangeMaximumBytes",
+        "segmentCache",
+        "segmentCache.enabled",
+        "segmentCache.maxBytes",
+        "repair",
+        "repair.backgroundEnabled",
+        "repair.par2Enabled",
+        "repair.degradedToleranceEnabled",
+        "repair.corruptionTrackingEnabled",
+        "providers",
+        "providers.alias",
+        "providers.type",
+        "providers.maxConnections",
+        "providers.tlsEnabled",
+        "providers.tlsVerification",
+        "providers.warmConnectionFloor",
+        "source",
+        "source.streaming",
+        "source.streaming.articleBufferSize",
+        "source.streaming.pipelinedBodyRequests",
+        "source.streaming.bodyBatchWidth",
+        "source.streaming.containerAwareFill",
+        "source.streaming.bandwidthLimitBytesPerSecond",
+        "source.streaming.streamingPriority",
+        "source.streaming.segmentRetryCount",
+        "source.streaming.readTimeoutSeconds",
+        "source.streaming.writeTimeoutSeconds",
+        "source.streaming.segmentTimeoutSeconds",
+        "source.connections",
+        "source.connections.effectiveTotalDownloadLimit",
+        "source.connections.perStreamModeEnabled",
+        "source.connections.warmConnectionsEnabled",
+        "source.memory",
+        "source.memory.inFlightArticleBudgetBytes",
+        "source.memory.sharedStreamsEnabled",
+        "source.memory.sharedStreamRingBytes",
+        "source.memory.sharedStreamMaxEntries",
+        "source.memory.maxEntriesPerFile",
+        "source.memory.graceSeconds",
+        "source.memory.smallRangeMaximumBytes",
+        "source.segmentCache",
+        "source.segmentCache.enabled",
+        "source.segmentCache.maxBytes",
+        "source.repair",
+        "source.repair.backgroundEnabled",
+        "source.repair.par2Enabled",
+        "source.repair.degradedToleranceEnabled",
+        "source.repair.corruptionTrackingEnabled",
+        "source.providers",
+    ];
+
+    private static readonly HashSet<string> ForbiddenJsonPathSegments = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "path",
+        "host",
+        "user",
+        "pass",
+        "password",
+        "providerId",
+        "storageGroup",
+        "apiKey",
+    };
 
     private static void CollectJsonNames(JsonElement element, string path, List<string> offenders)
     {
@@ -187,25 +300,28 @@ public sealed class EffectiveStreamingConfigManifestTests
         }
     }
 
-    private static IEnumerable<string> CollectPropertyNames(Type type)
+    private static HashSet<string> CollectJsonPaths(JsonElement element)
     {
-        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        var paths = new HashSet<string>(StringComparer.Ordinal);
+        CollectJsonPaths(element, prefix: "", paths);
+        return paths;
+    }
+
+    private static void CollectJsonPaths(JsonElement element, string prefix, HashSet<string> paths)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
         {
-            yield return property.Name;
-            var propertyType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
-            if (propertyType.IsGenericType
-                && propertyType.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
+            foreach (var property in element.EnumerateObject())
             {
-                foreach (var nested in CollectPropertyNames(propertyType.GetGenericArguments()[0]))
-                    yield return nested;
+                var path = prefix.Length == 0 ? property.Name : $"{prefix}.{property.Name}";
+                paths.Add(path);
+                CollectJsonPaths(property.Value, path, paths);
             }
-            else if (propertyType.Namespace == typeof(EffectiveStreamingConfigDocument).Namespace
-                     && propertyType.IsClass
-                     && propertyType != typeof(string))
-            {
-                foreach (var nested in CollectPropertyNames(propertyType))
-                    yield return nested;
-            }
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in element.EnumerateArray())
+                CollectJsonPaths(item, prefix, paths);
         }
     }
 }

--- a/tests/NzbWebDAV.Tests/Services/Observability/PrometheusMetricsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Observability/PrometheusMetricsTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Connections;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Models;
@@ -10,6 +11,30 @@ namespace NzbWebDAV.Tests.Services.Observability;
 
 public sealed class PrometheusMetricsTests
 {
+    private static readonly string[] SegmentCacheMetricNames =
+    [
+        "nzbdav_segment_cache_enabled",
+        "nzbdav_segment_cache_catalog_ready",
+        "nzbdav_segment_cache_catalog_load_duration_seconds",
+        "nzbdav_segment_cache_entries",
+        "nzbdav_segment_cache_bytes",
+        "nzbdav_segment_cache_max_bytes",
+        "nzbdav_segment_cache_hits_total",
+        "nzbdav_segment_cache_misses_total",
+        "nzbdav_segment_cache_lookup_unavailable_total",
+        "nzbdav_segment_cache_bytes_served_total",
+        "nzbdav_segment_cache_batch_bypass_requests_total",
+        "nzbdav_segment_cache_batch_bypass_articles_total",
+        "nzbdav_segment_cache_write_attempts_total",
+        "nzbdav_segment_cache_write_commits_total",
+        "nzbdav_segment_cache_write_skipped_total",
+        "nzbdav_segment_cache_write_failures_total",
+        "nzbdav_segment_cache_read_failures_total",
+        "nzbdav_segment_cache_evictions_total",
+        "nzbdav_segment_cache_evicted_bytes_total",
+        "nzbdav_segment_cache_temporary_files_cleaned_total",
+    ];
+
     [Fact]
     public async Task RecordsOnlyBoundedSeekAndFetchLabels()
     {
@@ -130,6 +155,142 @@ public sealed class PrometheusMetricsTests
         Assert.DoesNotContain("nzbdav_health_check_gate_operations{", exposition);
         Assert.DoesNotContain("nzbdav_health_check_gate_limit{", exposition);
     }
+
+    [Fact]
+    public async Task SegmentCacheMetrics_RegisterWithoutDynamicLabels()
+    {
+        var registry = new CollectorRegistry();
+        var metrics = new PrometheusMetrics(registry);
+        metrics.SetSegmentCache(DisabledSnapshot());
+
+        var exposition = await ExportAsync(registry);
+        foreach (var name in SegmentCacheMetricNames)
+            Assert.Contains(name, exposition);
+
+        Assert.DoesNotContain("path=", exposition);
+        Assert.DoesNotContain("filename=", exposition);
+        Assert.DoesNotContain("message_id=", exposition);
+        Assert.DoesNotContain("provider_host=", exposition);
+        Assert.DoesNotContain("nzbdav_segment_cache_queued", exposition);
+        foreach (var line in exposition.Split('\n'))
+        {
+            if (!line.StartsWith("nzbdav_segment_cache_", StringComparison.Ordinal) || line.StartsWith('#'))
+                continue;
+            Assert.DoesNotContain("NaN", line);
+            Assert.DoesNotContain("+Inf", line);
+            Assert.DoesNotContain("-Inf", line);
+        }
+    }
+
+    [Fact]
+    public async Task SegmentCacheMetrics_ProjectDisabledInitialAndReadySnapshots()
+    {
+        var registry = new CollectorRegistry();
+        var metrics = new PrometheusMetrics(registry);
+
+        metrics.SetSegmentCache(DisabledSnapshot());
+        var disabled = await ExportAsync(registry);
+        Assert.Contains("nzbdav_segment_cache_enabled 0", disabled);
+        Assert.Contains("nzbdav_segment_cache_catalog_ready 0", disabled);
+
+        metrics.SetSegmentCache(new SegmentCacheSnapshot(
+            Enabled: true,
+            CatalogReady: false,
+            CatalogLoadDurationMs: null,
+            Entries: 0,
+            CurrentBytes: 0,
+            MaxBytes: 1024,
+            Hits: 0,
+            Misses: 0,
+            LookupUnavailable: 0,
+            BytesServed: 0,
+            BatchBypassRequests: 0,
+            BatchBypassArticles: 0,
+            WriteAttempts: 0,
+            WriteCommits: 0,
+            WriteSkipped: 0,
+            WriteFailures: 0,
+            ReadFailures: 0,
+            Evictions: 0,
+            BytesEvicted: 0,
+            TemporaryFilesCleaned: 0,
+            QueuedWriteBytes: null,
+            PeakQueuedWriteBytes: null));
+        var initial = await ExportAsync(registry);
+        Assert.Contains("nzbdav_segment_cache_enabled 1", initial);
+        Assert.Contains("nzbdav_segment_cache_catalog_ready 0", initial);
+        Assert.Contains("nzbdav_segment_cache_max_bytes 1024", initial);
+
+        var ready = ReadySnapshot();
+        metrics.SetSegmentCache(ready);
+        var readyExposition = await ExportAsync(registry);
+        Assert.Contains("nzbdav_segment_cache_catalog_ready 1", readyExposition);
+        Assert.Contains("nzbdav_segment_cache_catalog_load_duration_seconds 0.012", readyExposition);
+        Assert.Contains("nzbdav_segment_cache_entries 4", readyExposition);
+        Assert.Contains("nzbdav_segment_cache_bytes 40", readyExposition);
+        Assert.Contains("nzbdav_segment_cache_hits_total 3", readyExposition);
+        Assert.Contains("nzbdav_segment_cache_bytes_served_total 30", readyExposition);
+
+        metrics.SetSegmentCache(ready);
+        var second = await ExportAsync(registry);
+        Assert.Equal(
+            CountMetric(readyExposition, "nzbdav_segment_cache_hits_total"),
+            CountMetric(second, "nzbdav_segment_cache_hits_total"));
+        Assert.Contains("nzbdav_segment_cache_hits_total 3", second);
+    }
+
+    private static SegmentCacheSnapshot DisabledSnapshot() =>
+        new(
+            Enabled: false,
+            CatalogReady: false,
+            CatalogLoadDurationMs: null,
+            Entries: 0,
+            CurrentBytes: 0,
+            MaxBytes: 0,
+            Hits: 0,
+            Misses: 0,
+            LookupUnavailable: 0,
+            BytesServed: 0,
+            BatchBypassRequests: 0,
+            BatchBypassArticles: 0,
+            WriteAttempts: 0,
+            WriteCommits: 0,
+            WriteSkipped: 0,
+            WriteFailures: 0,
+            ReadFailures: 0,
+            Evictions: 0,
+            BytesEvicted: 0,
+            TemporaryFilesCleaned: 0,
+            QueuedWriteBytes: null,
+            PeakQueuedWriteBytes: null);
+
+    private static SegmentCacheSnapshot ReadySnapshot() =>
+        new(
+            Enabled: true,
+            CatalogReady: true,
+            CatalogLoadDurationMs: 12,
+            Entries: 4,
+            CurrentBytes: 40,
+            MaxBytes: 1024,
+            Hits: 3,
+            Misses: 1,
+            LookupUnavailable: 0,
+            BytesServed: 30,
+            BatchBypassRequests: 2,
+            BatchBypassArticles: 7,
+            WriteAttempts: 4,
+            WriteCommits: 3,
+            WriteSkipped: 1,
+            WriteFailures: 0,
+            ReadFailures: 0,
+            Evictions: 1,
+            BytesEvicted: 10,
+            TemporaryFilesCleaned: 2,
+            QueuedWriteBytes: null,
+            PeakQueuedWriteBytes: null);
+
+    private static int CountMetric(string exposition, string name) =>
+        exposition.Split('\n').Count(line => line.StartsWith(name, StringComparison.Ordinal) && !line.StartsWith('#'));
 
     private static async Task<string> ExportAsync(CollectorRegistry registry)
     {

--- a/tests/NzbWebDAV.Tests/Services/Observability/PrometheusMetricsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Observability/PrometheusMetricsTests.cs
@@ -172,10 +172,11 @@ public sealed class PrometheusMetricsTests
         Assert.DoesNotContain("message_id=", exposition);
         Assert.DoesNotContain("provider_host=", exposition);
         Assert.DoesNotContain("nzbdav_segment_cache_queued", exposition);
-        foreach (var line in exposition.Split('\n'))
+        foreach (var line in exposition.Split('\n')
+                     .Where(static line =>
+                         line.StartsWith("nzbdav_segment_cache_", StringComparison.Ordinal)
+                         && !line.StartsWith('#')))
         {
-            if (!line.StartsWith("nzbdav_segment_cache_", StringComparison.Ordinal) || line.StartsWith('#'))
-                continue;
             Assert.DoesNotContain("NaN", line);
             Assert.DoesNotContain("+Inf", line);
             Assert.DoesNotContain("-Inf", line);

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -6,8 +6,10 @@ using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
 using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Logging;
+using NzbWebDAV.Models;
 using NzbWebDAV.Services;
 using NzbWebDAV.Services.Diagnostics;
 using NzbWebDAV.Services.Metrics;
@@ -482,6 +484,121 @@ public sealed class SupportPackContentsTests : IDisposable
     }
 
     [Fact]
+    public async Task Pack_IncludesEffectiveStreamingConfigAndSegmentCacheMetrics()
+    {
+        var statistics = new SegmentCacheStatistics();
+        statistics.BeginGeneration(enabled: true, maxBytes: 2048);
+        statistics.RecordHit(32);
+        statistics.RecordMiss();
+        statistics.RecordBatchBypass(4);
+        var generation = statistics.BeginGeneration(enabled: true, maxBytes: 4096);
+        generation.SetCatalogReady(15, entries: 2, currentBytes: 64);
+
+        var entries = await ReadPackEntriesAsync(
+            new LogBufferSink(10),
+            new WarningLogBuffer(new LogBufferSink(50)),
+            segmentCacheStatistics: statistics);
+
+        Assert.True(entries.ContainsKey("configuration-effective-streaming.json"));
+        Assert.True(entries.ContainsKey("metrics/segment-cache.json"));
+        Assert.Contains("public benchmark extraction", entries["README.txt"]);
+
+        using var effective = JsonDocument.Parse(entries["configuration-effective-streaming.json"]);
+        Assert.Equal(1, effective.RootElement.GetProperty("schemaVersion").GetInt32());
+        Assert.Equal(40, effective.RootElement.GetProperty("streaming").GetProperty("articleBufferSize").GetInt32());
+        Assert.True(effective.RootElement.GetProperty("streaming").GetProperty("pipelinedBodyRequests").GetBoolean());
+        Assert.Equal(4, effective.RootElement.GetProperty("streaming").GetProperty("bodyBatchWidth").GetInt32());
+        Assert.True(effective.RootElement.GetProperty("segmentCache").GetProperty("enabled").GetBoolean());
+        Assert.Equal(
+            "default",
+            effective.RootElement.GetProperty("source").GetProperty("streaming").GetProperty("articleBufferSize").GetString());
+        Assert.DoesNotContain("/config/segment-cache", entries["configuration-effective-streaming.json"]);
+
+        using var cache = JsonDocument.Parse(entries["metrics/segment-cache.json"]);
+        Assert.Equal(1, cache.RootElement.GetProperty("schemaVersion").GetInt32());
+        var snapshot = cache.RootElement.GetProperty("cache");
+        Assert.True(snapshot.GetProperty("enabled").GetBoolean());
+        Assert.True(snapshot.GetProperty("catalogReady").GetBoolean());
+        Assert.Equal(15, snapshot.GetProperty("catalogLoadDurationMs").GetInt64());
+        Assert.Equal(2, snapshot.GetProperty("entries").GetInt64());
+        Assert.Equal(64, snapshot.GetProperty("currentBytes").GetInt64());
+        Assert.Equal(4096, snapshot.GetProperty("maxBytes").GetInt64());
+        Assert.Equal(1, snapshot.GetProperty("hits").GetInt64());
+        Assert.Equal(32, snapshot.GetProperty("bytesServed").GetInt64());
+        Assert.Equal(1, snapshot.GetProperty("misses").GetInt64());
+        Assert.Equal(1, snapshot.GetProperty("batchBypassRequests").GetInt64());
+        Assert.Equal(4, snapshot.GetProperty("batchBypassArticles").GetInt64());
+        Assert.Equal(JsonValueKind.Null, snapshot.GetProperty("queuedWriteBytes").ValueKind);
+
+        using var manifest = JsonDocument.Parse(entries["manifest.json"]);
+        Assert.Equal(5, manifest.RootElement.GetProperty("schemaVersion").GetInt32());
+        Assert.Equal(
+            "included",
+            manifest.RootElement.GetProperty("sections").GetProperty("configurationEffectiveStreaming").GetString());
+        Assert.Equal(
+            "included",
+            manifest.RootElement.GetProperty("sections").GetProperty("segmentCache").GetString());
+
+        var offenders = new List<string>();
+        CollectNonCamelCaseNames(effective.RootElement, "configuration-effective-streaming.json", offenders);
+        CollectNonCamelCaseNames(cache.RootElement, "metrics/segment-cache.json", offenders);
+        Assert.True(offenders.Count == 0, string.Join(", ", offenders));
+    }
+
+    [Fact]
+    public async Task Pack_EffectiveStreamingConfigOmitsSentinelSecrets()
+    {
+        var configManager = new ConfigManager();
+        configManager.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig
+                {
+                    Providers =
+                    [
+                        new UsenetProviderConfig.ConnectionDetails
+                        {
+                            ProviderId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+                            Type = ProviderType.Pooled,
+                            Host = "news.sentinel.example",
+                            Port = 563,
+                            UseSsl = true,
+                            User = "sentinel-user",
+                            Pass = "sentinel-pass",
+                            MaxConnections = 8,
+                            StorageGroup = "sentinel-group",
+                        },
+                    ],
+                }),
+            },
+            new ConfigItem { ConfigName = ConfigKeys.UsenetSegmentCachePath, ConfigValue = "/tmp/sentinel-cache" },
+            new ConfigItem { ConfigName = ConfigKeys.ApiKey, ConfigValue = "sentinel-api-key" },
+            new ConfigItem { ConfigName = ConfigKeys.WebdavPass, ConfigValue = "sentinel-webdav" },
+        ]);
+
+        var entries = await ReadPackEntriesAsync(
+            new LogBufferSink(10),
+            new WarningLogBuffer(new LogBufferSink(50)),
+            configManager: configManager);
+
+        var effective = entries["configuration-effective-streaming.json"];
+        var cache = entries["metrics/segment-cache.json"];
+        foreach (var forbidden in new[]
+                 {
+                     "news.sentinel.example", "sentinel-user", "sentinel-pass",
+                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "sentinel-group",
+                     "/tmp/sentinel-cache", "sentinel-api-key", "sentinel-webdav",
+                     "<msg@example>",
+                 })
+        {
+            Assert.DoesNotContain(forbidden, effective);
+            Assert.DoesNotContain(forbidden, cache);
+        }
+    }
+
+    [Fact]
     public async Task Pack_IncludesRetainedStreamTracesUntilDiscarded()
     {
         var buffer = new StreamTraceBuffer(100, enabled: false);
@@ -768,22 +885,28 @@ public sealed class SupportPackContentsTests : IDisposable
         LogBufferSink logBuffer,
         WarningLogBuffer warningBuffer,
         RuntimeUsageTracker? runtimeUsage = null,
-        ConcurrentReadTracker? concurrentReadTracker = null) =>
+        ConcurrentReadTracker? concurrentReadTracker = null,
+        SegmentCacheStatistics? segmentCacheStatistics = null,
+        ConfigManager? configManager = null) =>
         ReadPackEntriesAsync(
             logBuffer,
             warningBuffer,
             new StreamTraceBuffer(100, enabled: false),
             runtimeUsage,
-            concurrentReadTracker);
+            concurrentReadTracker,
+            segmentCacheStatistics,
+            configManager);
 
     private static async Task<Dictionary<string, string>> ReadPackEntriesAsync(
         LogBufferSink logBuffer,
         WarningLogBuffer warningBuffer,
         StreamTraceBuffer streamTraceBuffer,
         RuntimeUsageTracker? runtimeUsage = null,
-        ConcurrentReadTracker? concurrentReadTracker = null)
+        ConcurrentReadTracker? concurrentReadTracker = null,
+        SegmentCacheStatistics? segmentCacheStatistics = null,
+        ConfigManager? configManager = null)
     {
-        var configManager = new ConfigManager();
+        configManager ??= new ConfigManager();
         var websocketManager = new WebsocketManager();
         var usenet = new UsenetStreamingClient(
             configManager,
@@ -816,7 +939,9 @@ public sealed class SupportPackContentsTests : IDisposable
             par2RepairService,
             repairPatchStore,
             healthCheckConnectionGate,
-            concurrentReadTracker);
+            concurrentReadTracker,
+            queueCoordinator: null,
+            segmentCacheStatistics);
 
         using var memory = new MemoryStream();
         await service.WriteAsync(memory, CancellationToken.None);

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackRedactorTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackRedactorTests.cs
@@ -76,6 +76,16 @@ public class SupportPackRedactorTests
     }
 
     [Fact]
+    public void RedactText_StillRedactsSentinelSecretsInsideAllowlistedJson()
+    {
+        var redactor = new SupportPackRedactor(["sentinel-api-key"]);
+        var json = """{"schemaVersion":1,"streaming":{"note":"sentinel-api-key"}}""";
+        var result = redactor.RedactText(json);
+        Assert.DoesNotContain("sentinel-api-key", result);
+        Assert.Contains("[REDACTED]", result);
+    }
+
+    [Fact]
     public void RedactConfigurationValue_FailsClosedForMalformedStructuredConfig()
     {
         var redactor = new SupportPackRedactor([]);

--- a/tests/NzbWebDAV.Tests/Streams/RepeatableStreamingBenchmarkCoverageTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/RepeatableStreamingBenchmarkCoverageTests.cs
@@ -143,6 +143,136 @@ public sealed class RepeatableStreamingBenchmarkCoverageTests
         Assert.Equal(1 + GapFillLimits.MaxConsecutiveZeroFills, transport.BodyRequestCount);
     }
 
+    [Fact]
+    public async Task ProductionShapedPipelinedFixture_RecordsCurrentNonzeroWarmTransport()
+    {
+        var fixture = CreateFixture();
+        var cacheDir = Path.Join(Path.GetTempPath(), "nzbdav-streaming-pipelined-" + Guid.NewGuid().ToString("N"));
+        var statistics = new SegmentCacheStatistics();
+
+        try
+        {
+            var transport = fixture.CreateClient();
+            using var cached = new SegmentCacheNntpClient(
+                transport,
+                cacheDir,
+                maxBytes: fixture.Source.Length * 2L,
+                usageTracker: null,
+                metricsWriter: null,
+                enumerateCacheFiles: null,
+                statistics);
+            await WaitForCatalogAsync(cached);
+
+            var beforeCold = Capture(transport, fixture, statistics);
+            await AssertProductionReadMatchesAsync(cached, fixture);
+            var cold = Delta(beforeCold, Capture(transport, fixture, statistics), fixture.Source.Length);
+            Assert.Equal(fixture.Source.Length, cold.Bytes);
+            Assert.Equal(SegmentCount, cold.TransportRequests);
+            Assert.Equal(fixture.Source.Length, cold.TransportBytes);
+            Assert.Equal(2, cold.TransportBatchRequests);
+            Assert.Equal(0, cold.CacheHits);
+            Assert.Equal(1, cold.CacheMisses);
+            Assert.Equal(0, cold.CacheBytesServed);
+            Assert.Equal(2, cold.CacheBatchBypassRequests);
+            Assert.Equal(5, cold.CacheBatchBypassArticles);
+            Assert.Equal(1, cold.CacheWriteCommits);
+
+            var beforeWarm = Capture(transport, fixture, statistics);
+            await AssertProductionReadMatchesAsync(cached, fixture);
+            var warm = Delta(beforeWarm, Capture(transport, fixture, statistics), fixture.Source.Length);
+            Assert.Equal(fixture.Source.Length, warm.Bytes);
+            AssertPipelinedWarmTransportContract(warm.TransportRequests, warm.TransportBytes);
+            Assert.Equal(5, warm.TransportRequests);
+            Assert.Equal(5 * SegmentSize, warm.TransportBytes);
+            Assert.Equal(2, warm.TransportBatchRequests);
+            Assert.Equal(1, warm.CacheHits);
+            Assert.Equal(0, warm.CacheMisses);
+            Assert.Equal(SegmentSize, warm.CacheBytesServed);
+            Assert.Equal(2, warm.CacheBatchBypassRequests);
+            Assert.Equal(5, warm.CacheBatchBypassArticles);
+            Assert.Equal(0, warm.CacheWriteCommits);
+
+            var repeatBefore = Capture(transport, fixture, statistics);
+            await AssertProductionReadMatchesAsync(cached, fixture);
+            var repeat = Delta(repeatBefore, Capture(transport, fixture, statistics), fixture.Source.Length);
+            Assert.Equal(warm.TransportRequests, repeat.TransportRequests);
+            Assert.Equal(warm.TransportBytes, repeat.TransportBytes);
+            Assert.Equal(warm.CacheHits, repeat.CacheHits);
+            Assert.Equal(warm.CacheBatchBypassArticles, repeat.CacheBatchBypassArticles);
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+                Directory.Delete(cacheDir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// After the batch-local cache overlay, this helper must assert zero transport
+    /// requests and bytes. This measurement slice records the current nonzero bypass
+    /// so the fixture stays green until that overlay lands.
+    /// </summary>
+    internal static void AssertPipelinedWarmTransportContract(long transportRequests, long transportBytes)
+    {
+        Assert.True(
+            transportRequests > 0 && transportBytes > 0,
+            "Current pipelined warm re-read still reaches transport; the overlay PR must change this helper to assert zeros.");
+    }
+
+    private static Counters Capture(
+        FakeNntpClient transport,
+        Fixture fixture,
+        SegmentCacheStatistics statistics)
+    {
+        var snapshot = statistics.GetSnapshot();
+        return new Counters(
+            transport.BodyRequestCount,
+            transport.BodyRequestCounts.Sum(pair =>
+                fixture.Segments.TryGetValue(pair.Key, out var bytes) ? bytes.Length * (long)pair.Value : 0),
+            transport.BatchRequestCount,
+            snapshot.Hits,
+            snapshot.Misses,
+            snapshot.BytesServed,
+            snapshot.BatchBypassRequests,
+            snapshot.BatchBypassArticles,
+            snapshot.WriteCommits,
+            Bytes: 0);
+    }
+
+    private static Counters Delta(Counters before, Counters after, long bytes) =>
+        new(
+            after.TransportRequests - before.TransportRequests,
+            after.TransportBytes - before.TransportBytes,
+            after.TransportBatchRequests - before.TransportBatchRequests,
+            after.CacheHits - before.CacheHits,
+            after.CacheMisses - before.CacheMisses,
+            after.CacheBytesServed - before.CacheBytesServed,
+            after.CacheBatchBypassRequests - before.CacheBatchBypassRequests,
+            after.CacheBatchBypassArticles - before.CacheBatchBypassArticles,
+            after.CacheWriteCommits - before.CacheWriteCommits,
+            bytes);
+
+    private readonly record struct Counters(
+        long TransportRequests,
+        long TransportBytes,
+        long TransportBatchRequests,
+        long CacheHits,
+        long CacheMisses,
+        long CacheBytesServed,
+        long CacheBatchBypassRequests,
+        long CacheBatchBypassArticles,
+        long CacheWriteCommits,
+        long Bytes);
+
+    private static async Task AssertProductionReadMatchesAsync(INntpClient client, Fixture fixture)
+    {
+        await using var stream = fixture.CreateProductionShapedStream(client);
+        var buffer = new byte[fixture.Source.Length];
+        var read = await stream.ReadAtLeastAsync(buffer, buffer.Length, throwOnEndOfStream: true);
+        Assert.Equal(fixture.Source.Length, read);
+        Assert.Equal(fixture.Source, buffer);
+    }
+
     private static async Task AssertTransportDeltaAsync(
         FakeNntpClient transport,
         IReadOnlyDictionary<string, byte[]> servedSegments,
@@ -244,5 +374,16 @@ public sealed class RepeatableStreamingBenchmarkCoverageTests
         public NzbFileStream CreateStream(INntpClient client) =>
             new(SegmentIds, Source.Length, client, articleBufferSize: 0, segmentByteRanges: Ranges,
                 usePipelinedBodyRequests: false, fileName: "repeatable-streaming-benchmark.bin");
+
+        public NzbFileStream CreateProductionShapedStream(INntpClient client) =>
+            new(
+                SegmentIds,
+                Source.Length,
+                client,
+                articleBufferSize: 40,
+                segmentByteRanges: Ranges,
+                usePipelinedBodyRequests: true,
+                fileName: "repeatable-streaming-pipelined-benchmark.bin",
+                streamingBodyBatchWidth: 4);
     }
 }


### PR DESCRIPTION
## Summary
- Add production-shaped `pipelined-cold-read` / `pipelined-warm-reread` streaming scenarios (article buffer 40, pipelined BODY, batch width 4) so the deterministic report exercises the same batch path WebDAV uses.
- Record cache hits, misses, write outcomes, evictions, and current batch-bypass counters without changing cache data flow. Current warm re-read still performs 11 transport requests after a 12-segment cold prime; that nonzero result is the intended baseline signal.
- Expose unlabeled Prometheus cache metrics plus support-pack entries `configuration-effective-streaming.json` and `metrics/segment-cache.json` for public benchmark extraction. Existing unbuffered scenarios and PR `--deterministic-only` comparison are unchanged.

The later batch-local cache overlay must update only the new warm scenario’s deterministic baseline to zero transport requests and zero transport bytes. Do not special-case or skip that scenario in CI.

## Test plan
- [x] Focused tests: segment-cache counters/concurrency, production-shaped coverage, Prometheus projection, effective-config allowlist, support-pack entries
- [x] Generated three streaming candidates; deterministic maps agreed; merged only the two new scenario objects into `streaming-baseline.json`
- [x] `python3 scripts/check-performance-baseline.py --deterministic-only` against the merged baseline
- [x] `bash scripts/test-performance-baseline-gate.sh` including missing-scenario and warm-transport fixtures
- [ ] PR CI full frontend/backend gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed segment-cache monitoring for availability, hits, misses, reads, writes, failures, evictions, and temporary-file cleanup.
  * Support packages now include redacted effective streaming configuration and cache metrics.
  * Added pipelined cold-read and warm-reread performance scenarios.

* **Bug Fixes**
  * Improved handling of corrupted cache entries, partial reads, failed writes, and cache initialization issues.

* **Tests**
  * Expanded coverage for cache behavior, configuration redaction, observability metrics, support packages, and streaming performance gates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->