### PR TITLE
chore(ci): stop publishing the Docker Hub LTS tag

### DIFF
--- a/.github/workflows/promote-lts.yml
+++ b/.github/workflows/promote-lts.yml
@@ -74,12 +74,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v4.6.0
-        with:
-          username: infinidysk
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -90,9 +84,7 @@ jobs:
           set -euo pipefail
           SOURCE="ghcr.io/${{ github.repository }}:v${VERSION}"
           GHCR_TARGET="ghcr.io/${{ github.repository }}:lts"
-          DOCKERHUB_TARGET="docker.io/infinidysk/infinidysk:lts"
           docker buildx imagetools create \
             --tag "$GHCR_TARGET" \
-            --tag "$DOCKERHUB_TARGET" \
             "$SOURCE"
-          echo "Retagged ${SOURCE} -> ${GHCR_TARGET}, ${DOCKERHUB_TARGET}"
+          echo "Retagged ${SOURCE} -> ${GHCR_TARGET}"


### PR DESCRIPTION
## Summary
- remove Docker Hub authentication from the LTS promotion workflow
- retain the GitHub Container Registry `lts` image and movable git tag

## Test plan
- [x] Checked the workflow diff for whitespace errors
- [x] Confirmed no YAML diagnostics are reported
- [ ] Run the Promote LTS workflow after merging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the LTS release process to publish the LTS image tag only to GitHub Container Registry.
  * Removed Docker Hub publishing from the LTS workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->