### PR TITLE
fix(usenet): warm rereads no longer re-download cached pipelined segments

### DIFF
--- a/backend.Benchmarks/Baselines/streaming-baseline.json
+++ b/backend.Benchmarks/Baselines/streaming-baseline.json
@@ -217,11 +217,11 @@
         "transportBytes": 3145728,
         "transportBatchRequests": 3,
         "cacheHits": 0,
-        "cacheMisses": 1,
+        "cacheMisses": 12,
         "cacheBytesServed": 0,
-        "cacheBatchBypassRequests": 3,
-        "cacheBatchBypassArticles": 11,
-        "cacheWriteCommits": 1
+        "cacheBatchBypassRequests": 0,
+        "cacheBatchBypassArticles": 0,
+        "cacheWriteCommits": 12
       },
       "timing": {
         "firstByteMs": {
@@ -249,14 +249,14 @@
     "pipelined-warm-reread": {
       "deterministic": {
         "bytes": 3145728,
-        "transportRequests": 11,
-        "transportBytes": 2883584,
-        "transportBatchRequests": 3,
-        "cacheHits": 1,
+        "transportRequests": 0,
+        "transportBytes": 0,
+        "transportBatchRequests": 0,
+        "cacheHits": 12,
         "cacheMisses": 0,
-        "cacheBytesServed": 262144,
-        "cacheBatchBypassRequests": 3,
-        "cacheBatchBypassArticles": 11,
+        "cacheBytesServed": 3145728,
+        "cacheBatchBypassRequests": 0,
+        "cacheBatchBypassArticles": 0,
         "cacheWriteCommits": 0
       },
       "timing": {

--- a/backend/Clients/Usenet/ArticleCachingNntpClient.cs
+++ b/backend/Clients/Usenet/ArticleCachingNntpClient.cs
@@ -356,7 +356,11 @@ public class ArticleCachingNntpClient(
             previousCompletion = responses[index];
         }
 
-        return new UsenetDecodedBodyBatch { Responses = responses };
+        return new UsenetDecodedBodyBatch
+        {
+            Responses = responses,
+            Completion = uncachedBatch?.Completion ?? Task.CompletedTask,
+        };
     }
 
     private static async Task<UsenetDecodedBodyResponse> CompleteInOrderAsync(

--- a/backend/Clients/Usenet/DownloadingNntpClient.cs
+++ b/backend/Clients/Usenet/DownloadingNntpClient.cs
@@ -103,8 +103,16 @@ public class DownloadingNntpClient : WrappingNntpClient
         ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken cancellationToken)
     {
         var semaphore = await AcquireExclusiveConnectionAsync(onConnectionReadyAgain, cancellationToken).ConfigureAwait(false);
-        return await base.DecodedBodyAsync(
-            segmentId, CreatePermitCompletion(semaphore, onConnectionReadyAgain), cancellationToken).ConfigureAwait(false);
+        var permit = CreatePermitCompletion(semaphore, onConnectionReadyAgain);
+        try
+        {
+            return await base.DecodedBodyAsync(segmentId, permit, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            permit(ArticleBodyResult.NotRetrieved, "body-setup");
+            throw;
+        }
     }
 
     public override async Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
@@ -113,17 +121,32 @@ public class DownloadingNntpClient : WrappingNntpClient
         CancellationToken cancellationToken)
     {
         var semaphore = await AcquireExclusiveConnectionAsync(onConnectionReadyAgain, cancellationToken).ConfigureAwait(false);
-        return await base.DecodedBodiesAsync(
-            segmentIds, CreatePermitCompletion(semaphore, onConnectionReadyAgain), cancellationToken).ConfigureAwait(false);
+        var permit = CreatePermitCompletion(semaphore, onConnectionReadyAgain);
+        try
+        {
+            return await base.DecodedBodiesAsync(segmentIds, permit, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            permit(ArticleBodyResult.NotRetrieved, "batch-setup");
+            throw;
+        }
     }
 
     public override async Task<UsenetDecodedArticleResponse> DecodedArticleAsync(SegmentId segmentId,
         ArticleBodyCompletionHandler? onConnectionReadyAgain, CancellationToken cancellationToken)
     {
         var semaphore = await AcquireExclusiveConnectionAsync(onConnectionReadyAgain, cancellationToken).ConfigureAwait(false);
-        return await base.DecodedArticleAsync(
-            segmentId, CreatePermitCompletion(semaphore, onConnectionReadyAgain), cancellationToken)
-            .ConfigureAwait(false);
+        var permit = CreatePermitCompletion(semaphore, onConnectionReadyAgain);
+        try
+        {
+            return await base.DecodedArticleAsync(segmentId, permit, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            permit(ArticleBodyResult.NotRetrieved, "article-setup");
+            throw;
+        }
     }
 
     private async Task<PrioritizedSemaphore> AcquireExclusiveConnectionAsync(ArticleBodyCompletionHandler? onConnectionReadyAgain,

--- a/backend/Clients/Usenet/LocalDataBatchOverlay.cs
+++ b/backend/Clients/Usenet/LocalDataBatchOverlay.cs
@@ -365,13 +365,11 @@ internal sealed class BatchCompletionState
     private readonly ArticleBodyCompletionHandler? _outer;
     private readonly CancellationToken _callerToken;
     private readonly bool _hasInnerBatch;
-    private int _innerCallbackSeen;
     private int _outerCallbackFired;
     private int _notFound;
     private int _cancelled;
     private ExceptionDispatchInfo? _firstFailure;
-    private ArticleBodyResult _innerResult = ArticleBodyResult.Retrieved;
-    private string? _innerReason;
+    private InnerCallback? _inner;
 
     public BatchCompletionState(
         ArticleBodyCompletionHandler? outer,
@@ -385,10 +383,8 @@ internal sealed class BatchCompletionState
 
     public void RecordInner(ArticleBodyResult result, string? reason)
     {
-        if (Interlocked.Exchange(ref _innerCallbackSeen, 1) != 0)
-            return;
-        _innerResult = result;
-        _innerReason = reason;
+        var payload = new InnerCallback(result, reason);
+        Interlocked.CompareExchange(ref _inner, payload, null);
     }
 
     public void ObserveResponse(UsenetDecodedBodyResponse response)
@@ -429,7 +425,7 @@ internal sealed class BatchCompletionState
         if (innerFailure is not null)
             ObserveFailure(innerFailure);
 
-        if (Volatile.Read(ref _innerCallbackSeen) == 0 && _hasInnerBatch)
+        if (Volatile.Read(ref _inner) is null && _hasInnerBatch)
             RecordInner(ArticleBodyResult.NotRetrieved, "inner-callback-missing");
 
         FireOuterOnce(SelectResult(), SelectReason());
@@ -448,16 +444,17 @@ internal sealed class BatchCompletionState
 
     private ArticleBodyResult SelectResult()
     {
+        var inner = Volatile.Read(ref _inner);
         if (Volatile.Read(ref _firstFailure) is not null)
             return ArticleBodyResult.NotRetrieved;
         if (Volatile.Read(ref _cancelled) != 0)
             return ArticleBodyResult.Cancelled;
-        if (_hasInnerBatch && _innerResult == ArticleBodyResult.NotRetrieved)
+        if (_hasInnerBatch && inner?.Result == ArticleBodyResult.NotRetrieved)
             return ArticleBodyResult.NotRetrieved;
-        if (_hasInnerBatch && _innerResult == ArticleBodyResult.Cancelled)
+        if (_hasInnerBatch && inner?.Result == ArticleBodyResult.Cancelled)
             return ArticleBodyResult.Cancelled;
         if (Volatile.Read(ref _notFound) != 0 ||
-            (_hasInnerBatch && _innerResult == ArticleBodyResult.NotFound))
+            (_hasInnerBatch && inner?.Result == ArticleBodyResult.NotFound))
         {
             return ArticleBodyResult.NotFound;
         }
@@ -467,14 +464,15 @@ internal sealed class BatchCompletionState
 
     private string? SelectReason()
     {
+        var inner = Volatile.Read(ref _inner);
         var result = SelectResult();
         return result switch
         {
             ArticleBodyResult.NotRetrieved when Volatile.Read(ref _firstFailure) is not null
                 => "overlay-lifecycle-failure",
-            ArticleBodyResult.NotRetrieved => _innerReason,
-            ArticleBodyResult.Cancelled => _innerReason,
-            ArticleBodyResult.NotFound => _innerReason,
+            ArticleBodyResult.NotRetrieved => inner?.Reason,
+            ArticleBodyResult.Cancelled => inner?.Reason,
+            ArticleBodyResult.NotFound => inner?.Reason,
             _ => null,
         };
     }
@@ -498,6 +496,8 @@ internal sealed class BatchCompletionState
             return exception;
         }
     }
+
+    private sealed record InnerCallback(ArticleBodyResult Result, string? Reason);
 }
 
 internal sealed class OrderedBatchYencStream : YencStream

--- a/backend/Clients/Usenet/LocalDataBatchOverlay.cs
+++ b/backend/Clients/Usenet/LocalDataBatchOverlay.cs
@@ -1,0 +1,605 @@
+using System.Runtime.ExceptionServices;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Clients.Usenet;
+
+internal sealed record LocalBatchHit(
+    int OriginalIndex,
+    SegmentId RequestedId,
+    UsenetDecodedBodyResponse Response);
+
+internal sealed record RemoteBatchMiss(
+    int OriginalIndex,
+    int RemoteIndex,
+    SegmentId RequestedId);
+
+internal sealed record LocalBatchPartition(
+    IReadOnlyList<LocalBatchHit> Hits,
+    IReadOnlyList<RemoteBatchMiss> Misses);
+
+internal readonly struct LocalLookupResult
+{
+    public bool Found { get; }
+    public UsenetDecodedBodyResponse? Response { get; }
+
+    private LocalLookupResult(bool found, UsenetDecodedBodyResponse? response)
+    {
+        Found = found;
+        Response = response;
+    }
+
+    public static LocalLookupResult Miss => default;
+
+    public static LocalLookupResult Hit(UsenetDecodedBodyResponse response) =>
+        new(true, response ?? throw new ArgumentNullException(nameof(response)));
+}
+
+/// <summary>
+/// Ordered local-data overlay for pipelined BODY batches. Store-specific lookup and
+/// cache population stay in the owning wrappers; this helper owns partition, merge,
+/// readiness gating, and the exactly-once aggregate callback.
+/// </summary>
+internal static class LocalDataBatchOverlay
+{
+    internal static Task<UsenetDecodedBodyResponse> PassThroughRemote(
+        SegmentId _,
+        UsenetDecodedBodyResponse response,
+        CancellationToken __) =>
+        Task.FromResult(response);
+
+    internal static async Task<UsenetDecodedBodyBatch> ExecuteAsync(
+        IReadOnlyList<SegmentId> segmentIds,
+        ArticleBodyCompletionHandler? outerCallback,
+        Func<SegmentId, LocalLookupResult> tryOpenLocal,
+        Func<IReadOnlyList<SegmentId>, ArticleBodyCompletionHandler, CancellationToken,
+            Task<UsenetDecodedBodyBatch>> fetchMisses,
+        Func<SegmentId, UsenetDecodedBodyResponse, CancellationToken,
+            Task<UsenetDecodedBodyResponse>> transformRemote,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(segmentIds);
+        ArgumentNullException.ThrowIfNull(tryOpenLocal);
+        ArgumentNullException.ThrowIfNull(fetchMisses);
+        ArgumentNullException.ThrowIfNull(transformRemote);
+        if (segmentIds.Count == 0)
+        {
+            throw new ArgumentException("At least one segment ID is required.", nameof(segmentIds));
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            ArticleBodyCompletion.InvokeContained(outerCallback, ArticleBodyResult.Cancelled);
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        LocalBatchPartition partition;
+        try
+        {
+            partition = Partition(segmentIds, tryOpenLocal, cancellationToken);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            var cancelled = exception is OperationCanceledException &&
+                            cancellationToken.IsCancellationRequested;
+            ArticleBodyCompletion.InvokeContained(
+                outerCallback,
+                cancelled ? ArticleBodyResult.Cancelled : ArticleBodyResult.NotRetrieved,
+                cancelled ? null : "local-batch-setup");
+            throw;
+        }
+
+        var output = CreateOutputSources(segmentIds.Count);
+        var responses = new Task<UsenetDecodedBodyResponse>[output.Length];
+        for (var index = 0; index < output.Length; index++)
+            responses[index] = output[index].Task;
+
+        if (partition.Misses.Count == 0)
+        {
+            var state = new BatchCompletionState(outerCallback, hasInnerBatch: false, cancellationToken);
+            var publisher = PublishInOrderAsync(
+                segmentIds, partition, inner: null, output, state, transformRemote, cancellationToken);
+#pragma warning disable CA2025 // returned Completion observes the publisher; callers own returned local streams
+            return new UsenetDecodedBodyBatch
+            {
+                Responses = responses,
+                Completion = state.CompleteAsync(publisher, Task.CompletedTask),
+            };
+#pragma warning restore CA2025
+        }
+
+        var deferred = new DeferredArticleBodyCallback();
+        var abandonCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        UsenetDecodedBodyBatch? inner = null;
+        var mismatchHandled = false;
+        try
+        {
+            var missIds = new SegmentId[partition.Misses.Count];
+            for (var index = 0; index < partition.Misses.Count; index++)
+                missIds[index] = partition.Misses[index].RequestedId;
+
+            inner = await fetchMisses(missIds, deferred.Invoke, abandonCts.Token)
+                .ConfigureAwait(false);
+            if (inner.Responses.Count != partition.Misses.Count)
+            {
+                await DrainMismatchedBatchAsync(inner, abandonCts).ConfigureAwait(false);
+                deferred.Discard();
+                DisposeHits(partition.Hits);
+                ArticleBodyCompletion.InvokeContained(
+                    outerCallback, ArticleBodyResult.NotRetrieved, "batch-response-count-mismatch");
+                mismatchHandled = true;
+                throw new InvalidOperationException(
+                    $"Pipelined BODY returned {inner.Responses.Count} responses for {partition.Misses.Count} requests.");
+            }
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            if (!mismatchHandled)
+            {
+                deferred.Discard();
+                DisposeHits(partition.Hits);
+                if (inner is not null)
+                    await ObserveCompletionAsync(inner.Completion).ConfigureAwait(false);
+                ArticleBodyCompletion.InvokeContained(
+                    outerCallback, ArticleBodyResult.NotRetrieved, "local-batch-setup");
+            }
+
+            abandonCts.Dispose();
+            throw;
+        }
+
+        var overlayState = new BatchCompletionState(outerCallback, hasInnerBatch: true, cancellationToken);
+        deferred.Activate(overlayState.RecordInner);
+        var overlayPublisher = PublishInOrderAsync(
+            segmentIds, partition, inner, output, overlayState, transformRemote, cancellationToken);
+#pragma warning disable CA2025 // Completion owns abandonCts and disposes it after overlay and inner lifecycle finish
+        return new UsenetDecodedBodyBatch
+        {
+            Responses = responses,
+            Completion = CompleteThenDisposeAsync(
+                overlayState.CompleteAsync(overlayPublisher, inner.Completion),
+                abandonCts),
+        };
+#pragma warning restore CA2025
+    }
+
+    private static LocalBatchPartition Partition(
+        IReadOnlyList<SegmentId> segmentIds,
+        Func<SegmentId, LocalLookupResult> tryOpenLocal,
+        CancellationToken cancellationToken)
+    {
+        var hits = new List<LocalBatchHit>();
+        var misses = new List<RemoteBatchMiss>();
+        try
+        {
+            for (var index = 0; index < segmentIds.Count; index++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var requested = segmentIds[index];
+                var lookup = tryOpenLocal(requested);
+                if (lookup.Found && lookup.Response is not null)
+                {
+                    hits.Add(new LocalBatchHit(index, requested, lookup.Response));
+                }
+                else
+                {
+                    misses.Add(new RemoteBatchMiss(index, misses.Count, requested));
+                }
+            }
+
+            return new LocalBatchPartition(hits, misses);
+        }
+        catch
+        {
+            DisposeHits(hits);
+            throw;
+        }
+    }
+
+    private static TaskCompletionSource<UsenetDecodedBodyResponse>[] CreateOutputSources(int count)
+    {
+        var output = new TaskCompletionSource<UsenetDecodedBodyResponse>[count];
+        for (var index = 0; index < count; index++)
+        {
+            output[index] = new TaskCompletionSource<UsenetDecodedBodyResponse>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        return output;
+    }
+
+    private static async Task PublishInOrderAsync(
+        IReadOnlyList<SegmentId> requested,
+        LocalBatchPartition partition,
+        UsenetDecodedBodyBatch? inner,
+        TaskCompletionSource<UsenetDecodedBodyResponse>[] output,
+        BatchCompletionState state,
+        Func<SegmentId, UsenetDecodedBodyResponse, CancellationToken,
+            Task<UsenetDecodedBodyResponse>> transformRemote,
+        CancellationToken cancellationToken)
+    {
+        var localByIndex = new LocalBatchHit?[requested.Count];
+        foreach (var hit in partition.Hits)
+            localByIndex[hit.OriginalIndex] = hit;
+
+        var missByIndex = new RemoteBatchMiss?[requested.Count];
+        foreach (var miss in partition.Misses)
+            missByIndex[miss.OriginalIndex] = miss;
+
+        Task previousTerminal = Task.CompletedTask;
+        for (var index = 0; index < requested.Count; index++)
+        {
+            await ObserveForOrderingAsync(previousTerminal).ConfigureAwait(false);
+
+            try
+            {
+                UsenetDecodedBodyResponse response;
+                if (localByIndex[index] is { } local)
+                {
+                    response = local.Response;
+                }
+                else
+                {
+                    var miss = missByIndex[index]!;
+                    response = await inner!.Responses[miss.RemoteIndex].ConfigureAwait(false);
+                    response = await transformRemote(miss.RequestedId, response, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+
+                if (response.Stream is null)
+                {
+                    output[index].TrySetResult(response);
+                    previousTerminal = Task.CompletedTask;
+                    state.ObserveResponse(response);
+                    continue;
+                }
+
+                var terminal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                response = response with
+                {
+                    Stream = new OrderedBatchYencStream(
+                        response.Stream,
+                        terminal,
+                        state.ObserveStreamTerminal),
+                };
+
+                output[index].TrySetResult(response);
+                previousTerminal = terminal.Task;
+                state.ObserveResponse(response);
+            }
+            catch (Exception exception) when (exception is not OutOfMemoryException)
+            {
+                state.ObserveFailure(exception);
+                output[index].TrySetException(exception);
+                previousTerminal = Task.CompletedTask;
+            }
+        }
+
+        await ObserveForOrderingAsync(previousTerminal).ConfigureAwait(false);
+    }
+
+    private static async Task ObserveForOrderingAsync(Task previous)
+    {
+        try
+        {
+            await previous.ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            // Predecessor already recorded and surfaced on its own response/stream path.
+        }
+    }
+
+    private static async Task DrainMismatchedBatchAsync(
+        UsenetDecodedBodyBatch inner,
+        CancellationTokenSource abandonCts)
+    {
+        try
+        {
+            await abandonCts.CancelAsync().ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            // Drain still has to run so the inner lifecycle can finish.
+        }
+
+        foreach (var responseTask in inner.Responses)
+        {
+            try
+            {
+                var response = await responseTask.ConfigureAwait(false);
+                if (response.Stream is not null)
+                    await response.Stream.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception exception) when (exception is not OutOfMemoryException)
+            {
+                // Continue so every supplied response and the inner completion are observed.
+            }
+        }
+
+        await ObserveCompletionAsync(inner.Completion).ConfigureAwait(false);
+    }
+
+    private static async Task ObserveCompletionAsync(Task completion)
+    {
+        try
+        {
+            await completion.ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            // Observed so the producer cannot become unobserved.
+        }
+    }
+
+    private static async Task CompleteThenDisposeAsync(Task completion, CancellationTokenSource abandonCts)
+    {
+        try
+        {
+            await completion.ConfigureAwait(false);
+        }
+        finally
+        {
+            abandonCts.Dispose();
+        }
+    }
+
+    private static void DisposeHits(IEnumerable<LocalBatchHit> hits)
+    {
+        foreach (var hit in hits)
+        {
+            try
+            {
+                hit.Response.Stream?.Dispose();
+            }
+            catch (Exception exception) when (exception is not OutOfMemoryException)
+            {
+                // Setup cleanup must continue for every already-opened local stream.
+            }
+        }
+    }
+}
+
+internal sealed class BatchCompletionState
+{
+    private readonly ArticleBodyCompletionHandler? _outer;
+    private readonly CancellationToken _callerToken;
+    private readonly bool _hasInnerBatch;
+    private int _innerCallbackSeen;
+    private int _outerCallbackFired;
+    private int _notFound;
+    private int _cancelled;
+    private ExceptionDispatchInfo? _firstFailure;
+    private ArticleBodyResult _innerResult = ArticleBodyResult.Retrieved;
+    private string? _innerReason;
+
+    public BatchCompletionState(
+        ArticleBodyCompletionHandler? outer,
+        bool hasInnerBatch,
+        CancellationToken callerToken)
+    {
+        _outer = outer;
+        _callerToken = callerToken;
+        _hasInnerBatch = hasInnerBatch;
+    }
+
+    public void RecordInner(ArticleBodyResult result, string? reason)
+    {
+        if (Interlocked.Exchange(ref _innerCallbackSeen, 1) != 0)
+            return;
+        _innerResult = result;
+        _innerReason = reason;
+    }
+
+    public void ObserveResponse(UsenetDecodedBodyResponse response)
+    {
+        if (response.ResponseType == UsenetResponseType.NoArticleWithThatMessageId ||
+            UsenetArticleAvailability.IsDefinitiveMissing(response))
+        {
+            Interlocked.Increment(ref _notFound);
+        }
+    }
+
+    public void ObserveStreamTerminal(Exception? failure)
+    {
+        if (failure is not null)
+            ObserveFailure(failure);
+    }
+
+    public void ObserveFailure(Exception exception)
+    {
+        if (exception is OperationCanceledException && _callerToken.IsCancellationRequested)
+        {
+            Volatile.Write(ref _cancelled, 1);
+            return;
+        }
+
+        Interlocked.CompareExchange(
+            ref _firstFailure,
+            ExceptionDispatchInfo.Capture(exception),
+            null);
+    }
+
+    public async Task CompleteAsync(Task publisher, Task innerCompletion)
+    {
+        var publisherFailure = await ObserveAsync(publisher).ConfigureAwait(false);
+        var innerFailure = await ObserveAsync(innerCompletion).ConfigureAwait(false);
+        if (publisherFailure is not null)
+            ObserveFailure(publisherFailure);
+        if (innerFailure is not null)
+            ObserveFailure(innerFailure);
+
+        if (Volatile.Read(ref _innerCallbackSeen) == 0 && _hasInnerBatch)
+            RecordInner(ArticleBodyResult.NotRetrieved, "inner-callback-missing");
+
+        FireOuterOnce(SelectResult(), SelectReason());
+
+        var firstFailure = Volatile.Read(ref _firstFailure);
+        if (firstFailure is null)
+            return;
+        if (firstFailure.SourceException is OperationCanceledException &&
+            _callerToken.IsCancellationRequested)
+        {
+            return;
+        }
+
+        firstFailure.Throw();
+    }
+
+    private ArticleBodyResult SelectResult()
+    {
+        if (Volatile.Read(ref _firstFailure) is not null)
+            return ArticleBodyResult.NotRetrieved;
+        if (Volatile.Read(ref _cancelled) != 0)
+            return ArticleBodyResult.Cancelled;
+        if (_hasInnerBatch && _innerResult == ArticleBodyResult.NotRetrieved)
+            return ArticleBodyResult.NotRetrieved;
+        if (_hasInnerBatch && _innerResult == ArticleBodyResult.Cancelled)
+            return ArticleBodyResult.Cancelled;
+        if (Volatile.Read(ref _notFound) != 0 ||
+            (_hasInnerBatch && _innerResult == ArticleBodyResult.NotFound))
+        {
+            return ArticleBodyResult.NotFound;
+        }
+
+        return ArticleBodyResult.Retrieved;
+    }
+
+    private string? SelectReason()
+    {
+        var result = SelectResult();
+        return result switch
+        {
+            ArticleBodyResult.NotRetrieved when Volatile.Read(ref _firstFailure) is not null
+                => "overlay-lifecycle-failure",
+            ArticleBodyResult.NotRetrieved => _innerReason,
+            ArticleBodyResult.Cancelled => _innerReason,
+            ArticleBodyResult.NotFound => _innerReason,
+            _ => null,
+        };
+    }
+
+    private void FireOuterOnce(ArticleBodyResult result, string? reason)
+    {
+        if (Interlocked.Exchange(ref _outerCallbackFired, 1) != 0)
+            return;
+        ArticleBodyCompletion.InvokeContained(_outer, result, reason);
+    }
+
+    private static async Task<Exception?> ObserveAsync(Task task)
+    {
+        try
+        {
+            await task.ConfigureAwait(false);
+            return null;
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            return exception;
+        }
+    }
+}
+
+internal sealed class OrderedBatchYencStream : YencStream
+{
+    private readonly YencStream _inner;
+    private readonly TaskCompletionSource _terminal;
+    private readonly Action<Exception?> _observeTerminal;
+    private int _signaled;
+    private int _disposed;
+
+    public OrderedBatchYencStream(
+        YencStream inner,
+        TaskCompletionSource terminal,
+        Action<Exception?> observeTerminal)
+        : base(Null)
+    {
+        _inner = inner;
+        _terminal = terminal;
+        _observeTerminal = observeTerminal;
+    }
+
+    public override ValueTask<UsenetYencHeader?> GetYencHeadersAsync(
+        CancellationToken cancellationToken = default) =>
+        _inner.GetYencHeadersAsync(cancellationToken);
+
+    public override async ValueTask<int> ReadAsync(
+        Memory<byte> buffer,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var read = await _inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+                Signal(null);
+            return read;
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            Signal(exception);
+            throw;
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (!disposing)
+            return;
+
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            Signal(null);
+            return;
+        }
+
+        Exception? failure = null;
+        try
+        {
+            _inner.Dispose();
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            failure = exception;
+            throw;
+        }
+        finally
+        {
+            Signal(failure);
+            base.Dispose(disposing);
+        }
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            Signal(null);
+            await base.DisposeAsync().ConfigureAwait(false);
+            return;
+        }
+
+        Exception? failure = null;
+        try
+        {
+            await _inner.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            failure = exception;
+            throw;
+        }
+        finally
+        {
+            Signal(failure);
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private void Signal(Exception? failure)
+    {
+        if (Interlocked.Exchange(ref _signaled, 1) != 0)
+            return;
+        _observeTerminal(failure);
+        _terminal.TrySetResult();
+    }
+}

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using NzbWebDAV.Clients.Usenet.Concurrency;
 using NzbWebDAV.Clients.Usenet.Connections;
 using NzbWebDAV.Clients.Usenet.Contexts;
@@ -360,42 +361,55 @@ public class MultiConnectionNntpClient(
                     wrapped[i] = RecordSuccessfulResponseAsync(batch.Responses[i], issuedAt, workload, operation);
 
                 var callbackInvoked = 0;
+                var callbackCompletion = new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
                 deferredCallback.Activate(OnConnectionReadyAgain);
-                return new UsenetDecodedBodyBatch { Responses = wrapped };
+                return new UsenetDecodedBodyBatch
+                {
+                    Responses = wrapped,
+                    Completion = CompleteBatchLifecycleAsync(batch.Completion, callbackCompletion.Task),
+                };
 
                 void OnConnectionReadyAgain(ArticleBodyResult result, string? failureReason)
                 {
                     if (Interlocked.Exchange(ref callbackInvoked, 1) != 0) return;
-                    switch (result)
+                    try
                     {
-                        case ArticleBodyResult.Retrieved:
-                            circuitBreaker.RecordSuccess(probe: probeLease);
-                            break;
-                        case ArticleBodyResult.NotFound:
-                            circuitBreaker.RecordArticleNotFound(probeLease);
-                            break;
-                        case ArticleBodyResult.Cancelled:
-                            break;
-                        case ArticleBodyResult.NotRetrieved:
-                            // Seek/abort cancels mid-pipeline; UsenetSharp reports NotRetrieved
-                            // (socket unsafe to reuse). Replace the connection but do not treat
-                            // client cancellation as provider health failure.
-                            LogException(() => connectionLock.Replace("pipelined-body-not-retrieved"));
-                            if (!ct.IsCancellationRequested)
+                        switch (result)
+                        {
+                            case ArticleBodyResult.Retrieved:
+                                circuitBreaker.RecordSuccess(probe: probeLease);
+                                break;
+                            case ArticleBodyResult.NotFound:
+                                circuitBreaker.RecordArticleNotFound(probeLease);
+                                break;
+                            case ArticleBodyResult.Cancelled:
+                                break;
+                            case ArticleBodyResult.NotRetrieved:
+                                // Seek/abort cancels mid-pipeline; UsenetSharp reports NotRetrieved
+                                // (socket unsafe to reuse). Replace the connection but do not treat
+                                // client cancellation as provider health failure.
+                                LogException(() => connectionLock.Replace("pipelined-body-not-retrieved"));
+                                if (!ct.IsCancellationRequested)
+                                    RecordProviderFailure(failureReason is null
+                                        ? $"pipeline-callback-{result}"
+                                        : $"pipeline-callback-{result} ({failureReason})", probeLease);
+                                break;
+                            default:
                                 RecordProviderFailure(failureReason is null
                                     ? $"pipeline-callback-{result}"
                                     : $"pipeline-callback-{result} ({failureReason})", probeLease);
-                            break;
-                        default:
-                            RecordProviderFailure(failureReason is null
-                                ? $"pipeline-callback-{result}"
-                                : $"pipeline-callback-{result} ({failureReason})", probeLease);
-                            LogException(() => connectionLock.Replace($"pipelined-body-{result}"));
-                            break;
-                    }
+                                LogException(() => connectionLock.Replace($"pipelined-body-{result}"));
+                                break;
+                        }
 
-                    LogException(connectionLock.Dispose);
-                    LogException(() => onConnectionReadyAgain?.Invoke(result, failureReason));
+                        LogException(connectionLock.Dispose);
+                        LogException(() => onConnectionReadyAgain?.Invoke(result, failureReason));
+                    }
+                    finally
+                    {
+                        callbackCompletion.TrySetResult();
+                    }
                 }
             }
             catch (Exception e) when (
@@ -1182,6 +1196,31 @@ public class MultiConnectionNntpClient(
         return new NntpClientRetiredException(
             $"Connection pool for provider '{Host}' retired while the request was waiting.",
             inner);
+    }
+
+    private static async Task CompleteBatchLifecycleAsync(Task transportCompletion, Task callbackCompletion)
+    {
+        Exception? first = null;
+        try
+        {
+            await transportCompletion.ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            first = exception;
+        }
+
+        try
+        {
+            await callbackCompletion.ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            first ??= exception;
+        }
+
+        if (first is not null)
+            ExceptionDispatchInfo.Capture(first).Throw();
     }
 
     private async Task<UsenetDecodedBodyResponse> RecordSuccessfulResponseAsync(

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -390,10 +390,11 @@ public class MultiProviderNntpClient(
             {
                 var provider = orderedProviders[providerIndex];
                 var deferredCallback = new DeferredArticleBodyCallback();
+                UsenetDecodedBodyBatch? primaryBatch = null;
                 try
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    var primaryBatch = await provider.DecodedBodiesAsync(
+                    primaryBatch = await provider.DecodedBodiesAsync(
                         segmentIds, deferredCallback.Invoke, cancellationToken).ConfigureAwait(false);
                     var coordinator = new BatchCallbackCoordinator(
                     primaryBatch.Responses.Count, CompleteBatchFetches);
@@ -425,10 +426,16 @@ public class MultiProviderNntpClient(
 #pragma warning restore CA2025
                         previousFallbackAdmission = fallbackAdmission.Task;
                     }
-                    return new UsenetDecodedBodyBatch { Responses = responses };
+                    return new UsenetDecodedBodyBatch
+                    {
+                        Responses = responses,
+                        Completion = ComposeBatchCompletionAsync(
+                            primaryBatch.Completion, coordinator.Completion),
+                    };
                 }
                 catch (NntpClientRetiredException)
                 {
+                    ObserveAbandonedBatch(primaryBatch);
                     // Every provider in this client belongs to the same retired generation.
                     // Do not walk the remaining disposed pools or record network failures.
                     deferredCallback.Discard();
@@ -438,6 +445,7 @@ public class MultiProviderNntpClient(
                 }
                 catch (Exception e) when (e.TryGetCausingException(out UsenetArticleNotFoundException? _) && e is not OutOfMemoryException)
                 {
+                    ObserveAbandonedBatch(primaryBatch);
                     // Invalid / permanently missing segment ids are invalid on every provider.
                     deferredCallback.Discard();
                     ArticleBodyCompletion.InvokeContained(
@@ -446,11 +454,13 @@ public class MultiProviderNntpClient(
                 }
                 catch (Exception e) when (!e.IsCancellationException(cancellationToken) && e is not OutOfMemoryException)
                 {
+                    ObserveAbandonedBatch(primaryBatch);
                     deferredCallback.Discard();
                     lastException = ExceptionDispatchInfo.Capture(e);
                 }
                 catch
                 {
+                    ObserveAbandonedBatch(primaryBatch);
                     deferredCallback.Discard();
                     ArticleBodyCompletion.InvokeContained(
                         CompleteBatchFetches, ArticleBodyResult.NotRetrieved);
@@ -731,6 +741,49 @@ public class MultiProviderNntpClient(
         }
     }
 
+    private static async Task ComposeBatchCompletionAsync(Task transportCompletion, Task coordinatorCompletion)
+    {
+        Exception? first = null;
+        try
+        {
+            await transportCompletion.ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            first = exception;
+        }
+
+        try
+        {
+            await coordinatorCompletion.ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            first ??= exception;
+        }
+
+        if (first is not null)
+            ExceptionDispatchInfo.Capture(first).Throw();
+    }
+
+    private static void ObserveAbandonedBatch(UsenetDecodedBodyBatch? batch)
+    {
+        if (batch is null) return;
+        _ = ObserveAbandonedBatchCompletionAsync(batch.Completion);
+    }
+
+    private static async Task ObserveAbandonedBatchCompletionAsync(Task completion)
+    {
+        try
+        {
+            await completion.ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            Log.Debug(exception, "Abandoned pipelined BODY batch completion failed");
+        }
+    }
+
     private sealed class BatchCallbackCoordinator(
         int responseCount,
         ArticleBodyCompletionHandler? callback)
@@ -778,19 +831,34 @@ public class MultiProviderNntpClient(
 
         private void CompleteOne()
         {
-            if (Interlocked.Decrement(ref _remaining) != 0 ||
-                Interlocked.Exchange(ref _callbackInvoked, 1) != 0)
+            if (Interlocked.Decrement(ref _remaining) != 0)
+                return;
+
+            if (Interlocked.Exchange(ref _callbackInvoked, 1) != 0)
             {
+                _completion.TrySetResult();
                 return;
             }
 
-            var failed = Volatile.Read(ref _transportFailed) != 0 ||
-                         Volatile.Read(ref _resolutionFailed) != 0;
-            ArticleBodyCompletion.InvokeContained(
-                callback,
-                failed ? ArticleBodyResult.NotRetrieved : ArticleBodyResult.Retrieved,
-                failed ? Volatile.Read(ref _firstFailureReason) : null);
+            try
+            {
+                var failed = Volatile.Read(ref _transportFailed) != 0 ||
+                             Volatile.Read(ref _resolutionFailed) != 0;
+                ArticleBodyCompletion.InvokeContained(
+                    callback,
+                    failed ? ArticleBodyResult.NotRetrieved : ArticleBodyResult.Retrieved,
+                    failed ? Volatile.Read(ref _firstFailureReason) : null);
+            }
+            finally
+            {
+                _completion.TrySetResult();
+            }
         }
+
+        public Task Completion => _completion.Task;
+
+        private readonly TaskCompletionSource _completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 
     public override async Task<UsenetDecodedArticleResponse> DecodedArticleAsync

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -310,6 +310,7 @@ public abstract class NntpClient : INntpClient
             var batch = await DecodedBodiesAsync(
                 batchIds, onConnectionReadyAgain: null, batchCts.Token).ConfigureAwait(false);
             var position = 0;
+            var fullyEnumerated = false;
             try
             {
                 for (; position < batch.Responses.Count; position++)
@@ -318,12 +319,14 @@ public abstract class NntpClient : INntpClient
                     yield return await MapPipelinedBodyResultAsync(
                         batch.Responses[position], segmentId, cancellationToken).ConfigureAwait(false);
                 }
+
+                fullyEnumerated = true;
             }
             finally
             {
                 // A fully drained batch belongs to the consumer, and cancelling would tear
                 // down streams it still holds.
-                if (position < batch.Responses.Count)
+                if (!fullyEnumerated && position < batch.Responses.Count)
                 {
                     try
                     {
@@ -337,6 +340,8 @@ public abstract class NntpClient : INntpClient
 
                     await ReleaseRemainingBodiesAsync(batch.Responses, position).ConfigureAwait(false);
                 }
+
+                await ObserveBatchCompletionAsync(batch.Completion).ConfigureAwait(false);
             }
         }
     }
@@ -373,6 +378,18 @@ public abstract class NntpClient : INntpClient
             {
                 Log.Debug(e, "Failed to release abandoned pipelined BODY response");
             }
+        }
+    }
+
+    private static async Task ObserveBatchCompletionAsync(Task completion)
+    {
+        try
+        {
+            await completion.ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            Log.Debug(exception, "Pipelined BODY batch completion failed");
         }
     }
 

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -339,9 +339,15 @@ public abstract class NntpClient : INntpClient
                     }
 
                     await ReleaseRemainingBodiesAsync(batch.Responses, position).ConfigureAwait(false);
+                    await ObserveBatchCompletionAsync(batch.Completion).ConfigureAwait(false);
                 }
-
-                await ObserveBatchCompletionAsync(batch.Completion).ConfigureAwait(false);
+                else
+                {
+                    // Fully enumerated responses still belong to the consumer. Transport
+                    // Completion waits for the last stream's EOF/dispose, so joining here
+                    // would hang the final MoveNextAsync until that stream is released.
+                    _ = ObserveBatchCompletionAsync(batch.Completion);
+                }
             }
         }
     }

--- a/backend/Clients/Usenet/RepairedSegmentNntpClient.cs
+++ b/backend/Clients/Usenet/RepairedSegmentNntpClient.cs
@@ -76,6 +76,50 @@ public sealed class RepairedSegmentNntpClient : WrappingNntpClient
         return await base.DecodedBodyAsync(segmentId, exclusiveConnection, ct).ConfigureAwait(false);
     }
 
+    public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+        IReadOnlyList<SegmentId> segmentIds,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
+        CancellationToken cancellationToken)
+    {
+        if (MultiProviderNntpClient.AttributionContext.Value is not null)
+            return base.DecodedBodiesAsync(segmentIds, onConnectionReadyAgain, cancellationToken);
+
+        return LocalDataBatchOverlay.ExecuteAsync(
+            segmentIds,
+            onConnectionReadyAgain,
+            TryOpenPatchedResponse,
+            (misses, callback, token) => base.DecodedBodiesAsync(misses, callback, token),
+            LocalDataBatchOverlay.PassThroughRemote,
+            cancellationToken);
+    }
+
+    public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+        IReadOnlyList<SegmentId> segmentIds,
+        UsenetExclusiveConnection exclusiveConnection,
+        CancellationToken cancellationToken)
+    {
+        if (MultiProviderNntpClient.AttributionContext.Value is not null)
+            return base.DecodedBodiesAsync(segmentIds, exclusiveConnection, cancellationToken);
+
+        return LocalDataBatchOverlay.ExecuteAsync(
+            segmentIds,
+            exclusiveConnection.OnConnectionReadyAgain,
+            TryOpenPatchedResponse,
+            (misses, callback, token) =>
+                base.DecodedBodiesAsync(misses, new UsenetExclusiveConnection(callback), token),
+            LocalDataBatchOverlay.PassThroughRemote,
+            cancellationToken);
+    }
+
+    private LocalLookupResult TryOpenPatchedResponse(SegmentId segmentId)
+    {
+        if (!TryGetPatchedResponse(segmentId, out var patched) || patched is null)
+            return LocalLookupResult.Miss;
+
+        PrometheusMetrics.Current?.RecordPar2PatchHit();
+        return LocalLookupResult.Hit(patched);
+    }
+
     private bool TryGetPatchedResponse(SegmentId segmentId, out UsenetDecodedBodyResponse? response)
     {
         string id = segmentId;

--- a/backend/Clients/Usenet/SegmentCacheNntpClient.cs
+++ b/backend/Clients/Usenet/SegmentCacheNntpClient.cs
@@ -358,6 +358,11 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
                 return SegmentCacheCommitResult.AlreadyPresent;
             }
 
+            // Catalog leaves recent malformed pairs on disk without indexing them.
+            // Remove that residue while we hold the stripe so this commit can publish.
+            TryDelete(blobPath);
+            TryDelete(headerPath);
+
             var blobPublished = false;
             try
             {

--- a/backend/Clients/Usenet/SegmentCacheNntpClient.cs
+++ b/backend/Clients/Usenet/SegmentCacheNntpClient.cs
@@ -19,6 +19,8 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
 {
     public const string CacheProviderName = "segment-cache";
     internal const string DefaultCachePath = "/config/segment-cache";
+    internal static readonly TimeSpan TemporaryFileGracePeriod = TimeSpan.FromHours(1);
+    private const int CommitStripeCount = 64;
 
     private readonly string _dir;
     private readonly long _maxBytes;
@@ -28,10 +30,12 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
     private readonly SegmentCacheGeneration _generation;
     private readonly ConcurrentDictionary<string, CacheEntry> _index = new();
     private readonly object _evictLock = new();
+    private readonly object[] _commitStripes = CreateCommitStripes();
     private readonly Func<IEnumerable<string>> _enumerateCacheFiles;
     private long _currentBytes;
     private int _catalogReady;
     private int _catalogDegraded;
+    private long _lastWriteWarningTicks;
 
     private static readonly JsonSerializerOptions HeaderJsonOptions = new() { IncludeFields = true };
 
@@ -86,19 +90,15 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         if (MultiProviderNntpClient.AttributionContext.Value != null)
             return await base.DecodedBodyAsync(segmentId, onConnectionReadyAgain, ct).ConfigureAwait(false);
 
-        string id = segmentId;
-        var lookup = TryServeFromCache(id, out var cached, out var servedBytes);
-        if (lookup == CacheLookupResult.Hit)
+        var local = TryOpenCacheResponse(segmentId);
+        if (local.Found)
         {
-            _statistics.RecordHit(servedBytes);
-            RecordCacheHit();
             ArticleBodyCompletion.InvokeContained(onConnectionReadyAgain, ArticleBodyResult.Retrieved);
-            return cached!;
+            return local.Response!;
         }
 
-        RecordLookup(lookup);
         var response = await base.DecodedBodyAsync(segmentId, onConnectionReadyAgain, ct).ConfigureAwait(false);
-        return await WrapForCachingAsync(id, response, ct).ConfigureAwait(false);
+        return await TransformRemoteForCachingAsync(segmentId, response, ct).ConfigureAwait(false);
     }
 
     public override async Task<UsenetDecodedBodyResponse?> TryGetLocalDecodedBodyAsync(
@@ -106,15 +106,9 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
     {
         if (MultiProviderNntpClient.AttributionContext.Value == null)
         {
-            var lookup = TryServeFromCache(segmentId.ToString(), out var cached, out var servedBytes);
-            if (lookup == CacheLookupResult.Hit)
-            {
-                _statistics.RecordHit(servedBytes);
-                RecordCacheHit();
-                return cached;
-            }
-
-            RecordLookup(lookup);
+            var local = TryOpenCacheResponse(segmentId);
+            if (local.Found)
+                return local.Response;
         }
 
         return await base.TryGetLocalDecodedBodyAsync(segmentId, ct).ConfigureAwait(false);
@@ -136,20 +130,16 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         if (MultiProviderNntpClient.AttributionContext.Value != null)
             return await base.DecodedBodyAsync(segmentId, exclusiveConnection, ct).ConfigureAwait(false);
 
-        string id = segmentId;
-        var lookup = TryServeFromCache(id, out var cached, out var servedBytes);
-        if (lookup == CacheLookupResult.Hit)
+        var local = TryOpenCacheResponse(segmentId);
+        if (local.Found)
         {
-            _statistics.RecordHit(servedBytes);
-            RecordCacheHit();
             ArticleBodyCompletion.InvokeContained(
                 exclusiveConnection.OnConnectionReadyAgain, ArticleBodyResult.Retrieved);
-            return cached!;
+            return local.Response!;
         }
 
-        RecordLookup(lookup);
         var response = await base.DecodedBodyAsync(segmentId, exclusiveConnection, ct).ConfigureAwait(false);
-        return await WrapForCachingAsync(id, response, ct).ConfigureAwait(false);
+        return await TransformRemoteForCachingAsync(segmentId, response, ct).ConfigureAwait(false);
     }
 
     public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
@@ -157,8 +147,19 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         ArticleBodyCompletionHandler? onConnectionReadyAgain,
         CancellationToken cancellationToken)
     {
-        _statistics.RecordBatchBypass(segmentIds.Count);
-        return base.DecodedBodiesAsync(segmentIds, onConnectionReadyAgain, cancellationToken);
+        if (MultiProviderNntpClient.AttributionContext.Value is not null)
+        {
+            _statistics.RecordBatchBypass(segmentIds.Count);
+            return base.DecodedBodiesAsync(segmentIds, onConnectionReadyAgain, cancellationToken);
+        }
+
+        return LocalDataBatchOverlay.ExecuteAsync(
+            segmentIds,
+            onConnectionReadyAgain,
+            TryOpenCacheResponse,
+            (misses, callback, token) => base.DecodedBodiesAsync(misses, callback, token),
+            TransformRemoteForCachingAsync,
+            cancellationToken);
     }
 
     public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
@@ -166,34 +167,96 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         UsenetExclusiveConnection exclusiveConnection,
         CancellationToken cancellationToken)
     {
-        _statistics.RecordBatchBypass(segmentIds.Count);
-        return base.DecodedBodiesAsync(segmentIds, exclusiveConnection, cancellationToken);
+        if (MultiProviderNntpClient.AttributionContext.Value is not null)
+        {
+            _statistics.RecordBatchBypass(segmentIds.Count);
+            return base.DecodedBodiesAsync(segmentIds, exclusiveConnection, cancellationToken);
+        }
+
+        return LocalDataBatchOverlay.ExecuteAsync(
+            segmentIds,
+            exclusiveConnection.OnConnectionReadyAgain,
+            TryOpenCacheResponse,
+            (misses, callback, token) =>
+                base.DecodedBodiesAsync(misses, new UsenetExclusiveConnection(callback), token),
+            TransformRemoteForCachingAsync,
+            cancellationToken);
     }
 
-    private async Task<UsenetDecodedBodyResponse> WrapForCachingAsync(
-        string id, UsenetDecodedBodyResponse response, CancellationToken ct)
+    private LocalLookupResult TryOpenCacheResponse(SegmentId segmentId)
+    {
+        string id = segmentId;
+        var lookup = TryServeFromCache(id, out var cached, out var servedBytes);
+        if (lookup == CacheLookupResult.Hit)
+        {
+            _statistics.RecordHit(servedBytes);
+            RecordCacheHit();
+            return LocalLookupResult.Hit(cached!);
+        }
+
+        RecordLookup(lookup);
+        return LocalLookupResult.Miss;
+    }
+
+    private async Task<UsenetDecodedBodyResponse> TransformRemoteForCachingAsync(
+        SegmentId requestedId,
+        UsenetDecodedBodyResponse response,
+        CancellationToken cancellationToken)
     {
         if (response.ResponseType != UsenetResponseType.ArticleRetrievedBodyFollows ||
-            response.Stream == null)
+            response.Stream is null)
+        {
+            return response;
+        }
+
+        if (!string.Equals(requestedId.ToString(), response.SegmentId, StringComparison.Ordinal))
             return response;
 
-        var source = response.Stream;
-        UsenetYencHeader? header = null;
+        UsenetYencHeader? header;
         try
         {
-            header = await source.GetYencHeadersAsync(ct).ConfigureAwait(false);
+            header = await response.Stream.GetYencHeadersAsync(cancellationToken).ConfigureAwait(false);
         }
-        catch
+        catch (Exception exception) when (exception is not OutOfMemoryException)
         {
-            header = null;
+            return response;
         }
 
-        if (header == null) return response;
+        if (header is null || !IsCoherentHeader(header))
+            return response;
+
+        var hash = Hash(requestedId.ToString());
         var attempt = _statistics.BeginWriteAttempt();
         return response with
         {
-            Stream = new WriteThroughStream(source, header, BlobPath(Hash(id)), OnCommitted, attempt),
+            Stream = new ValidatedCacheWriteStream(
+                response.Stream,
+                header,
+                BlobPath(hash),
+                hash,
+                CommitPublishedPair,
+                attempt,
+                WarnCacheWriteFailure),
         };
+    }
+
+    internal static bool IsCoherentHeader(UsenetYencHeader header)
+    {
+        if (header.PartSize <= 0 || header.PartOffset < 0 || header.FileSize < 0 || header.LineLength < 0)
+            return false;
+        if (header.PartNumber < 0 || header.TotalParts < 0)
+            return false;
+        if (header.PartNumber > 0 && header.TotalParts > 0 && header.PartNumber > header.TotalParts)
+            return false;
+
+        try
+        {
+            return header.FileSize >= checked(header.PartOffset + header.PartSize);
+        }
+        catch (OverflowException)
+        {
+            return false;
+        }
     }
 
     private CacheLookupResult TryServeFromCache(string id, out UsenetDecodedBodyResponse? response, out long servedBytes)
@@ -210,7 +273,7 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         {
             var header = JsonSerializer.Deserialize<UsenetYencHeader>(
                 File.ReadAllText(blobPath + ".h"), HeaderJsonOptions);
-            if (header == null || header.PartSize != entry.Size)
+            if (header == null || header.PartSize != entry.Size || !IsCoherentHeader(header))
             {
                 RecordReadFailureAndDrop(hash);
                 return CacheLookupResult.ReadFailure;
@@ -272,21 +335,108 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         });
     }
 
-    private void OnCommitted(string hash, long size)
+    private SegmentCacheCommitResult CommitPublishedPair(
+        string hash,
+        string blobTempPath,
+        string headerTempPath,
+        UsenetYencHeader header,
+        long decodedBytes)
     {
-        long evictedEntries = 0;
-        long evictedBytes = 0;
-        lock (_evictLock)
+        if (decodedBytes != header.PartSize)
+            return SegmentCacheCommitResult.InvalidLength;
+
+        var blobPath = BlobPath(hash);
+        var headerPath = blobPath + ".h";
+        var commitLock = StripeFor(hash);
+        var result = SegmentCacheCommitResult.Failed;
+        lock (commitLock)
         {
-            if (_index.TryGetValue(hash, out var existing)) _currentBytes -= existing.Size;
-            _index[hash] = new CacheEntry { Size = size, LastAccessTicks = DateTime.UtcNow.Ticks };
-            _currentBytes += size;
-            EvictWhileLocked(ref evictedEntries, ref evictedBytes);
+            if (TryValidatePublishedEntry(hash, out _))
+            {
+                TryDelete(blobTempPath);
+                TryDelete(headerTempPath);
+                return SegmentCacheCommitResult.AlreadyPresent;
+            }
+
+            var blobPublished = false;
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(blobPath)!);
+                File.Move(blobTempPath, blobPath, overwrite: false);
+                blobPublished = true;
+                File.Move(headerTempPath, headerPath, overwrite: false);
+                PublishIndexEntry(hash, decodedBytes);
+                result = SegmentCacheCommitResult.Committed;
+            }
+            catch (IOException) when (TryValidatePublishedEntry(hash, out _))
+            {
+                return SegmentCacheCommitResult.AlreadyPresent;
+            }
+            catch
+            {
+                if (blobPublished && !_index.ContainsKey(hash))
+                    TryDelete(blobPath);
+                throw;
+            }
+            finally
+            {
+                TryDelete(blobTempPath);
+                TryDelete(headerTempPath);
+            }
         }
 
-        if (evictedEntries > 0)
-            _statistics.RecordEviction(evictedEntries, evictedBytes);
-        PublishIndexGauges();
+        if (result == SegmentCacheCommitResult.Committed)
+        {
+            EvictIfNeeded();
+            PublishIndexGauges();
+        }
+
+        return result;
+    }
+
+    private void PublishIndexEntry(string hash, long size)
+    {
+        lock (_evictLock)
+        {
+            if (_index.TryGetValue(hash, out var existing))
+            {
+                if (existing.Size == size)
+                {
+                    existing.LastAccessTicks = DateTime.UtcNow.Ticks;
+                    return;
+                }
+
+                _currentBytes -= existing.Size;
+            }
+
+            _index[hash] = new CacheEntry { Size = size, LastAccessTicks = DateTime.UtcNow.Ticks };
+            _currentBytes += size;
+        }
+    }
+
+    private bool TryValidatePublishedEntry(string hash, out long size)
+    {
+        size = 0;
+        var blobPath = BlobPath(hash);
+        var headerPath = blobPath + ".h";
+        if (!File.Exists(blobPath) || !File.Exists(headerPath))
+            return false;
+
+        try
+        {
+            var info = new FileInfo(blobPath);
+            var header = JsonSerializer.Deserialize<UsenetYencHeader>(
+                File.ReadAllText(headerPath), HeaderJsonOptions);
+            if (header is null || !IsCoherentHeader(header) || header.PartSize != info.Length)
+                return false;
+
+            size = info.Length;
+            return true;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException)
+        {
+            return false;
+        }
     }
 
     private void Drop(string hash)
@@ -342,30 +492,79 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         {
             foreach (var file in _enumerateCacheFiles())
             {
-                if (file.EndsWith(".tmp", StringComparison.Ordinal))
+                try
                 {
-                    if (TryDelete(file))
+                    if (file.EndsWith(".tmp", StringComparison.Ordinal))
                     {
-                        cleaned++;
-                        _statistics.RecordTemporaryFileCleaned();
+                        if (IsStale(file) && TryDelete(file))
+                        {
+                            cleaned++;
+                            _statistics.RecordTemporaryFileCleaned();
+                        }
+
+                        continue;
                     }
 
-                    continue;
+                    if (file.EndsWith(".h", StringComparison.Ordinal))
+                    {
+                        var blobForHeader = file[..^2];
+                        if (!File.Exists(blobForHeader) && IsStale(file))
+                            TryDelete(file);
+                        continue;
+                    }
+
+                    var info = new FileInfo(file);
+                    if (!info.Exists) continue;
+
+                    var headerPath = file + ".h";
+                    if (!File.Exists(headerPath))
+                    {
+                        if (IsStale(file))
+                            TryDelete(file);
+                        continue;
+                    }
+
+                    UsenetYencHeader? header;
+                    try
+                    {
+                        header = JsonSerializer.Deserialize<UsenetYencHeader>(
+                            File.ReadAllText(headerPath), HeaderJsonOptions);
+                    }
+                    catch (Exception exception) when (
+                        exception is IOException or UnauthorizedAccessException or JsonException)
+                    {
+                        _statistics.RecordReadFailure();
+                        continue;
+                    }
+
+                    if (header is null || !IsCoherentHeader(header) || header.PartSize != info.Length)
+                    {
+                        _statistics.RecordReadFailure();
+                        if (IsStale(file))
+                        {
+                            TryDelete(file);
+                            TryDelete(headerPath);
+                        }
+
+                        continue;
+                    }
+
+                    var entry = new CacheEntry
+                    {
+                        Size = info.Length,
+                        LastAccessTicks = info.LastWriteTimeUtc.Ticks,
+                    };
+
+                    lock (_evictLock)
+                    {
+                        if (_index.TryAdd(Path.GetFileName(file), entry))
+                            _currentBytes += info.Length;
+                    }
                 }
-
-                if (file.EndsWith(".h", StringComparison.Ordinal)) continue;
-                var info = new FileInfo(file);
-                if (!info.Exists) continue;
-                var entry = new CacheEntry
+                catch (Exception exception) when (
+                    exception is IOException or UnauthorizedAccessException or JsonException)
                 {
-                    Size = info.Length,
-                    LastAccessTicks = info.LastWriteTimeUtc.Ticks,
-                };
-
-                lock (_evictLock)
-                {
-                    if (_index.TryAdd(Path.GetFileName(file), entry))
-                        _currentBytes += info.Length;
+                    // One malformed entry must not abort the rest of the scan.
                 }
             }
         }
@@ -404,10 +603,45 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         }
     }
 
+    private static bool IsStale(string path)
+    {
+        try
+        {
+            var info = new FileInfo(path);
+            return info.Exists && DateTime.UtcNow - info.LastWriteTimeUtc > TemporaryFileGracePeriod;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
     private string BlobPath(string hash) => Path.Join(_dir, hash[..2], hash);
 
     private static string Hash(string id)
         => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(id)));
+
+    private object StripeFor(string hash) =>
+        _commitStripes[(hash.GetHashCode(StringComparison.Ordinal) & 0x7fffffff) % CommitStripeCount];
+
+    private static object[] CreateCommitStripes()
+    {
+        var stripes = new object[CommitStripeCount];
+        for (var index = 0; index < stripes.Length; index++)
+            stripes[index] = new object();
+        return stripes;
+    }
+
+    private void WarnCacheWriteFailure()
+    {
+        var nowTicks = DateTimeOffset.UtcNow.UtcTicks;
+        var last = Interlocked.Read(ref _lastWriteWarningTicks);
+        if (nowTicks - last < TimeSpan.FromSeconds(30).Ticks) return;
+        if (Interlocked.CompareExchange(ref _lastWriteWarningTicks, nowTicks, last) != last)
+            return;
+
+        Log.Warning("Segment cache write failed. Reason: {Reason}", "storage-unavailable");
+    }
 
     private static bool TryDelete(string path)
     {
@@ -437,32 +671,44 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         public long LastAccessTicks;
     }
 
-    private sealed class WriteThroughStream : YencStream
+    private sealed class ValidatedCacheWriteStream : YencStream
     {
         private readonly YencStream _source;
         private readonly UsenetYencHeader _header;
         private readonly string _blobPath;
-        private readonly string _tempPath;
-        private readonly Action<string, long> _onCommitted;
+        private readonly string _blobTempPath;
+        private readonly string _headerTempPath;
+        private readonly string _hash;
+        private readonly Func<string, string, string, UsenetYencHeader, long, SegmentCacheCommitResult> _commit;
         private readonly SegmentCacheWriteAttempt _attempt;
+        private readonly Action _warnWriteFailure;
         private FileStream? _temp;
         private long _written;
         private bool _eof;
         private bool _writeFailed;
+        private bool _writeEnabled = true;
+        private int _completed;
+        private int _disposed;
 
-        public WriteThroughStream(
+        public ValidatedCacheWriteStream(
             YencStream source,
             UsenetYencHeader header,
             string blobPath,
-            Action<string, long> onCommitted,
-            SegmentCacheWriteAttempt attempt) : base(Null)
+            string hash,
+            Func<string, string, string, UsenetYencHeader, long, SegmentCacheCommitResult> commit,
+            SegmentCacheWriteAttempt attempt,
+            Action warnWriteFailure) : base(Null)
         {
             _source = source;
             _header = header;
             _blobPath = blobPath;
-            _tempPath = blobPath + "." + Guid.NewGuid().ToString("N") + ".tmp";
-            _onCommitted = onCommitted;
+            _hash = hash;
+            _commit = commit;
             _attempt = attempt;
+            _warnWriteFailure = warnWriteFailure;
+            var unique = Guid.NewGuid().ToString("N");
+            _blobTempPath = blobPath + "." + unique + ".tmp";
+            _headerTempPath = blobPath + ".h." + unique + ".tmp";
         }
 
         public override ValueTask<UsenetYencHeader?> GetYencHeadersAsync(CancellationToken cancellationToken = default)
@@ -470,78 +716,186 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
 
         public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
-            var n = await _source.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
-            if (n > 0)
-            {
-                if (!_writeFailed)
-                {
-                    try
-                    {
-                        _temp ??= OpenTemp();
-                        await _temp.WriteAsync(buffer[..n], cancellationToken).ConfigureAwait(false);
-                        _written += n;
-                    }
-                    catch
-                    {
-                        _writeFailed = true;
-                    }
-                }
-            }
-            else
+            var read = await _source.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            if (read == 0)
             {
                 _eof = true;
+                return 0;
             }
 
-            return n;
+            if (_writeEnabled)
+            {
+                try
+                {
+                    _temp ??= OpenTemp();
+                    await _temp.WriteAsync(buffer[..read], cancellationToken).ConfigureAwait(false);
+                    _written = checked(_written + read);
+                    if (_written > _header.PartSize)
+                        DisableWrite(failed: false);
+                }
+                catch (Exception exception) when (IsBestEffortCacheIoFailure(exception))
+                {
+                    DisableWrite(failed: true);
+                }
+            }
+
+            return read;
         }
 
         private FileStream OpenTemp()
         {
             Directory.CreateDirectory(Path.GetDirectoryName(_blobPath)!);
-            return new FileStream(_tempPath, FileMode.Create, FileAccess.Write, FileShare.None,
-                bufferSize: 81920, useAsync: true);
+            return new FileStream(
+                _blobTempPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 81920,
+                FileOptions.Asynchronous);
+        }
+
+        private void DisableWrite(bool failed)
+        {
+            _writeEnabled = false;
+            if (failed)
+            {
+                _writeFailed = true;
+                _warnWriteFailure();
+            }
+
+            try
+            {
+                _temp?.Dispose();
+            }
+            catch (Exception exception) when (IsBestEffortCacheIoFailure(exception))
+            {
+                // Best-effort: playback continues without a cache entry.
+            }
+
+            _temp = null;
+            TryDelete(_blobTempPath);
+            TryDelete(_headerTempPath);
         }
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
-            {
-                _source.Dispose();
-                try
-                {
-                    _temp?.Dispose();
-                }
-                catch
-                {
-                    // ignore
-                }
+            if (!disposing)
+                return;
 
-                try
-                {
-                    if (_eof && !_writeFailed && _temp != null && _written == _header.PartSize)
-                    {
-                        File.WriteAllText(_blobPath + ".h", JsonSerializer.Serialize(_header, HeaderJsonOptions));
-                        File.Move(_tempPath, _blobPath, overwrite: true);
-                        _onCommitted(Path.GetFileName(_blobPath), _written);
-                        _attempt.Complete(SegmentCacheWriteOutcome.Committed, _written);
-                    }
-                    else
-                    {
-                        TryDelete(_tempPath);
-                        _attempt.Complete(
-                            _writeFailed ? SegmentCacheWriteOutcome.Failed : SegmentCacheWriteOutcome.Skipped,
-                            _written);
-                    }
-                }
-                catch
-                {
-                    TryDelete(_tempPath);
-                    TryDelete(_blobPath + ".h");
-                    _attempt.Complete(SegmentCacheWriteOutcome.Failed, _written);
-                }
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                base.Dispose(disposing);
+                return;
             }
 
-            base.Dispose(disposing);
+            Exception? sourceFailure = null;
+            try
+            {
+                _source.Dispose();
+            }
+            catch (Exception exception) when (exception is not OutOfMemoryException)
+            {
+                sourceFailure = exception;
+                throw;
+            }
+            finally
+            {
+                CompleteWrite(sourceFailure is null);
+                base.Dispose(disposing);
+            }
         }
+
+        public override async ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                await base.DisposeAsync().ConfigureAwait(false);
+                return;
+            }
+
+            Exception? sourceFailure = null;
+            try
+            {
+                await _source.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception exception) when (exception is not OutOfMemoryException)
+            {
+                sourceFailure = exception;
+                throw;
+            }
+            finally
+            {
+                CompleteWrite(sourceFailure is null);
+                await base.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        private void CompleteWrite(bool sourceSucceeded)
+        {
+            if (Interlocked.Exchange(ref _completed, 1) != 0)
+                return;
+
+            try
+            {
+                try
+                {
+                    _temp?.Flush();
+                    _temp?.Dispose();
+                }
+                catch (Exception exception) when (IsBestEffortCacheIoFailure(exception))
+                {
+                    _writeFailed = true;
+                    _warnWriteFailure();
+                }
+
+                _temp = null;
+
+                if (sourceSucceeded && _eof && !_writeFailed && _written == _header.PartSize)
+                {
+                    File.WriteAllText(_headerTempPath, JsonSerializer.Serialize(_header, HeaderJsonOptions));
+                    var result = _commit(_hash, _blobTempPath, _headerTempPath, _header, _written);
+                    switch (result)
+                    {
+                        case SegmentCacheCommitResult.Committed:
+                            _attempt.Complete(SegmentCacheWriteOutcome.Committed, _written);
+                            break;
+                        case SegmentCacheCommitResult.AlreadyPresent:
+                        case SegmentCacheCommitResult.InvalidLength:
+                            _attempt.Complete(SegmentCacheWriteOutcome.Skipped, _written);
+                            break;
+                        default:
+                            _attempt.Complete(SegmentCacheWriteOutcome.Failed, _written);
+                            break;
+                    }
+
+                    return;
+                }
+
+                TryDelete(_blobTempPath);
+                TryDelete(_headerTempPath);
+                _attempt.Complete(
+                    _writeFailed ? SegmentCacheWriteOutcome.Failed : SegmentCacheWriteOutcome.Skipped,
+                    _written);
+            }
+            catch (Exception exception) when (exception is not OutOfMemoryException)
+            {
+                TryDelete(_blobTempPath);
+                TryDelete(_headerTempPath);
+                _attempt.Complete(SegmentCacheWriteOutcome.Failed, _written);
+                if (IsBestEffortCacheIoFailure(exception))
+                    _warnWriteFailure();
+            }
+        }
+
+        private static bool IsBestEffortCacheIoFailure(Exception exception) =>
+            exception is IOException or UnauthorizedAccessException or DirectoryNotFoundException;
     }
+}
+
+internal enum SegmentCacheCommitResult
+{
+    Committed,
+    AlreadyPresent,
+    InvalidLength,
+    Failed,
 }

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -581,8 +581,11 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
 
     private void EnqueueBatchCompletionObserver(Task completion)
     {
-        while (_batchCompletionObservers.TryPeek(out var head) && head.IsCompleted)
+        while (_batchCompletionObservers.TryPeek(out var head) &&
+               head.Status == TaskStatus.RanToCompletion)
+        {
             _batchCompletionObservers.TryDequeue(out _);
+        }
 
         _batchCompletionObservers.Enqueue(ObserveBatchCompletionAsync(completion));
     }

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -53,6 +53,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     // the producer; DisposeCoreAsync must join them so DisposeAsync does not return
     // while their BudgetedStream leases are still held (#840 scrub wedge).
     private readonly ConcurrentQueue<Task> _orphanedDisposals = new();
+    private readonly ConcurrentQueue<Task> _batchCompletionObservers = new();
     private readonly HashSet<string>? _knownCorruptSegmentIds;
     private readonly IReadOnlySet<int>? _knownMissingSegmentIndices;
 
@@ -421,8 +422,10 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 if (liveIndexes.Length > 0)
                 {
                     var liveIds = liveIndexes.Select(index => segmentIds[index]).ToArray();
-                    liveResponses = await FetchAttributedBatchResponsesAsync(liveIds, cancellationToken)
+                    var fetched = await FetchAttributedBatchResponsesAsync(liveIds, cancellationToken)
                         .ConfigureAwait(false);
+                    liveResponses = fetched.Responses;
+                    _batchCompletionObservers.Enqueue(ObserveBatchCompletionAsync(fetched.Completion));
                 }
 
                 streamTasks = new Task<SegmentDownloadResult>[batchCount];
@@ -531,7 +534,11 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         return false;
     }
 
-    private async Task<Task<UsenetDecodedBodyResponse>[]> FetchAttributedBatchResponsesAsync(
+    private sealed record FetchedBodyBatch(
+        Task<UsenetDecodedBodyResponse>[] Responses,
+        Task Completion);
+
+    private async Task<FetchedBodyBatch> FetchAttributedBatchResponsesAsync(
         SegmentId[] liveIds,
         CancellationToken cancellationToken)
     {
@@ -552,15 +559,36 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 }
                 catch (Exception e) when (e is not OutOfMemoryException)
                 {
-                    Log.Debug(e, "Failed to drain BODY response after batch size mismatch for {FileName}.", _fileName);
+                    Log.Debug(e, "Failed to drain BODY response after batch size mismatch.");
                 }
+            }
+
+            try
+            {
+                await batch.Completion.ConfigureAwait(false);
+            }
+            catch (Exception e) when (e is not OutOfMemoryException)
+            {
+                Log.Debug(e, "Failed to observe BODY batch completion after size mismatch.");
             }
 
             throw new InvalidOperationException(
                 $"Pipelined BODY returned {batch.Responses.Count} responses for {liveIds.Length} requests.");
         }
 
-        return batch.Responses.ToArray();
+        return new FetchedBodyBatch(batch.Responses.ToArray(), batch.Completion);
+    }
+
+    private static async Task ObserveBatchCompletionAsync(Task completion)
+    {
+        try
+        {
+            await completion.ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            Log.Debug(exception, "Pipelined BODY batch completion failed.");
+        }
     }
 
     /// <summary>
@@ -1714,6 +1742,9 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         // so no new orphans can be enqueued; drain is safe without a lock.
         while (_orphanedDisposals.TryDequeue(out var orphaned))
             pending.Add(orphaned);
+
+        while (_batchCompletionObservers.TryDequeue(out var observer))
+            pending.Add(observer);
 
         if (pending.Count > 0)
             await Task.WhenAll(pending).ConfigureAwait(false);

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -1713,54 +1713,59 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     {
         try
         {
+            try
+            {
 #pragma warning disable CA1849 // synchronous Cancel is required -- teardown callbacks must run before _streamTasks.Writer completes; CancelAsync would race TryComplete
-            _cts.Cancel();
+                _cts.Cancel();
 #pragma warning restore CA1849
+            }
+            catch (ObjectDisposedException)
+            {
+                // Already torn down.
+            }
+
+            _streamTasks.Writer.TryComplete();
+
+            if (_stream is not null)
+            {
+                await _stream.DisposeAsync().ConfigureAwait(false);
+                _stream = null;
+            }
+
+            // Drain queued segments concurrently so a task blocked on LeaseAsync can
+            // wake when another queued BudgetedStream releases its lease.
+            var pending = new List<Task>();
+            while (_streamTasks.Reader.TryRead(out var streamTask))
+                pending.Add(DisposeStreamAsync(streamTask, releaseInFlight: true));
+
+            try
+            {
+                await _downloadTask.ConfigureAwait(false);
+            }
+            catch
+            {
+                // Producer failures are surfaced on ReadAsync; teardown only needs cleanup.
+            }
+
+            while (_streamTasks.Reader.TryRead(out var streamTask))
+                pending.Add(DisposeStreamAsync(streamTask, releaseInFlight: true));
+
+            // Join the producer's out-of-band disposals so leases they hold are released
+            // before DisposeAsync completes. The producer has exited by now (awaited above),
+            // so no new orphans can be enqueued; drain is safe without a lock.
+            while (_orphanedDisposals.TryDequeue(out var orphaned))
+                pending.Add(orphaned);
+
+            while (_batchCompletionObservers.TryDequeue(out var observer))
+                pending.Add(observer);
+
+            if (pending.Count > 0)
+                await Task.WhenAll(pending).ConfigureAwait(false);
         }
-        catch (ObjectDisposedException)
+        finally
         {
-            // Already torn down.
+            _cts.Dispose();
         }
-
-        _streamTasks.Writer.TryComplete();
-
-        if (_stream is not null)
-        {
-            await _stream.DisposeAsync().ConfigureAwait(false);
-            _stream = null;
-        }
-
-        // Drain queued segments concurrently so a task blocked on LeaseAsync can
-        // wake when another queued BudgetedStream releases its lease.
-        var pending = new List<Task>();
-        while (_streamTasks.Reader.TryRead(out var streamTask))
-            pending.Add(DisposeStreamAsync(streamTask, releaseInFlight: true));
-
-        try
-        {
-            await _downloadTask.ConfigureAwait(false);
-        }
-        catch
-        {
-            // Producer failures are surfaced on ReadAsync; teardown only needs cleanup.
-        }
-
-        while (_streamTasks.Reader.TryRead(out var streamTask))
-            pending.Add(DisposeStreamAsync(streamTask, releaseInFlight: true));
-
-        // Join the producer's out-of-band disposals so leases they hold are released
-        // before DisposeAsync completes. The producer has exited by now (awaited above),
-        // so no new orphans can be enqueued; drain is safe without a lock.
-        while (_orphanedDisposals.TryDequeue(out var orphaned))
-            pending.Add(orphaned);
-
-        while (_batchCompletionObservers.TryDequeue(out var observer))
-            pending.Add(observer);
-
-        if (pending.Count > 0)
-            await Task.WhenAll(pending).ConfigureAwait(false);
-
-        _cts.Dispose();
     }
 
     private readonly record struct DrainedSegment(Stream Stream, bool ShortPadded);

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -425,7 +425,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                     var fetched = await FetchAttributedBatchResponsesAsync(liveIds, cancellationToken)
                         .ConfigureAwait(false);
                     liveResponses = fetched.Responses;
-                    _batchCompletionObservers.Enqueue(ObserveBatchCompletionAsync(fetched.Completion));
+                    EnqueueBatchCompletionObserver(fetched.Completion);
                 }
 
                 streamTasks = new Task<SegmentDownloadResult>[batchCount];
@@ -577,6 +577,14 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         }
 
         return new FetchedBodyBatch(batch.Responses.ToArray(), batch.Completion);
+    }
+
+    private void EnqueueBatchCompletionObserver(Task completion)
+    {
+        while (_batchCompletionObservers.TryPeek(out var head) && head.IsCompleted)
+            _batchCompletionObservers.TryDequeue(out _);
+
+        _batchCompletionObservers.Enqueue(ObserveBatchCompletionAsync(completion));
     }
 
     private static async Task ObserveBatchCompletionAsync(Task completion)

--- a/libs/UsenetSharp/Clients/IUsenetClient.cs
+++ b/libs/UsenetSharp/Clients/IUsenetClient.cs
@@ -61,7 +61,9 @@ public interface IUsenetClient
     /// <remarks>
     /// Consume or dispose each response stream before awaiting the next response. Later responses
     /// remain blocked until earlier streams are drained, and each decoded pipe applies bounded
-    /// backpressure according to <see cref="UsenetClientOptions"/>.
+    /// backpressure according to <see cref="UsenetClientOptions"/>. Observe
+    /// <see cref="UsenetDecodedBodyBatch.Completion"/> after draining or abandoning the batch;
+    /// it finishes only after the producer has released the connection lifecycle.
     /// </remarks>
     Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
         IReadOnlyList<SegmentId> segmentIds, CancellationToken cancellationToken)
@@ -77,7 +79,8 @@ public interface IUsenetClient
     /// remain blocked until earlier streams are drained, and each decoded pipe applies bounded
     /// backpressure according to <see cref="UsenetClientOptions"/>. The completion callback
     /// distinguishes clean not-found and drained-cancellation outcomes from failures that make the
-    /// connection unsafe to reuse.
+    /// connection unsafe to reuse. Observe <see cref="UsenetDecodedBodyBatch.Completion"/> after
+    /// draining or abandoning the batch; it finishes only after that lifecycle is released.
     /// </remarks>
     Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
         IReadOnlyList<SegmentId> segmentIds, ArticleBodyCompletionHandler? onConnectionReadyAgain,

--- a/libs/UsenetSharp/Clients/UsenetClient.DecodedBodiesAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.DecodedBodiesAsync.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.IO.Pipelines;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Text;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
@@ -15,7 +16,8 @@ public partial class UsenetClient
     /// <remarks>
     /// Consume or dispose each response stream before awaiting the next response. Later responses
     /// remain blocked until earlier streams are drained, and each decoded pipe applies bounded
-    /// backpressure according to <see cref="UsenetClientOptions"/>.
+    /// backpressure according to <see cref="UsenetClientOptions"/>. Observe
+    /// <see cref="UsenetDecodedBodyBatch.Completion"/> after draining or abandoning the batch.
     /// </remarks>
     public Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
         IReadOnlyList<SegmentId> segmentIds,
@@ -34,6 +36,8 @@ public partial class UsenetClient
     /// <see cref="ArticleBodyResult.NotFound"/> for clean 430 responses,
     /// <see cref="ArticleBodyResult.Cancelled"/> after a successfully drained cancellation, and
     /// <see cref="ArticleBodyResult.NotRetrieved"/> only when the connection is unsafe to reuse.
+    /// <see cref="UsenetDecodedBodyBatch.Completion"/> finishes after that callback and after the
+    /// command lock is released.
     /// </remarks>
     public async Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
         IReadOnlyList<SegmentId> segmentIds,
@@ -180,7 +184,7 @@ public partial class UsenetClient
                 await enumerationCts.CancelAsync().ConfigureAwait(false);
                 await DisposeUnyieldedResponsesAsync(batch, yieldedResponseCount)
                     .ConfigureAwait(false);
-                await batch.Completion.ConfigureAwait(false);
+                await ObserveBatchCompletionAsync(batch.Completion).ConfigureAwait(false);
             }
         }
     }
@@ -212,6 +216,18 @@ public partial class UsenetClient
         catch
         {
             // Cleanup must continue so the batch pump can release the command lease.
+        }
+    }
+
+    private static async Task ObserveBatchCompletionAsync(Task completion)
+    {
+        try
+        {
+            await completion.ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            // Early abandonment must still observe the producer task.
         }
     }
 
@@ -419,6 +435,9 @@ public partial class UsenetClient
                 completionResult,
                 completionReason);
         }
+
+        if (failure != null)
+            ExceptionDispatchInfo.Capture(failure).Throw();
     }
 
     private async Task<Exception?> TryDrainPipelinedBodiesAsync(int responseCount)

--- a/libs/UsenetSharp/Models/UsenetDecodedBodyBatch.cs
+++ b/libs/UsenetSharp/Models/UsenetDecodedBodyBatch.cs
@@ -16,5 +16,27 @@ public sealed record UsenetDecodedBodyBatch
     /// </summary>
     public required IReadOnlyList<Task<UsenetDecodedBodyResponse>> Responses { get; init; }
 
-    internal Task Completion { get; init; } = Task.CompletedTask;
+    /// <summary>
+    /// Gets a task that completes after the producer has released this batch's transport and
+    /// connection lifecycle.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is not a substitute for consuming or disposing each response stream. A later
+    /// response still cannot become ready while an earlier stream remains undrained.
+    /// </para>
+    /// <para>
+    /// The task may fault or cancel when the batch pump fails. Callers that abandon a batch
+    /// must first cancel and dispose or drain handed-out streams, then await this task.
+    /// Wrappers that construct a replacement batch must compose and expose the inner task.
+    /// Consumers must observe it even when an individual response task has already failed.
+    /// </para>
+    /// <para>
+    /// The default value is an already-completed task so existing construction sites remain
+    /// source-compatible. Replacement wrappers that omit an assignment silently drop inner
+    /// lifecycle; construction-site audits must assign a composed task whenever the wrapper
+    /// replaces <see cref="Responses"/>.
+    /// </para>
+    /// </remarks>
+    public Task Completion { get; init; } = Task.CompletedTask;
 }

--- a/scripts/fixtures/performance-gate-expanded-baseline.json
+++ b/scripts/fixtures/performance-gate-expanded-baseline.json
@@ -19,11 +19,11 @@
         "transportBytes": 3145728,
         "transportBatchRequests": 3,
         "cacheHits": 0,
-        "cacheMisses": 1,
+        "cacheMisses": 12,
         "cacheBytesServed": 0,
-        "cacheBatchBypassRequests": 3,
-        "cacheBatchBypassArticles": 11,
-        "cacheWriteCommits": 1
+        "cacheBatchBypassRequests": 0,
+        "cacheBatchBypassArticles": 0,
+        "cacheWriteCommits": 12
       },
       "timing": {
         "firstByteMs": { "baseline": 1.0, "envelope": 16.0, "policy": "fail" },
@@ -35,14 +35,14 @@
     "pipelined-warm-reread": {
       "deterministic": {
         "bytes": 3145728,
-        "transportRequests": 11,
-        "transportBytes": 2883584,
-        "transportBatchRequests": 3,
-        "cacheHits": 1,
+        "transportRequests": 0,
+        "transportBytes": 0,
+        "transportBatchRequests": 0,
+        "cacheHits": 12,
         "cacheMisses": 0,
-        "cacheBytesServed": 262144,
-        "cacheBatchBypassRequests": 3,
-        "cacheBatchBypassArticles": 11,
+        "cacheBytesServed": 3145728,
+        "cacheBatchBypassRequests": 0,
+        "cacheBatchBypassArticles": 0,
         "cacheWriteCommits": 0
       },
       "timing": {

--- a/scripts/fixtures/performance-gate-expanded-candidate.json
+++ b/scripts/fixtures/performance-gate-expanded-candidate.json
@@ -14,25 +14,25 @@
         "transportBytes": 3145728,
         "transportBatchRequests": 3,
         "cacheHits": 0,
-        "cacheMisses": 1,
+        "cacheMisses": 12,
         "cacheBytesServed": 0,
-        "cacheBatchBypassRequests": 3,
-        "cacheBatchBypassArticles": 11,
-        "cacheWriteCommits": 1
+        "cacheBatchBypassRequests": 0,
+        "cacheBatchBypassArticles": 0,
+        "cacheWriteCommits": 12
       },
       "timing": { "firstByteMs": 1.0, "elapsedMs": 2.0, "throughputMiBs": 30.0, "cpuSeconds": 0.01 }
     },
     "pipelined-warm-reread": {
       "deterministic": {
         "bytes": 3145728,
-        "transportRequests": 11,
-        "transportBytes": 2883584,
-        "transportBatchRequests": 3,
-        "cacheHits": 1,
+        "transportRequests": 0,
+        "transportBytes": 0,
+        "transportBatchRequests": 0,
+        "cacheHits": 12,
         "cacheMisses": 0,
-        "cacheBytesServed": 262144,
-        "cacheBatchBypassRequests": 3,
-        "cacheBatchBypassArticles": 11,
+        "cacheBytesServed": 3145728,
+        "cacheBatchBypassRequests": 0,
+        "cacheBatchBypassArticles": 0,
         "cacheWriteCommits": 0
       },
       "timing": { "firstByteMs": 1.0, "elapsedMs": 2.0, "throughputMiBs": 40.0, "cpuSeconds": 0.01 }

--- a/scripts/fixtures/performance-gate-expanded-missing-cold.json
+++ b/scripts/fixtures/performance-gate-expanded-missing-cold.json
@@ -24,14 +24,14 @@
     "pipelined-warm-reread": {
       "deterministic": {
         "bytes": 3145728,
-        "transportRequests": 11,
-        "transportBytes": 2883584,
-        "transportBatchRequests": 3,
-        "cacheHits": 1,
+        "transportRequests": 0,
+        "transportBytes": 0,
+        "transportBatchRequests": 0,
+        "cacheHits": 12,
         "cacheMisses": 0,
-        "cacheBytesServed": 262144,
-        "cacheBatchBypassRequests": 3,
-        "cacheBatchBypassArticles": 11,
+        "cacheBytesServed": 3145728,
+        "cacheBatchBypassRequests": 0,
+        "cacheBatchBypassArticles": 0,
         "cacheWriteCommits": 0
       },
       "timing": {

--- a/scripts/fixtures/performance-gate-expanded-missing-warm.json
+++ b/scripts/fixtures/performance-gate-expanded-missing-warm.json
@@ -28,11 +28,11 @@
         "transportBytes": 3145728,
         "transportBatchRequests": 3,
         "cacheHits": 0,
-        "cacheMisses": 1,
+        "cacheMisses": 12,
         "cacheBytesServed": 0,
-        "cacheBatchBypassRequests": 3,
-        "cacheBatchBypassArticles": 11,
-        "cacheWriteCommits": 1
+        "cacheBatchBypassRequests": 0,
+        "cacheBatchBypassArticles": 0,
+        "cacheWriteCommits": 12
       },
       "timing": {
         "firstByteMs": 1.0,

--- a/scripts/fixtures/performance-gate-expanded-timing.json
+++ b/scripts/fixtures/performance-gate-expanded-timing.json
@@ -28,11 +28,11 @@
         "transportBytes": 3145728,
         "transportBatchRequests": 3,
         "cacheHits": 0,
-        "cacheMisses": 1,
+        "cacheMisses": 12,
         "cacheBytesServed": 0,
-        "cacheBatchBypassRequests": 3,
-        "cacheBatchBypassArticles": 11,
-        "cacheWriteCommits": 1
+        "cacheBatchBypassRequests": 0,
+        "cacheBatchBypassArticles": 0,
+        "cacheWriteCommits": 12
       },
       "timing": {
         "firstByteMs": 1.0,
@@ -44,14 +44,14 @@
     "pipelined-warm-reread": {
       "deterministic": {
         "bytes": 3145728,
-        "transportRequests": 11,
-        "transportBytes": 2883584,
-        "transportBatchRequests": 3,
-        "cacheHits": 1,
+        "transportRequests": 0,
+        "transportBytes": 0,
+        "transportBatchRequests": 0,
+        "cacheHits": 12,
         "cacheMisses": 0,
-        "cacheBytesServed": 262144,
-        "cacheBatchBypassRequests": 3,
-        "cacheBatchBypassArticles": 11,
+        "cacheBytesServed": 3145728,
+        "cacheBatchBypassRequests": 0,
+        "cacheBatchBypassArticles": 0,
         "cacheWriteCommits": 0
       },
       "timing": {

--- a/scripts/fixtures/performance-gate-expanded-warm-transport.json
+++ b/scripts/fixtures/performance-gate-expanded-warm-transport.json
@@ -28,11 +28,11 @@
         "transportBytes": 3145728,
         "transportBatchRequests": 3,
         "cacheHits": 0,
-        "cacheMisses": 1,
+        "cacheMisses": 12,
         "cacheBytesServed": 0,
-        "cacheBatchBypassRequests": 3,
-        "cacheBatchBypassArticles": 11,
-        "cacheWriteCommits": 1
+        "cacheBatchBypassRequests": 0,
+        "cacheBatchBypassArticles": 0,
+        "cacheWriteCommits": 12
       },
       "timing": {
         "firstByteMs": 1.0,
@@ -44,14 +44,14 @@
     "pipelined-warm-reread": {
       "deterministic": {
         "bytes": 3145728,
-        "transportRequests": 0,
-        "transportBytes": 0,
-        "transportBatchRequests": 3,
-        "cacheHits": 1,
+        "transportRequests": 11,
+        "transportBytes": 2883584,
+        "transportBatchRequests": 0,
+        "cacheHits": 12,
         "cacheMisses": 0,
-        "cacheBytesServed": 262144,
-        "cacheBatchBypassRequests": 3,
-        "cacheBatchBypassArticles": 11,
+        "cacheBytesServed": 3145728,
+        "cacheBatchBypassRequests": 0,
+        "cacheBatchBypassArticles": 0,
         "cacheWriteCommits": 0
       },
       "timing": {

--- a/scripts/fixtures/performance-gate-expanded-write-1.json
+++ b/scripts/fixtures/performance-gate-expanded-write-1.json
@@ -28,11 +28,11 @@
         "transportBytes": 3145728,
         "transportBatchRequests": 3,
         "cacheHits": 0,
-        "cacheMisses": 1,
+        "cacheMisses": 12,
         "cacheBytesServed": 0,
-        "cacheBatchBypassRequests": 3,
-        "cacheBatchBypassArticles": 11,
-        "cacheWriteCommits": 1
+        "cacheBatchBypassRequests": 0,
+        "cacheBatchBypassArticles": 0,
+        "cacheWriteCommits": 12
       },
       "timing": {
         "firstByteMs": 1.0,
@@ -44,14 +44,14 @@
     "pipelined-warm-reread": {
       "deterministic": {
         "bytes": 3145728,
-        "transportRequests": 11,
-        "transportBytes": 2883584,
-        "transportBatchRequests": 3,
-        "cacheHits": 1,
+        "transportRequests": 0,
+        "transportBytes": 0,
+        "transportBatchRequests": 0,
+        "cacheHits": 12,
         "cacheMisses": 0,
-        "cacheBytesServed": 262144,
-        "cacheBatchBypassRequests": 3,
-        "cacheBatchBypassArticles": 11,
+        "cacheBytesServed": 3145728,
+        "cacheBatchBypassRequests": 0,
+        "cacheBatchBypassArticles": 0,
         "cacheWriteCommits": 0
       },
       "timing": {

--- a/scripts/fixtures/performance-gate-expanded-write-2.json
+++ b/scripts/fixtures/performance-gate-expanded-write-2.json
@@ -28,11 +28,11 @@
         "transportBytes": 3145728,
         "transportBatchRequests": 3,
         "cacheHits": 0,
-        "cacheMisses": 1,
+        "cacheMisses": 12,
         "cacheBytesServed": 0,
-        "cacheBatchBypassRequests": 3,
-        "cacheBatchBypassArticles": 11,
-        "cacheWriteCommits": 1
+        "cacheBatchBypassRequests": 0,
+        "cacheBatchBypassArticles": 0,
+        "cacheWriteCommits": 12
       },
       "timing": {
         "firstByteMs": 1.0,
@@ -44,14 +44,14 @@
     "pipelined-warm-reread": {
       "deterministic": {
         "bytes": 3145728,
-        "transportRequests": 11,
-        "transportBytes": 2883584,
-        "transportBatchRequests": 3,
-        "cacheHits": 1,
+        "transportRequests": 0,
+        "transportBytes": 0,
+        "transportBatchRequests": 0,
+        "cacheHits": 12,
         "cacheMisses": 0,
-        "cacheBytesServed": 262144,
-        "cacheBatchBypassRequests": 3,
-        "cacheBatchBypassArticles": 11,
+        "cacheBytesServed": 3145728,
+        "cacheBatchBypassRequests": 0,
+        "cacheBatchBypassArticles": 0,
         "cacheWriteCommits": 0
       },
       "timing": {

--- a/scripts/fixtures/performance-gate-expanded-write-3.json
+++ b/scripts/fixtures/performance-gate-expanded-write-3.json
@@ -28,11 +28,11 @@
         "transportBytes": 3145728,
         "transportBatchRequests": 3,
         "cacheHits": 0,
-        "cacheMisses": 1,
+        "cacheMisses": 12,
         "cacheBytesServed": 0,
-        "cacheBatchBypassRequests": 3,
-        "cacheBatchBypassArticles": 11,
-        "cacheWriteCommits": 1
+        "cacheBatchBypassRequests": 0,
+        "cacheBatchBypassArticles": 0,
+        "cacheWriteCommits": 12
       },
       "timing": {
         "firstByteMs": 1.0,
@@ -44,14 +44,14 @@
     "pipelined-warm-reread": {
       "deterministic": {
         "bytes": 3145728,
-        "transportRequests": 11,
-        "transportBytes": 2883584,
-        "transportBatchRequests": 3,
-        "cacheHits": 1,
+        "transportRequests": 0,
+        "transportBytes": 0,
+        "transportBatchRequests": 0,
+        "cacheHits": 12,
         "cacheMisses": 0,
-        "cacheBytesServed": 262144,
-        "cacheBatchBypassRequests": 3,
-        "cacheBatchBypassArticles": 11,
+        "cacheBytesServed": 3145728,
+        "cacheBatchBypassRequests": 0,
+        "cacheBatchBypassArticles": 0,
         "cacheWriteCommits": 0
       },
       "timing": {

--- a/scripts/fixtures/performance-gate-schema-v2.json
+++ b/scripts/fixtures/performance-gate-schema-v2.json
@@ -28,11 +28,11 @@
         "transportBytes": 3145728,
         "transportBatchRequests": 3,
         "cacheHits": 0,
-        "cacheMisses": 1,
+        "cacheMisses": 12,
         "cacheBytesServed": 0,
-        "cacheBatchBypassRequests": 3,
-        "cacheBatchBypassArticles": 11,
-        "cacheWriteCommits": 1
+        "cacheBatchBypassRequests": 0,
+        "cacheBatchBypassArticles": 0,
+        "cacheWriteCommits": 12
       },
       "timing": {
         "firstByteMs": 1.0,
@@ -44,14 +44,14 @@
     "pipelined-warm-reread": {
       "deterministic": {
         "bytes": 3145728,
-        "transportRequests": 11,
-        "transportBytes": 2883584,
-        "transportBatchRequests": 3,
-        "cacheHits": 1,
+        "transportRequests": 0,
+        "transportBytes": 0,
+        "transportBatchRequests": 0,
+        "cacheHits": 12,
         "cacheMisses": 0,
-        "cacheBytesServed": 262144,
-        "cacheBatchBypassRequests": 3,
-        "cacheBatchBypassArticles": 11,
+        "cacheBytesServed": 3145728,
+        "cacheBatchBypassRequests": 0,
+        "cacheBatchBypassArticles": 0,
         "cacheWriteCommits": 0
       },
       "timing": {

--- a/scripts/test-performance-baseline-gate.sh
+++ b/scripts/test-performance-baseline-gate.sh
@@ -225,10 +225,10 @@ from pathlib import Path
 
 baseline = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 cold = baseline["scenarios"]["pipelined-cold-read"]["deterministic"]
-if cold["bytes"] != 3145728 or cold["transportBatchRequests"] != 3 or cold["cacheWriteCommits"] != 1:
+if cold["bytes"] != 3145728 or cold["transportBatchRequests"] != 3 or cold["cacheWriteCommits"] != 12:
     raise SystemExit(f"write-baseline lost integer deterministic values: {cold}")
 warm = baseline["scenarios"]["pipelined-warm-reread"]["deterministic"]
-if warm["transportRequests"] != 11 or warm["cacheHits"] != 1:
+if warm["transportRequests"] != 0 or warm["cacheHits"] != 12:
     raise SystemExit(f"write-baseline lost warm integers: {warm}")
 timing = baseline["scenarios"]["pipelined-cold-read"]["timing"]["elapsedMs"]
 if "baseline" not in timing or "envelope" not in timing or timing["policy"] != "fail":

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/BatchLocalDataChainTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/BatchLocalDataChainTests.cs
@@ -1,0 +1,190 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services.Repair;
+using NzbWebDAV.Tests.Fakes;
+using NzbWebDAV.Tests.TestUtils;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public sealed class BatchLocalDataChainTests
+{
+    [Fact]
+    public async Task PatchCacheNetworkMixedBatch_UsesPatchThenCacheThenOneNetworkMiss()
+    {
+        var root = Path.Join(Path.GetTempPath(), "nzbdav-chain-" + Guid.NewGuid().ToString("N"));
+        var cacheDir = Path.Join(root, "cache");
+        var patchDir = Path.Join(root, "patch");
+        var a = "a@test";
+        var b = "b@test";
+        var c = "c@test";
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            Directory.CreateDirectory(patchDir);
+            WriteCache(cacheDir, c, "ccc"u8.ToArray());
+            var store = new RepairPatchStore(patchDir, 1024 * 1024);
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
+            store.CommitPatch(a, "aaa"u8.ToArray(), Header("aaa"u8.ToArray()));
+
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>
+            {
+                [b] = "bbb"u8.ToArray(),
+                [c] = "ccc"u8.ToArray(),
+            }, useCachedYencStreams: true);
+            var statistics = new SegmentCacheStatistics();
+            using var cache = new SegmentCacheNntpClient(
+                inner, cacheDir, 1024 * 1024, usageTracker: null, metricsWriter: null, enumerateCacheFiles: null, statistics);
+            await cache.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+            using var repair = new RepairedSegmentNntpClient(cache, store);
+
+            var recorder = new ArticleBodyCompletionRecorder();
+            var batch = await repair.DecodedBodiesAsync([a, b, c], recorder.Invoke, CancellationToken.None);
+            await batch.DrainAsync();
+
+            Assert.Equal(1, inner.BatchRequestCount);
+            Assert.Equal(["b@test"], inner.RequestedSegmentIds.OrderBy(x => x).ToArray());
+            Assert.Equal(1, recorder.Count);
+            Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
+            Assert.Equal(1, statistics.GetSnapshot().Hits);
+            Assert.Equal(1, statistics.GetSnapshot().Misses);
+            Assert.Equal(1, statistics.GetSnapshot().WriteCommits);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PatchHit_IsNeverWrittenIntoSegmentCache()
+    {
+        var root = Path.Join(Path.GetTempPath(), "nzbdav-chain-" + Guid.NewGuid().ToString("N"));
+        var cacheDir = Path.Join(root, "cache");
+        var patchDir = Path.Join(root, "patch");
+        const string id = "patched@test";
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            Directory.CreateDirectory(patchDir);
+            var store = new RepairPatchStore(patchDir, 1024 * 1024);
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
+            store.CommitPatch(id, "patch"u8.ToArray(), Header("patch"u8.ToArray()));
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
+            var statistics = new SegmentCacheStatistics();
+            using var cache = new SegmentCacheNntpClient(
+                inner, cacheDir, 1024 * 1024, usageTracker: null, metricsWriter: null, enumerateCacheFiles: null, statistics);
+            await cache.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+            using var repair = new RepairedSegmentNntpClient(cache, store);
+
+            var batch = await repair.DecodedBodiesAsync([id], onConnectionReadyAgain: null, CancellationToken.None);
+            await batch.DrainAsync();
+
+            Assert.Equal(0, inner.BatchRequestCount);
+            Assert.Equal(0, statistics.GetSnapshot().WriteAttempts);
+            Assert.Equal(0, statistics.GetSnapshot().Hits);
+            Assert.Equal(0, statistics.GetSnapshot().Misses);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task FullyLocalOrdinaryBatch_BypassesDownloadingPermitAndProvider()
+    {
+        var root = Path.Join(Path.GetTempPath(), "nzbdav-chain-" + Guid.NewGuid().ToString("N"));
+        var cacheDir = Path.Join(root, "cache");
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            WriteCache(cacheDir, "a", "aaa"u8.ToArray());
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
+            var config = CreateConfig();
+            using var downloading = new DownloadingNntpClient(inner, config);
+            using var cache = new SegmentCacheNntpClient(downloading, cacheDir, 1024 * 1024);
+            await cache.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var batch = await cache.DecodedBodiesAsync(["a"], onConnectionReadyAgain: null, CancellationToken.None);
+            await batch.DrainAsync();
+            Assert.Equal(0, inner.BatchRequestCount);
+            Assert.Equal(0, inner.BodyRequestCount);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task FullyLocalExclusiveBatch_ReleasesExistingPermitExactlyOnce()
+    {
+        var root = Path.Join(Path.GetTempPath(), "nzbdav-chain-" + Guid.NewGuid().ToString("N"));
+        var cacheDir = Path.Join(root, "cache");
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            WriteCache(cacheDir, "a", "aaa"u8.ToArray());
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
+            using var cache = new SegmentCacheNntpClient(inner, cacheDir, 1024 * 1024);
+            await cache.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+            var recorder = new ArticleBodyCompletionRecorder();
+            var exclusive = new UsenetExclusiveConnection(recorder.Invoke);
+            var batch = await cache.DecodedBodiesAsync(["a"], exclusive, CancellationToken.None);
+            await batch.DrainAsync();
+            Assert.Equal(1, recorder.Count);
+            Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
+            Assert.Equal(0, inner.BatchRequestCount);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static ConfigManager CreateConfig()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue =
+                    """{"providers":[{"host":"nntp.example","port":563,"useSsl":true,"user":"u","pass":"p","maxConnections":2,"type":1}]}""",
+            },
+            new ConfigItem { ConfigName = ConfigKeys.UsenetMaxQueueConnections, ConfigValue = "2" },
+            new ConfigItem { ConfigName = ConfigKeys.UsenetMaxDownloadConnections, ConfigValue = "2" },
+        ]);
+        return config;
+    }
+
+    private static void WriteCache(string cacheDir, string segmentId, byte[] content)
+    {
+        var hash = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(segmentId)));
+        var directory = Path.Join(cacheDir, hash[..2]);
+        Directory.CreateDirectory(directory);
+        File.WriteAllBytes(Path.Join(directory, hash), content);
+        File.WriteAllText(
+            Path.Join(directory, hash) + ".h",
+            System.Text.Json.JsonSerializer.Serialize(Header(content), new System.Text.Json.JsonSerializerOptions { IncludeFields = true }));
+    }
+
+    private static UsenetYencHeader Header(byte[] content) => new()
+    {
+        FileName = "test.bin",
+        FileSize = content.Length,
+        LineLength = 128,
+        PartNumber = 1,
+        TotalParts = 1,
+        PartOffset = 0,
+        PartSize = content.Length,
+    };
+}

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadingNntpClientStatGateTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadingNntpClientStatGateTests.cs
@@ -539,6 +539,49 @@ public class DownloadingNntpClientStatGateTests
         await DrainAsync(CompletionApi.Body, bTask);
     }
 
+    [Fact]
+    public async Task BatchCompletion_IsObservableAfterPermitRelease()
+    {
+        var inner = new ManualCompletionNntpClient { DeferBatchLifecycle = true };
+        var config = CreateConfig(maxQueueConnections: 1, maxDownloadConnections: 10);
+        using var client = new DownloadingNntpClient(inner, config);
+        var outer = new ArticleBodyCompletionRecorder();
+
+        var aTask = StartApi(client, CompletionApi.Batch, "a", outer.Invoke, CancellationToken.None);
+        var aOp = await WaitForOpAsync(inner, 1);
+        aOp.Callback!(ArticleBodyResult.Retrieved, null);
+        var batch = await (Task<UsenetDecodedBodyBatch>)aTask;
+        Assert.Equal(1, outer.Count);
+        Assert.False(batch.Completion.IsCompleted);
+        inner.BatchLifecycle.TrySetResult();
+        await DrainAsync(CompletionApi.Batch, aTask);
+
+        var bTask = StartApi(client, CompletionApi.Batch, "b", null, CancellationToken.None);
+        var bOp = await WaitForOpAsync(inner, 2);
+        bOp.Callback!(ArticleBodyResult.Retrieved, null);
+        inner.BatchLifecycle.TrySetResult();
+        await DrainAsync(CompletionApi.Batch, bTask);
+    }
+
+    [Fact]
+    public async Task BatchSetupThrow_ReleasesPermitAndCompletesCallbackOnce()
+    {
+        var inner = new ThrowOnceBatchNntpClient();
+        var config = CreateConfig(maxQueueConnections: 1, maxDownloadConnections: 1);
+        using var client = new DownloadingNntpClient(inner, config);
+        var outer = new ArticleBodyCompletionRecorder();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.DecodedBodiesAsync(["a"], outer.Invoke, CancellationToken.None));
+        Assert.Equal(1, outer.Count);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, outer.Result);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var recovered = await client.DecodedBodiesAsync(["b"], onConnectionReadyAgain: null, timeout.Token);
+        await recovered.DrainAsync();
+        Assert.Equal(2, inner.Calls);
+    }
+
     private static Task StartApi(
         DownloadingNntpClient client,
         CompletionApi api,
@@ -580,6 +623,7 @@ public class DownloadingNntpClientStatGateTests
                     }
                 }
 
+                await batch.Completion;
                 break;
             }
             case CompletionApi.Article:
@@ -695,6 +739,8 @@ public class DownloadingNntpClientStatGateTests
         public ArticleBodyResult AutoResult { get; set; } = ArticleBodyResult.Retrieved;
         public string? AutoReason { get; set; }
         public bool Success { get; set; } = true;
+        public bool DeferBatchLifecycle { get; set; }
+        public TaskCompletionSource BatchLifecycle { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public IReadOnlyList<PendingOp> Ops
         {
@@ -735,7 +781,11 @@ public class DownloadingNntpClientStatGateTests
                 var responses = segmentIds
                     .Select(id => Task.FromResult(CreateBody(id)))
                     .ToArray();
-                return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
+                return Task.FromResult(new UsenetDecodedBodyBatch
+                {
+                    Responses = responses,
+                    Completion = DeferBatchLifecycle ? BatchLifecycle.Task : Task.CompletedTask,
+                });
             }
             finally
             {
@@ -845,6 +895,44 @@ public class DownloadingNntpClientStatGateTests
                     PartSize = bytes.Length,
                 },
                 new MemoryStream(bytes, writable: false));
+    }
+
+    private sealed class ThrowOnceBatchNntpClient : MinimalNntpClient
+    {
+        public int Calls { get; private set; }
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            Calls++;
+            if (Calls == 1)
+                throw new InvalidOperationException("batch-setup");
+
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            var responses = segmentIds
+                .Select(id => Task.FromResult(new UsenetDecodedBodyResponse
+                {
+                    SegmentId = id.ToString(),
+                    ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                    ResponseMessage = "222",
+                    Stream = new CachedYencStream(
+                        new UsenetYencHeader
+                        {
+                            FileName = "fake.bin",
+                            FileSize = 4,
+                            LineLength = 128,
+                            PartNumber = 1,
+                            TotalParts = 1,
+                            PartOffset = 0,
+                            PartSize = 4,
+                        },
+                        new MemoryStream("body"u8.ToArray(), writable: false)),
+                }))
+                .ToArray();
+            return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
+        }
     }
 
     private abstract class MinimalNntpClient : NntpClient

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadingNntpClientStatGateTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadingNntpClientStatGateTests.cs
@@ -553,13 +553,15 @@ public class DownloadingNntpClientStatGateTests
         var batch = await (Task<UsenetDecodedBodyBatch>)aTask;
         Assert.Equal(1, outer.Count);
         Assert.False(batch.Completion.IsCompleted);
-        inner.BatchLifecycle.TrySetResult();
+        Assert.NotNull(inner.LastBatchLifecycle);
+        inner.LastBatchLifecycle.TrySetResult();
         await DrainAsync(CompletionApi.Batch, aTask);
 
         var bTask = StartApi(client, CompletionApi.Batch, "b", null, CancellationToken.None);
         var bOp = await WaitForOpAsync(inner, 2);
         bOp.Callback!(ArticleBodyResult.Retrieved, null);
-        inner.BatchLifecycle.TrySetResult();
+        Assert.NotNull(inner.LastBatchLifecycle);
+        inner.LastBatchLifecycle.TrySetResult();
         await DrainAsync(CompletionApi.Batch, bTask);
     }
 
@@ -740,7 +742,7 @@ public class DownloadingNntpClientStatGateTests
         public string? AutoReason { get; set; }
         public bool Success { get; set; } = true;
         public bool DeferBatchLifecycle { get; set; }
-        public TaskCompletionSource BatchLifecycle { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource? LastBatchLifecycle { get; private set; }
 
         public IReadOnlyList<PendingOp> Ops
         {
@@ -781,10 +783,12 @@ public class DownloadingNntpClientStatGateTests
                 var responses = segmentIds
                     .Select(id => Task.FromResult(CreateBody(id)))
                     .ToArray();
+                var lifecycle = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                LastBatchLifecycle = lifecycle;
                 return Task.FromResult(new UsenetDecodedBodyBatch
                 {
                     Responses = responses,
-                    Completion = DeferBatchLifecycle ? BatchLifecycle.Task : Task.CompletedTask,
+                    Completion = DeferBatchLifecycle ? lifecycle.Task : Task.CompletedTask,
                 });
             }
             finally

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/LocalDataBatchOverlayTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/LocalDataBatchOverlayTests.cs
@@ -1,0 +1,571 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.TestUtils;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public sealed class LocalDataBatchOverlayTests
+{
+    [Fact]
+    public async Task AllLocal_PublishesResponsesOnlyAfterPreviousStreamTerminal()
+    {
+        var ids = Ids("a", "b");
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            ids,
+            outerCallback: null,
+            id => LocalLookupResult.Hit(Local(id)),
+            FetchShouldNotRun,
+            LocalDataBatchOverlay.PassThroughRemote,
+            CancellationToken.None);
+
+        var first = await batch.Responses[0].WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.False(batch.Responses[1].IsCompleted);
+        await first.Stream!.DisposeAsync();
+        var second = await batch.Responses[1].WaitAsync(TimeSpan.FromSeconds(5));
+        await second.Stream!.DisposeAsync();
+        await batch.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task AllRemote_PreservesInnerResponseAndCompletionOrder()
+    {
+        var inner = new ControlledDecodedBodyBatchClient();
+        var recorder = new ArticleBodyCompletionRecorder();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a", "b"),
+            recorder.Invoke,
+            _ => LocalLookupResult.Miss,
+            (misses, callback, token) => inner.DecodedBodiesAsync(misses, callback, token),
+            LocalDataBatchOverlay.PassThroughRemote,
+            CancellationToken.None);
+
+        Assert.Equal(1, inner.OrdinaryBatchCount);
+        Assert.Equal(["a", "b"], inner.RequestedIds);
+        var first = await batch.Responses[0].WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.False(batch.Responses[1].IsCompleted);
+        await first.Stream!.DisposeAsync();
+        var second = await batch.Responses[1].WaitAsync(TimeSpan.FromSeconds(5));
+        await second.Stream!.DisposeAsync();
+        await batch.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
+    }
+
+    [Fact]
+    public async Task MixedLocalRemoteLocal_RequestsOnlyRemoteAndPreservesPositions()
+    {
+        var inner = new ControlledDecodedBodyBatchClient();
+        var recorder = new ArticleBodyCompletionRecorder();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a", "b", "a"),
+            recorder.Invoke,
+            id => id.ToString() == "a"
+                ? LocalLookupResult.Hit(Local(id, "local-a"u8.ToArray()))
+                : LocalLookupResult.Miss,
+            (misses, callback, token) => inner.DecodedBodiesAsync(misses, callback, token),
+            LocalDataBatchOverlay.PassThroughRemote,
+            CancellationToken.None);
+
+        Assert.Equal(1, inner.OrdinaryBatchCount);
+        Assert.Equal(["b"], inner.RequestedIds);
+        await batch.DrainAsync();
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
+    }
+
+    [Fact]
+    public async Task DuplicateIds_PreserveEveryOriginalPosition()
+    {
+        var seen = new List<string>();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a", "a"),
+            outerCallback: null,
+            id =>
+            {
+                seen.Add(id.ToString());
+                return LocalLookupResult.Hit(Local(id, "dup"u8.ToArray()));
+            },
+            FetchShouldNotRun,
+            LocalDataBatchOverlay.PassThroughRemote,
+            CancellationToken.None);
+
+        Assert.Equal(["a", "a"], seen);
+        var first = await batch.Responses[0];
+        await first.Stream!.DisposeAsync();
+        var second = await batch.Responses[1];
+        Assert.NotSame(first.Stream, second.Stream);
+        await second.Stream!.DisposeAsync();
+        await batch.Completion;
+    }
+
+    [Fact]
+    public async Task InnerCallbackBeforeReturn_IsDeferredAndForwardedOnce()
+    {
+        var inner = new ControlledDecodedBodyBatchClient(callbackTiming: ControlledDecodedBodyBatchClient.CallbackTiming.BeforeReturn);
+        var recorder = new ArticleBodyCompletionRecorder();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a"),
+            recorder.Invoke,
+            _ => LocalLookupResult.Miss,
+            (misses, callback, token) => inner.DecodedBodiesAsync(misses, callback, token),
+            LocalDataBatchOverlay.PassThroughRemote,
+            CancellationToken.None);
+
+        Assert.Equal(0, recorder.Count);
+        await batch.DrainAsync();
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
+    }
+
+    [Fact]
+    public async Task InnerCallbackAfterActivation_IsForwardedOnce()
+    {
+        var inner = new ControlledDecodedBodyBatchClient(callbackTiming: ControlledDecodedBodyBatchClient.CallbackTiming.AfterReturn);
+        var recorder = new ArticleBodyCompletionRecorder();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a"),
+            recorder.Invoke,
+            _ => LocalLookupResult.Miss,
+            (misses, callback, token) => inner.DecodedBodiesAsync(misses, callback, token),
+            LocalDataBatchOverlay.PassThroughRemote,
+            CancellationToken.None);
+
+        Assert.Equal(0, recorder.Count);
+        inner.FireCapturedCallback(ArticleBodyResult.Retrieved);
+        inner.CompleteProducer();
+        await batch.DrainAsync();
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
+    }
+
+    [Fact]
+    public async Task DuplicateInnerCallback_FirstTerminalResultWins()
+    {
+        var inner = new ControlledDecodedBodyBatchClient(callbackTiming: ControlledDecodedBodyBatchClient.CallbackTiming.Twice);
+        var recorder = new ArticleBodyCompletionRecorder();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a"),
+            recorder.Invoke,
+            _ => LocalLookupResult.Miss,
+            (misses, callback, token) => inner.DecodedBodiesAsync(misses, callback, token),
+            LocalDataBatchOverlay.PassThroughRemote,
+            CancellationToken.None);
+
+        await batch.DrainAsync();
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
+    }
+
+    [Fact]
+    public async Task ThrowingOuterCallback_DoesNotFaultResponsesOrCompletion()
+    {
+        var recorder = new ArticleBodyCompletionRecorder(throwOnInvoke: true);
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a"),
+            recorder.Invoke,
+            id => LocalLookupResult.Hit(Local(id)),
+            FetchShouldNotRun,
+            LocalDataBatchOverlay.PassThroughRemote,
+            CancellationToken.None);
+
+        await batch.DrainAsync();
+        Assert.Equal(1, recorder.Count);
+        Assert.True(batch.Completion.IsCompletedSuccessfully);
+    }
+
+    [Fact]
+    public async Task InnerSetupThrow_CleansLocalStreamsAndReportsNotRetrievedOnce()
+    {
+        var recorder = new ArticleBodyCompletionRecorder();
+        var local = Local("a");
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            LocalDataBatchOverlay.ExecuteAsync(
+                Ids("a", "b"),
+                recorder.Invoke,
+                id => id.ToString() == "a" ? LocalLookupResult.Hit(local) : LocalLookupResult.Miss,
+                (_, _, _) => throw new InvalidOperationException("batch-setup"),
+                LocalDataBatchOverlay.PassThroughRemote,
+                CancellationToken.None));
+
+        Assert.Equal("batch-setup", error.Message);
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, recorder.Result);
+        Assert.True(IsDisposed(local.Stream!));
+    }
+
+    [Fact]
+    public async Task ResponseCountTooSmall_DrainsInnerAndReportsNotRetrievedOnce()
+    {
+        var inner = new ControlledDecodedBodyBatchClient(responseCountOverride: 0);
+        var recorder = new ArticleBodyCompletionRecorder();
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            LocalDataBatchOverlay.ExecuteAsync(
+                Ids("a", "b"),
+                recorder.Invoke,
+                _ => LocalLookupResult.Miss,
+                (misses, callback, token) => inner.DecodedBodiesAsync(misses, callback, token),
+                LocalDataBatchOverlay.PassThroughRemote,
+                CancellationToken.None));
+
+        Assert.Contains("returned 0 responses for 2 requests", error.Message);
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, recorder.Result);
+        Assert.Equal("batch-response-count-mismatch", recorder.FailureReason);
+    }
+
+    [Fact]
+    public async Task ResponseCountTooLarge_DrainsInnerAndReportsNotRetrievedOnce()
+    {
+        var inner = new ControlledDecodedBodyBatchClient(responseCountOverride: 3);
+        var recorder = new ArticleBodyCompletionRecorder();
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            LocalDataBatchOverlay.ExecuteAsync(
+                Ids("a", "b"),
+                recorder.Invoke,
+                _ => LocalLookupResult.Miss,
+                (misses, callback, token) => inner.DecodedBodiesAsync(misses, callback, token),
+                LocalDataBatchOverlay.PassThroughRemote,
+                CancellationToken.None));
+
+        Assert.Contains("returned 3 responses for 2 requests", error.Message);
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, recorder.Result);
+    }
+
+    [Fact]
+    public async Task ResponseTaskFailure_DoesNotStrandLaterPositions()
+    {
+        var recorder = new ArticleBodyCompletionRecorder();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a", "b"),
+            recorder.Invoke,
+            _ => LocalLookupResult.Miss,
+            (misses, callback, token) =>
+            {
+                callback(ArticleBodyResult.Retrieved);
+                return Task.FromResult(new UsenetDecodedBodyBatch
+                {
+                    Responses =
+                    [
+                        Task.FromException<UsenetDecodedBodyResponse>(new IOException("remote-fail")),
+                        Task.FromResult(ControlledDecodedBodyBatchClient.CreateSuccess(misses[1], "ok"u8.ToArray())),
+                    ],
+                    Completion = Task.CompletedTask,
+                });
+            },
+            LocalDataBatchOverlay.PassThroughRemote,
+            CancellationToken.None);
+
+        await Assert.ThrowsAsync<IOException>(() => batch.Responses[0]);
+        var second = await batch.Responses[1].WaitAsync(TimeSpan.FromSeconds(5));
+        await second.Stream!.DisposeAsync();
+        await Assert.ThrowsAsync<IOException>(() => batch.Completion);
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, recorder.Result);
+    }
+
+    [Fact]
+    public async Task StreamReadFailure_ReleasesNextReadinessGate()
+    {
+        var recorder = new ArticleBodyCompletionRecorder();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a", "b"),
+            recorder.Invoke,
+            id => LocalLookupResult.Hit(new UsenetDecodedBodyResponse
+            {
+                SegmentId = id.ToString(),
+                ResponseCode = 222,
+                ResponseMessage = "222",
+                Stream = id.ToString() == "a"
+                    ? new ThrowingReadYencStream()
+                    : new CachedYencStream(
+                        ControlledDecodedBodyBatchClient.HeaderFor("b"u8.ToArray()),
+                        new MemoryStream("b"u8.ToArray(), writable: false)),
+            }),
+            FetchShouldNotRun,
+            LocalDataBatchOverlay.PassThroughRemote,
+            CancellationToken.None);
+
+        var first = await batch.Responses[0];
+        await Assert.ThrowsAsync<IOException>(async () => await first.Stream!.ReadAsync(new byte[8]));
+        var second = await batch.Responses[1].WaitAsync(TimeSpan.FromSeconds(5));
+        await second.Stream!.DisposeAsync();
+        await first.Stream!.DisposeAsync();
+        await Assert.ThrowsAsync<IOException>(() => batch.Completion);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, recorder.Result);
+    }
+
+    [Fact]
+    public async Task StreamDisposeFailure_ReleasesNextReadinessGate()
+    {
+        var recorder = new ArticleBodyCompletionRecorder();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a", "b"),
+            recorder.Invoke,
+            id => LocalLookupResult.Hit(new UsenetDecodedBodyResponse
+            {
+                SegmentId = id.ToString(),
+                ResponseCode = 222,
+                ResponseMessage = "222",
+                Stream = id.ToString() == "a"
+                    ? new ThrowingDisposeYencStream()
+                    : new CachedYencStream(
+                        ControlledDecodedBodyBatchClient.HeaderFor("b"u8.ToArray()),
+                        new MemoryStream("b"u8.ToArray(), writable: false)),
+            }),
+            FetchShouldNotRun,
+            LocalDataBatchOverlay.PassThroughRemote,
+            CancellationToken.None);
+
+        var first = await batch.Responses[0];
+        await Assert.ThrowsAsync<IOException>(async () => await first.Stream!.DisposeAsync());
+        var second = await batch.Responses[1].WaitAsync(TimeSpan.FromSeconds(5));
+        await second.Stream!.DisposeAsync();
+        await Assert.ThrowsAsync<IOException>(() => batch.Completion);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, recorder.Result);
+    }
+
+    [Fact]
+    public async Task InnerCompletionFailure_IsObservedAndSurfaced()
+    {
+        var inner = new ControlledDecodedBodyBatchClient(
+            callbackTiming: ControlledDecodedBodyBatchClient.CallbackTiming.AfterReturn);
+        var recorder = new ArticleBodyCompletionRecorder();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a"),
+            recorder.Invoke,
+            _ => LocalLookupResult.Miss,
+            (misses, callback, token) => inner.DecodedBodiesAsync(misses, callback, token),
+            LocalDataBatchOverlay.PassThroughRemote,
+            CancellationToken.None);
+
+        inner.FireCapturedCallback(ArticleBodyResult.Retrieved);
+        inner.FaultProducer(new IOException("inner-completion"));
+        var response = await batch.Responses[0];
+        await response.Stream!.DisposeAsync();
+        await Assert.ThrowsAsync<IOException>(() => batch.Completion);
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, recorder.Result);
+    }
+
+    [Fact]
+    public async Task FailureAfterActivation_DowngradesEarlyRetrievedToNotRetrieved()
+    {
+        var inner = new ControlledDecodedBodyBatchClient(
+            callbackTiming: ControlledDecodedBodyBatchClient.CallbackTiming.BeforeReturn);
+        var recorder = new ArticleBodyCompletionRecorder();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a"),
+            recorder.Invoke,
+            _ => LocalLookupResult.Miss,
+            (misses, callback, token) => inner.DecodedBodiesAsync(misses, callback, token),
+            async (id, response, _) =>
+            {
+                await response.Stream!.DisposeAsync();
+                throw new IOException("transform-fail");
+            },
+            CancellationToken.None);
+
+        await Assert.ThrowsAsync<IOException>(() => batch.Responses[0]);
+        await Assert.ThrowsAsync<IOException>(() => batch.Completion);
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, recorder.Result);
+    }
+
+    [Fact]
+    public async Task ConcurrentDuplicateInnerCallbacks_ForwardOneCoherentPair()
+    {
+        var inner = new ControlledDecodedBodyBatchClient(
+            callbackTiming: ControlledDecodedBodyBatchClient.CallbackTiming.AfterReturn);
+        var recorder = new ArticleBodyCompletionRecorder();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a"),
+            recorder.Invoke,
+            _ => LocalLookupResult.Miss,
+            (misses, callback, token) => inner.DecodedBodiesAsync(misses, callback, token),
+            LocalDataBatchOverlay.PassThroughRemote,
+            CancellationToken.None);
+
+        await Task.WhenAll(
+            Task.Run(() => inner.FireCapturedCallback(ArticleBodyResult.Retrieved)),
+            Task.Run(() => inner.FireCapturedCallback(ArticleBodyResult.NotRetrieved, "duplicate")));
+        inner.CompleteProducer();
+        await batch.DrainAsync();
+        Assert.Equal(1, recorder.Count);
+    }
+
+    [Fact]
+    public async Task EarlyBatchAbandonment_CancelDisposeAwait_ReleasesEverything()
+    {
+        var recorder = new ArticleBodyCompletionRecorder();
+        using var cts = new CancellationTokenSource();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a", "b", "c"),
+            recorder.Invoke,
+            id => LocalLookupResult.Hit(Local(id)),
+            FetchShouldNotRun,
+            LocalDataBatchOverlay.PassThroughRemote,
+            cts.Token);
+
+        var first = await batch.Responses[0];
+        await first.Stream!.DisposeAsync();
+        await cts.CancelAsync();
+        for (var index = 1; index < batch.Responses.Count; index++)
+        {
+            var response = await batch.Responses[index].WaitAsync(TimeSpan.FromSeconds(5));
+            if (response.Stream is not null)
+                await response.Stream.DisposeAsync();
+        }
+
+        await batch.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(1, recorder.Count);
+    }
+
+    [Fact]
+    public async Task MissingInnerCallback_CompletesAsNotRetrievedWithoutHanging()
+    {
+        var inner = new ControlledDecodedBodyBatchClient(callbackTiming: ControlledDecodedBodyBatchClient.CallbackTiming.Never);
+        var recorder = new ArticleBodyCompletionRecorder();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a"),
+            recorder.Invoke,
+            _ => LocalLookupResult.Miss,
+            (misses, callback, token) => inner.DecodedBodiesAsync(misses, callback, token),
+            LocalDataBatchOverlay.PassThroughRemote,
+            CancellationToken.None);
+
+        inner.CompleteProducer();
+        await batch.DrainAsync();
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, recorder.Result);
+        Assert.Equal("inner-callback-missing", recorder.FailureReason);
+    }
+
+    [Fact]
+    public async Task CancellationBeforePartition_ReportsOnceAndOpensNothing()
+    {
+        var recorder = new ArticleBodyCompletionRecorder();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        var opened = 0;
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            LocalDataBatchOverlay.ExecuteAsync(
+                Ids("a"),
+                recorder.Invoke,
+                _ =>
+                {
+                    opened++;
+                    return LocalLookupResult.Miss;
+                },
+                FetchShouldNotRun,
+                LocalDataBatchOverlay.PassThroughRemote,
+                cts.Token));
+
+        Assert.Equal(0, opened);
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.Cancelled, recorder.Result);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task CancellationAtEachPosition_ReleasesAllGates(int cancelIndex)
+    {
+        var recorder = new ArticleBodyCompletionRecorder();
+        using var cts = new CancellationTokenSource();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a", "b", "c"),
+            recorder.Invoke,
+            id => LocalLookupResult.Hit(Local(id)),
+            FetchShouldNotRun,
+            LocalDataBatchOverlay.PassThroughRemote,
+            cts.Token);
+
+        for (var index = 0; index < batch.Responses.Count; index++)
+        {
+            var response = await batch.Responses[index].WaitAsync(TimeSpan.FromSeconds(5));
+            if (index == cancelIndex)
+                await cts.CancelAsync();
+            if (response.Stream is not null)
+                await response.Stream.DisposeAsync();
+        }
+
+        await batch.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(1, recorder.Count);
+    }
+
+    [Fact]
+    public async Task EmptyList_ThrowsBeforeCallbackOrStore()
+    {
+        var recorder = new ArticleBodyCompletionRecorder();
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            LocalDataBatchOverlay.ExecuteAsync(
+                [],
+                recorder.Invoke,
+                _ => throw new InvalidOperationException("should not open"),
+                FetchShouldNotRun,
+                LocalDataBatchOverlay.PassThroughRemote,
+                CancellationToken.None));
+        Assert.Equal(0, recorder.Count);
+    }
+
+    private static SegmentId[] Ids(params string[] ids) => ids.Select(id => new SegmentId(id)).ToArray();
+
+    private static UsenetDecodedBodyResponse Local(SegmentId id, byte[]? content = null) =>
+        ControlledDecodedBodyBatchClient.CreateSuccess(id, content ?? "local"u8.ToArray());
+
+    private static Task<UsenetDecodedBodyBatch> FetchShouldNotRun(
+        IReadOnlyList<SegmentId> _,
+        ArticleBodyCompletionHandler __,
+        CancellationToken ___) =>
+        throw new InvalidOperationException("inner batch should not run");
+
+    private static bool IsDisposed(Stream stream)
+    {
+        try
+        {
+            _ = stream.ReadByte();
+            return false;
+        }
+        catch (ObjectDisposedException)
+        {
+            return true;
+        }
+    }
+
+    private sealed class ThrowingReadYencStream : YencStream
+    {
+        public ThrowingReadYencStream() : base(Null)
+        {
+        }
+
+        public override ValueTask<UsenetYencHeader?> GetYencHeadersAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<UsenetYencHeader?>(ControlledDecodedBodyBatchClient.HeaderFor("x"u8.ToArray()));
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+            throw new IOException("read-fail");
+    }
+
+    private sealed class ThrowingDisposeYencStream : YencStream
+    {
+        public ThrowingDisposeYencStream() : base(Null)
+        {
+        }
+
+        public override ValueTask<UsenetYencHeader?> GetYencHeadersAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<UsenetYencHeader?>(ControlledDecodedBodyBatchClient.HeaderFor("x"u8.ToArray()));
+
+        public override ValueTask DisposeAsync() => throw new IOException("dispose-fail");
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                throw new IOException("dispose-fail");
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiConnectionStatsPipelinedTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiConnectionStatsPipelinedTests.cs
@@ -3,6 +3,7 @@ using NzbWebDAV.Clients.Usenet.Connections;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Models;
 using UsenetSharp.Models;
+using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Tests.Clients.Usenet;
 
@@ -125,6 +126,57 @@ public class MultiConnectionStatsPipelinedTests
         Assert.True(breaker.IsTripped);
     }
 
+    [Fact]
+    public async Task DecodedBodiesAsync_CompletionWaitsForConnectionLockRelease()
+    {
+        var inner = new GatedBodyBatchClient();
+        using var pool = new ConnectionPool<INntpClient>(
+            maxConnections: 1, _ => ValueTask.FromResult<INntpClient>(inner));
+        using var client = new MultiConnectionNntpClient(
+            pool,
+            ProviderType.Pooled,
+            new ProviderCircuitBreaker("body-pipeline-completion"),
+            "body-pipeline-completion",
+            maxTransferConnections: 1);
+
+        var batch = await client.DecodedBodiesAsync(
+            ["a@example"], onConnectionReadyAgain: null, CancellationToken.None);
+        Assert.False(batch.Completion.IsCompleted);
+        inner.TransportCompletion.TrySetResult();
+        Assert.False(batch.Completion.IsCompleted);
+        inner.CapturedCallback!(ArticleBodyResult.Retrieved, null);
+        await batch.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+        var response = await batch.Responses[0];
+        if (response.Stream is not null)
+            await response.Stream.DisposeAsync();
+        Assert.Equal(1, client.AvailableConnections);
+    }
+
+    [Fact]
+    public async Task DecodedBodiesAsync_DuplicateCallback_ReleasesOneConnectionLock()
+    {
+        var inner = new GatedBodyBatchClient();
+        using var pool = new ConnectionPool<INntpClient>(
+            maxConnections: 1, _ => ValueTask.FromResult<INntpClient>(inner));
+        using var client = new MultiConnectionNntpClient(
+            pool,
+            ProviderType.Pooled,
+            new ProviderCircuitBreaker("body-pipeline-duplicate"),
+            "body-pipeline-duplicate",
+            maxTransferConnections: 1);
+
+        var batch = await client.DecodedBodiesAsync(
+            ["a@example"], onConnectionReadyAgain: null, CancellationToken.None);
+        inner.TransportCompletion.TrySetResult();
+        inner.CapturedCallback!(ArticleBodyResult.Retrieved, null);
+        inner.CapturedCallback!(ArticleBodyResult.NotRetrieved, "duplicate");
+        await batch.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+        var response = await batch.Responses[0];
+        if (response.Stream is not null)
+            await response.Stream.DisposeAsync();
+        Assert.Equal(1, client.AvailableConnections);
+    }
+
     private sealed class ExistsStatClient(
         bool failAfterFirst = false,
         bool waitForCancellationAfterFirst = false) : NntpClient
@@ -183,6 +235,77 @@ public class MultiConnectionStatsPipelinedTests
 
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override void Dispose()
+        {
+        }
+    }
+
+    private sealed class GatedBodyBatchClient : NntpClient
+    {
+        public TaskCompletionSource TransportCompletion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public ArticleBodyCompletionHandler? CapturedCallback { get; private set; }
+
+        public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            CapturedCallback = onConnectionReadyAgain;
+            var responses = segmentIds
+                .Select(id => Task.FromResult(new UsenetDecodedBodyResponse
+                {
+                    SegmentId = id.ToString(),
+                    ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+                    ResponseMessage = "222 gated",
+                    Stream = new YencStream(new MemoryStream([], writable: false)),
+                }))
+                .ToArray();
+            return Task.FromResult(new UsenetDecodedBodyBatch
+            {
+                Responses = responses,
+                Completion = TransportCompletion.Task,
+            });
+        }
+
+        public override Task ConnectAsync(
+            string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override Task<UsenetResponse> AuthenticateAsync(
+            string user, string pass, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+            SegmentId segmentId,
             ArticleBodyCompletionHandler? onConnectionReadyAgain,
             CancellationToken cancellationToken) =>
             throw new NotSupportedException();

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -2013,6 +2013,53 @@ public class MultiProviderNntpClientTests
     }
 
     [Fact]
+    public async Task DecodedBodiesAsync_CompletionWaitsForPrimaryAndFallbackTransfers()
+    {
+        var primary = new ScriptedNntpClient
+        {
+            BatchResponseCode = 430,
+            SingularResponseCode = 430,
+        };
+        var backup = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            SingularResponseCode = 222,
+            DeferSingularCompletion = true,
+        };
+        using var client = new MultiProviderNntpClient(
+        [
+            CreateProvider(primary, host: "primary.example", maxConnections: 4),
+            CreateProvider(backup, host: "backup.example", maxConnections: 4),
+        ]);
+
+        UsenetDecodedBodyResponse? first = null;
+        UsenetDecodedBodyResponse? second = null;
+        try
+        {
+            var batch = await client.DecodedBodiesAsync(
+                ["seg-0", "seg-1"], onConnectionReadyAgain: null, CancellationToken.None);
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+            while (backup.SingularRequests < 2)
+            {
+                timeout.Token.ThrowIfCancellationRequested();
+                await Task.Delay(10, timeout.Token);
+            }
+
+            Assert.False(batch.Completion.IsCompleted);
+            backup.CompletePendingSingularRequests();
+            first = await batch.Responses[0];
+            second = await batch.Responses[1];
+            if (first.Stream is not null) await first.Stream.DisposeAsync();
+            if (second.Stream is not null) await second.Stream.DisposeAsync();
+            await batch.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            backup.CompletePendingSingularRequests();
+        }
+    }
+
+    [Fact]
     public async Task BatchResponse_WithCleanNotFound_SkipsPrimaryReprobeWhenDisabled()
     {
         var primary = new ScriptedNntpClient

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedTeardownTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedTeardownTests.cs
@@ -174,7 +174,7 @@ public class NntpClientPipelinedTeardownTests
     }
 
     [Fact]
-    public async Task DecodedBodiesPipelinedAsync_FullyEnumerated_AwaitsBatchCompletion()
+    public async Task DecodedBodiesPipelinedAsync_FullyEnumerated_DoesNotJoinBatchCompletion()
     {
         var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var client = new ScriptedBatchClient(gate.Task);
@@ -189,10 +189,10 @@ public class NntpClientPipelinedTeardownTests
             }
         });
 
-        await Task.Delay(50);
-        Assert.False(enumeration.IsCompleted);
-        gate.SetResult();
+        await client.BatchIssued.Task.WaitAsync(TimeSpan.FromSeconds(5));
         await enumeration.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.False(gate.Task.IsCompleted);
+        gate.SetResult();
     }
 
     [Fact]
@@ -210,11 +210,15 @@ public class NntpClientPipelinedTeardownTests
             }
         });
 
-        await Task.Delay(50);
+        await client.BatchIssued.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline && !client.Streams.TrueForAll(stream => stream.Disposed))
+            await Task.Delay(10);
+
+        Assert.True(client.Streams.TrueForAll(stream => stream.Disposed));
         Assert.False(enumeration.IsCompleted);
         gate.SetResult();
         await enumeration.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.True(client.Streams.All(stream => stream.Disposed));
     }
 
     [Fact]
@@ -243,13 +247,15 @@ public class NntpClientPipelinedTeardownTests
         {
         }
 
-        public int DisposeCount { get; private set; }
+        private int _disposeCount;
+
+        public int DisposeCount => Volatile.Read(ref _disposeCount);
 
         public bool Disposed => DisposeCount > 0;
 
         protected override void Dispose(bool disposing)
         {
-            DisposeCount++;
+            Interlocked.Increment(ref _disposeCount);
             base.Dispose(disposing);
         }
     }
@@ -436,6 +442,8 @@ public class NntpClientPipelinedTeardownTests
 
         public SemaphorePriority? BatchPriority { get; private set; }
 
+        public TaskCompletionSource BatchIssued { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
             ArticleBodyCompletionHandler? onConnectionReadyAgain,
@@ -456,6 +464,7 @@ public class NntpClientPipelinedTeardownTests
                 }));
             }
 
+            BatchIssued.TrySetResult();
             return Task.FromResult(new UsenetDecodedBodyBatch
             {
                 Responses = responses,

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedTeardownTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientPipelinedTeardownTests.cs
@@ -173,6 +173,70 @@ public class NntpClientPipelinedTeardownTests
         Assert.Equal(SemaphorePriority.High, client.BatchPriority);
     }
 
+    [Fact]
+    public async Task DecodedBodiesPipelinedAsync_FullyEnumerated_AwaitsBatchCompletion()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = new ScriptedBatchClient(gate.Task);
+        var enumeration = Task.Run(async () =>
+        {
+            await foreach (var result in client.DecodedBodiesPipelinedAsync(
+                               ["a@example"], depth: 1, CancellationToken.None))
+            {
+                Assert.True(result.Found);
+                if (result.Stream is not null)
+                    await result.Stream.DisposeAsync();
+            }
+        });
+
+        await Task.Delay(50);
+        Assert.False(enumeration.IsCompleted);
+        gate.SetResult();
+        await enumeration.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task DecodedBodiesPipelinedAsync_EarlyBreak_AwaitsBatchCompletionAfterCleanup()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = new ScriptedBatchClient(gate.Task);
+        var enumeration = Task.Run(async () =>
+        {
+            await foreach (var result in client.DecodedBodiesPipelinedAsync(
+                               ["a@example", "b@example"], depth: 2, CancellationToken.None))
+            {
+                Assert.True(result.Found);
+                break;
+            }
+        });
+
+        await Task.Delay(50);
+        Assert.False(enumeration.IsCompleted);
+        gate.SetResult();
+        await enumeration.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(client.Streams.All(stream => stream.Disposed));
+    }
+
+    [Fact]
+    public async Task DecodedBodiesPipelinedAsync_CompletionFault_IsObserved()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = new ScriptedBatchClient(gate.Task);
+        var enumeration = Task.Run(async () =>
+        {
+            await foreach (var result in client.DecodedBodiesPipelinedAsync(
+                               ["a@example"], depth: 1, CancellationToken.None))
+            {
+                Assert.True(result.Found);
+                if (result.Stream is not null)
+                    await result.Stream.DisposeAsync();
+            }
+        });
+
+        gate.SetException(new IOException("batch-completion"));
+        await enumeration.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
     private sealed class TrackingYencStream : YencStream
     {
         public TrackingYencStream() : base(new MemoryStream([], writable: false))
@@ -366,7 +430,7 @@ public class NntpClientPipelinedTeardownTests
         }
     }
 
-    private sealed class ScriptedBatchClient : NntpClient
+    private sealed class ScriptedBatchClient(Task? completion = null) : NntpClient
     {
         public List<TrackingYencStream> Streams { get; } = [];
 
@@ -392,7 +456,11 @@ public class NntpClientPipelinedTeardownTests
                 }));
             }
 
-            return Task.FromResult(new UsenetDecodedBodyBatch { Responses = responses });
+            return Task.FromResult(new UsenetDecodedBodyBatch
+            {
+                Responses = responses,
+                Completion = completion ?? Task.CompletedTask,
+            });
         }
 
         public override Task ConnectAsync(

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/RepairedSegmentNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/RepairedSegmentNntpClientTests.cs
@@ -1,4 +1,5 @@
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Services.Repair;
 using NzbWebDAV.Streams;
@@ -148,6 +149,125 @@ public sealed class RepairedSegmentNntpClientTests
             Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
             Assert.Equal(0, inner.BodyRequestCount);
             Assert.Equal(content, output.ToArray());
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DecodedBodiesAsync_AllPatched_RequestsNoInnerBatch_AndCompletesOnce(bool exclusive)
+    {
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-repair-patch-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024);
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
+            store.CommitPatch("a@test", "aaa"u8.ToArray(), HeaderFor("aaa"u8.ToArray()));
+            store.CommitPatch("b@test", "bbb"u8.ToArray(), HeaderFor("bbb"u8.ToArray()));
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
+            using var client = new RepairedSegmentNntpClient(inner, store);
+            var recorder = new ArticleBodyCompletionRecorder();
+            var ids = new SegmentId[] { "a@test", "b@test" };
+            var batch = exclusive
+                ? await client.DecodedBodiesAsync(ids, new UsenetExclusiveConnection(recorder.Invoke), CancellationToken.None)
+                : await client.DecodedBodiesAsync(ids, recorder.Invoke, CancellationToken.None);
+
+            Assert.Equal(0, inner.BatchRequestCount);
+            await batch.DrainAsync();
+            Assert.Equal(1, recorder.Count);
+            Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DecodedBodiesAsync_MixedPatchMissPatch_RequestsOnlyMiss(bool exclusive)
+    {
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-repair-patch-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024);
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
+            store.CommitPatch("a@test", "aaa"u8.ToArray(), HeaderFor("aaa"u8.ToArray()));
+            store.CommitPatch("c@test", "ccc"u8.ToArray(), HeaderFor("ccc"u8.ToArray()));
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]> { ["b@test"] = "bbb"u8.ToArray() }, useCachedYencStreams: true);
+            using var client = new RepairedSegmentNntpClient(inner, store);
+            var ids = new SegmentId[] { "a@test", "b@test", "c@test" };
+            var batch = exclusive
+                ? await client.DecodedBodiesAsync(ids, new UsenetExclusiveConnection(null), CancellationToken.None)
+                : await client.DecodedBodiesAsync(ids, onConnectionReadyAgain: null, CancellationToken.None);
+
+            Assert.Equal(1, inner.BatchRequestCount);
+            Assert.Equal(["b@test"], inner.RequestedSegmentIds.OrderBy(x => x).ToArray());
+            await batch.DrainAsync();
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task DecodedBodiesAsync_AttributionContext_BypassesPatchLookup()
+    {
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-repair-patch-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024);
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
+            store.CommitPatch("a@test", "aaa"u8.ToArray(), HeaderFor("aaa"u8.ToArray()));
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]> { ["a@test"] = "remote"u8.ToArray() }, useCachedYencStreams: true);
+            using var client = new RepairedSegmentNntpClient(inner, store);
+            MultiProviderNntpClient.AttributionContext.Value = new MultiProviderNntpClient.ResponderAttribution();
+            try
+            {
+                var batch = await client.DecodedBodiesAsync(["a@test"], onConnectionReadyAgain: null, CancellationToken.None);
+                await batch.DrainAsync();
+            }
+            finally
+            {
+                MultiProviderNntpClient.AttributionContext.Value = null;
+            }
+
+            Assert.Equal(1, inner.BatchRequestCount);
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task DecodedBodiesAsync_FetchAttributionContext_DoesNotBypassPatch()
+    {
+        var dir = Path.Join(Path.GetTempPath(), "nzbdav-repair-patch-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var store = new RepairPatchStore(dir, 1024 * 1024);
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
+            store.CommitPatch("a@test", "aaa"u8.ToArray(), HeaderFor("aaa"u8.ToArray()));
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
+            using var client = new RepairedSegmentNntpClient(inner, store);
+            using (FetchAttributionContext.Begin("movie.bin"))
+            {
+                var batch = await client.DecodedBodiesAsync(["a@test"], onConnectionReadyAgain: null, CancellationToken.None);
+                await batch.DrainAsync();
+            }
+
+            Assert.Equal(0, inner.BatchRequestCount);
         }
         finally
         {

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Streams;
 using NzbWebDAV.Tests.Fakes;
@@ -348,15 +349,16 @@ public sealed class SegmentCacheNntpClientTests
             var inner = new FakeNntpClient(new Dictionary<string, byte[]> { [segmentId] = content }, useCachedYencStreams: true);
             using var client = CreateClient(inner, cacheDir, statistics);
             await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
-            Assert.Equal(content.Length, client.CurrentBytes);
+            Assert.Equal(0, client.CurrentBytes);
+            Assert.Equal(1, statistics.GetSnapshot().ReadFailures);
 
             var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
-            response.Stream!.Dispose();
+            await using (response.Stream)
+                await response.Stream!.CopyToAsync(Stream.Null);
 
             var snapshot = statistics.GetSnapshot();
             Assert.Equal(1, snapshot.ReadFailures);
             Assert.Equal(0, snapshot.Hits);
-            Assert.Equal(0, client.CurrentBytes);
             Assert.Equal(0, snapshot.Entries);
         }
         finally
@@ -482,7 +484,9 @@ public sealed class SegmentCacheNntpClientTests
         try
         {
             Directory.CreateDirectory(cacheDir);
-            File.WriteAllText(Path.Join(cacheDir, "stale.tmp"), "tmp");
+            var tmpPath = Path.Join(cacheDir, "stale.tmp");
+            File.WriteAllText(tmpPath, "tmp");
+            File.SetLastWriteTimeUtc(tmpPath, DateTime.UtcNow - SegmentCacheNntpClient.TemporaryFileGracePeriod - TimeSpan.FromMinutes(1));
             var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
             using var client = CreateClient(inner, cacheDir, statistics);
             await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
@@ -509,6 +513,7 @@ public sealed class SegmentCacheNntpClientTests
             Directory.CreateDirectory(lockedDir);
             var tmpPath = Path.Join(lockedDir, "stale.tmp");
             File.WriteAllText(tmpPath, "tmp");
+            File.SetLastWriteTimeUtc(tmpPath, DateTime.UtcNow - SegmentCacheNntpClient.TemporaryFileGracePeriod - TimeSpan.FromMinutes(1));
             SetUnixMode(lockedDir, UnixFileMode.UserRead | UnixFileMode.UserExecute);
             Skip.IfNot(
                 FileDeleteEnforced(tmpPath),
@@ -548,15 +553,35 @@ public sealed class SegmentCacheNntpClientTests
     }
 
     [Fact]
-    public async Task OrdinaryBatch_IncrementsBypassOnceAndForwards()
+    public async Task LiveTempDuringCatalogScan_IsNotDeleted()
     {
-        await AssertBatchBypassAsync(exclusive: false);
+        var cacheDir = NewCacheDir();
+        var statistics = new SegmentCacheStatistics();
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            var tmpPath = Path.Join(cacheDir, "live.tmp");
+            File.WriteAllText(tmpPath, "tmp");
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
+            using var client = CreateClient(inner, cacheDir, statistics);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(0, statistics.GetSnapshot().TemporaryFilesCleaned);
+            Assert.True(File.Exists(tmpPath));
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
     }
 
-    [Fact]
-    public async Task ExclusiveBatch_IncrementsBypassOnceAndForwards()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task OrdinaryAndExclusiveBatch_AllMiss_RequestsOneInnerBatchWithoutBypass(bool exclusive)
     {
-        await AssertBatchBypassAsync(exclusive: true);
+        await AssertAllMissOverlayAsync(exclusive);
     }
 
     [Fact]
@@ -575,8 +600,8 @@ public sealed class SegmentCacheNntpClientTests
             var error = await Assert.ThrowsAsync<InvalidOperationException>(
                 () => client.DecodedBodiesAsync(["a", "b"], onConnectionReadyAgain: null, CancellationToken.None));
             Assert.Equal("batch-setup", error.Message);
-            Assert.Equal(1, statistics.GetSnapshot().BatchBypassRequests);
-            Assert.Equal(2, statistics.GetSnapshot().BatchBypassArticles);
+            Assert.Equal(0, statistics.GetSnapshot().BatchBypassRequests);
+            Assert.Equal(0, statistics.GetSnapshot().BatchBypassArticles);
         }
         finally
         {
@@ -584,7 +609,7 @@ public sealed class SegmentCacheNntpClientTests
         }
     }
 
-    private static async Task AssertBatchBypassAsync(bool exclusive)
+    private static async Task AssertAllMissOverlayAsync(bool exclusive)
     {
         var cacheDir = NewCacheDir();
         var statistics = new SegmentCacheStatistics();
@@ -603,17 +628,256 @@ public sealed class SegmentCacheNntpClientTests
             await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
 
             var ids = new SegmentId[] { "a", "b", "c" };
+            var recorder = new ArticleBodyCompletionRecorder();
             var batch = exclusive
-                ? await client.DecodedBodiesAsync(ids, new UsenetExclusiveConnection(null), CancellationToken.None)
-                : await client.DecodedBodiesAsync(ids, onConnectionReadyAgain: null, CancellationToken.None);
+                ? await client.DecodedBodiesAsync(ids, new UsenetExclusiveConnection(recorder.Invoke), CancellationToken.None)
+                : await client.DecodedBodiesAsync(ids, recorder.Invoke, CancellationToken.None);
 
             Assert.Equal(3, batch.Responses.Count);
             Assert.Equal(1, inner.BatchRequestCount);
             Assert.Equal(3, inner.BodyRequestCount);
+            await batch.DrainAsync();
             var snapshot = statistics.GetSnapshot();
-            Assert.Equal(1, snapshot.BatchBypassRequests);
-            Assert.Equal(3, snapshot.BatchBypassArticles);
+            Assert.Equal(0, snapshot.BatchBypassRequests);
+            Assert.Equal(0, snapshot.BatchBypassArticles);
             Assert.Equal(0, snapshot.Hits);
+            Assert.Equal(3, snapshot.Misses);
+            Assert.Equal(3, snapshot.WriteCommits);
+            Assert.Equal(1, recorder.Count);
+            Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
+
+            var warm = exclusive
+                ? await client.DecodedBodiesAsync(ids, new UsenetExclusiveConnection(null), CancellationToken.None)
+                : await client.DecodedBodiesAsync(ids, onConnectionReadyAgain: null, CancellationToken.None);
+            await warm.DrainAsync();
+            Assert.Equal(1, inner.BatchRequestCount);
+            Assert.Equal(3, statistics.GetSnapshot().Hits);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DecodedBodiesAsync_AllHit_RequestsNoInnerBatch_AndCompletesOnce(bool exclusive)
+    {
+        var cacheDir = NewCacheDir();
+        var statistics = new SegmentCacheStatistics();
+        const string a = "hit-a";
+        const string b = "hit-b";
+        byte[] bytesA = "aaaa"u8.ToArray();
+        byte[] bytesB = "bbbb"u8.ToArray();
+
+        try
+        {
+            WriteCacheEntry(cacheDir, a, bytesA);
+            WriteCacheEntry(cacheDir, b, bytesB);
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
+            using var client = CreateClient(inner, cacheDir, statistics);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+            var recorder = new ArticleBodyCompletionRecorder();
+            var ids = new SegmentId[] { a, b };
+            var batch = exclusive
+                ? await client.DecodedBodiesAsync(ids, new UsenetExclusiveConnection(recorder.Invoke), CancellationToken.None)
+                : await client.DecodedBodiesAsync(ids, recorder.Invoke, CancellationToken.None);
+
+            Assert.Equal(0, inner.BatchRequestCount);
+            Assert.Equal(0, inner.BodyRequestCount);
+            await batch.DrainAsync();
+            var snapshot = statistics.GetSnapshot();
+            Assert.Equal(2, snapshot.Hits);
+            Assert.Equal(0, snapshot.Misses);
+            Assert.Equal(0, snapshot.BatchBypassRequests);
+            Assert.Equal(1, recorder.Count);
+            Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DecodedBodiesAsync_MixedHitMissHit_RequestsOnlyMisses(bool exclusive)
+    {
+        var cacheDir = NewCacheDir();
+        var statistics = new SegmentCacheStatistics();
+        var segments = new Dictionary<string, byte[]>
+        {
+            ["a"] = "aaa"u8.ToArray(),
+            ["b"] = "bbb"u8.ToArray(),
+            ["c"] = "ccc"u8.ToArray(),
+        };
+
+        try
+        {
+            WriteCacheEntry(cacheDir, "a", segments["a"]);
+            WriteCacheEntry(cacheDir, "c", segments["c"]);
+            var inner = new FakeNntpClient(segments, useCachedYencStreams: true);
+            using var client = CreateClient(inner, cacheDir, statistics);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+            var ids = new SegmentId[] { "a", "b", "c" };
+            var batch = exclusive
+                ? await client.DecodedBodiesAsync(ids, new UsenetExclusiveConnection(null), CancellationToken.None)
+                : await client.DecodedBodiesAsync(ids, onConnectionReadyAgain: null, CancellationToken.None);
+
+            Assert.Equal(1, inner.BatchRequestCount);
+            Assert.Equal(["b"], inner.RequestedSegmentIds.OrderBy(x => x).ToArray());
+            await batch.DrainAsync();
+            var snapshot = statistics.GetSnapshot();
+            Assert.Equal(2, snapshot.Hits);
+            Assert.Equal(1, snapshot.Misses);
+            Assert.Equal(1, snapshot.WriteCommits);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
+    public async Task DecodedBodiesAsync_AttributionContext_BypassesLookupAndPopulation()
+    {
+        var cacheDir = NewCacheDir();
+        var statistics = new SegmentCacheStatistics();
+        WriteCacheEntry(cacheDir, "a", "cached"u8.ToArray());
+        var inner = new FakeNntpClient(new Dictionary<string, byte[]> { ["a"] = "remote"u8.ToArray() }, useCachedYencStreams: true);
+        try
+        {
+            using var client = CreateClient(inner, cacheDir, statistics);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+            MultiProviderNntpClient.AttributionContext.Value = new MultiProviderNntpClient.ResponderAttribution();
+            try
+            {
+                var batch = await client.DecodedBodiesAsync(["a"], onConnectionReadyAgain: null, CancellationToken.None);
+                await batch.DrainAsync();
+            }
+            finally
+            {
+                MultiProviderNntpClient.AttributionContext.Value = null;
+            }
+
+            Assert.Equal(1, inner.BatchRequestCount);
+            Assert.Equal(1, statistics.GetSnapshot().BatchBypassRequests);
+            Assert.Equal(0, statistics.GetSnapshot().Hits);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
+    public async Task DecodedBodiesAsync_FetchAttributionContext_DoesNotBypassCache()
+    {
+        var cacheDir = NewCacheDir();
+        var statistics = new SegmentCacheStatistics();
+        WriteCacheEntry(cacheDir, "a", "cached"u8.ToArray());
+        var inner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
+        try
+        {
+            using var client = CreateClient(inner, cacheDir, statistics);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+            using (FetchAttributionContext.Begin("movie.bin"))
+            {
+                var batch = await client.DecodedBodiesAsync(["a"], onConnectionReadyAgain: null, CancellationToken.None);
+                await batch.DrainAsync();
+            }
+
+            Assert.Equal(0, inner.BatchRequestCount);
+            Assert.Equal(1, statistics.GetSnapshot().Hits);
+            Assert.Equal(0, statistics.GetSnapshot().BatchBypassRequests);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
+    public async Task DecodedBodiesAsync_ResponseIdMismatch_DoesNotCreateCacheEntry()
+    {
+        var cacheDir = NewCacheDir();
+        var statistics = new SegmentCacheStatistics();
+        var inner = new FakeNntpClient(new Dictionary<string, byte[]> { ["a"] = "aaa"u8.ToArray() }, useCachedYencStreams: true)
+        {
+            ForcedResponseSegmentId = "other",
+        };
+        try
+        {
+            using var client = CreateClient(inner, cacheDir, statistics);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+            var batch = await client.DecodedBodiesAsync(["a"], onConnectionReadyAgain: null, CancellationToken.None);
+            await batch.DrainAsync();
+            Assert.Equal(0, statistics.GetSnapshot().WriteCommits);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
+    public async Task DecodedBodiesAsync_CompleteBodies_SurviveRestartHydration()
+    {
+        var cacheDir = NewCacheDir();
+        var segments = new Dictionary<string, byte[]>
+        {
+            ["a"] = "aaa"u8.ToArray(),
+            ["b"] = "bbb"u8.ToArray(),
+        };
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            var inner = new FakeNntpClient(segments, useCachedYencStreams: true);
+            using (var client = CreateClient(inner, cacheDir, new SegmentCacheStatistics()))
+            {
+                await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+                var batch = await client.DecodedBodiesAsync(["a", "b"], onConnectionReadyAgain: null, CancellationToken.None);
+                await batch.DrainAsync();
+            }
+
+            var restartInner = new FakeNntpClient(new Dictionary<string, byte[]>(), useCachedYencStreams: true);
+            var statistics = new SegmentCacheStatistics();
+            using var restarted = CreateClient(restartInner, cacheDir, statistics);
+            await restarted.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+            var warm = await restarted.DecodedBodiesAsync(["a", "b"], onConnectionReadyAgain: null, CancellationToken.None);
+            await warm.DrainAsync();
+            Assert.Equal(0, restartInner.BatchRequestCount);
+            Assert.Equal(2, statistics.GetSnapshot().Hits);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
+    public async Task DecodedBodiesAsync_ConcurrentSameId_CommitsOneValidEntryWithoutDeadlock()
+    {
+        var cacheDir = NewCacheDir();
+        var statistics = new SegmentCacheStatistics();
+        var segments = new Dictionary<string, byte[]> { ["a"] = "aaaa"u8.ToArray() };
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            var inner = new FakeNntpClient(segments, useCachedYencStreams: true);
+            using var client = CreateClient(inner, cacheDir, statistics);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+            var firstTask = client.DecodedBodiesAsync(["a"], onConnectionReadyAgain: null, CancellationToken.None);
+            var secondTask = client.DecodedBodiesAsync(["a"], onConnectionReadyAgain: null, CancellationToken.None);
+            var first = await firstTask;
+            var second = await secondTask;
+            await Task.WhenAll(first.DrainAsync(), second.DrainAsync());
+            Assert.Equal(1, statistics.GetSnapshot().WriteCommits);
+            Assert.True(inner.BatchRequestCount >= 1);
         }
         finally
         {

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
@@ -356,10 +356,22 @@ public sealed class SegmentCacheNntpClientTests
             await using (response.Stream)
                 await response.Stream!.CopyToAsync(Stream.Null);
 
+            var afterCommit = statistics.GetSnapshot();
+            Assert.Equal(1, afterCommit.ReadFailures);
+            Assert.Equal(0, afterCommit.Hits);
+            Assert.Equal(1, afterCommit.WriteCommits);
+            Assert.Equal(0, afterCommit.WriteFailures);
+            Assert.Equal(1, afterCommit.Entries);
+            Assert.Equal(1, inner.BodyRequestCount);
+
+            var reread = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            await using (reread.Stream)
+                await reread.Stream!.CopyToAsync(Stream.Null);
+
             var snapshot = statistics.GetSnapshot();
-            Assert.Equal(1, snapshot.ReadFailures);
-            Assert.Equal(0, snapshot.Hits);
-            Assert.Equal(0, snapshot.Entries);
+            Assert.Equal(1, snapshot.Hits);
+            Assert.Equal(1, snapshot.WriteCommits);
+            Assert.Equal(1, inner.BodyRequestCount);
         }
         finally
         {

--- a/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamBatchCompletionTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamBatchCompletionTests.cs
@@ -1,0 +1,174 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Models;
+using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.Fakes;
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Tests.Streams;
+
+public sealed class MultiSegmentStreamBatchCompletionTests
+{
+    [Fact]
+    public async Task PipelinedBatch_CompletionIsObservedWithoutSerializingNextBatch()
+    {
+        const int segmentSize = 32;
+        var segments = Enumerable.Range(0, 8)
+            .ToDictionary(i => $"seg-{i}", _ => Enumerable.Repeat((byte)7, segmentSize).ToArray());
+        var ranges = segments.Keys
+            .Select((id, index) => KeyValuePair.Create(id, new LongRange(index * segmentSize, (index + 1L) * segmentSize)))
+            .ToDictionary();
+        var inner = new FakeNntpClient(segments, useCachedYencStreams: true, segmentRanges: ranges);
+        using var delayed = new DelayedBatchCompletionClient(inner);
+        Stream? stream = null;
+        try
+        {
+            stream = MultiSegmentStream.Create(
+                segments.Keys.ToArray().AsMemory(),
+                delayed,
+                articleBufferSize: 40,
+                estimatedSegmentSize: segmentSize,
+                failFastOnFirstSegment: false,
+                usePipelinedBodyRequests: true,
+                CancellationToken.None,
+                fileName: "batch-completion.bin",
+                bodyPipelineBatchWidth: 4);
+
+            var buffer = new byte[segmentSize * 3];
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+            while (delayed.Completions.Count < 2 && DateTime.UtcNow < deadline)
+            {
+                var read = await stream.ReadAsync(buffer);
+                Assert.True(read > 0);
+            }
+
+            Assert.True(delayed.Completions.Count >= 2, "A second batch should issue while the first completion is still pending.");
+            Assert.False(delayed.Completions[0].Task.IsCompleted);
+        }
+        finally
+        {
+            foreach (var gate in delayed.Completions)
+                gate.TrySetResult();
+            if (stream is not null)
+                await stream.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task PipelinedBatch_ResponseCountMismatch_DrainsResponsesAndAwaitsCompletion()
+    {
+        const int segmentSize = 8;
+        var segments = new Dictionary<string, byte[]>
+        {
+            ["a"] = Enumerable.Repeat((byte)1, segmentSize).ToArray(),
+            ["b"] = Enumerable.Repeat((byte)2, segmentSize).ToArray(),
+            ["c"] = Enumerable.Repeat((byte)3, segmentSize).ToArray(),
+        };
+        var ranges = new Dictionary<string, LongRange>
+        {
+            ["a"] = new(0, segmentSize),
+            ["b"] = new(segmentSize, segmentSize * 2L),
+            ["c"] = new(segmentSize * 2L, segmentSize * 3L),
+        };
+        var inner = new FakeNntpClient(segments, useCachedYencStreams: true, segmentRanges: ranges);
+        using var mismatch = new MismatchBatchClient(inner);
+        await using var stream = MultiSegmentStream.Create(
+            segments.Keys.ToArray().AsMemory(),
+            mismatch,
+            articleBufferSize: 4,
+            estimatedSegmentSize: segmentSize,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: true,
+            CancellationToken.None,
+            fileName: "batch-mismatch.bin",
+            bodyPipelineBatchWidth: 4);
+
+        var buffer = new byte[segmentSize];
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await stream.ReadAtLeastAsync(buffer, segmentSize, throwOnEndOfStream: true));
+        Assert.True(mismatch.CompletionObserved);
+    }
+
+    [Fact]
+    public async Task PipelinedBatch_EarlyDispose_JoinsCompletionObservers()
+    {
+        const int segmentSize = 32;
+        var segments = Enumerable.Range(0, 4)
+            .ToDictionary(i => $"seg-{i}", _ => Enumerable.Repeat((byte)9, segmentSize).ToArray());
+        var ranges = segments.Keys
+            .Select((id, index) => KeyValuePair.Create(id, new LongRange(index * segmentSize, (index + 1L) * segmentSize)))
+            .ToDictionary();
+        var inner = new FakeNntpClient(segments, useCachedYencStreams: true, segmentRanges: ranges);
+        using var delayed = new DelayedBatchCompletionClient(inner);
+        var stream = MultiSegmentStream.Create(
+            segments.Keys.ToArray().AsMemory(),
+            delayed,
+            articleBufferSize: 40,
+            estimatedSegmentSize: segmentSize,
+            failFastOnFirstSegment: false,
+            usePipelinedBodyRequests: true,
+            CancellationToken.None,
+            fileName: "batch-dispose.bin",
+            bodyPipelineBatchWidth: 4);
+
+        var buffer = new byte[8];
+        _ = await stream.ReadAsync(buffer);
+        var dispose = stream.DisposeAsync();
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (!dispose.IsCompleted && DateTime.UtcNow < deadline)
+        {
+            foreach (var gate in delayed.Completions)
+                gate.TrySetResult();
+            await Task.Delay(10);
+        }
+
+        await dispose.AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    private sealed class DelayedBatchCompletionClient(INntpClient inner) : WrappingNntpClient(inner)
+    {
+        public List<TaskCompletionSource> Completions { get; } = [];
+
+        public override async Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            var batch = await base.DecodedBodiesAsync(segmentIds, onConnectionReadyAgain, cancellationToken)
+                .ConfigureAwait(false);
+            var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            Completions.Add(gate);
+            return batch with { Completion = gate.Task };
+        }
+    }
+
+    private sealed class MismatchBatchClient(INntpClient inner) : WrappingNntpClient(inner)
+    {
+        private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public bool CompletionObserved => _completion.Task.IsCompleted;
+
+        public override async Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+            IReadOnlyList<SegmentId> segmentIds,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            if (segmentIds.Count <= 1)
+            {
+                return await base.DecodedBodiesAsync(segmentIds, onConnectionReadyAgain, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(25);
+                _completion.TrySetResult();
+            });
+            return new UsenetDecodedBodyBatch
+            {
+                Responses = [],
+                Completion = _completion.Task,
+            };
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamBatchCompletionTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/MultiSegmentStreamBatchCompletionTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Models;
 using NzbWebDAV.Streams;
@@ -43,7 +44,8 @@ public sealed class MultiSegmentStreamBatchCompletionTests
             }
 
             Assert.True(delayed.Completions.Count >= 2, "A second batch should issue while the first completion is still pending.");
-            Assert.False(delayed.Completions[0].Task.IsCompleted);
+            Assert.True(delayed.Completions.TryPeek(out var firstCompletion));
+            Assert.False(firstCompletion.Task.IsCompleted);
         }
         finally
         {
@@ -127,7 +129,7 @@ public sealed class MultiSegmentStreamBatchCompletionTests
 
     private sealed class DelayedBatchCompletionClient(INntpClient inner) : WrappingNntpClient(inner)
     {
-        public List<TaskCompletionSource> Completions { get; } = [];
+        public ConcurrentQueue<TaskCompletionSource> Completions { get; } = new();
 
         public override async Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
             IReadOnlyList<SegmentId> segmentIds,
@@ -137,7 +139,7 @@ public sealed class MultiSegmentStreamBatchCompletionTests
             var batch = await base.DecodedBodiesAsync(segmentIds, onConnectionReadyAgain, cancellationToken)
                 .ConfigureAwait(false);
             var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            Completions.Add(gate);
+            Completions.Enqueue(gate);
             return batch with { Completion = gate.Task };
         }
     }

--- a/tests/NzbWebDAV.Tests/Streams/RepeatableStreamingBenchmarkCoverageTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/RepeatableStreamingBenchmarkCoverageTests.cs
@@ -144,7 +144,7 @@ public sealed class RepeatableStreamingBenchmarkCoverageTests
     }
 
     [Fact]
-    public async Task ProductionShapedPipelinedFixture_RecordsCurrentNonzeroWarmTransport()
+    public async Task ProductionShapedPipelinedFixture_WarmRereadUsesZeroTransport()
     {
         var fixture = CreateFixture();
         var cacheDir = Path.Join(Path.GetTempPath(), "nzbdav-streaming-pipelined-" + Guid.NewGuid().ToString("N"));
@@ -171,25 +171,25 @@ public sealed class RepeatableStreamingBenchmarkCoverageTests
             Assert.Equal(fixture.Source.Length, cold.TransportBytes);
             Assert.Equal(2, cold.TransportBatchRequests);
             Assert.Equal(0, cold.CacheHits);
-            Assert.Equal(1, cold.CacheMisses);
+            Assert.Equal(SegmentCount, cold.CacheMisses);
             Assert.Equal(0, cold.CacheBytesServed);
-            Assert.Equal(2, cold.CacheBatchBypassRequests);
-            Assert.Equal(5, cold.CacheBatchBypassArticles);
-            Assert.Equal(1, cold.CacheWriteCommits);
+            Assert.Equal(0, cold.CacheBatchBypassRequests);
+            Assert.Equal(0, cold.CacheBatchBypassArticles);
+            Assert.Equal(SegmentCount, cold.CacheWriteCommits);
 
             var beforeWarm = Capture(transport, fixture, statistics);
             await AssertProductionReadMatchesAsync(cached, fixture);
             var warm = Delta(beforeWarm, Capture(transport, fixture, statistics), fixture.Source.Length);
             Assert.Equal(fixture.Source.Length, warm.Bytes);
             AssertPipelinedWarmTransportContract(warm.TransportRequests, warm.TransportBytes);
-            Assert.Equal(5, warm.TransportRequests);
-            Assert.Equal(5 * SegmentSize, warm.TransportBytes);
-            Assert.Equal(2, warm.TransportBatchRequests);
-            Assert.Equal(1, warm.CacheHits);
+            Assert.Equal(0, warm.TransportRequests);
+            Assert.Equal(0, warm.TransportBytes);
+            Assert.Equal(0, warm.TransportBatchRequests);
+            Assert.Equal(6, warm.CacheHits);
             Assert.Equal(0, warm.CacheMisses);
-            Assert.Equal(SegmentSize, warm.CacheBytesServed);
-            Assert.Equal(2, warm.CacheBatchBypassRequests);
-            Assert.Equal(5, warm.CacheBatchBypassArticles);
+            Assert.Equal(fixture.Source.Length, warm.CacheBytesServed);
+            Assert.Equal(0, warm.CacheBatchBypassRequests);
+            Assert.Equal(0, warm.CacheBatchBypassArticles);
             Assert.Equal(0, warm.CacheWriteCommits);
 
             var repeatBefore = Capture(transport, fixture, statistics);
@@ -208,15 +208,97 @@ public sealed class RepeatableStreamingBenchmarkCoverageTests
     }
 
     /// <summary>
-    /// After the batch-local cache overlay, this helper must assert zero transport
-    /// requests and bytes. This measurement slice records the current nonzero bypass
-    /// so the fixture stays green until that overlay lands.
+    /// After the batch-local cache overlay, a fully consumed production-shaped
+    /// warm re-read must not touch the transport.
     /// </summary>
     internal static void AssertPipelinedWarmTransportContract(long transportRequests, long transportBytes)
     {
         Assert.True(
-            transportRequests > 0 && transportBytes > 0,
-            "Current pipelined warm re-read still reaches transport; the overlay PR must change this helper to assert zeros.");
+            transportRequests == 0 && transportBytes == 0,
+            $"Pipelined warm re-read must use zero transport; was requests={transportRequests} bytes={transportBytes}.");
+    }
+
+    [Fact]
+    public async Task PipelinedWarmReread_UsesZeroTransportRequestsAndBytes()
+    {
+        var fixture = CreateFixture();
+        var cacheDir = Path.Join(Path.GetTempPath(), "nzbdav-streaming-pipelined-zero-" + Guid.NewGuid().ToString("N"));
+        var statistics = new SegmentCacheStatistics();
+        try
+        {
+            var transport = fixture.CreateClient();
+            using var cached = new SegmentCacheNntpClient(
+                transport, cacheDir, fixture.Source.Length * 2L, null, null, null, statistics);
+            await WaitForCatalogAsync(cached);
+            await AssertProductionReadMatchesAsync(cached, fixture);
+            var before = Capture(transport, fixture, statistics);
+            await AssertProductionReadMatchesAsync(cached, fixture);
+            var warm = Delta(before, Capture(transport, fixture, statistics), fixture.Source.Length);
+            Assert.Equal(0, warm.TransportRequests);
+            Assert.Equal(0, warm.TransportBytes);
+            Assert.Equal(0, warm.TransportBatchRequests);
+            Assert.Equal(SegmentCount, warm.CacheHits);
+            Assert.Equal(0, warm.CacheMisses);
+            Assert.Equal(fixture.Source.Length, warm.CacheBytesServed);
+            Assert.Equal(fixture.Source.Length, warm.Bytes);
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+                Directory.Delete(cacheDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PipelinedColdRead_CommitsEveryCompleteTouchedSegment()
+    {
+        var fixture = CreateFixture();
+        var cacheDir = Path.Join(Path.GetTempPath(), "nzbdav-streaming-pipelined-cold-" + Guid.NewGuid().ToString("N"));
+        var statistics = new SegmentCacheStatistics();
+        try
+        {
+            var transport = fixture.CreateClient();
+            using var cached = new SegmentCacheNntpClient(
+                transport, cacheDir, fixture.Source.Length * 2L, null, null, null, statistics);
+            await WaitForCatalogAsync(cached);
+            var before = Capture(transport, fixture, statistics);
+            await AssertProductionReadMatchesAsync(cached, fixture);
+            var cold = Delta(before, Capture(transport, fixture, statistics), fixture.Source.Length);
+            Assert.Equal(SegmentCount, cold.CacheWriteCommits);
+            Assert.Equal(SegmentCount, cold.CacheMisses);
+            Assert.Equal(0, cold.CacheBatchBypassRequests);
+            Assert.Equal(fixture.Source.Length, cold.Bytes);
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+                Directory.Delete(cacheDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PipelinedWarmReread_UsesZeroTransportBatchRequests()
+    {
+        var fixture = CreateFixture();
+        var cacheDir = Path.Join(Path.GetTempPath(), "nzbdav-streaming-pipelined-batch-" + Guid.NewGuid().ToString("N"));
+        var statistics = new SegmentCacheStatistics();
+        try
+        {
+            var transport = fixture.CreateClient();
+            using var cached = new SegmentCacheNntpClient(
+                transport, cacheDir, fixture.Source.Length * 2L, null, null, null, statistics);
+            await WaitForCatalogAsync(cached);
+            await AssertProductionReadMatchesAsync(cached, fixture);
+            var before = Capture(transport, fixture, statistics);
+            await AssertProductionReadMatchesAsync(cached, fixture);
+            var warm = Delta(before, Capture(transport, fixture, statistics), fixture.Source.Length);
+            Assert.Equal(0, warm.TransportBatchRequests);
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+                Directory.Delete(cacheDir, recursive: true);
+        }
     }
 
     private static Counters Capture(

--- a/tests/NzbWebDAV.Tests/TestUtils/ControlledDecodedBodyBatchClient.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/ControlledDecodedBodyBatchClient.cs
@@ -1,0 +1,216 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Streams;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.TestUtils;
+
+internal static class DecodedBodyBatchTestDrain
+{
+    public static async Task DrainAsync(this UsenetDecodedBodyBatch batch, TimeSpan? timeout = null)
+    {
+        var wait = timeout ?? TimeSpan.FromSeconds(10);
+        foreach (var responseTask in batch.Responses)
+        {
+            UsenetDecodedBodyResponse? response = null;
+            try
+            {
+                response = await responseTask.WaitAsync(wait);
+            }
+            catch (Exception exception) when (exception is not OutOfMemoryException)
+            {
+                // A faulted position still releases overlay readiness for later responses.
+            }
+
+            if (response?.Stream is not null)
+            {
+                try
+                {
+                    await response.Stream.CopyToAsync(Stream.Null);
+                }
+                catch (Exception exception) when (exception is not OutOfMemoryException)
+                {
+                    // Still dispose so overlay readiness and cache commit/skip can finish.
+                }
+
+                await response.Stream.DisposeAsync();
+            }
+        }
+
+        await batch.Completion.WaitAsync(wait);
+    }
+}
+
+internal sealed class ControlledDecodedBodyBatchClient : NntpClient
+{
+    public enum CallbackTiming
+    {
+        BeforeReturn,
+        AfterReturn,
+        Never,
+        Twice,
+    }
+
+    private readonly Func<SegmentId, UsenetDecodedBodyResponse> _createResponse;
+    private readonly int? _responseCountOverride;
+    private readonly Exception? _setupException;
+    private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public ControlledDecodedBodyBatchClient(
+        Func<SegmentId, UsenetDecodedBodyResponse>? createResponse = null,
+        int? responseCountOverride = null,
+        Exception? setupException = null,
+        CallbackTiming callbackTiming = CallbackTiming.BeforeReturn)
+    {
+        _createResponse = createResponse ?? (id => CreateSuccess(id, "body"u8.ToArray()));
+        _responseCountOverride = responseCountOverride;
+        _setupException = setupException;
+        Timing = callbackTiming;
+    }
+
+    public CallbackTiming Timing { get; }
+    public int OrdinaryBatchCount { get; private set; }
+    public int ExclusiveBatchCount { get; private set; }
+    public List<string> RequestedIds { get; } = [];
+    public List<IReadOnlyList<string>> BatchIdLists { get; } = [];
+    public ArticleBodyCompletionHandler? CapturedCallback { get; private set; }
+    public Task ProducerCompletion => _completion.Task;
+
+    public void CompleteProducer() => _completion.TrySetResult();
+
+    public void FaultProducer(Exception exception) => _completion.TrySetException(exception);
+
+    public void FireCapturedCallback(ArticleBodyResult result = ArticleBodyResult.Retrieved, string? reason = null) =>
+        CapturedCallback?.Invoke(result, reason);
+
+    public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+        IReadOnlyList<SegmentId> segmentIds,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
+        CancellationToken cancellationToken)
+    {
+        OrdinaryBatchCount++;
+        return CreateBatchAsync(segmentIds, onConnectionReadyAgain, cancellationToken);
+    }
+
+    public override Task<UsenetDecodedBodyBatch> DecodedBodiesAsync(
+        IReadOnlyList<SegmentId> segmentIds,
+        UsenetExclusiveConnection exclusiveConnection,
+        CancellationToken cancellationToken)
+    {
+        ExclusiveBatchCount++;
+        return CreateBatchAsync(segmentIds, exclusiveConnection.OnConnectionReadyAgain, cancellationToken);
+    }
+
+    private Task<UsenetDecodedBodyBatch> CreateBatchAsync(
+        IReadOnlyList<SegmentId> segmentIds,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var ids = segmentIds.Select(id => id.ToString()).ToArray();
+        RequestedIds.AddRange(ids);
+        BatchIdLists.Add(ids);
+        CapturedCallback = onConnectionReadyAgain;
+
+        if (_setupException is not null)
+            throw _setupException;
+
+        var count = _responseCountOverride ?? segmentIds.Count;
+        var responses = new Task<UsenetDecodedBodyResponse>[Math.Max(0, count)];
+        for (var index = 0; index < responses.Length; index++)
+        {
+            var id = index < segmentIds.Count ? segmentIds[index] : new SegmentId($"extra-{index}");
+            responses[index] = Task.FromResult(_createResponse(id));
+        }
+
+        if (Timing is CallbackTiming.BeforeReturn or CallbackTiming.Twice)
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+        if (Timing == CallbackTiming.Twice)
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved, "duplicate");
+
+        if (Timing != CallbackTiming.Never && Timing != CallbackTiming.AfterReturn)
+            _completion.TrySetResult();
+
+        return Task.FromResult(new UsenetDecodedBodyBatch
+        {
+            Responses = responses,
+            Completion = _completion.Task,
+        });
+    }
+
+    public static UsenetDecodedBodyResponse CreateSuccess(SegmentId segmentId, byte[] content)
+    {
+        return new UsenetDecodedBodyResponse
+        {
+            SegmentId = segmentId.ToString(),
+            ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+            ResponseMessage = "222",
+            Stream = new CachedYencStream(HeaderFor(content), new MemoryStream(content, writable: false)),
+        };
+    }
+
+    public static UsenetDecodedBodyResponse CreateMissing(SegmentId segmentId) =>
+        new()
+        {
+            SegmentId = segmentId.ToString(),
+            ResponseCode = (int)UsenetResponseType.NoArticleWithThatMessageId,
+            ResponseMessage = "430",
+            Stream = null,
+        };
+
+    public static UsenetYencHeader HeaderFor(byte[] content) => new()
+    {
+        FileName = "test.bin",
+        FileSize = content.Length,
+        LineLength = 128,
+        PartNumber = 1,
+        TotalParts = 1,
+        PartOffset = 0,
+        PartSize = content.Length,
+    };
+
+    public override Task ConnectAsync(string host, int port, bool useSsl, CancellationToken cancellationToken) =>
+        Task.CompletedTask;
+
+    public override Task<UsenetResponse> AuthenticateAsync(
+        string user, string pass, CancellationToken cancellationToken) =>
+        throw new NotSupportedException();
+
+    public override Task<UsenetStatResponse> StatAsync(
+        SegmentId segmentId, CancellationToken cancellationToken) =>
+        throw new NotSupportedException();
+
+    public override Task<UsenetHeadResponse> HeadAsync(
+        SegmentId segmentId, CancellationToken cancellationToken) =>
+        throw new NotSupportedException();
+
+    public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+        SegmentId segmentId, CancellationToken cancellationToken) =>
+        DecodedBodyAsync(segmentId, null, cancellationToken);
+
+    public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+        SegmentId segmentId,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
+        CancellationToken cancellationToken)
+    {
+        onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+        return Task.FromResult(_createResponse(segmentId));
+    }
+
+    public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+        SegmentId segmentId, CancellationToken cancellationToken) =>
+        throw new NotSupportedException();
+
+    public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+        SegmentId segmentId,
+        ArticleBodyCompletionHandler? onConnectionReadyAgain,
+        CancellationToken cancellationToken) =>
+        throw new NotSupportedException();
+
+    public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken) =>
+        throw new NotSupportedException();
+
+    public override void Dispose()
+    {
+    }
+}

--- a/tests/NzbWebDAV.Tests/TestUtils/ControlledDecodedBodyBatchClient.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/ControlledDecodedBodyBatchClient.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Streams;
@@ -54,7 +55,7 @@ internal sealed class ControlledDecodedBodyBatchClient : NntpClient
     private readonly Func<SegmentId, UsenetDecodedBodyResponse> _createResponse;
     private readonly int? _responseCountOverride;
     private readonly Exception? _setupException;
-    private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly ConcurrentQueue<TaskCompletionSource> _completions = new();
 
     public ControlledDecodedBodyBatchClient(
         Func<SegmentId, UsenetDecodedBodyResponse>? createResponse = null,
@@ -74,11 +75,19 @@ internal sealed class ControlledDecodedBodyBatchClient : NntpClient
     public List<string> RequestedIds { get; } = [];
     public List<IReadOnlyList<string>> BatchIdLists { get; } = [];
     public ArticleBodyCompletionHandler? CapturedCallback { get; private set; }
-    public Task ProducerCompletion => _completion.Task;
+    public Task ProducerCompletion => _completions.LastOrDefault()?.Task ?? Task.CompletedTask;
 
-    public void CompleteProducer() => _completion.TrySetResult();
+    public void CompleteProducer()
+    {
+        foreach (var completion in _completions)
+            completion.TrySetResult();
+    }
 
-    public void FaultProducer(Exception exception) => _completion.TrySetException(exception);
+    public void FaultProducer(Exception exception)
+    {
+        foreach (var completion in _completions)
+            completion.TrySetException(exception);
+    }
 
     public void FireCapturedCallback(ArticleBodyResult result = ArticleBodyResult.Retrieved, string? reason = null) =>
         CapturedCallback?.Invoke(result, reason);
@@ -115,6 +124,9 @@ internal sealed class ControlledDecodedBodyBatchClient : NntpClient
         if (_setupException is not null)
             throw _setupException;
 
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _completions.Enqueue(completion);
+
         var count = _responseCountOverride ?? segmentIds.Count;
         var responses = new Task<UsenetDecodedBodyResponse>[Math.Max(0, count)];
         for (var index = 0; index < responses.Length; index++)
@@ -129,12 +141,12 @@ internal sealed class ControlledDecodedBodyBatchClient : NntpClient
             onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved, "duplicate");
 
         if (Timing != CallbackTiming.Never && Timing != CallbackTiming.AfterReturn)
-            _completion.TrySetResult();
+            completion.TrySetResult();
 
         return Task.FromResult(new UsenetDecodedBodyBatch
         {
             Responses = responses,
-            Completion = _completion.Task,
+            Completion = completion.Task,
         });
     }
 

--- a/tests/UsenetSharp.Tests/Clients/UsenetClientDeterministicTests.cs
+++ b/tests/UsenetSharp.Tests/Clients/UsenetClientDeterministicTests.cs
@@ -844,8 +844,52 @@ public class UsenetClientDeterministicTests
         Assert.That(await completion.Task.WaitAsync(TimeSpan.FromSeconds(2)),
             Is.EqualTo(ArticleBodyResult.Retrieved));
         Assert.That(callbackCount, Is.EqualTo(1));
+        Assert.That(batch.Completion.IsCompletedSuccessfully, Is.True);
         var date = await client.DateAsync(CancellationToken.None);
         Assert.That(date.ResponseCode, Is.EqualTo((int)UsenetResponseType.DateAndTime));
+    }
+
+    [Test]
+    public async Task DecodedBodiesAsync_CompletionWaitsForLastStreamEof()
+    {
+        await using var server = ScriptedNntpServer.StartConnectionScript(
+            async (reader, writer, cancellationToken) =>
+            {
+                Assert.That(await reader.ReadLineAsync(cancellationToken), Is.EqualTo("BODY <one@example.com>"));
+                await WriteSimpleYencArticleAsync(writer, "one"u8.ToArray(), "size=3", "one.bin");
+            });
+        await using var client = new UsenetClient();
+        await client.ConnectAsync("127.0.0.1", server.Port, false, CancellationToken.None);
+
+        var batch = await client.DecodedBodiesAsync(
+            new SegmentId[] { "one@example.com" }, CancellationToken.None);
+        var response = await batch.Responses[0];
+        Assert.That(batch.Completion.IsCompleted, Is.False);
+        await using (response.Stream)
+            await response.Stream!.CopyToAsync(Stream.Null);
+        await batch.Completion.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.That(batch.Completion.IsCompletedSuccessfully, Is.True);
+    }
+
+    [Test]
+    public async Task DecodedBodiesAsync_CompletionWaitsForLastStreamDisposal()
+    {
+        await using var server = ScriptedNntpServer.StartConnectionScript(
+            async (reader, writer, cancellationToken) =>
+            {
+                Assert.That(await reader.ReadLineAsync(cancellationToken), Is.EqualTo("BODY <one@example.com>"));
+                await WriteSimpleYencArticleAsync(writer, "one"u8.ToArray(), "size=3", "one.bin");
+            });
+        await using var client = new UsenetClient();
+        await client.ConnectAsync("127.0.0.1", server.Port, false, CancellationToken.None);
+
+        var batch = await client.DecodedBodiesAsync(
+            new SegmentId[] { "one@example.com" }, CancellationToken.None);
+        var response = await batch.Responses[0];
+        Assert.That(batch.Completion.IsCompleted, Is.False);
+        response.Stream!.Dispose();
+        await batch.Completion.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.That(batch.Completion.IsCompletedSuccessfully, Is.True);
     }
 
     [Test]
@@ -1521,6 +1565,32 @@ public class UsenetClientDeterministicTests
         Assert.That(await completion.Task.WaitAsync(TimeSpan.FromSeconds(2)),
             Is.EqualTo(ArticleBodyResult.NotRetrieved));
         Assert.That(client.IsHealthy, Is.False);
+        Assert.That(async () => await batch.Completion.WaitAsync(TimeSpan.FromSeconds(2)),
+            Throws.InstanceOf<UsenetProtocolException>());
+    }
+
+    [Test]
+    public async Task DecodedBodiesAsync_CompletionFaultsWhenPumpFails()
+    {
+        await using var server = ScriptedNntpServer.StartConnectionScript(
+            async (reader, writer, cancellationToken) =>
+            {
+                _ = await reader.ReadLineAsync(cancellationToken);
+                await writer.WriteAsync(
+                    "222 body follows\r\n" +
+                    "=ybegin line=128 size=10 name=truncated.bin\r\n" +
+                    "encoded-without-terminator\r\n");
+            });
+        await using var client = new UsenetClient();
+        await client.ConnectAsync("127.0.0.1", server.Port, false, CancellationToken.None);
+
+        var batch = await client.DecodedBodiesAsync(
+            new SegmentId[] { "truncated@example.com" }, CancellationToken.None);
+        var truncated = await batch.Responses[0];
+        Assert.ThrowsAsync<UsenetProtocolException>(async () =>
+            await truncated.Stream!.CopyToAsync(Stream.Null));
+        Assert.That(async () => await batch.Completion.WaitAsync(TimeSpan.FromSeconds(2)),
+            Throws.InstanceOf<UsenetProtocolException>());
     }
 
     [Test]

--- a/tests/UsenetSharp.Tests/Models/UsenetDecodedBodyBatchTests.cs
+++ b/tests/UsenetSharp.Tests/Models/UsenetDecodedBodyBatchTests.cs
@@ -1,0 +1,34 @@
+using UsenetSharp.Models;
+
+namespace UsenetSharpTest.Models;
+
+[TestFixture]
+public class UsenetDecodedBodyBatchTests
+{
+    [Test]
+    public void DefaultConstruction_CompletionIsAlreadyCompleted()
+    {
+        var batch = new UsenetDecodedBodyBatch
+        {
+            Responses = Array.Empty<Task<UsenetDecodedBodyResponse>>(),
+        };
+
+        Assert.That(batch.Completion.IsCompletedSuccessfully, Is.True);
+    }
+
+    [Test]
+    public async Task InitializerAssignedCompletion_IsExposedReadOnlyToConsumers()
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var batch = new UsenetDecodedBodyBatch
+        {
+            Responses = Array.Empty<Task<UsenetDecodedBodyResponse>>(),
+            Completion = completion.Task,
+        };
+
+        Assert.That(batch.Completion.IsCompleted, Is.False);
+        completion.SetResult();
+        await batch.Completion;
+        Assert.That(batch.Completion.IsCompletedSuccessfully, Is.True);
+    }
+}


### PR DESCRIPTION
## Summary
- Pipelined BODY batches now look up repair patches and the segment cache per position, request only misses, and merge responses in original order.
- Warm production-shaped rereads report zero transport requests/bytes/batch requests, with every complete cold segment committed into cache.
- Batch completion is public and observed through the wrapper chain so permits, connection locks, and prefetch teardown still finish exactly once.

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~LocalDataBatchOverlayTests|FullyQualifiedName~SegmentCacheNntpClientTests|FullyQualifiedName~RepairedSegmentNntpClientTests|FullyQualifiedName~BatchLocalDataChainTests"`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~DownloadingNntpClientStatGateTests|FullyQualifiedName~MultiProviderNntpClientTests|FullyQualifiedName~NntpClientPipelinedTeardownTests|FullyQualifiedName~MultiConnectionStatsPipelinedTests|FullyQualifiedName~RepeatableStreamingBenchmarkCoverageTests|FullyQualifiedName~MultiSegmentStreamBatchCompletionTests"`
- [x] `dotnet test tests/UsenetSharp.Tests/UsenetSharp.Tests.csproj -c Release --filter "FullyQualifiedName~UsenetDecodedBodyBatch|FullyQualifiedName~DecodedBodiesAsync|FullyQualifiedName~EnumerateDecodedBodiesAsync"` (with `RAPIDYENC_LIBRARY_PATH` set)
- [x] Repeatable streaming report run 3 times; `pipelined-warm-reread` is zero transport and 12 cache hits
- [x] `scripts/test-performance-baseline-gate.sh`
- [ ] PR CI (`ci.yml`) on this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added local batch retrieval that combines repaired, cached, and remote content while preserving requested order.
  - Exposed batch completion status for tracking transfer and connection lifecycle completion.

- **Bug Fixes**
  - Improved cleanup and connection recovery for cancelled, abandoned, interrupted, or failed downloads.
  - Strengthened cache validation, atomic writes, duplicate protection, and storage-error recovery.
  - Fixed completion reporting for mixed cached and remote requests.

- **Performance**
  - Warm rereads can now serve content entirely from cache without transport requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->