### PR TITLE
fix(usenet): preserve streaming priority and release every pipelined batch resource

### DIFF
--- a/backend/Clients/Usenet/ArticleCachingNntpClient.cs
+++ b/backend/Clients/Usenet/ArticleCachingNntpClient.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text;
+using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Models.Nzb;
 using NzbWebDAV.Streams;
@@ -130,8 +132,11 @@ public class ArticleCachingNntpClient(
         }
 
         var missingSegmentIds = partition.Missing.Select(item => item.SegmentId).ToArray();
-        var batch = await base.DecodedBodiesAsync(
-            missingSegmentIds, onConnectionReadyAgain, cancellationToken).ConfigureAwait(false);
+        var batch = await FetchUncachedBatchAsync(
+            missingSegmentIds,
+            (ids, callback, token) => base.DecodedBodiesAsync(ids, callback, token),
+            onConnectionReadyAgain,
+            cancellationToken).ConfigureAwait(false);
         return MergeBatchForCaching(
             segmentIds.Count, partition, batch, cancellationToken);
     }
@@ -283,8 +288,12 @@ public class ArticleCachingNntpClient(
         }
 
         var missingSegmentIds = partition.Missing.Select(item => item.SegmentId).ToArray();
-        var batch = await base.DecodedBodiesAsync(
-            missingSegmentIds, exclusiveConnection, cancellationToken).ConfigureAwait(false);
+        var batch = await FetchUncachedBatchAsync(
+            missingSegmentIds,
+            (ids, callback, token) =>
+                base.DecodedBodiesAsync(ids, new UsenetExclusiveConnection(callback), token),
+            exclusiveConnection.OnConnectionReadyAgain,
+            cancellationToken).ConfigureAwait(false);
         return MergeBatchForCaching(
             segmentIds.Count, partition, batch, cancellationToken);
     }
@@ -315,6 +324,88 @@ public class ArticleCachingNntpClient(
         var byteRange = GetByteRange(cacheEntry.YencHeaders);
         foreach (var segment in trackedSegments)
             segment.ByteRange = byteRange;
+    }
+
+    private static async Task<UsenetDecodedBodyBatch> FetchUncachedBatchAsync(
+        SegmentId[] missingSegmentIds,
+        Func<IReadOnlyList<SegmentId>, ArticleBodyCompletionHandler, CancellationToken,
+            Task<UsenetDecodedBodyBatch>> fetch,
+        ArticleBodyCompletionHandler? outerCallback,
+        CancellationToken cancellationToken)
+    {
+        var deferred = new DeferredArticleBodyCallback();
+        var attemptCts = ContextualCancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        UsenetDecodedBodyBatch? batch = null;
+        var mismatchHandled = false;
+        try
+        {
+            batch = await fetch(missingSegmentIds, deferred.Invoke, attemptCts.Token)
+                .ConfigureAwait(false);
+            if (batch.Responses.Count != missingSegmentIds.Length)
+            {
+                mismatchHandled = true;
+                deferred.Discard();
+                try
+                {
+                    await DecodedBodyBatchCleanup.AbandonAsync(batch, attemptCts).ConfigureAwait(false);
+                }
+                finally
+                {
+                    ArticleBodyCompletion.InvokeContained(
+                        outerCallback,
+                        ArticleBodyResult.NotRetrieved,
+                        "batch-response-count-mismatch");
+                }
+
+                throw new InvalidOperationException(
+                    "The NNTP batch response count did not match the request count.");
+            }
+        }
+        catch (Exception exception)
+        {
+            if (!mismatchHandled)
+            {
+                deferred.Discard();
+                if (batch is not null)
+                    await DecodedBodyBatchCleanup.AbandonAsync(batch, attemptCts).ConfigureAwait(false);
+                else
+                    attemptCts.Dispose();
+                var cancelled = exception.IsCancellationException(cancellationToken);
+                ArticleBodyCompletion.InvokeContained(
+                    outerCallback,
+                    cancelled ? ArticleBodyResult.Cancelled : ArticleBodyResult.NotRetrieved,
+                    cancelled ? null : "cache-batch-setup");
+            }
+
+            throw;
+        }
+
+        deferred.Activate(outerCallback ?? IgnoreCallback);
+        var ownedCts = attemptCts;
+#pragma warning disable CA2025 // Completion owns attemptCts and disposes it after inner lifecycle finishes
+        return batch with
+        {
+            Completion = CompleteThenDisposeAsync(batch.Completion, ownedCts),
+        };
+#pragma warning restore CA2025
+    }
+
+    private static void IgnoreCallback(ArticleBodyResult _, string? __)
+    {
+    }
+
+    private static async Task CompleteThenDisposeAsync(
+        Task completion,
+        ContextualCancellationTokenSource owner)
+    {
+        try
+        {
+            await completion.ConfigureAwait(false);
+        }
+        finally
+        {
+            owner.Dispose();
+        }
     }
 
     private UsenetDecodedBodyBatch MergeBatchForCaching(

--- a/backend/Clients/Usenet/ArticleCachingNntpClient.cs
+++ b/backend/Clients/Usenet/ArticleCachingNntpClient.cs
@@ -366,15 +366,21 @@ public class ArticleCachingNntpClient(
             if (!mismatchHandled)
             {
                 deferred.Discard();
-                if (batch is not null)
-                    await DecodedBodyBatchCleanup.AbandonAsync(batch, attemptCts).ConfigureAwait(false);
-                else
-                    attemptCts.Dispose();
                 var cancelled = exception.IsCancellationException(cancellationToken);
-                ArticleBodyCompletion.InvokeContained(
-                    outerCallback,
-                    cancelled ? ArticleBodyResult.Cancelled : ArticleBodyResult.NotRetrieved,
-                    cancelled ? null : "cache-batch-setup");
+                try
+                {
+                    if (batch is not null)
+                        await DecodedBodyBatchCleanup.AbandonAsync(batch, attemptCts).ConfigureAwait(false);
+                }
+                finally
+                {
+                    ArticleBodyCompletion.InvokeContained(
+                        outerCallback,
+                        cancelled ? ArticleBodyResult.Cancelled : ArticleBodyResult.NotRetrieved,
+                        cancelled ? null : "cache-batch-setup");
+                    if (batch is null)
+                        attemptCts.Dispose();
+                }
             }
 
             throw;

--- a/backend/Clients/Usenet/BatchLifecycle.cs
+++ b/backend/Clients/Usenet/BatchLifecycle.cs
@@ -1,0 +1,55 @@
+using System.Runtime.ExceptionServices;
+
+namespace NzbWebDAV.Clients.Usenet;
+
+/// <summary>
+/// Observes sibling batch-lifecycle tasks without dropping fatal failures.
+/// Fatality controls what is rethrown, not whether remaining work is awaited.
+/// </summary>
+internal static class BatchLifecycle
+{
+    public static ExceptionDispatchInfo PreferFailure(
+        ExceptionDispatchInfo? current,
+        Exception candidate)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+        if (current is null ||
+            (candidate is OutOfMemoryException &&
+             current.SourceException is not OutOfMemoryException))
+        {
+            return ExceptionDispatchInfo.Capture(candidate);
+        }
+
+        return current;
+    }
+
+    public static ExceptionDispatchInfo? Combine(
+        ExceptionDispatchInfo? current,
+        ExceptionDispatchInfo? candidate)
+    {
+        if (candidate is null)
+            return current;
+        return PreferFailure(current, candidate.SourceException);
+    }
+
+    public static async Task<ExceptionDispatchInfo?> ObserveAsync(Task task)
+    {
+        try
+        {
+            await task.ConfigureAwait(false);
+            return null;
+        }
+        catch (Exception exception)
+        {
+            return ExceptionDispatchInfo.Capture(exception);
+        }
+    }
+
+    public static async Task ObserveAllAsync(Task first, Task second)
+    {
+        var failure = Combine(
+            await ObserveAsync(first).ConfigureAwait(false),
+            await ObserveAsync(second).ConfigureAwait(false));
+        failure?.Throw();
+    }
+}

--- a/backend/Clients/Usenet/BatchLifecycle.cs
+++ b/backend/Clients/Usenet/BatchLifecycle.cs
@@ -45,11 +45,15 @@ internal static class BatchLifecycle
         }
     }
 
-    public static async Task ObserveAllAsync(Task first, Task second)
+    public static async Task ObserveAllAsync(params Task[] tasks)
     {
-        var failure = Combine(
-            await ObserveAsync(first).ConfigureAwait(false),
-            await ObserveAsync(second).ConfigureAwait(false));
+        ArgumentNullException.ThrowIfNull(tasks);
+        ExceptionDispatchInfo? failure = null;
+        foreach (var task in tasks)
+        {
+            failure = Combine(failure, await ObserveAsync(task).ConfigureAwait(false));
+        }
+
         failure?.Throw();
     }
 }

--- a/backend/Clients/Usenet/DecodedBodyBatchCleanup.cs
+++ b/backend/Clients/Usenet/DecodedBodyBatchCleanup.cs
@@ -1,0 +1,65 @@
+using System.Runtime.ExceptionServices;
+using NzbWebDAV.Clients.Usenet.Contexts;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Clients.Usenet;
+
+/// <summary>
+/// Cancels, drains, and observes a decoded BODY batch that cannot be returned to
+/// its caller. The layer that rejects a batch owns this protocol.
+/// </summary>
+internal static class DecodedBodyBatchCleanup
+{
+    public static async Task AbandonAsync(
+        UsenetDecodedBodyBatch batch,
+        ContextualCancellationTokenSource owner)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentNullException.ThrowIfNull(owner);
+
+        ExceptionDispatchInfo? fatal = null;
+        try
+        {
+            try
+            {
+                await owner.CancelAsync().ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                if (exception is OutOfMemoryException)
+                    fatal = ExceptionDispatchInfo.Capture(exception);
+            }
+
+            foreach (var responseTask in batch.Responses)
+            {
+                try
+                {
+                    var response = await responseTask.ConfigureAwait(false);
+                    if (response.Stream is not null)
+                        await response.Stream.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception exception)
+                {
+                    if (exception is OutOfMemoryException)
+                        fatal = BatchLifecycle.PreferFailure(fatal, exception);
+                }
+            }
+
+            try
+            {
+                await batch.Completion.ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                if (exception is OutOfMemoryException)
+                    fatal = BatchLifecycle.PreferFailure(fatal, exception);
+            }
+        }
+        finally
+        {
+            owner.Dispose();
+        }
+
+        fatal?.Throw();
+    }
+}

--- a/backend/Clients/Usenet/LocalDataBatchOverlay.cs
+++ b/backend/Clients/Usenet/LocalDataBatchOverlay.cs
@@ -145,14 +145,23 @@ internal static class LocalDataBatchOverlay
             if (!mismatchHandled)
             {
                 deferred.Discard();
-                DisposeHits(partition.Hits);
-                if (inner is not null)
-                    await ObserveCompletionAsync(inner.Completion).ConfigureAwait(false);
-                ArticleBodyCompletion.InvokeContained(
-                    outerCallback, ArticleBodyResult.NotRetrieved, "local-batch-setup");
+                try
+                {
+                    DisposeHits(partition.Hits);
+                    if (inner is not null)
+                        await ObserveCompletionAsync(inner.Completion).ConfigureAwait(false);
+                }
+                finally
+                {
+                    ArticleBodyCompletion.InvokeContained(
+                        outerCallback, ArticleBodyResult.NotRetrieved, "local-batch-setup");
+                    abandonCts.Dispose();
+                }
             }
-
-            abandonCts.Dispose();
+            else
+            {
+                abandonCts.Dispose();
+            }
             throw;
         }
 
@@ -571,6 +580,9 @@ internal sealed class OrderedBatchYencStream : YencStream
         if (Interlocked.Exchange(ref _signaled, 1) != 0)
             return;
         _observeTerminal(failure);
-        _terminal.TrySetResult();
+        if (failure is null)
+            _terminal.TrySetResult();
+        else
+            _terminal.TrySetException(failure);
     }
 }

--- a/backend/Clients/Usenet/LocalDataBatchOverlay.cs
+++ b/backend/Clients/Usenet/LocalDataBatchOverlay.cs
@@ -126,7 +126,7 @@ internal static class LocalDataBatchOverlay
                 mismatchHandled = true;
                 try
                 {
-                    await DrainMismatchedBatchAsync(inner, abandonCts).ConfigureAwait(false);
+                    await DecodedBodyBatchCleanup.AbandonAsync(inner, abandonCts).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -296,49 +296,6 @@ internal static class LocalDataBatchOverlay
         {
             // Predecessor already recorded and surfaced on its own response/stream path.
         }
-    }
-
-    private static async Task DrainMismatchedBatchAsync(
-        UsenetDecodedBodyBatch inner,
-        ContextualCancellationTokenSource abandonCts)
-    {
-        ExceptionDispatchInfo? fatal = null;
-        try
-        {
-            await abandonCts.CancelAsync().ConfigureAwait(false);
-        }
-        catch (Exception exception)
-        {
-            if (exception is OutOfMemoryException)
-                fatal = ExceptionDispatchInfo.Capture(exception);
-        }
-
-        foreach (var responseTask in inner.Responses)
-        {
-            try
-            {
-                var response = await responseTask.ConfigureAwait(false);
-                if (response.Stream is not null)
-                    await response.Stream.DisposeAsync().ConfigureAwait(false);
-            }
-            catch (Exception exception)
-            {
-                if (exception is OutOfMemoryException)
-                    fatal = BatchLifecycle.PreferFailure(fatal, exception);
-            }
-        }
-
-        try
-        {
-            await inner.Completion.ConfigureAwait(false);
-        }
-        catch (Exception exception)
-        {
-            if (exception is OutOfMemoryException)
-                fatal = BatchLifecycle.PreferFailure(fatal, exception);
-        }
-
-        fatal?.Throw();
     }
 
     private static async Task ObserveCompletionAsync(Task completion)

--- a/backend/Clients/Usenet/LocalDataBatchOverlay.cs
+++ b/backend/Clients/Usenet/LocalDataBatchOverlay.cs
@@ -1,4 +1,5 @@
 using System.Runtime.ExceptionServices;
+using NzbWebDAV.Clients.Usenet.Contexts;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
 
@@ -78,7 +79,7 @@ internal static class LocalDataBatchOverlay
         {
             partition = Partition(segmentIds, tryOpenLocal, cancellationToken);
         }
-        catch (Exception exception) when (exception is not OutOfMemoryException)
+        catch (Exception exception)
         {
             var cancelled = exception is OperationCanceledException &&
                             cancellationToken.IsCancellationRequested;
@@ -109,7 +110,7 @@ internal static class LocalDataBatchOverlay
         }
 
         var deferred = new DeferredArticleBodyCallback();
-        var abandonCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var abandonCts = ContextualCancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         UsenetDecodedBodyBatch? inner = null;
         var mismatchHandled = false;
         try
@@ -122,17 +123,24 @@ internal static class LocalDataBatchOverlay
                 .ConfigureAwait(false);
             if (inner.Responses.Count != partition.Misses.Count)
             {
-                await DrainMismatchedBatchAsync(inner, abandonCts).ConfigureAwait(false);
-                deferred.Discard();
-                DisposeHits(partition.Hits);
-                ArticleBodyCompletion.InvokeContained(
-                    outerCallback, ArticleBodyResult.NotRetrieved, "batch-response-count-mismatch");
                 mismatchHandled = true;
+                try
+                {
+                    await DrainMismatchedBatchAsync(inner, abandonCts).ConfigureAwait(false);
+                }
+                finally
+                {
+                    deferred.Discard();
+                    DisposeHits(partition.Hits);
+                    ArticleBodyCompletion.InvokeContained(
+                        outerCallback, ArticleBodyResult.NotRetrieved, "batch-response-count-mismatch");
+                }
+
                 throw new InvalidOperationException(
                     $"Pipelined BODY returned {inner.Responses.Count} responses for {partition.Misses.Count} requests.");
             }
         }
-        catch (Exception exception) when (exception is not OutOfMemoryException)
+        catch (Exception)
         {
             if (!mismatchHandled)
             {
@@ -267,7 +275,7 @@ internal static class LocalDataBatchOverlay
                 previousTerminal = terminal.Task;
                 state.ObserveResponse(response);
             }
-            catch (Exception exception) when (exception is not OutOfMemoryException)
+            catch (Exception exception)
             {
                 state.ObserveFailure(exception);
                 output[index].TrySetException(exception);
@@ -284,7 +292,7 @@ internal static class LocalDataBatchOverlay
         {
             await previous.ConfigureAwait(false);
         }
-        catch (Exception exception) when (exception is not OutOfMemoryException)
+        catch (Exception)
         {
             // Predecessor already recorded and surfaced on its own response/stream path.
         }
@@ -292,15 +300,17 @@ internal static class LocalDataBatchOverlay
 
     private static async Task DrainMismatchedBatchAsync(
         UsenetDecodedBodyBatch inner,
-        CancellationTokenSource abandonCts)
+        ContextualCancellationTokenSource abandonCts)
     {
+        ExceptionDispatchInfo? fatal = null;
         try
         {
             await abandonCts.CancelAsync().ConfigureAwait(false);
         }
-        catch (Exception exception) when (exception is not OutOfMemoryException)
+        catch (Exception exception)
         {
-            // Drain still has to run so the inner lifecycle can finish.
+            if (exception is OutOfMemoryException)
+                fatal = ExceptionDispatchInfo.Capture(exception);
         }
 
         foreach (var responseTask in inner.Responses)
@@ -311,13 +321,24 @@ internal static class LocalDataBatchOverlay
                 if (response.Stream is not null)
                     await response.Stream.DisposeAsync().ConfigureAwait(false);
             }
-            catch (Exception exception) when (exception is not OutOfMemoryException)
+            catch (Exception exception)
             {
-                // Continue so every supplied response and the inner completion are observed.
+                if (exception is OutOfMemoryException)
+                    fatal = BatchLifecycle.PreferFailure(fatal, exception);
             }
         }
 
-        await ObserveCompletionAsync(inner.Completion).ConfigureAwait(false);
+        try
+        {
+            await inner.Completion.ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            if (exception is OutOfMemoryException)
+                fatal = BatchLifecycle.PreferFailure(fatal, exception);
+        }
+
+        fatal?.Throw();
     }
 
     private static async Task ObserveCompletionAsync(Task completion)
@@ -326,13 +347,16 @@ internal static class LocalDataBatchOverlay
         {
             await completion.ConfigureAwait(false);
         }
-        catch (Exception exception) when (exception is not OutOfMemoryException)
+        catch (Exception exception)
         {
-            // Observed so the producer cannot become unobserved.
+            if (exception is OutOfMemoryException)
+                ExceptionDispatchInfo.Capture(exception).Throw();
         }
     }
 
-    private static async Task CompleteThenDisposeAsync(Task completion, CancellationTokenSource abandonCts)
+    private static async Task CompleteThenDisposeAsync(
+        Task completion,
+        ContextualCancellationTokenSource abandonCts)
     {
         try
         {
@@ -346,17 +370,21 @@ internal static class LocalDataBatchOverlay
 
     private static void DisposeHits(IEnumerable<LocalBatchHit> hits)
     {
+        ExceptionDispatchInfo? fatal = null;
         foreach (var hit in hits)
         {
             try
             {
                 hit.Response.Stream?.Dispose();
             }
-            catch (Exception exception) when (exception is not OutOfMemoryException)
+            catch (Exception exception)
             {
-                // Setup cleanup must continue for every already-opened local stream.
+                if (exception is OutOfMemoryException)
+                    fatal = BatchLifecycle.PreferFailure(fatal, exception);
             }
         }
+
+        fatal?.Throw();
     }
 }
 
@@ -418,12 +446,11 @@ internal sealed class BatchCompletionState
 
     public async Task CompleteAsync(Task publisher, Task innerCompletion)
     {
-        var publisherFailure = await ObserveAsync(publisher).ConfigureAwait(false);
-        var innerFailure = await ObserveAsync(innerCompletion).ConfigureAwait(false);
-        if (publisherFailure is not null)
-            ObserveFailure(publisherFailure);
-        if (innerFailure is not null)
-            ObserveFailure(innerFailure);
+        var publisherFailure = await BatchLifecycle.ObserveAsync(publisher).ConfigureAwait(false);
+        var innerFailure = await BatchLifecycle.ObserveAsync(innerCompletion).ConfigureAwait(false);
+        var observed = BatchLifecycle.Combine(publisherFailure, innerFailure);
+        if (observed is not null)
+            ObserveFailure(observed.SourceException);
 
         if (Volatile.Read(ref _inner) is null && _hasInnerBatch)
             RecordInner(ArticleBodyResult.NotRetrieved, "inner-callback-missing");
@@ -447,10 +474,10 @@ internal sealed class BatchCompletionState
         var inner = Volatile.Read(ref _inner);
         if (Volatile.Read(ref _firstFailure) is not null)
             return ArticleBodyResult.NotRetrieved;
-        if (Volatile.Read(ref _cancelled) != 0)
-            return ArticleBodyResult.Cancelled;
         if (_hasInnerBatch && inner?.Result == ArticleBodyResult.NotRetrieved)
             return ArticleBodyResult.NotRetrieved;
+        if (Volatile.Read(ref _cancelled) != 0)
+            return ArticleBodyResult.Cancelled;
         if (_hasInnerBatch && inner?.Result == ArticleBodyResult.Cancelled)
             return ArticleBodyResult.Cancelled;
         if (Volatile.Read(ref _notFound) != 0 ||
@@ -482,19 +509,6 @@ internal sealed class BatchCompletionState
         if (Interlocked.Exchange(ref _outerCallbackFired, 1) != 0)
             return;
         ArticleBodyCompletion.InvokeContained(_outer, result, reason);
-    }
-
-    private static async Task<Exception?> ObserveAsync(Task task)
-    {
-        try
-        {
-            await task.ConfigureAwait(false);
-            return null;
-        }
-        catch (Exception exception) when (exception is not OutOfMemoryException)
-        {
-            return exception;
-        }
     }
 
     private sealed record InnerCallback(ArticleBodyResult Result, string? Reason);
@@ -534,7 +548,7 @@ internal sealed class OrderedBatchYencStream : YencStream
                 Signal(null);
             return read;
         }
-        catch (Exception exception) when (exception is not OutOfMemoryException)
+        catch (Exception exception)
         {
             Signal(exception);
             throw;
@@ -557,7 +571,7 @@ internal sealed class OrderedBatchYencStream : YencStream
         {
             _inner.Dispose();
         }
-        catch (Exception exception) when (exception is not OutOfMemoryException)
+        catch (Exception exception)
         {
             failure = exception;
             throw;
@@ -583,7 +597,7 @@ internal sealed class OrderedBatchYencStream : YencStream
         {
             await _inner.DisposeAsync().ConfigureAwait(false);
         }
-        catch (Exception exception) when (exception is not OutOfMemoryException)
+        catch (Exception exception)
         {
             failure = exception;
             throw;

--- a/backend/Clients/Usenet/LocalDataBatchOverlay.cs
+++ b/backend/Clients/Usenet/LocalDataBatchOverlay.cs
@@ -140,21 +140,32 @@ internal static class LocalDataBatchOverlay
                     $"Pipelined BODY returned {inner.Responses.Count} responses for {partition.Misses.Count} requests.");
             }
         }
-        catch (Exception)
+        catch (Exception exception)
         {
             if (!mismatchHandled)
             {
                 deferred.Discard();
+                var cancelled = exception is OperationCanceledException &&
+                                cancellationToken.IsCancellationRequested;
                 try
                 {
-                    DisposeHits(partition.Hits);
-                    if (inner is not null)
-                        await ObserveCompletionAsync(inner.Completion).ConfigureAwait(false);
+                    try
+                    {
+                        DisposeHits(partition.Hits);
+                    }
+                    finally
+                    {
+                        if (inner is not null)
+                            await DecodedBodyBatchCleanup.AbandonAsync(inner, abandonCts)
+                                .ConfigureAwait(false);
+                    }
                 }
                 finally
                 {
                     ArticleBodyCompletion.InvokeContained(
-                        outerCallback, ArticleBodyResult.NotRetrieved, "local-batch-setup");
+                        outerCallback,
+                        cancelled ? ArticleBodyResult.Cancelled : ArticleBodyResult.NotRetrieved,
+                        cancelled ? null : "local-batch-setup");
                     abandonCts.Dispose();
                 }
             }
@@ -304,19 +315,6 @@ internal static class LocalDataBatchOverlay
         catch (Exception)
         {
             // Predecessor already recorded and surfaced on its own response/stream path.
-        }
-    }
-
-    private static async Task ObserveCompletionAsync(Task completion)
-    {
-        try
-        {
-            await completion.ConfigureAwait(false);
-        }
-        catch (Exception exception)
-        {
-            if (exception is OutOfMemoryException)
-                ExceptionDispatchInfo.Capture(exception).Throw();
         }
     }
 

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -1200,27 +1200,7 @@ public class MultiConnectionNntpClient(
 
     private static async Task CompleteBatchLifecycleAsync(Task transportCompletion, Task callbackCompletion)
     {
-        Exception? first = null;
-        try
-        {
-            await transportCompletion.ConfigureAwait(false);
-        }
-        catch (Exception exception) when (exception is not OutOfMemoryException)
-        {
-            first = exception;
-        }
-
-        try
-        {
-            await callbackCompletion.ConfigureAwait(false);
-        }
-        catch (Exception exception) when (exception is not OutOfMemoryException)
-        {
-            first ??= exception;
-        }
-
-        if (first is not null)
-            ExceptionDispatchInfo.Capture(first).Throw();
+        await BatchLifecycle.ObserveAllAsync(transportCompletion, callbackCompletion).ConfigureAwait(false);
     }
 
     private async Task<UsenetDecodedBodyResponse> RecordSuccessfulResponseAsync(

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -743,27 +743,7 @@ public class MultiProviderNntpClient(
 
     private static async Task ComposeBatchCompletionAsync(Task transportCompletion, Task coordinatorCompletion)
     {
-        Exception? first = null;
-        try
-        {
-            await transportCompletion.ConfigureAwait(false);
-        }
-        catch (Exception exception) when (exception is not OutOfMemoryException)
-        {
-            first = exception;
-        }
-
-        try
-        {
-            await coordinatorCompletion.ConfigureAwait(false);
-        }
-        catch (Exception exception) when (exception is not OutOfMemoryException)
-        {
-            first ??= exception;
-        }
-
-        if (first is not null)
-            ExceptionDispatchInfo.Capture(first).Throw();
+        await BatchLifecycle.ObserveAllAsync(transportCompletion, coordinatorCompletion).ConfigureAwait(false);
     }
 
     private static void ObserveAbandonedBatch(UsenetDecodedBodyBatch? batch)

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -410,19 +410,19 @@ public class MultiProviderNntpClient(
                     var fallbackProviders = orderedProviders
                         .Skip(providerIndex + 1)
                         .ToArray();
-                    var responses =
+                    var rawResponses =
                         new Task<UsenetDecodedBodyResponse>[primaryBatch.Responses.Count];
                     // Admission (start-order) is separate from transfer completion so segment
                     // N+1 can begin its fallback walk after N has admitted/started, without
                     // waiting for N's body stream to finish. Concurrent starts are bounded by
                     // _batchFallbackStartGate until each transfer's body callback fires.
                     Task previousFallbackAdmission = Task.CompletedTask;
-                    for (var index = 0; index < responses.Length; index++)
+                    for (var index = 0; index < rawResponses.Length; index++)
                     {
                         var fallbackAdmission = new TaskCompletionSource(
                             TaskCreationOptions.RunContinuationsAsynchronously);
 #pragma warning disable CA2025 // batch response tasks intentionally outlive this scope: releasePending only returns the pending-admission reservation, while in-flight transfers hold (and release via completion callbacks) their own per-provider connection locks
-                        responses[index] = ResolveBatchResponseAsync(
+                        rawResponses[index] = ResolveBatchResponseAsync(
                             primaryBatch.Responses[index],
                             segmentIds[index],
                             provider,
@@ -435,15 +435,21 @@ public class MultiProviderNntpClient(
                         previousFallbackAdmission = fallbackAdmission.Task;
                     }
 
+                    var output = CreateBatchOutputSources(rawResponses.Length);
+                    var publicResponses = new Task<UsenetDecodedBodyResponse>[output.Length];
+                    for (var index = 0; index < output.Length; index++)
+                        publicResponses[index] = output[index].Task;
+                    var publisher = OrderedBatchResponsePublisher.PublishAsync(rawResponses, output);
                     var ownedCts = attemptCts;
                     attemptCts = null;
-#pragma warning disable CA2025 // Completion owns the attempt token until transport and coordinator finish
+#pragma warning disable CA2025 // Completion owns the attempt token until transport, coordinator, and publication finish
                     return new UsenetDecodedBodyBatch
                     {
-                        Responses = responses,
+                        Responses = publicResponses,
                         Completion = CompleteOwnedBatchAsync(
                             primaryBatch.Completion,
                             coordinator.Completion,
+                            publisher,
                             ownedCts),
                     };
 #pragma warning restore CA2025
@@ -756,14 +762,28 @@ public class MultiProviderNntpClient(
         }
     }
 
+    private static TaskCompletionSource<UsenetDecodedBodyResponse>[] CreateBatchOutputSources(int count)
+    {
+        var output = new TaskCompletionSource<UsenetDecodedBodyResponse>[count];
+        for (var index = 0; index < count; index++)
+        {
+            output[index] = new TaskCompletionSource<UsenetDecodedBodyResponse>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        return output;
+    }
+
     private static async Task CompleteOwnedBatchAsync(
         Task transportCompletion,
         Task coordinatorCompletion,
+        Task publisher,
         ContextualCancellationTokenSource owner)
     {
         try
         {
-            await BatchLifecycle.ObserveAllAsync(transportCompletion, coordinatorCompletion)
+            await BatchLifecycle.ObserveAllAsync(
+                    transportCompletion, coordinatorCompletion, publisher)
                 .ConfigureAwait(false);
         }
         finally

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -391,13 +391,21 @@ public class MultiProviderNntpClient(
                 var provider = orderedProviders[providerIndex];
                 var deferredCallback = new DeferredArticleBodyCallback();
                 UsenetDecodedBodyBatch? primaryBatch = null;
+                ContextualCancellationTokenSource? attemptCts = null;
                 try
                 {
                     cancellationToken.ThrowIfCancellationRequested();
+                    attemptCts = ContextualCancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                     primaryBatch = await provider.DecodedBodiesAsync(
-                        segmentIds, deferredCallback.Invoke, cancellationToken).ConfigureAwait(false);
+                        segmentIds, deferredCallback.Invoke, attemptCts.Token).ConfigureAwait(false);
+                    if (primaryBatch.Responses.Count != segmentIds.Count)
+                    {
+                        throw new InvalidOperationException(
+                            $"Pipelined BODY returned {primaryBatch.Responses.Count} responses for {segmentIds.Count} requests.");
+                    }
+
                     var coordinator = new BatchCallbackCoordinator(
-                    primaryBatch.Responses.Count, CompleteBatchFetches);
+                        primaryBatch.Responses.Count, CompleteBatchFetches);
                     deferredCallback.Activate(coordinator.CompleteTransfer);
                     var fallbackProviders = orderedProviders
                         .Skip(providerIndex + 1)
@@ -426,42 +434,49 @@ public class MultiProviderNntpClient(
 #pragma warning restore CA2025
                         previousFallbackAdmission = fallbackAdmission.Task;
                     }
+
+                    var ownedCts = attemptCts;
+                    attemptCts = null;
+#pragma warning disable CA2025 // Completion owns the attempt token until transport and coordinator finish
                     return new UsenetDecodedBodyBatch
                     {
                         Responses = responses,
-                        Completion = ComposeBatchCompletionAsync(
-                            primaryBatch.Completion, coordinator.Completion),
+                        Completion = CompleteOwnedBatchAsync(
+                            primaryBatch.Completion,
+                            coordinator.Completion,
+                            ownedCts),
                     };
+#pragma warning restore CA2025
                 }
                 catch (NntpClientRetiredException)
                 {
-                    ObserveAbandonedBatch(primaryBatch);
+                    deferredCallback.Discard();
+                    await AbandonProviderAttemptAsync(primaryBatch, attemptCts).ConfigureAwait(false);
                     // Every provider in this client belongs to the same retired generation.
                     // Do not walk the remaining disposed pools or record network failures.
-                    deferredCallback.Discard();
                     ArticleBodyCompletion.InvokeContained(
                         CompleteBatchFetches, ArticleBodyResult.NotRetrieved);
                     throw;
                 }
                 catch (Exception e) when (e.TryGetCausingException(out UsenetArticleNotFoundException? _) && e is not OutOfMemoryException)
                 {
-                    ObserveAbandonedBatch(primaryBatch);
-                    // Invalid / permanently missing segment ids are invalid on every provider.
                     deferredCallback.Discard();
+                    await AbandonProviderAttemptAsync(primaryBatch, attemptCts).ConfigureAwait(false);
+                    // Invalid / permanently missing segment ids are invalid on every provider.
                     ArticleBodyCompletion.InvokeContained(
                         CompleteBatchFetches, ArticleBodyResult.NotRetrieved);
                     throw;
                 }
                 catch (Exception e) when (!e.IsCancellationException(cancellationToken) && e is not OutOfMemoryException)
                 {
-                    ObserveAbandonedBatch(primaryBatch);
                     deferredCallback.Discard();
+                    await AbandonProviderAttemptAsync(primaryBatch, attemptCts).ConfigureAwait(false);
                     lastException = ExceptionDispatchInfo.Capture(e);
                 }
                 catch
                 {
-                    ObserveAbandonedBatch(primaryBatch);
                     deferredCallback.Discard();
+                    await AbandonProviderAttemptAsync(primaryBatch, attemptCts).ConfigureAwait(false);
                     ArticleBodyCompletion.InvokeContained(
                         CompleteBatchFetches, ArticleBodyResult.NotRetrieved);
                     throw;
@@ -741,27 +756,33 @@ public class MultiProviderNntpClient(
         }
     }
 
-    private static async Task ComposeBatchCompletionAsync(Task transportCompletion, Task coordinatorCompletion)
-    {
-        await BatchLifecycle.ObserveAllAsync(transportCompletion, coordinatorCompletion).ConfigureAwait(false);
-    }
-
-    private static void ObserveAbandonedBatch(UsenetDecodedBodyBatch? batch)
-    {
-        if (batch is null) return;
-        _ = ObserveAbandonedBatchCompletionAsync(batch.Completion);
-    }
-
-    private static async Task ObserveAbandonedBatchCompletionAsync(Task completion)
+    private static async Task CompleteOwnedBatchAsync(
+        Task transportCompletion,
+        Task coordinatorCompletion,
+        ContextualCancellationTokenSource owner)
     {
         try
         {
-            await completion.ConfigureAwait(false);
+            await BatchLifecycle.ObserveAllAsync(transportCompletion, coordinatorCompletion)
+                .ConfigureAwait(false);
         }
-        catch (Exception exception) when (exception is not OutOfMemoryException)
+        finally
         {
-            Log.Debug(exception, "Abandoned pipelined BODY batch completion failed");
+            owner.Dispose();
         }
+    }
+
+    private static async Task AbandonProviderAttemptAsync(
+        UsenetDecodedBodyBatch? batch,
+        ContextualCancellationTokenSource? owner)
+    {
+        if (batch is not null && owner is not null)
+        {
+            await DecodedBodyBatchCleanup.AbandonAsync(batch, owner).ConfigureAwait(false);
+            return;
+        }
+
+        owner?.Dispose();
     }
 
     private sealed class BatchCallbackCoordinator(

--- a/backend/Clients/Usenet/OrderedBatchResponsePublisher.cs
+++ b/backend/Clients/Usenet/OrderedBatchResponsePublisher.cs
@@ -1,3 +1,4 @@
+using System.Runtime.ExceptionServices;
 using UsenetSharp.Models;
 using UsenetSharp.Streams;
 
@@ -23,9 +24,19 @@ internal static class OrderedBatchResponsePublisher
         }
 
         Task previousTerminal = Task.CompletedTask;
+        ExceptionDispatchInfo? fatal = null;
+        void ObserveTerminal(Exception? exception)
+        {
+            observeTerminal?.Invoke(exception);
+            if (exception is OutOfMemoryException)
+                fatal = BatchLifecycle.PreferFailure(fatal, exception);
+        }
+
         for (var index = 0; index < rawResponses.Count; index++)
         {
-            await ObservePredecessorAsync(previousTerminal).ConfigureAwait(false);
+            CaptureFatal(
+                ref fatal,
+                await ObservePredecessorAsync(previousTerminal).ConfigureAwait(false));
             try
             {
                 var response = await rawResponses[index].ConfigureAwait(false);
@@ -42,33 +53,33 @@ internal static class OrderedBatchResponsePublisher
                     Stream = new OrderedBatchYencStream(
                         response.Stream,
                         terminal,
-                        observeTerminal ?? Noop),
+                        ObserveTerminal),
                 });
                 previousTerminal = terminal.Task;
             }
             catch (Exception exception)
             {
                 output[index].TrySetException(exception);
+                if (exception is OutOfMemoryException)
+                    fatal = BatchLifecycle.PreferFailure(fatal, exception);
                 previousTerminal = Task.CompletedTask;
             }
         }
 
-        await ObservePredecessorAsync(previousTerminal).ConfigureAwait(false);
+        CaptureFatal(
+            ref fatal,
+            await ObservePredecessorAsync(previousTerminal).ConfigureAwait(false));
+        fatal?.Throw();
     }
 
-    private static void Noop(Exception? _)
+    private static void CaptureFatal(
+        ref ExceptionDispatchInfo? current,
+        ExceptionDispatchInfo? candidate)
     {
+        if (candidate?.SourceException is OutOfMemoryException exception)
+            current = BatchLifecycle.PreferFailure(current, exception);
     }
 
-    private static async Task ObservePredecessorAsync(Task previous)
-    {
-        try
-        {
-            await previous.ConfigureAwait(false);
-        }
-        catch (Exception)
-        {
-            // Predecessor already surfaced on its own response or stream.
-        }
-    }
+    private static Task<ExceptionDispatchInfo?> ObservePredecessorAsync(Task previous) =>
+        BatchLifecycle.ObserveAsync(previous);
 }

--- a/backend/Clients/Usenet/OrderedBatchResponsePublisher.cs
+++ b/backend/Clients/Usenet/OrderedBatchResponsePublisher.cs
@@ -1,0 +1,74 @@
+using UsenetSharp.Models;
+using UsenetSharp.Streams;
+
+namespace NzbWebDAV.Clients.Usenet;
+
+/// <summary>
+/// Publishes already-started batch responses so callers observe them strictly in
+/// request order, while fallback/start work may already be running concurrently.
+/// </summary>
+internal static class OrderedBatchResponsePublisher
+{
+    public static async Task PublishAsync(
+        IReadOnlyList<Task<UsenetDecodedBodyResponse>> rawResponses,
+        TaskCompletionSource<UsenetDecodedBodyResponse>[] output,
+        Action<Exception?>? observeTerminal = null)
+    {
+        ArgumentNullException.ThrowIfNull(rawResponses);
+        ArgumentNullException.ThrowIfNull(output);
+        if (rawResponses.Count != output.Length)
+        {
+            throw new ArgumentException(
+                "Ordered publication requires one output source per raw response.");
+        }
+
+        Task previousTerminal = Task.CompletedTask;
+        for (var index = 0; index < rawResponses.Count; index++)
+        {
+            await ObservePredecessorAsync(previousTerminal).ConfigureAwait(false);
+            try
+            {
+                var response = await rawResponses[index].ConfigureAwait(false);
+                if (response.Stream is null)
+                {
+                    output[index].TrySetResult(response);
+                    previousTerminal = Task.CompletedTask;
+                    continue;
+                }
+
+                var terminal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                output[index].TrySetResult(response with
+                {
+                    Stream = new OrderedBatchYencStream(
+                        response.Stream,
+                        terminal,
+                        observeTerminal ?? Noop),
+                });
+                previousTerminal = terminal.Task;
+            }
+            catch (Exception exception)
+            {
+                output[index].TrySetException(exception);
+                previousTerminal = Task.CompletedTask;
+            }
+        }
+
+        await ObservePredecessorAsync(previousTerminal).ConfigureAwait(false);
+    }
+
+    private static void Noop(Exception? _)
+    {
+    }
+
+    private static async Task ObservePredecessorAsync(Task previous)
+    {
+        try
+        {
+            await previous.ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Predecessor already surfaced on its own response or stream.
+        }
+    }
+}

--- a/backend/Clients/Usenet/SegmentCacheNntpClient.cs
+++ b/backend/Clients/Usenet/SegmentCacheNntpClient.cs
@@ -32,6 +32,7 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
     private readonly object _evictLock = new();
     private readonly object[] _commitStripes = CreateCommitStripes();
     private readonly Func<IEnumerable<string>> _enumerateCacheFiles;
+    private readonly Func<string, SegmentCacheDeleteResult?>? _tryDelete;
     private long _currentBytes;
     private int _catalogReady;
     private int _catalogDegraded;
@@ -56,7 +57,8 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         ProviderUsageTracker? usageTracker,
         MetricsWriter? metricsWriter,
         Func<IEnumerable<string>>? enumerateCacheFiles,
-        SegmentCacheStatistics? statistics = null) : base(inner)
+        SegmentCacheStatistics? statistics = null,
+        Func<string, SegmentCacheDeleteResult?>? tryDelete = null) : base(inner)
     {
         _dir = cacheDir;
         _maxBytes = maxBytes;
@@ -67,6 +69,7 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         Directory.CreateDirectory(_dir);
         _enumerateCacheFiles = enumerateCacheFiles
                                ?? (() => Directory.EnumerateFiles(_dir, "*", SearchOption.AllDirectories));
+        _tryDelete = tryDelete;
         CatalogLoadTask = Task.Run(LoadIndex);
     }
 
@@ -269,6 +272,7 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         if (!_index.TryGetValue(hash, out var entry)) return CacheLookupResult.Miss;
 
         var blobPath = BlobPath(hash);
+        FileStream? fileStream = null;
         try
         {
             var header = JsonSerializer.Deserialize<UsenetYencHeader>(
@@ -279,8 +283,16 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
                 return CacheLookupResult.ReadFailure;
             }
 
-            var fileStream = new FileStream(blobPath, FileMode.Open, FileAccess.Read,
+            fileStream = new FileStream(blobPath, FileMode.Open, FileAccess.Read,
                 FileShare.Read | FileShare.Delete, bufferSize: 81920, useAsync: true);
+            if (fileStream.Length != header.PartSize)
+            {
+                fileStream.Dispose();
+                fileStream = null;
+                RecordReadFailureAndDrop(hash);
+                return CacheLookupResult.ReadFailure;
+            }
+
             entry.LastAccessTicks = DateTime.UtcNow.Ticks;
             servedBytes = header.PartSize;
             response = new UsenetDecodedBodyResponse
@@ -290,10 +302,13 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
                 ResponseMessage = "222 - Article retrieved from segment cache",
                 Stream = new CachedYencStream(header, fileStream),
             };
+            fileStream = null;
             return CacheLookupResult.Hit;
         }
-        catch
+        catch (Exception exception) when (
+            exception is IOException or UnauthorizedAccessException or JsonException)
         {
+            fileStream?.Dispose();
             RecordReadFailureAndDrop(hash);
             return CacheLookupResult.ReadFailure;
         }
@@ -351,46 +366,50 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         var result = SegmentCacheCommitResult.Failed;
         lock (commitLock)
         {
-            if (TryValidatePublishedEntry(hash, out _))
+            if (TryValidatePublishedEntry(hash, out var existingSize))
             {
                 TryDelete(blobTempPath);
                 TryDelete(headerTempPath);
-                return SegmentCacheCommitResult.AlreadyPresent;
+                PublishIndexEntry(hash, existingSize);
+                result = SegmentCacheCommitResult.AlreadyPresent;
             }
+            else
+            {
+                // Catalog leaves recent malformed pairs on disk without indexing them.
+                // Remove that residue while we hold the stripe so this commit can publish.
+                TryDelete(blobPath);
+                TryDelete(headerPath);
 
-            // Catalog leaves recent malformed pairs on disk without indexing them.
-            // Remove that residue while we hold the stripe so this commit can publish.
-            TryDelete(blobPath);
-            TryDelete(headerPath);
-
-            var blobPublished = false;
-            try
-            {
-                Directory.CreateDirectory(Path.GetDirectoryName(blobPath)!);
-                File.Move(blobTempPath, blobPath, overwrite: false);
-                blobPublished = true;
-                File.Move(headerTempPath, headerPath, overwrite: false);
-                PublishIndexEntry(hash, decodedBytes);
-                result = SegmentCacheCommitResult.Committed;
-            }
-            catch (IOException) when (TryValidatePublishedEntry(hash, out _))
-            {
-                return SegmentCacheCommitResult.AlreadyPresent;
-            }
-            catch
-            {
-                if (blobPublished && !_index.ContainsKey(hash))
-                    TryDelete(blobPath);
-                throw;
-            }
-            finally
-            {
-                TryDelete(blobTempPath);
-                TryDelete(headerTempPath);
+                var blobPublished = false;
+                try
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(blobPath)!);
+                    File.Move(blobTempPath, blobPath, overwrite: false);
+                    blobPublished = true;
+                    File.Move(headerTempPath, headerPath, overwrite: false);
+                    PublishIndexEntry(hash, decodedBytes);
+                    result = SegmentCacheCommitResult.Committed;
+                }
+                catch (IOException) when (TryValidatePublishedEntry(hash, out var racedSize))
+                {
+                    PublishIndexEntry(hash, racedSize);
+                    result = SegmentCacheCommitResult.AlreadyPresent;
+                }
+                catch
+                {
+                    if (blobPublished && !_index.ContainsKey(hash))
+                        TryDelete(blobPath);
+                    throw;
+                }
+                finally
+                {
+                    TryDelete(blobTempPath);
+                    TryDelete(headerTempPath);
+                }
             }
         }
 
-        if (result == SegmentCacheCommitResult.Committed)
+        if (result is SegmentCacheCommitResult.Committed or SegmentCacheCommitResult.AlreadyPresent)
         {
             EvictIfNeeded();
             PublishIndexGauges();
@@ -477,17 +496,32 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         foreach (var kv in _index.OrderBy(x => x.Value.LastAccessTicks).ToList())
         {
             if (_currentBytes <= _maxBytes) break;
-            if (!_index.TryRemove(kv.Key, out var entry)) continue;
+            var blobResult = TryDelete(BlobPath(kv.Key));
+            if (blobResult == SegmentCacheDeleteResult.Failed)
+                continue;
+
+            TryDelete(BlobPath(kv.Key) + ".h");
+            if (!_index.TryRemove(kv.Key, out var entry))
+                continue;
+
             _currentBytes -= entry.Size;
             evictedEntries++;
             evictedBytes += entry.Size;
-            TryDelete(BlobPath(kv.Key));
-            TryDelete(BlobPath(kv.Key) + ".h");
         }
     }
 
-    private void PublishIndexGauges() =>
-        _generation.SetIndex(_index.Count, Interlocked.Read(ref _currentBytes));
+    private void PublishIndexGauges()
+    {
+        long entries;
+        long bytes;
+        lock (_evictLock)
+        {
+            entries = _index.Count;
+            bytes = _currentBytes;
+        }
+
+        _generation.SetIndex(entries, bytes);
+    }
 
     private void LoadIndex()
     {
@@ -501,7 +535,7 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
                 {
                     if (file.EndsWith(".tmp", StringComparison.Ordinal))
                     {
-                        if (IsStale(file) && TryDelete(file))
+                        if (IsStale(file) && TryDelete(file) == SegmentCacheDeleteResult.Deleted)
                         {
                             cleaned++;
                             _statistics.RecordTemporaryFileCleaned();
@@ -587,10 +621,16 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
             }
             finally
             {
-                Volatile.Write(ref _catalogReady, 1);
+                long entries;
+                long bytes;
+                lock (_evictLock)
+                {
+                    Volatile.Write(ref _catalogReady, 1);
+                    entries = _index.Count;
+                    bytes = _currentBytes;
+                }
+
                 stopwatch.Stop();
-                var entries = _index.Count;
-                var bytes = Interlocked.Read(ref _currentBytes);
                 _generation.SetCatalogReady(stopwatch.ElapsedMilliseconds, entries, bytes);
                 Log.Information(
                     "Segment cache catalog ready. Enabled: {Enabled}. Path: {PathClass}. MaxBytes: {MaxBytes}. " +
@@ -648,17 +688,32 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         Log.Warning("Segment cache write failed. Reason: {Reason}", "storage-unavailable");
     }
 
-    private static bool TryDelete(string path)
+    private SegmentCacheDeleteResult TryDelete(string path)
+    {
+        var overrideResult = _tryDelete?.Invoke(path);
+        if (overrideResult is not null)
+            return overrideResult.Value;
+
+        return DeleteCacheFile(path);
+    }
+
+    private static SegmentCacheDeleteResult DeleteCacheFile(string path)
     {
         try
         {
-            if (!File.Exists(path)) return false;
+            if (!File.Exists(path))
+                return SegmentCacheDeleteResult.Absent;
+
             File.Delete(path);
-            return true;
+            return SegmentCacheDeleteResult.Deleted;
         }
-        catch
+        catch (Exception exception) when (exception is FileNotFoundException or DirectoryNotFoundException)
         {
-            return false;
+            return SegmentCacheDeleteResult.Absent;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return SegmentCacheDeleteResult.Failed;
         }
     }
 
@@ -778,8 +833,8 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
             }
 
             _temp = null;
-            TryDelete(_blobTempPath);
-            TryDelete(_headerTempPath);
+            DeleteCacheFile(_blobTempPath);
+            DeleteCacheFile(_headerTempPath);
         }
 
         protected override void Dispose(bool disposing)
@@ -876,16 +931,16 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
                     return;
                 }
 
-                TryDelete(_blobTempPath);
-                TryDelete(_headerTempPath);
+                DeleteCacheFile(_blobTempPath);
+                DeleteCacheFile(_headerTempPath);
                 _attempt.Complete(
                     _writeFailed ? SegmentCacheWriteOutcome.Failed : SegmentCacheWriteOutcome.Skipped,
                     _written);
             }
             catch (Exception exception) when (exception is not OutOfMemoryException)
             {
-                TryDelete(_blobTempPath);
-                TryDelete(_headerTempPath);
+                DeleteCacheFile(_blobTempPath);
+                DeleteCacheFile(_headerTempPath);
                 _attempt.Complete(SegmentCacheWriteOutcome.Failed, _written);
                 if (IsBestEffortCacheIoFailure(exception))
                     _warnWriteFailure();
@@ -895,6 +950,13 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         private static bool IsBestEffortCacheIoFailure(Exception exception) =>
             exception is IOException or UnauthorizedAccessException or DirectoryNotFoundException;
     }
+}
+
+internal enum SegmentCacheDeleteResult
+{
+    Absent,
+    Deleted,
+    Failed,
 }
 
 internal enum SegmentCacheCommitResult

--- a/backend/Clients/Usenet/SegmentCacheNntpClient.cs
+++ b/backend/Clients/Usenet/SegmentCacheNntpClient.cs
@@ -701,9 +701,7 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
     {
         try
         {
-            if (!File.Exists(path))
-                return SegmentCacheDeleteResult.Absent;
-
+            _ = File.GetAttributes(path);
             File.Delete(path);
             return SegmentCacheDeleteResult.Deleted;
         }

--- a/backend/Services/SupportPack/SupportPackRedactor.cs
+++ b/backend/Services/SupportPack/SupportPackRedactor.cs
@@ -60,11 +60,7 @@ internal sealed partial class SupportPackRedactor
         {
             try
             {
-                using var document = JsonDocument.Parse(value);
-                var buffer = new ArrayBufferWriter<byte>();
-                using (var writer = new Utf8JsonWriter(buffer, new JsonWriterOptions { Indented = true }))
-                    WriteRedactedJson(writer, document.RootElement);
-                return Encoding.UTF8.GetString(buffer.WrittenSpan);
+                return RedactJson(value);
             }
             catch (JsonException)
             {
@@ -74,6 +70,15 @@ internal sealed partial class SupportPackRedactor
         }
 
         return RedactText(value);
+    }
+
+    public string RedactJson(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(buffer, new JsonWriterOptions { Indented = true }))
+            WriteRedactedJson(writer, document.RootElement);
+        return Encoding.UTF8.GetString(buffer.WrittenSpan);
     }
 
     public string RedactText(string? value)

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -150,20 +150,26 @@ public sealed class SupportPackService(
             redactor,
             cancellationToken).ConfigureAwait(false);
 
+        EffectiveStreamingConfigDocument? effective = null;
         try
         {
-            await WriteTextAsync(
-                archive,
-                "configuration-effective-streaming.json",
-                redactor.RedactText(JsonSerializer.Serialize(
-                    EffectiveStreamingConfigManifest.Create(configManager),
-                    EffectiveStreamingConfigManifest.SerializerOptions)),
-                cancellationToken).ConfigureAwait(false);
-            sectionStatus["configurationEffectiveStreaming"] = "included";
+            effective = EffectiveStreamingConfigManifest.Create(configManager);
         }
         catch (Exception e) when (e is not OutOfMemoryException and not OperationCanceledException)
         {
             sectionStatus["configurationEffectiveStreaming"] = "unavailable";
+        }
+
+        if (effective is not null)
+        {
+            await WriteJsonAsync(
+                archive,
+                "configuration-effective-streaming.json",
+                effective,
+                redactor,
+                cancellationToken,
+                EffectiveStreamingConfigManifest.SerializerOptions).ConfigureAwait(false);
+            sectionStatus["configurationEffectiveStreaming"] = "included";
         }
 
         try
@@ -1390,11 +1396,12 @@ public sealed class SupportPackService(
         string name,
         object value,
         SupportPackRedactor redactor,
-        CancellationToken cancellationToken) =>
+        CancellationToken cancellationToken,
+        JsonSerializerOptions? options = null) =>
         await WriteTextAsync(
             archive,
             name,
-            redactor.RedactText(JsonSerializer.Serialize(value, JsonOptions)),
+            redactor.RedactJson(JsonSerializer.Serialize(value, options ?? JsonOptions)),
             cancellationToken).ConfigureAwait(false);
 
     private static async Task WriteTextAsync(

--- a/libs/UsenetSharp/Clients/UsenetClient.DecodedBodiesAsync.cs
+++ b/libs/UsenetSharp/Clients/UsenetClient.DecodedBodiesAsync.cs
@@ -115,7 +115,7 @@ public partial class UsenetClient
                 Completion = completion
             };
         }
-        catch (Exception exception) when (exception is not OutOfMemoryException)
+        catch (Exception exception)
         {
             if (writeStarted)
             {
@@ -280,10 +280,15 @@ public partial class UsenetClient
         var completionResult = ArticleBodyResult.Retrieved;
         string? completionReason = null;
         var nextResponseIndex = 0;
-        using var operationCts = CreateOperationTokenSource(callerCancellationToken);
-        using var sharedReadTimeout = new CoalescedReadTimeout(_options.ReadTimeout, _timeProvider, operationCts.Token);
+        CancellationTokenSource? operationCts = null;
+        CoalescedReadTimeout? sharedReadTimeout = null;
         try
         {
+            operationCts = CreateOperationTokenSource(callerCancellationToken);
+            sharedReadTimeout = new CoalescedReadTimeout(
+                _options.ReadTimeout,
+                _timeProvider,
+                operationCts.Token);
             while (nextResponseIndex < segmentIds.Length)
             {
                 var segmentId = segmentIds[nextResponseIndex];
@@ -412,11 +417,13 @@ public partial class UsenetClient
                 }
             }
         }
-        catch (Exception exception) when (exception is not OutOfMemoryException)
+        catch (Exception exception)
         {
             failure = exception;
             completionResult = ArticleBodyResult.NotRetrieved;
-            completionReason = DescribeFailure(exception);
+            completionReason = exception is OutOfMemoryException
+                ? "out-of-memory"
+                : DescribeFailure(exception);
             RecordConnectionFailure(exception);
         }
         finally
@@ -429,6 +436,8 @@ public partial class UsenetClient
                 }
             }
 
+            sharedReadTimeout?.Dispose();
+            operationCts?.Dispose();
             _commandLock.Release();
             InvokeBatchCallback(
                 onConnectionReadyAgain,
@@ -487,7 +496,7 @@ public partial class UsenetClient
         {
             callback?.Invoke(result, failureReason);
         }
-        catch
+        catch (Exception exception) when (exception is not OutOfMemoryException)
         {
             // User callbacks must not fault command setup or the background pump.
         }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleCachingNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleCachingNntpClientTests.cs
@@ -143,6 +143,40 @@ public class ArticleCachingNntpClientTests
     }
 
     [Fact]
+    public async Task DecodedBodiesAsync_MalformedInnerBatchCompletionOom_StillReportsNotRetrieved()
+    {
+        var inner = new ControlledDecodedBodyBatchClient(
+            responseCountOverride: 0,
+            completionException: new OutOfMemoryException("batch-cleanup"));
+        using var client = new ArticleCachingNntpClient(inner);
+        var recorder = new ArticleBodyCompletionRecorder();
+
+        await Assert.ThrowsAsync<OutOfMemoryException>(() =>
+            client.DecodedBodiesAsync(["a", "b"], recorder.Invoke, CancellationToken.None));
+
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, recorder.Result);
+        Assert.Equal("batch-response-count-mismatch", recorder.FailureReason);
+    }
+
+    [Fact]
+    public async Task DecodedBodiesAsync_SetupCleanupOom_StillReportsNotRetrieved()
+    {
+        var inner = new ControlledDecodedBodyBatchClient(
+            completionException: new OutOfMemoryException("cleanup"),
+            responses: new ThrowingCountResponses());
+        var recorder = new ArticleBodyCompletionRecorder();
+        using var client = new ArticleCachingNntpClient(inner);
+
+        await Assert.ThrowsAsync<OutOfMemoryException>(() =>
+            client.DecodedBodiesAsync(["a"], recorder.Invoke, CancellationToken.None));
+
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, recorder.Result);
+        Assert.Equal("cache-batch-setup", recorder.FailureReason);
+    }
+
+    [Fact]
     public async Task DecodedArticleAsync_FullCacheHit_ThrowingCallbackReturnsCachedArticle()
     {
         const string segmentId = "article-segment";
@@ -230,6 +264,19 @@ public class ArticleCachingNntpClientTests
             await stream.CopyToAsync(destination);
             return destination.ToArray();
         }
+    }
+
+    private sealed class ThrowingCountResponses : IReadOnlyList<Task<UsenetDecodedBodyResponse>>
+    {
+        public int Count => throw new InvalidOperationException("response-count");
+
+        public Task<UsenetDecodedBodyResponse> this[int index] =>
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        public IEnumerator<Task<UsenetDecodedBodyResponse>> GetEnumerator() =>
+            Enumerable.Empty<Task<UsenetDecodedBodyResponse>>().GetEnumerator();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     private sealed class CacheProbeNntpClient : NntpClient

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleCachingNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/ArticleCachingNntpClientTests.cs
@@ -116,6 +116,32 @@ public class ArticleCachingNntpClientTests
         Assert.Equal(0, inner.BatchRequestCount);
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(3)]
+    public async Task DecodedBodiesAsync_MalformedInnerBatch_AbandonsAndReportsNotRetrieved(int responseCount)
+    {
+        var inner = new ControlledDecodedBodyBatchClient(
+            responseCountOverride: responseCount,
+            blockCompletionUntilStreamsDisposed: true);
+        using var client = new ArticleCachingNntpClient(inner);
+        using var caller = new CancellationTokenSource();
+        var recorder = new ArticleBodyCompletionRecorder();
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            client.DecodedBodiesAsync(["a", "b"], recorder.Invoke, caller.Token));
+
+        Assert.Equal("The NNTP batch response count did not match the request count.", error.Message);
+        Assert.Equal(1, inner.OrdinaryBatchCount);
+        Assert.True(inner.LastCancellationToken.IsCancellationRequested);
+        Assert.False(caller.IsCancellationRequested);
+        Assert.Equal(responseCount, inner.DisposedStreamCount);
+        Assert.True(inner.ProducerCompletion.IsCompleted);
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, recorder.Result);
+        Assert.Equal("batch-response-count-mismatch", recorder.FailureReason);
+    }
+
     [Fact]
     public async Task DecodedArticleAsync_FullCacheHit_ThrowingCallbackReturnsCachedArticle()
     {

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/BatchLocalDataChainTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/BatchLocalDataChainTests.cs
@@ -1,7 +1,11 @@
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Concurrency;
+using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Services;
 using NzbWebDAV.Services.Repair;
 using NzbWebDAV.Tests.Fakes;
 using NzbWebDAV.Tests.TestUtils;
@@ -141,6 +145,62 @@ public sealed class BatchLocalDataChainTests
             Assert.Equal(1, recorder.Count);
             Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
             Assert.Equal(0, inner.BatchRequestCount);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task NestedRepairAndCacheOverlays_PreserveStreamingContextsOnRemoteMiss()
+    {
+        var root = Path.Join(Path.GetTempPath(), "nzbdav-chain-ctx-" + Guid.NewGuid().ToString("N"));
+        var cacheDir = Path.Join(root, "cache");
+        var patchDir = Path.Join(root, "patch");
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            Directory.CreateDirectory(patchDir);
+            var store = new RepairPatchStore(patchDir, 1024 * 1024);
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
+            var inner = new FakeNntpClient(new Dictionary<string, byte[]>
+            {
+                ["miss@test"] = "miss"u8.ToArray(),
+            }, useCachedYencStreams: true);
+            using var cache = new SegmentCacheNntpClient(inner, cacheDir, 1024 * 1024);
+            await cache.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+            using var repair = new RepairedSegmentNntpClient(cache, store);
+            using var cts = new CancellationTokenSource();
+            var priority = new DownloadPriorityContext { Priority = SemaphorePriority.High };
+            var timeout = new StreamingTimeoutContext
+            {
+                PerSegmentTimeout = TimeSpan.FromSeconds(7),
+                MaxRetries = 1,
+            };
+            var queue = new QueueDownloadContext
+            {
+                IsPrimary = true,
+                GetFanOutConcurrency = static () => 1,
+            };
+            var config = new ConfigManager();
+            using var gate = new HealthCheckConnectionGate(config);
+            var health = new HealthCheckAdmissionContext(gate, HealthCheckAdmissionPriority.Background);
+            using var priorityScope = cts.Token.SetContext(priority);
+            using var timeoutScope = cts.Token.SetContext(timeout);
+            using var queueScope = cts.Token.SetContext(queue);
+            using var maintenanceScope = cts.Token.SetContext(MaintenanceDownloadContext.Instance);
+            using var healthScope = cts.Token.SetContext(health);
+
+            var batch = await repair.DecodedBodiesAsync(["miss@test"], onConnectionReadyAgain: null, cts.Token);
+            Assert.Equal(1, inner.BatchRequestCount);
+            Assert.Same(priority, inner.LastBatchToken.GetContext<DownloadPriorityContext>());
+            Assert.Same(timeout, inner.LastBatchToken.GetContext<StreamingTimeoutContext>());
+            Assert.Same(queue, inner.LastBatchToken.GetContext<QueueDownloadContext>());
+            Assert.Same(MaintenanceDownloadContext.Instance, inner.LastBatchToken.GetContext<MaintenanceDownloadContext>());
+            Assert.Same(health, inner.LastBatchToken.GetContext<HealthCheckAdmissionContext>());
+            await batch.DrainAsync();
         }
         finally
         {

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/LocalDataBatchOverlayTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/LocalDataBatchOverlayTests.cs
@@ -1,5 +1,10 @@
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Concurrency;
+using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Config;
+using NzbWebDAV.Extensions;
+using NzbWebDAV.Services;
 using NzbWebDAV.Streams;
 using NzbWebDAV.Tests.TestUtils;
 using UsenetSharp.Models;
@@ -513,6 +518,180 @@ public sealed class LocalDataBatchOverlayTests
         Assert.Equal(0, recorder.Count);
     }
 
+    [Fact]
+    public async Task AllMiss_PreservesEveryTokenContextOnFetch()
+    {
+        using var harness = TokenContextHarness.Create();
+        var inner = new ControlledDecodedBodyBatchClient();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a", "b"),
+            outerCallback: null,
+            _ => LocalLookupResult.Miss,
+            (misses, callback, token) => inner.DecodedBodiesAsync(misses, callback, token),
+            LocalDataBatchOverlay.PassThroughRemote,
+            harness.Token);
+
+        harness.AssertCopiedOnto(inner.LastCancellationToken);
+        await batch.DrainAsync();
+    }
+
+    [Fact]
+    public async Task MixedLocalRemote_PreservesEveryTokenContextOnFetch()
+    {
+        using var harness = TokenContextHarness.Create();
+        var inner = new ControlledDecodedBodyBatchClient();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a", "b"),
+            outerCallback: null,
+            id => id.ToString() == "a" ? LocalLookupResult.Hit(Local(id)) : LocalLookupResult.Miss,
+            (misses, callback, token) => inner.DecodedBodiesAsync(misses, callback, token),
+            LocalDataBatchOverlay.PassThroughRemote,
+            harness.Token);
+
+        harness.AssertCopiedOnto(inner.LastCancellationToken);
+        await batch.DrainAsync();
+    }
+
+    [Fact]
+    public async Task MismatchCancellation_DoesNotCancelCallerSource()
+    {
+        using var harness = TokenContextHarness.Create();
+        var inner = new ControlledDecodedBodyBatchClient(responseCountOverride: 0);
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            LocalDataBatchOverlay.ExecuteAsync(
+                Ids("a", "b"),
+                outerCallback: null,
+                _ => LocalLookupResult.Miss,
+                (misses, callback, token) => inner.DecodedBodiesAsync(misses, callback, token),
+                LocalDataBatchOverlay.PassThroughRemote,
+                harness.Token));
+
+        Assert.False(harness.Caller.IsCancellationRequested);
+        Assert.True(inner.LastCancellationToken.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task InnerNotRetrieved_OutranksConcurrentCallerCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        var inner = new ControlledDecodedBodyBatchClient(
+            callbackTiming: ControlledDecodedBodyBatchClient.CallbackTiming.AfterReturn);
+        var recorder = new ArticleBodyCompletionRecorder();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a"),
+            recorder.Invoke,
+            _ => LocalLookupResult.Miss,
+            (misses, callback, token) => inner.DecodedBodiesAsync(misses, callback, token),
+            LocalDataBatchOverlay.PassThroughRemote,
+            cts.Token);
+
+        await cts.CancelAsync();
+        inner.FireCapturedCallback(ArticleBodyResult.NotRetrieved, "drain-failed");
+        inner.CompleteProducer();
+        var response = await batch.Responses[0];
+        if (response.Stream is not null)
+            await response.Stream.DisposeAsync();
+        await batch.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, recorder.Result);
+        Assert.Equal("drain-failed", recorder.FailureReason);
+    }
+
+    [Fact]
+    public async Task InnerCancelled_RemainsCancelledWhenCallerCancelsAfterCleanDrain()
+    {
+        using var cts = new CancellationTokenSource();
+        var inner = new ControlledDecodedBodyBatchClient(
+            callbackTiming: ControlledDecodedBodyBatchClient.CallbackTiming.AfterReturn);
+        var recorder = new ArticleBodyCompletionRecorder();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a"),
+            recorder.Invoke,
+            _ => LocalLookupResult.Miss,
+            (misses, callback, token) => inner.DecodedBodiesAsync(misses, callback, token),
+            LocalDataBatchOverlay.PassThroughRemote,
+            cts.Token);
+
+        inner.FireCapturedCallback(ArticleBodyResult.Cancelled);
+        inner.CompleteProducer();
+        var response = await batch.Responses[0];
+        if (response.Stream is not null)
+            await response.Stream.DisposeAsync();
+        await cts.CancelAsync();
+        await batch.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.Cancelled, recorder.Result);
+    }
+
+    [Fact]
+    public async Task InnerCompletionOom_StillObservesPublisherAndFiresNotRetrieved()
+    {
+        var oom = new OutOfMemoryException("inner-completion");
+        var innerHeld = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var recorder = new ArticleBodyCompletionRecorder();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a"),
+            recorder.Invoke,
+            _ => LocalLookupResult.Miss,
+            (misses, callback, _) =>
+            {
+                callback(ArticleBodyResult.NotRetrieved, "out-of-memory");
+                return Task.FromResult(new UsenetDecodedBodyBatch
+                {
+                    Responses = [Task.FromResult(ControlledDecodedBodyBatchClient.CreateSuccess(misses[0], "ok"u8.ToArray()))],
+                    Completion = innerHeld.Task,
+                });
+            },
+            LocalDataBatchOverlay.PassThroughRemote,
+            CancellationToken.None);
+
+        var response = await batch.Responses[0].WaitAsync(TimeSpan.FromSeconds(5));
+        await response.Stream!.DisposeAsync();
+        Assert.False(batch.Completion.IsCompleted);
+        innerHeld.SetException(oom);
+        var thrown = await Assert.ThrowsAsync<OutOfMemoryException>(
+            () => batch.Completion.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Same(oom, thrown);
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, recorder.Result);
+    }
+
+    [Fact]
+    public async Task StreamReadOom_ReleasesNextReadinessGate()
+    {
+        var oom = new OutOfMemoryException("read-oom");
+        var recorder = new ArticleBodyCompletionRecorder();
+        var batch = await LocalDataBatchOverlay.ExecuteAsync(
+            Ids("a", "b"),
+            recorder.Invoke,
+            id => LocalLookupResult.Hit(new UsenetDecodedBodyResponse
+            {
+                SegmentId = id.ToString(),
+                ResponseCode = 222,
+                ResponseMessage = "222",
+                Stream = id.ToString() == "a"
+                    ? new ThrowingOomYencStream(oom)
+                    : new CachedYencStream(
+                        ControlledDecodedBodyBatchClient.HeaderFor("b"u8.ToArray()),
+                        new MemoryStream("b"u8.ToArray(), writable: false)),
+            }),
+            FetchShouldNotRun,
+            LocalDataBatchOverlay.PassThroughRemote,
+            CancellationToken.None);
+
+        var first = await batch.Responses[0];
+        var thrown = await Assert.ThrowsAsync<OutOfMemoryException>(
+            async () => await first.Stream!.ReadAsync(new byte[8]));
+        Assert.Same(oom, thrown);
+        var second = await batch.Responses[1].WaitAsync(TimeSpan.FromSeconds(5));
+        await second.Stream!.DisposeAsync();
+        await first.Stream!.DisposeAsync();
+        var completionThrown = await Assert.ThrowsAsync<OutOfMemoryException>(
+            () => batch.Completion.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Same(oom, completionThrown);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, recorder.Result);
+    }
+
     private static SegmentId[] Ids(params string[] ids) => ids.Select(id => new SegmentId(id)).ToArray();
 
     private static UsenetDecodedBodyResponse Local(SegmentId id, byte[]? content = null) =>
@@ -566,6 +745,81 @@ public sealed class LocalDataBatchOverlayTests
             if (disposing)
                 throw new IOException("dispose-fail");
             base.Dispose(disposing);
+        }
+    }
+
+    private sealed class ThrowingOomYencStream : YencStream
+    {
+        private readonly OutOfMemoryException _exception;
+
+        public ThrowingOomYencStream(OutOfMemoryException exception) : base(Null)
+        {
+            _exception = exception;
+        }
+
+        public override ValueTask<UsenetYencHeader?> GetYencHeadersAsync(
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<UsenetYencHeader?>(ControlledDecodedBodyBatchClient.HeaderFor("x"u8.ToArray()));
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default) =>
+            throw _exception;
+    }
+
+    private sealed class TokenContextHarness : IDisposable
+    {
+        private readonly List<IDisposable> _scopes = [];
+        private readonly ConfigManager _config = new();
+        private readonly HealthCheckConnectionGate _gate;
+
+        private TokenContextHarness()
+        {
+            Caller = new CancellationTokenSource();
+            _gate = new HealthCheckConnectionGate(_config);
+            Priority = new DownloadPriorityContext { Priority = SemaphorePriority.High };
+            Timeout = new StreamingTimeoutContext
+            {
+                PerSegmentTimeout = TimeSpan.FromSeconds(9),
+                MaxRetries = 2,
+            };
+            Queue = new QueueDownloadContext
+            {
+                IsPrimary = true,
+                GetFanOutConcurrency = static () => 3,
+            };
+            Health = new HealthCheckAdmissionContext(_gate, HealthCheckAdmissionPriority.Queue);
+            _scopes.Add(Caller.Token.SetContext(Priority));
+            _scopes.Add(Caller.Token.SetContext(Timeout));
+            _scopes.Add(Caller.Token.SetContext(Queue));
+            _scopes.Add(Caller.Token.SetContext(MaintenanceDownloadContext.Instance));
+            _scopes.Add(Caller.Token.SetContext(Health));
+        }
+
+        public static TokenContextHarness Create() => new();
+
+        public CancellationTokenSource Caller { get; }
+        public CancellationToken Token => Caller.Token;
+        public DownloadPriorityContext Priority { get; }
+        public StreamingTimeoutContext Timeout { get; }
+        public QueueDownloadContext Queue { get; }
+        public HealthCheckAdmissionContext Health { get; }
+
+        public void AssertCopiedOnto(CancellationToken token)
+        {
+            Assert.Same(Priority, token.GetContext<DownloadPriorityContext>());
+            Assert.Same(Timeout, token.GetContext<StreamingTimeoutContext>());
+            Assert.Same(Queue, token.GetContext<QueueDownloadContext>());
+            Assert.Same(MaintenanceDownloadContext.Instance, token.GetContext<MaintenanceDownloadContext>());
+            Assert.Same(Health, token.GetContext<HealthCheckAdmissionContext>());
+        }
+
+        public void Dispose()
+        {
+            foreach (var scope in _scopes)
+                scope.Dispose();
+            Caller.Dispose();
+            _gate.Dispose();
         }
     }
 }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/LocalDataBatchOverlayTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/LocalDataBatchOverlayTests.cs
@@ -202,6 +202,54 @@ public sealed class LocalDataBatchOverlayTests
     }
 
     [Fact]
+    public async Task InnerSetupFailure_AbandonsCreatedInnerBatch()
+    {
+        var inner = new ControlledDecodedBodyBatchClient(
+            blockCompletionUntilStreamsDisposed: true,
+            responses: new ThrowingCountResponses());
+        var recorder = new ArticleBodyCompletionRecorder();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            LocalDataBatchOverlay.ExecuteAsync(
+                Ids("a"),
+                recorder.Invoke,
+                _ => LocalLookupResult.Miss,
+                (misses, callback, token) => inner.DecodedBodiesAsync(misses, callback, token),
+                LocalDataBatchOverlay.PassThroughRemote,
+                CancellationToken.None));
+
+        Assert.True(inner.LastCancellationToken.IsCancellationRequested);
+        Assert.True(inner.ProducerCompletion.IsCompleted);
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, recorder.Result);
+        Assert.Equal("local-batch-setup", recorder.FailureReason);
+    }
+
+    [Fact]
+    public async Task InnerSetupCancellation_ReportsCancelled()
+    {
+        using var cts = new CancellationTokenSource();
+        var recorder = new ArticleBodyCompletionRecorder();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            LocalDataBatchOverlay.ExecuteAsync(
+                Ids("a"),
+                recorder.Invoke,
+                _ => LocalLookupResult.Miss,
+                (_, _, _) =>
+                {
+                    cts.Cancel();
+                    throw new OperationCanceledException(cts.Token);
+                },
+                LocalDataBatchOverlay.PassThroughRemote,
+                cts.Token));
+
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.Cancelled, recorder.Result);
+        Assert.Null(recorder.FailureReason);
+    }
+
+    [Fact]
     public async Task ResponseCountTooSmall_DrainsInnerAndReportsNotRetrievedOnce()
     {
         var inner = new ControlledDecodedBodyBatchClient(responseCountOverride: 0);
@@ -765,6 +813,19 @@ public sealed class LocalDataBatchOverlayTests
             Memory<byte> buffer,
             CancellationToken cancellationToken = default) =>
             throw _exception;
+    }
+
+    private sealed class ThrowingCountResponses : IReadOnlyList<Task<UsenetDecodedBodyResponse>>
+    {
+        public int Count => throw new InvalidOperationException("response-count");
+
+        public Task<UsenetDecodedBodyResponse> this[int index] =>
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        public IEnumerator<Task<UsenetDecodedBodyResponse>> GetEnumerator() =>
+            Enumerable.Empty<Task<UsenetDecodedBodyResponse>>().GetEnumerator();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     private sealed class TokenContextHarness : IDisposable

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiConnectionBatchLifecycleTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiConnectionBatchLifecycleTests.cs
@@ -1,0 +1,40 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Connections;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Models;
+using NzbWebDAV.Tests.TestUtils;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public sealed class MultiConnectionBatchLifecycleTests
+{
+    [Fact]
+    public async Task InnerCompletionOom_WaitsForCallbackBeforeReleasingConnection()
+    {
+        var oom = new OutOfMemoryException("inner-completion");
+        var inner = new ControlledDecodedBodyBatchClient(
+            callbackTiming: ControlledDecodedBodyBatchClient.CallbackTiming.AfterReturn,
+            completionException: oom);
+        using var pool = new ConnectionPool<INntpClient>(
+            maxConnections: 1, _ => ValueTask.FromResult<INntpClient>(inner));
+        using var client = new MultiConnectionNntpClient(
+            pool,
+            ProviderType.Pooled,
+            new ProviderCircuitBreaker("batch-oom"),
+            "batch-oom");
+
+        var recorder = new ArticleBodyCompletionRecorder();
+        var batch = await client.DecodedBodiesAsync(["a@test"], recorder.Invoke, CancellationToken.None);
+        Assert.Equal(0, client.AvailableConnections);
+        Assert.False(batch.Completion.IsCompleted);
+
+        inner.FireCapturedCallback(ArticleBodyResult.NotRetrieved, "out-of-memory");
+        var thrown = await Assert.ThrowsAsync<OutOfMemoryException>(
+            () => batch.Completion.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Same(oom, thrown);
+        Assert.Equal(1, client.AvailableConnections);
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, recorder.Result);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -2081,6 +2081,62 @@ public class MultiProviderNntpClientTests
     }
 
     [Fact]
+    public async Task BatchResponse_OomFaultsResponseAndBatchCompletion()
+    {
+        var connection = new ScriptedNntpClient
+        {
+            BatchResponseCode = 222,
+            FaultBatchResponsesWith = () => new OutOfMemoryException("batch-response"),
+        };
+        using var client = new MultiProviderNntpClient([CreateProvider(connection)]);
+
+        var batch = await client.DecodedBodiesAsync(
+            ["segment"], onConnectionReadyAgain: null, CancellationToken.None);
+
+        await Assert.ThrowsAsync<OutOfMemoryException>(() => batch.Responses[0]);
+        await Assert.ThrowsAsync<OutOfMemoryException>(() => batch.Completion);
+    }
+
+    [Fact]
+    public async Task OrderedBatchResponsePublisher_StreamOomFaultsPublisher()
+    {
+        var oom = new OutOfMemoryException("stream-read");
+        var raw = new Task<UsenetDecodedBodyResponse>[]
+        {
+            Task.FromResult(new UsenetDecodedBodyResponse
+            {
+                SegmentId = "first",
+                ResponseCode = 222,
+                ResponseMessage = "222",
+                Stream = new ThrowingOomYencStream(oom),
+            }),
+            Task.FromResult(new UsenetDecodedBodyResponse
+            {
+                SegmentId = "second",
+                ResponseCode = 222,
+                ResponseMessage = "222",
+                Stream = new YencStream(new MemoryStream([], writable: false)),
+            }),
+        };
+        var output = new[]
+        {
+            new TaskCompletionSource<UsenetDecodedBodyResponse>(
+                TaskCreationOptions.RunContinuationsAsynchronously),
+            new TaskCompletionSource<UsenetDecodedBodyResponse>(
+                TaskCreationOptions.RunContinuationsAsynchronously),
+        };
+
+        var publisher = OrderedBatchResponsePublisher.PublishAsync(raw, output);
+        var first = await output[0].Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.ThrowsAsync<OutOfMemoryException>(
+            async () => await first.Stream!.ReadAsync(new byte[1]));
+        var second = await output[1].Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await second.Stream!.DisposeAsync();
+
+        await Assert.ThrowsAsync<OutOfMemoryException>(() => publisher);
+    }
+
+    [Fact]
     public async Task DecodedBodiesAsync_CompletionWaitsForPrimaryAndFallbackTransfers()
     {
         var primary = new ScriptedNntpClient
@@ -2432,6 +2488,14 @@ public class MultiProviderNntpClientTests
         breaker.RecordFailure();
         breaker.RecordFailure();
         return breaker;
+    }
+
+    private sealed class ThrowingOomYencStream(OutOfMemoryException exception) : YencStream(Null)
+    {
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default) =>
+            throw exception;
     }
 
     internal sealed class ScriptedNntpClient : NntpClient

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -608,7 +608,14 @@ public class MultiProviderNntpClientTests
         var results = new List<PipelinedBodyResult>();
         await foreach (var result in client.DecodedBodiesPipelinedAsync(
                            segmentIds, depth, CancellationToken.None))
+        {
             results.Add(result);
+            // Later responses stay pending until the earlier stream is drained, matching
+            // UsenetDecodedBodyBatch's ordered-readiness contract.
+            if (result.Stream is not null)
+                await result.Stream.DisposeAsync();
+        }
+
         return results;
     }
 
@@ -1995,13 +2002,14 @@ public class MultiProviderNntpClientTests
 
             var firstTask = batch.Responses[0];
             var secondTask = batch.Responses[1];
-            Assert.True(firstTask.IsCompleted);
-            Assert.True(secondTask.IsCompleted);
-            first = await firstTask;
-            second = await secondTask;
+            first = await firstTask.WaitAsync(TimeSpan.FromSeconds(3));
+            Assert.False(secondTask.IsCompleted);
             Assert.Equal(UsenetResponseType.ArticleRetrievedBodyFollows, first.ResponseType);
-            Assert.Equal(UsenetResponseType.ArticleRetrievedBodyFollows, second.ResponseType);
             Assert.Equal("seg-0", first.SegmentId);
+            await first.Stream!.DisposeAsync();
+            first = first with { Stream = null };
+            second = await secondTask.WaitAsync(TimeSpan.FromSeconds(3));
+            Assert.Equal(UsenetResponseType.ArticleRetrievedBodyFollows, second.ResponseType);
             Assert.Equal("seg-1", second.SegmentId);
         }
         finally
@@ -2107,9 +2115,13 @@ public class MultiProviderNntpClientTests
 
             Assert.False(batch.Completion.IsCompleted);
             backup.CompletePendingSingularRequests();
-            first = await batch.Responses[0];
-            second = await batch.Responses[1];
-            if (first.Stream is not null) await first.Stream.DisposeAsync();
+            first = await batch.Responses[0].WaitAsync(TimeSpan.FromSeconds(5));
+            if (first.Stream is not null)
+            {
+                await first.Stream.DisposeAsync();
+                first = first with { Stream = null };
+            }
+            second = await batch.Responses[1].WaitAsync(TimeSpan.FromSeconds(5));
             if (second.Stream is not null) await second.Stream.DisposeAsync();
             await batch.Completion.WaitAsync(TimeSpan.FromSeconds(5));
         }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientTests.cs
@@ -2012,6 +2012,66 @@ public class MultiProviderNntpClientTests
         }
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(3)]
+    public async Task MalformedBatch_IsAbandonedBeforeRetryingNextProvider(int responseCount)
+    {
+        var first = new ControlledDecodedBodyBatchClient(
+            responseCountOverride: responseCount,
+            blockCompletionUntilStreamsDisposed: true);
+        var firstProvider = CreateProvider(first, host: "malformed.example", maxConnections: 1);
+        var secondStartedAvailable = -1;
+        var second = new ControlledDecodedBodyBatchClient
+        {
+            OnBatchStart = () => secondStartedAvailable = firstProvider.AvailableConnections,
+        };
+        var secondProvider = CreateProvider(second, host: "healthy.example", maxConnections: 1);
+        using var client = new MultiProviderNntpClient([firstProvider, secondProvider]);
+        using var caller = new CancellationTokenSource();
+        var recorder = new ArticleBodyCompletionRecorder();
+
+        var batch = await client.DecodedBodiesAsync(["a", "b"], recorder.Invoke, caller.Token);
+        await batch.DrainAsync();
+
+        Assert.Equal(1, first.OrdinaryBatchCount);
+        Assert.Equal(1, second.OrdinaryBatchCount);
+        Assert.Equal(1, secondStartedAvailable);
+        Assert.Equal(1, firstProvider.AvailableConnections);
+        Assert.True(first.LastCancellationToken.IsCancellationRequested);
+        Assert.False(caller.IsCancellationRequested);
+        Assert.Equal(responseCount, first.DisposedStreamCount);
+        Assert.True(first.ProducerCompletion.IsCompleted);
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.Retrieved, recorder.Result);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(3)]
+    public async Task MalformedBatch_WithNoFallback_ReportsNotRetrievedOnce(int responseCount)
+    {
+        var inner = new ControlledDecodedBodyBatchClient(
+            responseCountOverride: responseCount,
+            blockCompletionUntilStreamsDisposed: true);
+        var provider = CreateProvider(inner, host: "solo.example", maxConnections: 1);
+        using var client = new MultiProviderNntpClient([provider]);
+        using var caller = new CancellationTokenSource();
+        var recorder = new ArticleBodyCompletionRecorder();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            client.DecodedBodiesAsync(["a", "b"], recorder.Invoke, caller.Token));
+
+        Assert.Equal(1, inner.OrdinaryBatchCount);
+        Assert.Equal(1, provider.AvailableConnections);
+        Assert.True(inner.LastCancellationToken.IsCancellationRequested);
+        Assert.False(caller.IsCancellationRequested);
+        Assert.Equal(responseCount, inner.DisposedStreamCount);
+        Assert.True(inner.ProducerCompletion.IsCompleted);
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(ArticleBodyResult.NotRetrieved, recorder.Result);
+    }
+
     [Fact]
     public async Task DecodedBodiesAsync_CompletionWaitsForPrimaryAndFallbackTransfers()
     {

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
@@ -897,6 +897,194 @@ public sealed class SegmentCacheNntpClientTests
         }
     }
 
+    [Fact]
+    public async Task TruncatedBlobAfterHydration_DropsEntryAndRefetchesOnce()
+    {
+        var cacheDir = NewCacheDir();
+        const string segmentId = "truncated-blob";
+        byte[] content = "cached-then-truncated"u8.ToArray();
+        var statistics = new SegmentCacheStatistics();
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            WriteCacheEntry(cacheDir, segmentId, content);
+            var inner = new FakeNntpClient(
+                new Dictionary<string, byte[]> { [segmentId] = content },
+                useCachedYencStreams: true);
+            using var client = CreateClient(inner, cacheDir, statistics);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var blobPath = CacheBlobPath(cacheDir, segmentId);
+            using (var stream = new FileStream(blobPath, FileMode.Open, FileAccess.Write, FileShare.None))
+                stream.SetLength(Math.Max(1, content.Length / 2));
+
+            await ReadFullyAsync(client, segmentId);
+            var afterRepair = statistics.GetSnapshot();
+            Assert.Equal(1, afterRepair.ReadFailures);
+            Assert.Equal(1, inner.BodyRequestCount);
+
+            await ReadFullyAsync(client, segmentId);
+            var snapshot = statistics.GetSnapshot();
+            Assert.Equal(1, inner.BodyRequestCount);
+            Assert.Equal(1, snapshot.ReadFailures);
+            Assert.Equal(1, snapshot.Hits);
+            Assert.Equal(content.Length, snapshot.BytesServed);
+            Assert.Equal(content.Length, client.CurrentBytes);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
+    public async Task DegradedCatalog_ReindexesExistingPairOnCommit()
+    {
+        var cacheDir = NewCacheDir();
+        const string segmentId = "preexisting-pair";
+        byte[] content = "already-on-disk"u8.ToArray();
+        var statistics = new SegmentCacheStatistics();
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            WriteCacheEntry(cacheDir, segmentId, content);
+            var inner = new FakeNntpClient(
+                new Dictionary<string, byte[]> { [segmentId] = content },
+                useCachedYencStreams: true);
+            using var client = new SegmentCacheNntpClient(
+                inner,
+                cacheDir,
+                maxBytes: 1024 * 1024,
+                usageTracker: null,
+                metricsWriter: null,
+                enumerateCacheFiles: () => throw new IOException("catalog scan failed"),
+                statistics);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.True(client.IsCatalogReady);
+            Assert.Equal(0, client.CurrentBytes);
+
+            await ReadFullyAsync(client, segmentId);
+            Assert.Equal(1, inner.BodyRequestCount);
+            Assert.Equal(content.Length, client.CurrentBytes);
+
+            await ReadFullyAsync(client, segmentId);
+            var snapshot = statistics.GetSnapshot();
+            Assert.Equal(1, inner.BodyRequestCount);
+            Assert.Equal(1, snapshot.Hits);
+            Assert.Equal(1, snapshot.Entries);
+            Assert.Equal(content.Length, snapshot.CurrentBytes);
+            Assert.Equal(1, snapshot.WriteSkipped);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
+    public async Task CapacityEviction_FailedBodyDelete_KeepsIndexAndDoesNotCountEviction()
+    {
+        var cacheDir = NewCacheDir();
+        byte[] first = "first-cache-entry"u8.ToArray();
+        byte[] second = "second-cache-entry!!"u8.ToArray();
+        var statistics = new SegmentCacheStatistics();
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            var inner = new FakeNntpClient(
+                new Dictionary<string, byte[]>
+                {
+                    ["first"] = first,
+                    ["second"] = second,
+                },
+                useCachedYencStreams: true);
+            using var client = new SegmentCacheNntpClient(
+                inner,
+                cacheDir,
+                maxBytes: second.Length,
+                usageTracker: null,
+                metricsWriter: null,
+                enumerateCacheFiles: null,
+                statistics,
+                tryDelete: path =>
+                {
+                    var name = Path.GetFileName(path);
+                    return name is { Length: 64 } && name.IndexOf('.') < 0
+                        ? SegmentCacheDeleteResult.Failed
+                        : null;
+                });
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await ReadFullyAsync(client, "first");
+            await ReadFullyAsync(client, "second");
+
+            var snapshot = statistics.GetSnapshot();
+            Assert.Equal(0, snapshot.Evictions);
+            Assert.Equal(0, snapshot.BytesEvicted);
+            Assert.Equal(first.Length + second.Length, client.CurrentBytes);
+            Assert.Equal(2, snapshot.Entries);
+            Assert.True(File.Exists(CacheBlobPath(cacheDir, "first")));
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
+    public async Task CatalogReadyGauges_MatchIndexAfterCommitDuringLoad()
+    {
+        var cacheDir = NewCacheDir();
+        var loadStarted = new ManualResetEventSlim();
+        var allowLoad = new ManualResetEventSlim();
+        const string segmentId = "written-during-catalog";
+        byte[] content = "gauge-race-content"u8.ToArray();
+        var statistics = new SegmentCacheStatistics();
+
+        try
+        {
+            var inner = new FakeNntpClient(
+                new Dictionary<string, byte[]> { [segmentId] = content },
+                useCachedYencStreams: true);
+            using var client = new SegmentCacheNntpClient(
+                inner,
+                cacheDir,
+                maxBytes: 1024 * 1024,
+                usageTracker: null,
+                metricsWriter: null,
+                enumerateCacheFiles: () =>
+                {
+                    loadStarted.Set();
+                    allowLoad.Wait();
+                    return Directory.EnumerateFiles(cacheDir, "*", SearchOption.AllDirectories);
+                },
+                statistics);
+
+            Assert.True(loadStarted.Wait(TimeSpan.FromSeconds(5)));
+            await ReadFullyAsync(client, segmentId);
+            Assert.Equal(content.Length, client.CurrentBytes);
+
+            allowLoad.Set();
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var snapshot = statistics.GetSnapshot();
+            Assert.True(snapshot.CatalogReady);
+            Assert.Equal(1, snapshot.Entries);
+            Assert.Equal(content.Length, snapshot.CurrentBytes);
+            Assert.Equal(client.CurrentBytes, snapshot.CurrentBytes);
+        }
+        finally
+        {
+            allowLoad.Set();
+            DeleteCacheDir(cacheDir);
+            loadStarted.Dispose();
+            allowLoad.Dispose();
+        }
+    }
+
     private static SegmentCacheNntpClient CreateClient(
         INntpClient inner,
         string cacheDir,
@@ -963,9 +1151,18 @@ public sealed class SegmentCacheNntpClientTests
             await stream.CopyToAsync(Stream.Null);
     }
 
+    private static string SegmentHash(string segmentId) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(segmentId)));
+
+    private static string CacheBlobPath(string cacheDir, string segmentId)
+    {
+        var hash = SegmentHash(segmentId);
+        return Path.Join(cacheDir, hash[..2], hash);
+    }
+
     private static void WriteCacheEntry(string cacheDir, string segmentId, byte[] content)
     {
-        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(segmentId)));
+        var hash = SegmentHash(segmentId);
         var directory = Path.Join(cacheDir, hash[..2]);
         Directory.CreateDirectory(directory);
         File.WriteAllBytes(Path.Join(directory, hash), content);

--- a/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
+++ b/tests/NzbWebDAV.Tests/Fakes/FakeNntpClient.cs
@@ -25,6 +25,7 @@ internal sealed class FakeNntpClient(
     public int BatchRequestCount { get; private set; }
     public int BodyRequestCount { get; private set; }
     public int CompletionCallbackCount { get; private set; }
+    public CancellationToken LastBatchToken { get; private set; }
     public Dictionary<string, int> BodyRequestCounts { get; } = new(StringComparer.Ordinal);
     public Dictionary<string, int> CompletionCallbackCounts { get; } = new(StringComparer.Ordinal);
     public Dictionary<string, int> StatRequestCounts { get; } = new(StringComparer.Ordinal);
@@ -118,6 +119,7 @@ internal sealed class FakeNntpClient(
         CancellationToken cancellationToken)
     {
         BatchRequestCount++;
+        LastBatchToken = cancellationToken;
         var responses = segmentIds
             .Select(segmentId => DecodedBodyAsync(segmentId, cancellationToken))
             .ToArray();

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -599,6 +599,51 @@ public sealed class SupportPackContentsTests : IDisposable
     }
 
     [Fact]
+    public async Task Pack_JsonArtifacts_RemainValidWithPathologicalSecrets()
+    {
+        var configManager = new ConfigManager();
+        configManager.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.ApiKey, ConfigValue = "true" },
+            new ConfigItem { ConfigName = ConfigKeys.ApiStrmKey, ConfigValue = "null" },
+            new ConfigItem { ConfigName = ConfigKeys.WebdavPass, ConfigValue = "schema" },
+            new ConfigItem { ConfigName = ConfigKeys.RclonePass, ConfigValue = "enabled" },
+            new ConfigItem { ConfigName = ConfigKeys.WatchtowerProfileToken, ConfigValue = "203.0.113.50" },
+        ]);
+
+        var entries = await ReadPackEntriesAsync(
+            new LogBufferSink(10),
+            new WarningLogBuffer(new LogBufferSink(50)),
+            configManager: configManager);
+
+        foreach (var (name, content) in entries)
+        {
+            if (!name.EndsWith(".json", StringComparison.Ordinal))
+                continue;
+
+            using var document = JsonDocument.Parse(content);
+            Assert.Equal(JsonValueKind.Object, document.RootElement.ValueKind);
+        }
+
+        using var effective = JsonDocument.Parse(entries["configuration-effective-streaming.json"]);
+        Assert.Equal(1, effective.RootElement.GetProperty("schemaVersion").GetInt32());
+        Assert.Equal(
+            JsonValueKind.True,
+            effective.RootElement.GetProperty("streaming").GetProperty("pipelinedBodyRequests").ValueKind);
+        Assert.Equal(
+            JsonValueKind.True,
+            effective.RootElement.GetProperty("segmentCache").GetProperty("enabled").ValueKind);
+
+        using var manifest = JsonDocument.Parse(entries["manifest.json"]);
+        Assert.Equal(
+            "included",
+            manifest.RootElement.GetProperty("sections").GetProperty("configurationEffectiveStreaming").GetString());
+        Assert.Equal(
+            "included",
+            manifest.RootElement.GetProperty("sections").GetProperty("segmentCache").GetString());
+    }
+
+    [Fact]
     public async Task Pack_IncludesRetainedStreamTracesUntilDiscarded()
     {
         var buffer = new StreamTraceBuffer(100, enabled: false);

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackRedactorTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackRedactorTests.cs
@@ -94,4 +94,36 @@ public class SupportPackRedactorTests
 
         Assert.Equal("[REDACTED_MALFORMED_STRUCTURED_VALUE]", result);
     }
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData("null")]
+    [InlineData("schema")]
+    [InlineData("enabled")]
+    [InlineData("203.0.113.50")]
+    public void RedactJson_PreservesPropertyNamesAndPrimitiveSyntax(string secret)
+    {
+        var redactor = new SupportPackRedactor([secret]);
+        var json = """
+            {
+              "schemaVersion": 1,
+              "enabled": true,
+              "flag": null,
+              "note": "value-before",
+              "nested": { "schema": "inner", "enabled": false }
+            }
+            """.Replace("value-before", secret, StringComparison.Ordinal);
+
+        var result = redactor.RedactJson(json);
+        using var document = JsonDocument.Parse(result);
+        var root = document.RootElement;
+
+        Assert.Equal(JsonValueKind.Number, root.GetProperty("schemaVersion").ValueKind);
+        Assert.Equal(1, root.GetProperty("schemaVersion").GetInt32());
+        Assert.Equal(JsonValueKind.True, root.GetProperty("enabled").ValueKind);
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("flag").ValueKind);
+        Assert.Equal("[REDACTED]", root.GetProperty("note").GetString());
+        Assert.Equal("inner", root.GetProperty("nested").GetProperty("schema").GetString());
+        Assert.Equal(JsonValueKind.False, root.GetProperty("nested").GetProperty("enabled").ValueKind);
+    }
 }

--- a/tests/NzbWebDAV.Tests/TestUtils/ControlledDecodedBodyBatchClient.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/ControlledDecodedBodyBatchClient.cs
@@ -55,17 +55,20 @@ internal sealed class ControlledDecodedBodyBatchClient : NntpClient
     private readonly Func<SegmentId, UsenetDecodedBodyResponse> _createResponse;
     private readonly int? _responseCountOverride;
     private readonly Exception? _setupException;
+    private readonly Exception? _completionException;
     private readonly ConcurrentQueue<TaskCompletionSource> _completions = new();
 
     public ControlledDecodedBodyBatchClient(
         Func<SegmentId, UsenetDecodedBodyResponse>? createResponse = null,
         int? responseCountOverride = null,
         Exception? setupException = null,
-        CallbackTiming callbackTiming = CallbackTiming.BeforeReturn)
+        CallbackTiming callbackTiming = CallbackTiming.BeforeReturn,
+        Exception? completionException = null)
     {
         _createResponse = createResponse ?? (id => CreateSuccess(id, "body"u8.ToArray()));
         _responseCountOverride = responseCountOverride;
         _setupException = setupException;
+        _completionException = completionException;
         Timing = callbackTiming;
     }
 
@@ -75,6 +78,7 @@ internal sealed class ControlledDecodedBodyBatchClient : NntpClient
     public List<string> RequestedIds { get; } = [];
     public List<IReadOnlyList<string>> BatchIdLists { get; } = [];
     public ArticleBodyCompletionHandler? CapturedCallback { get; private set; }
+    public CancellationToken LastCancellationToken { get; private set; }
     public Task ProducerCompletion => _completions.LastOrDefault()?.Task ?? Task.CompletedTask;
 
     public void CompleteProducer()
@@ -116,6 +120,7 @@ internal sealed class ControlledDecodedBodyBatchClient : NntpClient
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        LastCancellationToken = cancellationToken;
         var ids = segmentIds.Select(id => id.ToString()).ToArray();
         RequestedIds.AddRange(ids);
         BatchIdLists.Add(ids);
@@ -140,7 +145,9 @@ internal sealed class ControlledDecodedBodyBatchClient : NntpClient
         if (Timing == CallbackTiming.Twice)
             onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved, "duplicate");
 
-        if (Timing != CallbackTiming.Never && Timing != CallbackTiming.AfterReturn)
+        if (_completionException is not null)
+            completion.TrySetException(_completionException);
+        else if (Timing != CallbackTiming.Never && Timing != CallbackTiming.AfterReturn)
             completion.TrySetResult();
 
         return Task.FromResult(new UsenetDecodedBodyBatch

--- a/tests/NzbWebDAV.Tests/TestUtils/ControlledDecodedBodyBatchClient.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/ControlledDecodedBodyBatchClient.cs
@@ -59,6 +59,7 @@ internal sealed class ControlledDecodedBodyBatchClient : NntpClient
     private readonly Exception? _setupException;
     private readonly Exception? _completionException;
     private readonly bool _blockCompletionUntilStreamsDisposed;
+    private readonly IReadOnlyList<Task<UsenetDecodedBodyResponse>>? _responses;
     private readonly ConcurrentQueue<TaskCompletionSource> _completions = new();
     private int _disposedStreams;
 
@@ -68,13 +69,15 @@ internal sealed class ControlledDecodedBodyBatchClient : NntpClient
         Exception? setupException = null,
         CallbackTiming callbackTiming = CallbackTiming.BeforeReturn,
         Exception? completionException = null,
-        bool blockCompletionUntilStreamsDisposed = false)
+        bool blockCompletionUntilStreamsDisposed = false,
+        IReadOnlyList<Task<UsenetDecodedBodyResponse>>? responses = null)
     {
         _createResponse = createResponse ?? (id => CreateSuccess(id, "body"u8.ToArray()));
         _responseCountOverride = responseCountOverride;
         _setupException = setupException;
         _completionException = completionException;
         _blockCompletionUntilStreamsDisposed = blockCompletionUntilStreamsDisposed;
+        _responses = responses;
         Timing = callbackTiming;
     }
 
@@ -149,22 +152,32 @@ internal sealed class ControlledDecodedBodyBatchClient : NntpClient
                 completion.TrySetResult();
         }
 
-        var count = _responseCountOverride ?? segmentIds.Count;
-        var responses = new Task<UsenetDecodedBodyResponse>[Math.Max(0, count)];
-        for (var index = 0; index < responses.Length; index++)
+        IReadOnlyList<Task<UsenetDecodedBodyResponse>> responses;
+        if (_responses is not null)
         {
-            var id = index < segmentIds.Count ? segmentIds[index] : new SegmentId($"extra-{index}");
-            var response = _createResponse(id);
-            if (_blockCompletionUntilStreamsDisposed && response.Stream is not null)
+            responses = _responses;
+        }
+        else
+        {
+            var count = _responseCountOverride ?? segmentIds.Count;
+            var created = new Task<UsenetDecodedBodyResponse>[Math.Max(0, count)];
+            for (var index = 0; index < created.Length; index++)
             {
-                remainingHolder.Value++;
-                response = response with
+                var id = index < segmentIds.Count ? segmentIds[index] : new SegmentId($"extra-{index}");
+                var response = _createResponse(id);
+                if (_blockCompletionUntilStreamsDisposed && response.Stream is not null)
                 {
-                    Stream = new DisposeTrackingYencStream(response.Stream, OnStreamDisposed),
-                };
+                    remainingHolder.Value++;
+                    response = response with
+                    {
+                        Stream = new DisposeTrackingYencStream(response.Stream, OnStreamDisposed),
+                    };
+                }
+
+                created[index] = Task.FromResult(response);
             }
 
-            responses[index] = Task.FromResult(response);
+            responses = created;
         }
 
         if (Timing is CallbackTiming.BeforeReturn or CallbackTiming.Twice)

--- a/tests/NzbWebDAV.Tests/TestUtils/ControlledDecodedBodyBatchClient.cs
+++ b/tests/NzbWebDAV.Tests/TestUtils/ControlledDecodedBodyBatchClient.cs
@@ -1,8 +1,10 @@
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Streams;
 using UsenetSharp.Models;
+using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Tests.TestUtils;
 
@@ -56,19 +58,23 @@ internal sealed class ControlledDecodedBodyBatchClient : NntpClient
     private readonly int? _responseCountOverride;
     private readonly Exception? _setupException;
     private readonly Exception? _completionException;
+    private readonly bool _blockCompletionUntilStreamsDisposed;
     private readonly ConcurrentQueue<TaskCompletionSource> _completions = new();
+    private int _disposedStreams;
 
     public ControlledDecodedBodyBatchClient(
         Func<SegmentId, UsenetDecodedBodyResponse>? createResponse = null,
         int? responseCountOverride = null,
         Exception? setupException = null,
         CallbackTiming callbackTiming = CallbackTiming.BeforeReturn,
-        Exception? completionException = null)
+        Exception? completionException = null,
+        bool blockCompletionUntilStreamsDisposed = false)
     {
         _createResponse = createResponse ?? (id => CreateSuccess(id, "body"u8.ToArray()));
         _responseCountOverride = responseCountOverride;
         _setupException = setupException;
         _completionException = completionException;
+        _blockCompletionUntilStreamsDisposed = blockCompletionUntilStreamsDisposed;
         Timing = callbackTiming;
     }
 
@@ -79,6 +85,8 @@ internal sealed class ControlledDecodedBodyBatchClient : NntpClient
     public List<IReadOnlyList<string>> BatchIdLists { get; } = [];
     public ArticleBodyCompletionHandler? CapturedCallback { get; private set; }
     public CancellationToken LastCancellationToken { get; private set; }
+    public Action? OnBatchStart { get; set; }
+    public int DisposedStreamCount => Volatile.Read(ref _disposedStreams);
     public Task ProducerCompletion => _completions.LastOrDefault()?.Task ?? Task.CompletedTask;
 
     public void CompleteProducer()
@@ -120,6 +128,7 @@ internal sealed class ControlledDecodedBodyBatchClient : NntpClient
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        OnBatchStart?.Invoke();
         LastCancellationToken = cancellationToken;
         var ids = segmentIds.Select(id => id.ToString()).ToArray();
         RequestedIds.AddRange(ids);
@@ -132,12 +141,30 @@ internal sealed class ControlledDecodedBodyBatchClient : NntpClient
         var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         _completions.Enqueue(completion);
 
+        var remainingHolder = new StrongBox<int>(0);
+        void OnStreamDisposed()
+        {
+            Interlocked.Increment(ref _disposedStreams);
+            if (Interlocked.Decrement(ref remainingHolder.Value) == 0)
+                completion.TrySetResult();
+        }
+
         var count = _responseCountOverride ?? segmentIds.Count;
         var responses = new Task<UsenetDecodedBodyResponse>[Math.Max(0, count)];
         for (var index = 0; index < responses.Length; index++)
         {
             var id = index < segmentIds.Count ? segmentIds[index] : new SegmentId($"extra-{index}");
-            responses[index] = Task.FromResult(_createResponse(id));
+            var response = _createResponse(id);
+            if (_blockCompletionUntilStreamsDisposed && response.Stream is not null)
+            {
+                remainingHolder.Value++;
+                response = response with
+                {
+                    Stream = new DisposeTrackingYencStream(response.Stream, OnStreamDisposed),
+                };
+            }
+
+            responses[index] = Task.FromResult(response);
         }
 
         if (Timing is CallbackTiming.BeforeReturn or CallbackTiming.Twice)
@@ -147,6 +174,15 @@ internal sealed class ControlledDecodedBodyBatchClient : NntpClient
 
         if (_completionException is not null)
             completion.TrySetException(_completionException);
+        else if (_blockCompletionUntilStreamsDisposed)
+        {
+            if (remainingHolder.Value == 0)
+            {
+                cancellationToken.Register(() => completion.TrySetResult());
+                if (cancellationToken.IsCancellationRequested)
+                    completion.TrySetResult();
+            }
+        }
         else if (Timing != CallbackTiming.Never && Timing != CallbackTiming.AfterReturn)
             completion.TrySetResult();
 
@@ -231,5 +267,52 @@ internal sealed class ControlledDecodedBodyBatchClient : NntpClient
 
     public override void Dispose()
     {
+    }
+
+    private sealed class DisposeTrackingYencStream : YencStream
+    {
+        private readonly YencStream _inner;
+        private readonly Action _onDisposed;
+        private int _disposed;
+
+        public DisposeTrackingYencStream(YencStream inner, Action onDisposed) : base(Null)
+        {
+            _inner = inner;
+            _onDisposed = onDisposed;
+        }
+
+        public override ValueTask<UsenetYencHeader?> GetYencHeadersAsync(
+            CancellationToken cancellationToken = default) =>
+            _inner.GetYencHeadersAsync(cancellationToken);
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default) =>
+            _inner.ReadAsync(buffer, cancellationToken);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+                SignalDisposed();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await _inner.DisposeAsync().ConfigureAwait(false);
+            SignalDisposed();
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
+
+        private void SignalDisposed()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                return;
+            _onDisposed();
+        }
     }
 }

--- a/tests/UsenetSharp.Tests/Clients/UsenetClientDeterministicTests.cs
+++ b/tests/UsenetSharp.Tests/Clients/UsenetClientDeterministicTests.cs
@@ -3710,6 +3710,105 @@ public class UsenetClientDeterministicTests
         Assert.That(client.IsHealthy, Is.False);
     }
 
+    [Test]
+    public async Task DecodedBodiesAsync_OomDuringPumpSetup_FaultsResponsesReleasesLockAndReportsNotRetrieved()
+    {
+        var oom = new OutOfMemoryException("pump-setup");
+        var time = new CountingThrowingTimeProvider(oom);
+        await using var server = new ScriptedNntpServer(async (command, writer, _) =>
+        {
+            if (command.StartsWith("BODY", StringComparison.Ordinal))
+                await writer.WriteLineAsync("222 body follows");
+        });
+        await using var client = new UsenetClient(
+            new UsenetClientOptions { ReadTimeout = TimeSpan.FromSeconds(30) },
+            time);
+        await client.ConnectAsync("127.0.0.1", server.Port, false, CancellationToken.None);
+        time.ThrowOnCreateCount = time.CreatedTimerCount + 2;
+
+        var callbackCount = 0;
+        ArticleBodyResult? callbackResult = null;
+        string? callbackReason = null;
+        var batch = await client.DecodedBodiesAsync(
+            new SegmentId[] { "first@example.com", "second@example.com" },
+            (result, reason) =>
+            {
+                Interlocked.Increment(ref callbackCount);
+                callbackResult = result;
+                callbackReason = reason;
+            },
+            CancellationToken.None);
+
+        foreach (var responseTask in batch.Responses)
+        {
+            var thrown = Assert.ThrowsAsync<OutOfMemoryException>(
+                () => responseTask.WaitAsync(TimeSpan.FromSeconds(2)));
+            Assert.That(thrown, Is.SameAs(oom));
+        }
+
+        var completionThrown = Assert.ThrowsAsync<OutOfMemoryException>(
+            () => batch.Completion.WaitAsync(TimeSpan.FromSeconds(2)));
+        Assert.That(completionThrown, Is.SameAs(oom));
+        Assert.That(callbackCount, Is.EqualTo(1));
+        Assert.That(callbackResult, Is.EqualTo(ArticleBodyResult.NotRetrieved));
+        Assert.That(callbackReason, Is.EqualTo("out-of-memory"));
+        Assert.That(async () => await client.WaitForReadyAsync().WaitAsync(TimeSpan.FromSeconds(2)),
+            Throws.Nothing);
+        Assert.That(client.IsHealthy, Is.False);
+    }
+
+    [Test]
+    public async Task DecodedBodiesAsync_OomAfterFirstResponse_FaultsRemainingAndDoesNotReportRetrieved()
+    {
+        var oom = new OutOfMemoryException("pump-execution");
+        var time = new CountingThrowingTimeProvider(oom);
+        await using var server = ScriptedNntpServer.StartConnectionScript(
+            async (reader, writer, cancellationToken) =>
+            {
+                _ = await reader.ReadLineAsync(cancellationToken);
+                _ = await reader.ReadLineAsync(cancellationToken);
+                await WriteSimpleYencArticleAsync(writer, [1, 2], "size=2", "first.bin");
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            });
+        await using var client = new UsenetClient(
+            new UsenetClientOptions { ReadTimeout = TimeSpan.FromSeconds(30) },
+            time);
+        await client.ConnectAsync("127.0.0.1", server.Port, false, CancellationToken.None);
+        time.PumpTimerCount = time.CreatedTimerCount + 2;
+        time.AllowGetTimestampAfterPump = 1;
+
+        var callbackCount = 0;
+        ArticleBodyResult? callbackResult = null;
+        var batch = await client.DecodedBodiesAsync(
+            new SegmentId[] { "first@example.com", "second@example.com" },
+            (result, _) =>
+            {
+                Interlocked.Increment(ref callbackCount);
+                callbackResult = result;
+            },
+            CancellationToken.None);
+
+        var first = await batch.Responses[0].WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.That(first.Stream, Is.Not.Null);
+        var remainingThrown = Assert.ThrowsAsync<OutOfMemoryException>(
+            () => batch.Responses[1].WaitAsync(TimeSpan.FromSeconds(2)));
+        Assert.That(remainingThrown, Is.SameAs(oom));
+        var completionThrown = Assert.ThrowsAsync<OutOfMemoryException>(
+            () => batch.Completion.WaitAsync(TimeSpan.FromSeconds(2)));
+        Assert.That(completionThrown, Is.SameAs(oom));
+        Assert.That(callbackCount, Is.EqualTo(1));
+        Assert.That(callbackResult, Is.EqualTo(ArticleBodyResult.NotRetrieved));
+        Assert.That(client.IsHealthy, Is.False);
+        try
+        {
+            first.Stream!.Dispose();
+        }
+        catch (OutOfMemoryException)
+        {
+            // Decoder may still be on the fatal path while the published stream is disposed.
+        }
+    }
+
     private static async Task WriteYencArticleAsync(
         StreamWriter writer,
         byte[] decoded,
@@ -3799,6 +3898,45 @@ public class UsenetClientDeterministicTests
                 if (buffered != _sum && Mismatch is null)
                     Mismatch = $"observer sum {_sum} != BufferedDecodedBodyBytes {buffered}";
             }
+        }
+    }
+
+    private sealed class CountingThrowingTimeProvider(OutOfMemoryException exception) : TimeProvider
+    {
+        private int _created;
+        private int _timestampsAfterPump;
+
+        public int ThrowOnCreateCount { get; set; } = int.MaxValue;
+        public int PumpTimerCount { get; set; } = int.MaxValue;
+        public int AllowGetTimestampAfterPump { get; set; } = int.MaxValue;
+        public int CreatedTimerCount => Volatile.Read(ref _created);
+
+        public override long TimestampFrequency => TimeProvider.System.TimestampFrequency;
+
+        public override DateTimeOffset GetUtcNow() => TimeProvider.System.GetUtcNow();
+
+        public override long GetTimestamp()
+        {
+            if (Volatile.Read(ref _created) >= PumpTimerCount)
+            {
+                var afterPump = Interlocked.Increment(ref _timestampsAfterPump);
+                if (afterPump > AllowGetTimestampAfterPump)
+                    throw exception;
+            }
+
+            return TimeProvider.System.GetTimestamp();
+        }
+
+        public override ITimer CreateTimer(
+            TimerCallback callback,
+            object? state,
+            TimeSpan dueTime,
+            TimeSpan period)
+        {
+            var created = Interlocked.Increment(ref _created);
+            if (created == ThrowOnCreateCount)
+                throw exception;
+            return TimeProvider.System.CreateTimer(callback, state, dueTime, period);
         }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1288/#1289 that keeps pipelined warm rereads on the cache while making every batch path release its resources.

- Overlay batches keep download-priority and streaming-deadline token context through cache/repair nesting.
- Fatal NNTP pump failures still fault pending responses, mark the connection unsafe, release the lock, and callback `NotRetrieved` before rethrowing, including OOM.
- Rejected or mismatched batches are cancelled, drained, and observed before the next provider attempt instead of being fire-and-forget.
- Provider fallbacks still start concurrently (bounded), but public responses stay in request order until the previous stream reaches EOF, fails, or is disposed.
- Persistent segment cache drops truncated blobs, re-indexes valid on-disk pairs after a degraded catalog, counts eviction only after the body is gone, and publishes gauges under the eviction lock.
- Support-pack JSON redaction walks parsed values so secrets equal to `true`, `null`, `schema`, `enabled`, or IP-like text cannot rewrite property names or boolean/null syntax.

## Test plan

- [x] Overlay, malformed-batch, ordered-fallback, and article-cache tests
- [x] Segment-cache truncation, degraded-catalog reindex, failed-eviction, and catalog-gauge tests
- [x] Support-pack `RedactJson` plus pack-level parse of every `.json` artifact with pathological secrets
- [x] Three local `--streaming-report` repetitions (excluded from PR CI)

`pipelined-warm-reread` stayed at **0** transport requests/bytes/batches and **12** cache hits on all three runs. Timing envelopes were not changed.

PR CI still owns the standard frontend/backend suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when retrieving multiple Usenet articles, including malformed or incomplete batch responses.
  - Added safer cancellation, cleanup, stream handling, and provider failover so failed downloads do not leave resources or connections stuck.
  - Improved handling of severe memory failures during article retrieval.
  - Improved cache recovery for truncated data and failed evictions.

- **Support Packs**
  - Improved structured JSON redaction while preserving valid formatting and data types.
  - Streaming configuration details are now generated more consistently in support packs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->