### PR TITLE
chore(test): add whole-path NNTP CPU profiling coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,8 @@ jobs:
             --streaming-report --json /tmp/nzbdav-perf/streaming.json
           dotnet run --project backend.Benchmarks/NzbWebDAV.Benchmarks.csproj -c Release --no-build -- \
             --sab-api-report --json /tmp/nzbdav-perf/sab-api.json
+          dotnet run --project backend.Benchmarks/NzbWebDAV.Benchmarks.csproj -c Release --no-build -- \
+            --nntp-whole-path-report --set quick --json /tmp/nzbdav-perf/nntp-whole-path.json
           python3 scripts/check-performance-baseline.py \
             --baseline backend.Benchmarks/Baselines/streaming-baseline.json \
             --candidates /tmp/nzbdav-perf/streaming.json \
@@ -244,6 +246,11 @@ jobs:
           python3 scripts/check-performance-baseline.py \
             --baseline backend.Benchmarks/Baselines/sab-api-baseline.json \
             --candidates /tmp/nzbdav-perf/sab-api.json \
+            --deterministic-only \
+            --summary "${GITHUB_STEP_SUMMARY}"
+          python3 scripts/check-performance-baseline.py \
+            --baseline backend.Benchmarks/Baselines/nntp-whole-path-baseline.json \
+            --candidates /tmp/nzbdav-perf/nntp-whole-path.json \
             --deterministic-only \
             --summary "${GITHUB_STEP_SUMMARY}"
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Restore benchmarks
         run: dotnet restore backend.Benchmarks/NzbWebDAV.Benchmarks.csproj
 
+      - name: Build rapidyenc (linux-x64)
+        run: scripts/build-rapidyenc.sh linux-x64
+
       - name: Build benchmarks
         run: dotnet build backend.Benchmarks/NzbWebDAV.Benchmarks.csproj -c Release --no-restore
 
@@ -54,11 +57,11 @@ jobs:
 
           run_report() {
             local name="$1"
-            local flag="$2"
+            shift
             local i
             for i in 1 2 3; do
               dotnet run --project backend.Benchmarks/NzbWebDAV.Benchmarks.csproj -c Release --no-build -- \
-                "${flag}" --json "performance-out/${name}-${i}.json"
+                "$@" --json "performance-out/${name}-${i}.json"
             done
           }
 
@@ -76,8 +79,8 @@ jobs:
 
           run_with_retry() {
             local name="$1"
-            local flag="$2"
-            run_report "${name}" "${flag}"
+            shift
+            run_report "${name}" "$@"
             set +e
             set -o pipefail
             compare_report "${name}"
@@ -91,12 +94,14 @@ jobs:
               return 2
             fi
             echo "Envelope failure for ${name}; retrying once..."
-            run_report "${name}" "${flag}"
+            run_report "${name}" "$@"
             compare_report "${name}"
           }
 
           streaming_status=0
           sab_status=0
+          nntp_quick_status=0
+          nntp_sustained_status=0
           set +e
           run_with_retry streaming --streaming-report
           streaming_status=$?
@@ -111,7 +116,22 @@ jobs:
           if [ "${sab_status}" -eq 2 ]; then
             exit 2
           fi
-          if [ "${streaming_status}" -ne 0 ] || [ "${sab_status}" -ne 0 ]; then
+          set +e
+          run_with_retry nntp-whole-path --nntp-whole-path-report --set quick
+          nntp_quick_status=$?
+          set -e
+          if [ "${nntp_quick_status}" -eq 2 ]; then
+            exit 2
+          fi
+          set +e
+          run_with_retry nntp-whole-path-sustained --nntp-whole-path-report --set sustained
+          nntp_sustained_status=$?
+          set -e
+          if [ "${nntp_sustained_status}" -eq 2 ]; then
+            exit 2
+          fi
+          if [ "${streaming_status}" -ne 0 ] || [ "${sab_status}" -ne 0 ] || \
+             [ "${nntp_quick_status}" -ne 0 ] || [ "${nntp_sustained_status}" -ne 0 ]; then
             exit 1
           fi
 
@@ -189,6 +209,18 @@ jobs:
               performance-out/sab-api-2.json \
               performance-out/sab-api-3.json \
             --write-baseline backend.Benchmarks/Baselines/sab-api-baseline.json
+          python3 scripts/check-performance-baseline.py \
+            --candidates \
+              performance-out/nntp-whole-path-1.json \
+              performance-out/nntp-whole-path-2.json \
+              performance-out/nntp-whole-path-3.json \
+            --write-baseline backend.Benchmarks/Baselines/nntp-whole-path-baseline.json
+          python3 scripts/check-performance-baseline.py \
+            --candidates \
+              performance-out/nntp-whole-path-sustained-1.json \
+              performance-out/nntp-whole-path-sustained-2.json \
+              performance-out/nntp-whole-path-sustained-3.json \
+            --write-baseline backend.Benchmarks/Baselines/nntp-whole-path-sustained-baseline.json
 
           BODY_FILE="$(mktemp)"
           python3 - "${BODY_FILE}" "${RUN_URL}" <<'PY'
@@ -202,6 +234,8 @@ jobs:
           files = [
               ("streaming", "backend.Benchmarks/Baselines/streaming-baseline.json"),
               ("sab-api", "backend.Benchmarks/Baselines/sab-api-baseline.json"),
+              ("nntp-whole-path", "backend.Benchmarks/Baselines/nntp-whole-path-baseline.json"),
+              ("nntp-whole-path-sustained", "backend.Benchmarks/Baselines/nntp-whole-path-sustained-baseline.json"),
           ]
           lines = [
               "## Summary",
@@ -246,7 +280,9 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "chore/performance-rebaseline-${RUN_ID}"
           git add backend.Benchmarks/Baselines/streaming-baseline.json \
-            backend.Benchmarks/Baselines/sab-api-baseline.json
+            backend.Benchmarks/Baselines/sab-api-baseline.json \
+            backend.Benchmarks/Baselines/nntp-whole-path-baseline.json \
+            backend.Benchmarks/Baselines/nntp-whole-path-sustained-baseline.json
           if git diff --cached --quiet; then
             echo "Baselines are unchanged; no PR opened."
             exit 0

--- a/backend.Benchmarks/Baselines/nntp-whole-path-baseline.json
+++ b/backend.Benchmarks/Baselines/nntp-whole-path-baseline.json
@@ -1,0 +1,226 @@
+{
+  "schemaVersion": 1,
+  "report": "nntp-whole-path",
+  "meta": {
+    "commit": "unknown",
+    "generatedAt": "2026-08-31T19:42:21.649771+00:00",
+    "runner": "local"
+  },
+  "scenarios": {
+    "plain-transport-w4": {
+      "deterministic": {
+        "expectedBytes": 2097152,
+        "actualBytes": 2097152,
+        "sha256Match": 1,
+        "bodyCommands": 8,
+        "responses": 8,
+        "retrievedCallbacks": 2,
+        "cancelledCallbacks": 0,
+        "notFoundCallbacks": 0,
+        "notRetrievedCallbacks": 0,
+        "finalArticleBudgetBytes": 0,
+        "finalPipeBufferedBytes": 0,
+        "outstandingPermits": 0
+      },
+      "timing": {
+        "wallSeconds": {
+          "baseline": 0.007,
+          "envelope": 15.007,
+          "policy": "fail"
+        },
+        "clientCpuSeconds": {
+          "baseline": 0.007,
+          "envelope": 0.257,
+          "policy": "warn"
+        },
+        "serverCpuSeconds": {
+          "baseline": 0.009,
+          "envelope": 0.259,
+          "policy": "warn"
+        },
+        "clientCpuSecondsPerGb": {
+          "baseline": 3.426,
+          "envelope": 10.278,
+          "policy": "warn"
+        },
+        "throughputMbps": {
+          "baseline": 293.125,
+          "floor": 97.708,
+          "policy": "fail"
+        }
+      }
+    },
+    "plain-provider-w4": {
+      "deterministic": {
+        "expectedBytes": 2097152,
+        "actualBytes": 2097152,
+        "sha256Match": 1,
+        "bodyCommands": 8,
+        "responses": 8,
+        "retrievedCallbacks": 2,
+        "cancelledCallbacks": 0,
+        "notFoundCallbacks": 0,
+        "notRetrievedCallbacks": 0,
+        "finalArticleBudgetBytes": 0,
+        "finalPipeBufferedBytes": 0,
+        "outstandingPermits": 0
+      },
+      "timing": {
+        "wallSeconds": {
+          "baseline": 0.007,
+          "envelope": 15.007,
+          "policy": "fail"
+        },
+        "clientCpuSeconds": {
+          "baseline": 0.019,
+          "envelope": 0.269,
+          "policy": "warn"
+        },
+        "serverCpuSeconds": {
+          "baseline": 0.009,
+          "envelope": 0.259,
+          "policy": "warn"
+        },
+        "clientCpuSecondsPerGb": {
+          "baseline": 8.98,
+          "envelope": 26.94,
+          "policy": "warn"
+        },
+        "throughputMbps": {
+          "baseline": 301.268,
+          "floor": 100.423,
+          "policy": "fail"
+        }
+      }
+    },
+    "plain-buffered-w1": {
+      "deterministic": {
+        "expectedBytes": 2097152,
+        "actualBytes": 2097152,
+        "sha256Match": 1,
+        "bodyCommands": 8,
+        "responses": 8,
+        "retrievedCallbacks": 0,
+        "cancelledCallbacks": 0,
+        "notFoundCallbacks": 0,
+        "notRetrievedCallbacks": 0,
+        "finalArticleBudgetBytes": 0,
+        "finalPipeBufferedBytes": 0,
+        "outstandingPermits": 0
+      },
+      "timing": {
+        "wallSeconds": {
+          "baseline": 0.007,
+          "envelope": 15.007,
+          "policy": "fail"
+        },
+        "clientCpuSeconds": {
+          "baseline": 0.023,
+          "envelope": 0.273,
+          "policy": "warn"
+        },
+        "serverCpuSeconds": {
+          "baseline": 0.012,
+          "envelope": 0.262,
+          "policy": "warn"
+        },
+        "clientCpuSecondsPerGb": {
+          "baseline": 10.757,
+          "envelope": 32.271,
+          "policy": "warn"
+        },
+        "throughputMbps": {
+          "baseline": 317.028,
+          "floor": 105.676,
+          "policy": "fail"
+        }
+      }
+    },
+    "plain-buffered-w4": {
+      "deterministic": {
+        "expectedBytes": 2097152,
+        "actualBytes": 2097152,
+        "sha256Match": 1,
+        "bodyCommands": 8,
+        "responses": 8,
+        "retrievedCallbacks": 0,
+        "cancelledCallbacks": 0,
+        "notFoundCallbacks": 0,
+        "notRetrievedCallbacks": 0,
+        "finalArticleBudgetBytes": 0,
+        "finalPipeBufferedBytes": 0,
+        "outstandingPermits": 0
+      },
+      "timing": {
+        "wallSeconds": {
+          "baseline": 0.006,
+          "envelope": 15.006,
+          "policy": "fail"
+        },
+        "clientCpuSeconds": {
+          "baseline": 0.012,
+          "envelope": 0.262,
+          "policy": "warn"
+        },
+        "serverCpuSeconds": {
+          "baseline": 0.011,
+          "envelope": 0.261,
+          "policy": "warn"
+        },
+        "clientCpuSecondsPerGb": {
+          "baseline": 5.699,
+          "envelope": 17.097,
+          "policy": "warn"
+        },
+        "throughputMbps": {
+          "baseline": 346.305,
+          "floor": 115.435,
+          "policy": "fail"
+        }
+      }
+    },
+    "plain-http-like-w4": {
+      "deterministic": {
+        "expectedBytes": 2097152,
+        "actualBytes": 2097152,
+        "sha256Match": 1,
+        "bodyCommands": 8,
+        "responses": 8,
+        "retrievedCallbacks": 0,
+        "cancelledCallbacks": 0,
+        "notFoundCallbacks": 0,
+        "notRetrievedCallbacks": 0,
+        "finalArticleBudgetBytes": 0,
+        "finalPipeBufferedBytes": 0,
+        "outstandingPermits": 0
+      },
+      "timing": {
+        "wallSeconds": {
+          "baseline": 0.006,
+          "envelope": 15.006,
+          "policy": "fail"
+        },
+        "clientCpuSeconds": {
+          "baseline": 0.017,
+          "envelope": 0.267,
+          "policy": "warn"
+        },
+        "serverCpuSeconds": {
+          "baseline": 0.01,
+          "envelope": 0.26,
+          "policy": "warn"
+        },
+        "clientCpuSecondsPerGb": {
+          "baseline": 8.121,
+          "envelope": 24.363,
+          "policy": "warn"
+        },
+        "throughputMbps": {
+          "baseline": 353.693,
+          "floor": 117.898,
+          "policy": "fail"
+        }
+      }
+    }
+  }
+}

--- a/backend.Benchmarks/Baselines/nntp-whole-path-baseline.json
+++ b/backend.Benchmarks/Baselines/nntp-whole-path-baseline.json
@@ -3,7 +3,7 @@
   "report": "nntp-whole-path",
   "meta": {
     "commit": "unknown",
-    "generatedAt": "2026-08-31T19:42:21.649771+00:00",
+    "generatedAt": "2026-08-31T19:57:39.411218+00:00",
     "runner": "local"
   },
   "scenarios": {
@@ -18,14 +18,12 @@
         "cancelledCallbacks": 0,
         "notFoundCallbacks": 0,
         "notRetrievedCallbacks": 0,
-        "finalArticleBudgetBytes": 0,
-        "finalPipeBufferedBytes": 0,
-        "outstandingPermits": 0
+        "finalArticleBudgetBytes": 0
       },
       "timing": {
         "wallSeconds": {
-          "baseline": 0.007,
-          "envelope": 15.007,
+          "baseline": 0.006,
+          "envelope": 0.021,
           "policy": "fail"
         },
         "clientCpuSeconds": {
@@ -39,14 +37,34 @@
           "policy": "warn"
         },
         "clientCpuSecondsPerGb": {
-          "baseline": 3.426,
-          "envelope": 10.278,
+          "baseline": 3.397,
+          "envelope": 10.191,
           "policy": "warn"
         },
         "throughputMbps": {
-          "baseline": 293.125,
-          "floor": 97.708,
+          "baseline": 325.088,
+          "floor": 108.363,
           "policy": "fail"
+        },
+        "clientAllocatedBytes": {
+          "baseline": 617882.0,
+          "envelope": 1853646.0,
+          "policy": "warn"
+        },
+        "gen0Collections": {
+          "baseline": 0.0,
+          "envelope": 0.25,
+          "policy": "warn"
+        },
+        "gen1Collections": {
+          "baseline": 0.0,
+          "envelope": 0.25,
+          "policy": "warn"
+        },
+        "gen2Collections": {
+          "baseline": 0.0,
+          "envelope": 0.25,
+          "policy": "warn"
         }
       }
     },
@@ -61,35 +79,53 @@
         "cancelledCallbacks": 0,
         "notFoundCallbacks": 0,
         "notRetrievedCallbacks": 0,
-        "finalArticleBudgetBytes": 0,
-        "finalPipeBufferedBytes": 0,
-        "outstandingPermits": 0
+        "finalArticleBudgetBytes": 0
       },
       "timing": {
         "wallSeconds": {
           "baseline": 0.007,
-          "envelope": 15.007,
+          "envelope": 0.022,
           "policy": "fail"
         },
         "clientCpuSeconds": {
-          "baseline": 0.019,
-          "envelope": 0.269,
+          "baseline": 0.02,
+          "envelope": 0.27,
           "policy": "warn"
         },
         "serverCpuSeconds": {
-          "baseline": 0.009,
-          "envelope": 0.259,
+          "baseline": 0.01,
+          "envelope": 0.26,
           "policy": "warn"
         },
         "clientCpuSecondsPerGb": {
-          "baseline": 8.98,
-          "envelope": 26.94,
+          "baseline": 9.751,
+          "envelope": 29.253,
           "policy": "warn"
         },
         "throughputMbps": {
-          "baseline": 301.268,
-          "floor": 100.423,
+          "baseline": 284.728,
+          "floor": 94.909,
           "policy": "fail"
+        },
+        "clientAllocatedBytes": {
+          "baseline": 772464.0,
+          "envelope": 2317392.0,
+          "policy": "warn"
+        },
+        "gen0Collections": {
+          "baseline": 0.0,
+          "envelope": 0.25,
+          "policy": "warn"
+        },
+        "gen1Collections": {
+          "baseline": 0.0,
+          "envelope": 0.25,
+          "policy": "warn"
+        },
+        "gen2Collections": {
+          "baseline": 0.0,
+          "envelope": 0.25,
+          "policy": "warn"
         }
       }
     },
@@ -104,35 +140,53 @@
         "cancelledCallbacks": 0,
         "notFoundCallbacks": 0,
         "notRetrievedCallbacks": 0,
-        "finalArticleBudgetBytes": 0,
-        "finalPipeBufferedBytes": 0,
-        "outstandingPermits": 0
+        "finalArticleBudgetBytes": 0
       },
       "timing": {
         "wallSeconds": {
           "baseline": 0.007,
-          "envelope": 15.007,
+          "envelope": 0.022,
           "policy": "fail"
         },
         "clientCpuSeconds": {
-          "baseline": 0.023,
-          "envelope": 0.273,
+          "baseline": 0.016,
+          "envelope": 0.266,
           "policy": "warn"
         },
         "serverCpuSeconds": {
-          "baseline": 0.012,
-          "envelope": 0.262,
+          "baseline": 0.011,
+          "envelope": 0.261,
           "policy": "warn"
         },
         "clientCpuSecondsPerGb": {
-          "baseline": 10.757,
-          "envelope": 32.271,
+          "baseline": 7.428,
+          "envelope": 22.284,
           "policy": "warn"
         },
         "throughputMbps": {
-          "baseline": 317.028,
-          "floor": 105.676,
+          "baseline": 317.113,
+          "floor": 105.704,
           "policy": "fail"
+        },
+        "clientAllocatedBytes": {
+          "baseline": 586042.0,
+          "envelope": 1758126.0,
+          "policy": "warn"
+        },
+        "gen0Collections": {
+          "baseline": 0.0,
+          "envelope": 0.25,
+          "policy": "warn"
+        },
+        "gen1Collections": {
+          "baseline": 0.0,
+          "envelope": 0.25,
+          "policy": "warn"
+        },
+        "gen2Collections": {
+          "baseline": 0.0,
+          "envelope": 0.25,
+          "policy": "warn"
         }
       }
     },
@@ -147,35 +201,53 @@
         "cancelledCallbacks": 0,
         "notFoundCallbacks": 0,
         "notRetrievedCallbacks": 0,
-        "finalArticleBudgetBytes": 0,
-        "finalPipeBufferedBytes": 0,
-        "outstandingPermits": 0
+        "finalArticleBudgetBytes": 0
       },
       "timing": {
         "wallSeconds": {
-          "baseline": 0.006,
-          "envelope": 15.006,
+          "baseline": 0.009,
+          "envelope": 0.027,
           "policy": "fail"
         },
         "clientCpuSeconds": {
-          "baseline": 0.012,
-          "envelope": 0.262,
+          "baseline": 0.025,
+          "envelope": 0.275,
           "policy": "warn"
         },
         "serverCpuSeconds": {
-          "baseline": 0.011,
-          "envelope": 0.261,
+          "baseline": 0.01,
+          "envelope": 0.26,
           "policy": "warn"
         },
         "clientCpuSecondsPerGb": {
-          "baseline": 5.699,
-          "envelope": 17.097,
+          "baseline": 12.135,
+          "envelope": 36.405,
           "policy": "warn"
         },
         "throughputMbps": {
-          "baseline": 346.305,
-          "floor": 115.435,
+          "baseline": 294.037,
+          "floor": 98.012,
           "policy": "fail"
+        },
+        "clientAllocatedBytes": {
+          "baseline": 228048.0,
+          "envelope": 684144.0,
+          "policy": "warn"
+        },
+        "gen0Collections": {
+          "baseline": 0.0,
+          "envelope": 0.25,
+          "policy": "warn"
+        },
+        "gen1Collections": {
+          "baseline": 0.0,
+          "envelope": 0.25,
+          "policy": "warn"
+        },
+        "gen2Collections": {
+          "baseline": 0.0,
+          "envelope": 0.25,
+          "policy": "warn"
         }
       }
     },
@@ -190,19 +262,17 @@
         "cancelledCallbacks": 0,
         "notFoundCallbacks": 0,
         "notRetrievedCallbacks": 0,
-        "finalArticleBudgetBytes": 0,
-        "finalPipeBufferedBytes": 0,
-        "outstandingPermits": 0
+        "finalArticleBudgetBytes": 0
       },
       "timing": {
         "wallSeconds": {
           "baseline": 0.006,
-          "envelope": 15.006,
+          "envelope": 0.021,
           "policy": "fail"
         },
         "clientCpuSeconds": {
-          "baseline": 0.017,
-          "envelope": 0.267,
+          "baseline": 0.018,
+          "envelope": 0.268,
           "policy": "warn"
         },
         "serverCpuSeconds": {
@@ -211,14 +281,34 @@
           "policy": "warn"
         },
         "clientCpuSecondsPerGb": {
-          "baseline": 8.121,
-          "envelope": 24.363,
+          "baseline": 8.516,
+          "envelope": 25.548,
           "policy": "warn"
         },
         "throughputMbps": {
-          "baseline": 353.693,
-          "floor": 117.898,
+          "baseline": 359.673,
+          "floor": 119.891,
           "policy": "fail"
+        },
+        "clientAllocatedBytes": {
+          "baseline": 259448.0,
+          "envelope": 778344.0,
+          "policy": "warn"
+        },
+        "gen0Collections": {
+          "baseline": 0.0,
+          "envelope": 0.25,
+          "policy": "warn"
+        },
+        "gen1Collections": {
+          "baseline": 0.0,
+          "envelope": 0.25,
+          "policy": "warn"
+        },
+        "gen2Collections": {
+          "baseline": 0.0,
+          "envelope": 0.25,
+          "policy": "warn"
         }
       }
     }

--- a/backend.Benchmarks/Baselines/nntp-whole-path-sustained-baseline.json
+++ b/backend.Benchmarks/Baselines/nntp-whole-path-sustained-baseline.json
@@ -18,16 +18,18 @@
         "cancelledCallbacks": 0,
         "notFoundCallbacks": 0,
         "notRetrievedCallbacks": 0,
-        "finalArticleBudgetBytes": 0,
-        "finalPipeBufferedBytes": 0,
-        "outstandingPermits": 0
+        "finalArticleBudgetBytes": 0
       },
       "timing": {
         "wallSeconds": { "baseline": 10.0, "envelope": 30.0, "policy": "fail" },
         "clientCpuSeconds": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
         "serverCpuSeconds": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
         "clientCpuSecondsPerGb": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
-        "throughputMbps": { "baseline": 30.0, "floor": 10.0, "policy": "fail" }
+        "throughputMbps": { "baseline": 30.0, "floor": 10.0, "policy": "fail" },
+        "clientAllocatedBytes": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "gen0Collections": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "gen1Collections": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "gen2Collections": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" }
       }
     },
     "plain-buffered-w2": {
@@ -41,16 +43,18 @@
         "cancelledCallbacks": 0,
         "notFoundCallbacks": 0,
         "notRetrievedCallbacks": 0,
-        "finalArticleBudgetBytes": 0,
-        "finalPipeBufferedBytes": 0,
-        "outstandingPermits": 0
+        "finalArticleBudgetBytes": 0
       },
       "timing": {
         "wallSeconds": { "baseline": 10.0, "envelope": 30.0, "policy": "fail" },
         "clientCpuSeconds": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
         "serverCpuSeconds": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
         "clientCpuSecondsPerGb": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
-        "throughputMbps": { "baseline": 30.0, "floor": 10.0, "policy": "fail" }
+        "throughputMbps": { "baseline": 30.0, "floor": 10.0, "policy": "fail" },
+        "clientAllocatedBytes": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "gen0Collections": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "gen1Collections": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "gen2Collections": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" }
       }
     },
     "plain-buffered-w4": {
@@ -64,16 +68,18 @@
         "cancelledCallbacks": 0,
         "notFoundCallbacks": 0,
         "notRetrievedCallbacks": 0,
-        "finalArticleBudgetBytes": 0,
-        "finalPipeBufferedBytes": 0,
-        "outstandingPermits": 0
+        "finalArticleBudgetBytes": 0
       },
       "timing": {
         "wallSeconds": { "baseline": 10.0, "envelope": 30.0, "policy": "fail" },
         "clientCpuSeconds": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
         "serverCpuSeconds": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
         "clientCpuSecondsPerGb": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
-        "throughputMbps": { "baseline": 30.0, "floor": 10.0, "policy": "fail" }
+        "throughputMbps": { "baseline": 30.0, "floor": 10.0, "policy": "fail" },
+        "clientAllocatedBytes": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "gen0Collections": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "gen1Collections": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "gen2Collections": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" }
       }
     },
     "plain-buffered-w8": {
@@ -87,16 +93,18 @@
         "cancelledCallbacks": 0,
         "notFoundCallbacks": 0,
         "notRetrievedCallbacks": 0,
-        "finalArticleBudgetBytes": 0,
-        "finalPipeBufferedBytes": 0,
-        "outstandingPermits": 0
+        "finalArticleBudgetBytes": 0
       },
       "timing": {
         "wallSeconds": { "baseline": 10.0, "envelope": 30.0, "policy": "fail" },
         "clientCpuSeconds": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
         "serverCpuSeconds": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
         "clientCpuSecondsPerGb": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
-        "throughputMbps": { "baseline": 30.0, "floor": 10.0, "policy": "fail" }
+        "throughputMbps": { "baseline": 30.0, "floor": 10.0, "policy": "fail" },
+        "clientAllocatedBytes": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "gen0Collections": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "gen1Collections": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "gen2Collections": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" }
       }
     }
   }

--- a/backend.Benchmarks/Baselines/nntp-whole-path-sustained-baseline.json
+++ b/backend.Benchmarks/Baselines/nntp-whole-path-sustained-baseline.json
@@ -1,0 +1,103 @@
+{
+  "schemaVersion": 1,
+  "report": "nntp-whole-path",
+  "meta": {
+    "commit": "bootstrap",
+    "generatedAt": "2026-08-31T00:00:00+00:00",
+    "runner": "local"
+  },
+  "scenarios": {
+    "plain-buffered-w1": {
+      "deterministic": {
+        "expectedBytes": 1073741824,
+        "actualBytes": 1073741824,
+        "sha256Match": 1,
+        "bodyCommands": 256,
+        "responses": 256,
+        "retrievedCallbacks": 0,
+        "cancelledCallbacks": 0,
+        "notFoundCallbacks": 0,
+        "notRetrievedCallbacks": 0,
+        "finalArticleBudgetBytes": 0,
+        "finalPipeBufferedBytes": 0,
+        "outstandingPermits": 0
+      },
+      "timing": {
+        "wallSeconds": { "baseline": 10.0, "envelope": 30.0, "policy": "fail" },
+        "clientCpuSeconds": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "serverCpuSeconds": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "clientCpuSecondsPerGb": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "throughputMbps": { "baseline": 30.0, "floor": 10.0, "policy": "fail" }
+      }
+    },
+    "plain-buffered-w2": {
+      "deterministic": {
+        "expectedBytes": 1073741824,
+        "actualBytes": 1073741824,
+        "sha256Match": 1,
+        "bodyCommands": 256,
+        "responses": 256,
+        "retrievedCallbacks": 0,
+        "cancelledCallbacks": 0,
+        "notFoundCallbacks": 0,
+        "notRetrievedCallbacks": 0,
+        "finalArticleBudgetBytes": 0,
+        "finalPipeBufferedBytes": 0,
+        "outstandingPermits": 0
+      },
+      "timing": {
+        "wallSeconds": { "baseline": 10.0, "envelope": 30.0, "policy": "fail" },
+        "clientCpuSeconds": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "serverCpuSeconds": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "clientCpuSecondsPerGb": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "throughputMbps": { "baseline": 30.0, "floor": 10.0, "policy": "fail" }
+      }
+    },
+    "plain-buffered-w4": {
+      "deterministic": {
+        "expectedBytes": 1073741824,
+        "actualBytes": 1073741824,
+        "sha256Match": 1,
+        "bodyCommands": 256,
+        "responses": 256,
+        "retrievedCallbacks": 0,
+        "cancelledCallbacks": 0,
+        "notFoundCallbacks": 0,
+        "notRetrievedCallbacks": 0,
+        "finalArticleBudgetBytes": 0,
+        "finalPipeBufferedBytes": 0,
+        "outstandingPermits": 0
+      },
+      "timing": {
+        "wallSeconds": { "baseline": 10.0, "envelope": 30.0, "policy": "fail" },
+        "clientCpuSeconds": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "serverCpuSeconds": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "clientCpuSecondsPerGb": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "throughputMbps": { "baseline": 30.0, "floor": 10.0, "policy": "fail" }
+      }
+    },
+    "plain-buffered-w8": {
+      "deterministic": {
+        "expectedBytes": 1073741824,
+        "actualBytes": 1073741824,
+        "sha256Match": 1,
+        "bodyCommands": 256,
+        "responses": 256,
+        "retrievedCallbacks": 0,
+        "cancelledCallbacks": 0,
+        "notFoundCallbacks": 0,
+        "notRetrievedCallbacks": 0,
+        "finalArticleBudgetBytes": 0,
+        "finalPipeBufferedBytes": 0,
+        "outstandingPermits": 0
+      },
+      "timing": {
+        "wallSeconds": { "baseline": 10.0, "envelope": 30.0, "policy": "fail" },
+        "clientCpuSeconds": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "serverCpuSeconds": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "clientCpuSecondsPerGb": { "baseline": 0.0, "envelope": 0.25, "policy": "warn" },
+        "throughputMbps": { "baseline": 30.0, "floor": 10.0, "policy": "fail" }
+      }
+    }
+  }
+}

--- a/backend.Benchmarks/HttpLikeCountingSink.cs
+++ b/backend.Benchmarks/HttpLikeCountingSink.cs
@@ -1,0 +1,34 @@
+using System.Buffers;
+
+namespace NzbWebDAV.Benchmarks;
+
+/// <summary>
+/// Applies the bounded 64 KiB response-copy shape used by the WebDAV handler,
+/// while discarding output so timed benchmark passes do not include hashing.
+/// </summary>
+internal sealed class HttpLikeCountingSink
+{
+    private const int BufferBytes = 64 * 1024;
+
+    public long BytesWritten { get; private set; }
+
+    public async Task CopyFromAsync(Stream source, CancellationToken cancellationToken)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(BufferBytes);
+        try
+        {
+            while (true)
+            {
+                var read = await source.ReadAsync(buffer.AsMemory(0, BufferBytes), cancellationToken)
+                    .ConfigureAwait(false);
+                if (read == 0)
+                    return;
+                BytesWritten += read;
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+}

--- a/backend.Benchmarks/NntpLoopbackCorpus.cs
+++ b/backend.Benchmarks/NntpLoopbackCorpus.cs
@@ -1,0 +1,114 @@
+using System.Security.Cryptography;
+using System.Text;
+using RapidYencSharp;
+
+namespace NzbWebDAV.Benchmarks;
+
+/// <summary>
+/// Immutable deterministic yEnc corpus used by the loopback NNTP performance report.
+/// The server only writes these precomputed bytes so encoding work is not charged to
+/// the benchmark client process.
+/// </summary>
+internal sealed class NntpLoopbackCorpus
+{
+    private readonly Dictionary<string, NntpLoopbackArticle> _articles;
+
+    private NntpLoopbackCorpus(
+        IReadOnlyList<NntpLoopbackArticle> articles,
+        byte[] decodedFile,
+        string sha256)
+    {
+        Articles = articles;
+        DecodedFile = decodedFile;
+        ExpectedSha256 = sha256;
+        _articles = articles.ToDictionary(article => article.SegmentId, StringComparer.Ordinal);
+    }
+
+    public IReadOnlyList<NntpLoopbackArticle> Articles { get; }
+    public byte[] DecodedFile { get; }
+    public string ExpectedSha256 { get; }
+    public long ExpectedBytes => DecodedFile.LongLength;
+
+    public bool TryGetArticle(string segmentId, out NntpLoopbackArticle article) =>
+        _articles.TryGetValue(NormalizeSegmentId(segmentId), out article!);
+
+    public static NntpLoopbackCorpus Create(int articleCount, int decodedArticleBytes, int seed)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(articleCount);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(decodedArticleBytes);
+
+        YencEncoder.EnsureInitialized();
+        Crc32.EnsureInitialized();
+
+        var articles = new NntpLoopbackArticle[articleCount];
+        var decodedFile = GC.AllocateUninitializedArray<byte>(
+            checked(articleCount * decodedArticleBytes));
+        var random = new Random(seed);
+
+        for (var index = 0; index < articleCount; index++)
+        {
+            var payload = decodedFile.AsSpan(index * decodedArticleBytes, decodedArticleBytes);
+            random.NextBytes(payload);
+            var segmentId = $"bench-{index:D4}@loopback";
+            var crc32 = Crc32.Compute(payload);
+            articles[index] = new NntpLoopbackArticle(
+                segmentId,
+                payload.ToArray(),
+                EncodeWireBody(payload, index, articleCount, decodedFile.Length, crc32),
+                crc32);
+        }
+
+        return new NntpLoopbackCorpus(
+            articles,
+            decodedFile,
+            Convert.ToHexString(SHA256.HashData(decodedFile)).ToLowerInvariant());
+    }
+
+    private static byte[] EncodeWireBody(
+        ReadOnlySpan<byte> payload,
+        int index,
+        int articleCount,
+        int fileLength,
+        uint crc32)
+    {
+        int? column = 0;
+        var encoded = YencEncoder.EncodeEx(payload, ref column, 128, true);
+        var stuffed = DotStuff(encoded);
+        using var output = new MemoryStream(stuffed.Length + 256);
+        WriteAscii(
+            output,
+            $"=ybegin part={index + 1} total={articleCount} line=128 size={fileLength} name=loopback.bin\r\n");
+        WriteAscii(output, $"=ypart begin={index * payload.Length + 1} end={(index + 1) * payload.Length}\r\n");
+        output.Write(stuffed);
+        if (stuffed.Length > 0)
+            WriteAscii(output, "\r\n");
+        WriteAscii(output, $"=yend size={payload.Length} part={index + 1} pcrc32={crc32:x8}\r\n.\r\n");
+        return output.ToArray();
+    }
+
+    private static byte[] DotStuff(ReadOnlySpan<byte> source)
+    {
+        using var output = new MemoryStream(source.Length);
+        var atLineStart = true;
+        foreach (var value in source)
+        {
+            if (atLineStart && value == (byte)'.')
+                output.WriteByte(value);
+            output.WriteByte(value);
+            atLineStart = value == (byte)'\n';
+        }
+        return output.ToArray();
+    }
+
+    private static void WriteAscii(Stream stream, string value) =>
+        stream.Write(Encoding.ASCII.GetBytes(value));
+
+    public static string NormalizeSegmentId(string value) =>
+        value.Trim().Trim('<', '>');
+}
+
+internal sealed record NntpLoopbackArticle(
+    string SegmentId,
+    byte[] Decoded,
+    byte[] WireBody,
+    uint Crc32);

--- a/backend.Benchmarks/NntpLoopbackServer.cs
+++ b/backend.Benchmarks/NntpLoopbackServer.cs
@@ -1,0 +1,250 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+
+namespace NzbWebDAV.Benchmarks;
+
+/// <summary>
+/// Small deterministic NNTP server used only by the whole-path benchmark. It accepts
+/// pipelined BODY commands and writes precomputed wire bodies in command order.
+/// </summary>
+internal sealed class NntpLoopbackServer : IAsyncDisposable
+{
+    private const int MaximumCommandLength = 4096;
+    private readonly TcpListener _listener;
+    private readonly NntpLoopbackCorpus _corpus;
+    private readonly LoopbackNetworkImpairment _impairment;
+    private readonly HashSet<string> _missingIds;
+    private readonly CancellationTokenSource _stop = new();
+    private readonly ConcurrentBag<Task> _connectionTasks = [];
+    private readonly Task _acceptTask;
+    private int _activeConnections;
+    private int _peakActiveConnections;
+    private long _bodyCommands;
+    private long _responses;
+    private long _wireBytes;
+
+    private NntpLoopbackServer(
+        NntpLoopbackCorpus corpus,
+        LoopbackNetworkImpairment impairment,
+        IEnumerable<string>? missingIds)
+    {
+        _corpus = corpus;
+        _impairment = impairment;
+        _missingIds = missingIds is null
+            ? new HashSet<string>(StringComparer.Ordinal)
+            : new HashSet<string>(missingIds.Select(NntpLoopbackCorpus.NormalizeSegmentId), StringComparer.Ordinal);
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+        _acceptTask = AcceptLoopAsync();
+    }
+
+    public int Port => ((IPEndPoint)_listener.LocalEndpoint).Port;
+
+    public static Task<NntpLoopbackServer> StartAsync(
+        NntpLoopbackCorpus corpus,
+        int roundTripDelayMs = 0,
+        long? bandwidthBytesPerSecond = null,
+        IEnumerable<string>? missingIds = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(roundTripDelayMs);
+        return Task.FromResult(new NntpLoopbackServer(
+            corpus,
+            new LoopbackNetworkImpairment(roundTripDelayMs, bandwidthBytesPerSecond),
+            missingIds));
+    }
+
+    public NntpLoopbackServerSnapshot GetSnapshot() => new(
+        Volatile.Read(ref _bodyCommands),
+        Volatile.Read(ref _responses),
+        Volatile.Read(ref _activeConnections),
+        Volatile.Read(ref _peakActiveConnections),
+        Interlocked.Read(ref _wireBytes));
+
+    public async Task RunUntilCancelledAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    public async Task WriteSnapshotAsync(string path, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory))
+            Directory.CreateDirectory(directory);
+        await File.WriteAllTextAsync(
+                path,
+                JsonSerializer.Serialize(GetSnapshot()),
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task AcceptLoopAsync()
+    {
+        try
+        {
+            while (!_stop.IsCancellationRequested)
+            {
+                var client = await _listener.AcceptTcpClientAsync(_stop.Token).ConfigureAwait(false);
+                var task = ServeConnectionAsync(client);
+                _connectionTasks.Add(task);
+            }
+        }
+        catch (OperationCanceledException) when (_stop.IsCancellationRequested)
+        {
+        }
+        catch (ObjectDisposedException) when (_stop.IsCancellationRequested)
+        {
+        }
+    }
+
+    private async Task ServeConnectionAsync(TcpClient client)
+    {
+        var active = Interlocked.Increment(ref _activeConnections);
+        UpdateMaximum(ref _peakActiveConnections, active);
+        try
+        {
+            using (client)
+            await using (var stream = client.GetStream())
+            using (var reader = new StreamReader(stream, Encoding.Latin1, leaveOpen: true))
+            {
+                await WriteAsciiAsync(stream, "200 loopback benchmark ready\r\n", _stop.Token).ConfigureAwait(false);
+                while (!_stop.IsCancellationRequested)
+                {
+                    var command = await ReadCommandAsync(reader, _stop.Token).ConfigureAwait(false);
+                    if (command is null)
+                        return;
+                    if (command.Equals("QUIT", StringComparison.Ordinal))
+                    {
+                        await WriteAsciiAsync(stream, "205 closing connection\r\n", _stop.Token).ConfigureAwait(false);
+                        return;
+                    }
+                    if (command.StartsWith("AUTHINFO ", StringComparison.OrdinalIgnoreCase))
+                    {
+                        await WriteAsciiAsync(stream, "281 authentication accepted\r\n", _stop.Token).ConfigureAwait(false);
+                        continue;
+                    }
+                    if (!TryParseBody(command, out var segmentId))
+                    {
+                        await WriteAsciiAsync(stream, "500 unsupported command\r\n", _stop.Token).ConfigureAwait(false);
+                        continue;
+                    }
+
+                    Interlocked.Increment(ref _bodyCommands);
+                    await _impairment.BeforeResponseAsync(_stop.Token).ConfigureAwait(false);
+                    if (_missingIds.Contains(segmentId) || !_corpus.TryGetArticle(segmentId, out var article))
+                    {
+                        Interlocked.Increment(ref _responses);
+                        await WriteAsciiAsync(stream, "430 no such article\r\n", _stop.Token).ConfigureAwait(false);
+                        continue;
+                    }
+
+                    await WriteAsciiAsync(stream, $"222 0 <{article.SegmentId}> body follows\r\n", _stop.Token)
+                        .ConfigureAwait(false);
+                    await _impairment.WriteAsync(stream, article.WireBody, _stop.Token).ConfigureAwait(false);
+                    Interlocked.Increment(ref _responses);
+                    Interlocked.Add(ref _wireBytes, article.WireBody.Length);
+                }
+            }
+        }
+        catch (IOException) when (_stop.IsCancellationRequested)
+        {
+        }
+        finally
+        {
+            Interlocked.Decrement(ref _activeConnections);
+        }
+    }
+
+    private static async Task<string?> ReadCommandAsync(StreamReader reader, CancellationToken cancellationToken)
+    {
+        var command = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+        if (command is { Length: > MaximumCommandLength })
+            throw new InvalidDataException("Loopback NNTP command exceeded the configured limit.");
+        return command;
+    }
+
+    private static bool TryParseBody(string command, out string segmentId)
+    {
+        segmentId = string.Empty;
+        if (!command.StartsWith("BODY <", StringComparison.OrdinalIgnoreCase) ||
+            !command.EndsWith('>') ||
+            command.Length <= "BODY <>".Length)
+        {
+            return false;
+        }
+        segmentId = NntpLoopbackCorpus.NormalizeSegmentId(command[5..^1]);
+        return segmentId.Length > 0 && segmentId.Length <= MaximumCommandLength - 7;
+    }
+
+    private static Task WriteAsciiAsync(Stream stream, string value, CancellationToken cancellationToken) =>
+        stream.WriteAsync(Encoding.ASCII.GetBytes(value), cancellationToken).AsTask();
+
+    private static void UpdateMaximum(ref int maximum, int candidate)
+    {
+        var current = Volatile.Read(ref maximum);
+        while (candidate > current)
+        {
+            var observed = Interlocked.CompareExchange(ref maximum, candidate, current);
+            if (observed == current)
+                return;
+            current = observed;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _stop.CancelAsync().ConfigureAwait(false);
+        _listener.Stop();
+        _listener.Dispose();
+        try
+        {
+            await _acceptTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        await Task.WhenAll(_connectionTasks.ToArray()).ConfigureAwait(false);
+        _stop.Dispose();
+    }
+}
+
+internal sealed class LoopbackNetworkImpairment(int roundTripDelayMs, long? bandwidthBytesPerSecond)
+{
+    private const int WriteChunkBytes = 64 * 1024;
+
+    public Task BeforeResponseAsync(CancellationToken cancellationToken) =>
+        roundTripDelayMs == 0
+            ? Task.CompletedTask
+            : Task.Delay(TimeSpan.FromMilliseconds(roundTripDelayMs), cancellationToken);
+
+    public async Task WriteAsync(Stream stream, ReadOnlyMemory<byte> body, CancellationToken cancellationToken)
+    {
+        for (var offset = 0; offset < body.Length; offset += WriteChunkBytes)
+        {
+            var chunk = body.Slice(offset, Math.Min(WriteChunkBytes, body.Length - offset));
+            await stream.WriteAsync(chunk, cancellationToken).ConfigureAwait(false);
+            if (bandwidthBytesPerSecond is > 0)
+            {
+                var delay = TimeSpan.FromSeconds((double)chunk.Length / bandwidthBytesPerSecond.Value);
+                if (delay > TimeSpan.Zero)
+                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+}
+
+internal sealed record NntpLoopbackServerSnapshot(
+    long BodyCommands,
+    long Responses,
+    int ActiveConnections,
+    int PeakActiveConnections,
+    long WireBytes);

--- a/backend.Benchmarks/NntpLoopbackServer.cs
+++ b/backend.Benchmarks/NntpLoopbackServer.cs
@@ -71,6 +71,7 @@ internal sealed class NntpLoopbackServer : IAsyncDisposable
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            return;
         }
     }
 
@@ -100,9 +101,11 @@ internal sealed class NntpLoopbackServer : IAsyncDisposable
         }
         catch (OperationCanceledException) when (_stop.IsCancellationRequested)
         {
+            return;
         }
         catch (ObjectDisposedException) when (_stop.IsCancellationRequested)
         {
+            return;
         }
     }
 
@@ -157,6 +160,7 @@ internal sealed class NntpLoopbackServer : IAsyncDisposable
         }
         catch (IOException) when (_stop.IsCancellationRequested)
         {
+            // A peer may close while the server is stopping.
         }
         finally
         {
@@ -209,8 +213,9 @@ internal sealed class NntpLoopbackServer : IAsyncDisposable
         {
             await _acceptTask.ConfigureAwait(false);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (_stop.IsCancellationRequested)
         {
+            // Cancellation is the expected listener shutdown path.
         }
         await Task.WhenAll(_connectionTasks.ToArray()).ConfigureAwait(false);
         _stop.Dispose();

--- a/backend.Benchmarks/NntpWholePathReport.cs
+++ b/backend.Benchmarks/NntpWholePathReport.cs
@@ -475,7 +475,7 @@ internal sealed class LoopbackServerProcess : IAsyncDisposable
             }
             return new LoopbackServerProcess(process, countersPath) { Port = port };
         }
-        catch
+        catch (Exception exception) when (exception is TimeoutException or InvalidOperationException or IOException)
         {
             if (!process.HasExited)
             {

--- a/backend.Benchmarks/NntpWholePathReport.cs
+++ b/backend.Benchmarks/NntpWholePathReport.cs
@@ -18,7 +18,7 @@ namespace NzbWebDAV.Benchmarks;
 internal static class NntpWholePathReport
 {
     internal const string ReportName = "nntp-whole-path";
-    private const int CorpusSeed = 1025;
+    internal const int CorpusSeed = 1025;
     private const int TimedRepetitions = 3;
 
     public static async Task RunAsync(
@@ -65,8 +65,6 @@ internal static class NntpWholePathReport
                     ["notFoundCallbacks"] = deterministic.NotFoundCallbacks,
                     ["notRetrievedCallbacks"] = deterministic.NotRetrievedCallbacks,
                     ["finalArticleBudgetBytes"] = deterministic.FinalArticleBudgetBytes,
-                    ["finalPipeBufferedBytes"] = deterministic.FinalPipeBufferedBytes,
-                    ["outstandingPermits"] = deterministic.OutstandingPermits,
                 },
                 PerformanceReportJson.WholePathTiming(
                     timing.WallSeconds,
@@ -118,7 +116,7 @@ internal static class NntpWholePathReport
             scenario.ArticleCount,
             scenario.DecodedArticleBytes,
             CorpusSeed);
-        var countersPath = Path.Combine(Path.GetTempPath(), $"nntp-loopback-{Guid.NewGuid():N}.json");
+        var countersPath = Path.Join(Path.GetTempPath(), $"nntp-loopback-{Guid.NewGuid():N}.json");
         await using var server = await LoopbackServerProcess.StartAsync(scenario, countersPath).ConfigureAwait(false);
         var callbackCounts = new CallbackCounts();
         var budget = new InFlightArticleBudget(corpus.ExpectedBytes + scenario.DecodedArticleBytes);
@@ -171,8 +169,6 @@ internal static class NntpWholePathReport
                     callbackCounts.NotFound,
                     callbackCounts.NotRetrieved,
                     budget.LeasedBytes,
-                    0,
-                    0,
                     serverSnapshot.PeakActiveConnections),
                 new NntpWholePathTiming(
                     started.Elapsed.TotalSeconds,
@@ -306,7 +302,8 @@ internal static class NntpWholePathReport
         long total = 0;
         for (var start = 0; start < ids.Length; start += width)
         {
-            var batchIds = ids.Skip(start).Take(Math.Min(width, ids.Length - start)).ToArray();
+            var batchIds = new SegmentId[Math.Min(width, ids.Length - start)];
+            Array.Copy(ids, start, batchIds, 0, batchIds.Length);
             var batch = await readBatch(batchIds, counts.Record).ConfigureAwait(false);
             foreach (var responseTask in batch.Responses)
             {
@@ -454,7 +451,7 @@ internal sealed class LoopbackServerProcess : IAsyncDisposable
         startInfo.ArgumentList.Add("--article-bytes");
         startInfo.ArgumentList.Add(scenario.DecodedArticleBytes.ToString());
         startInfo.ArgumentList.Add("--seed");
-        startInfo.ArgumentList.Add("1025");
+        startInfo.ArgumentList.Add(NntpWholePathReport.CorpusSeed.ToString());
         startInfo.ArgumentList.Add("--rtt-ms");
         startInfo.ArgumentList.Add(scenario.RoundTripDelayMs.ToString());
         if (scenario.BandwidthBytesPerSecond is { } bandwidth)
@@ -467,15 +464,29 @@ internal sealed class LoopbackServerProcess : IAsyncDisposable
 
         var process = Process.Start(startInfo) ??
                       throw new InvalidOperationException("Could not start loopback NNTP server process.");
-        var line = await process.StandardOutput.ReadLineAsync().WaitAsync(TimeSpan.FromSeconds(15)).ConfigureAwait(false);
-        if (line is null || !line.StartsWith("READY ", StringComparison.Ordinal) ||
-            !int.TryParse(line[6..], out var port))
+        try
         {
-            var error = await process.StandardError.ReadToEndAsync().ConfigureAwait(false);
-            process.Kill(entireProcessTree: true);
-            throw new InvalidOperationException($"Loopback NNTP server did not become ready: {error}");
+            var line = await process.StandardOutput.ReadLineAsync().WaitAsync(TimeSpan.FromSeconds(15))
+                .ConfigureAwait(false);
+            if (line is null || !line.StartsWith("READY ", StringComparison.Ordinal) ||
+                !int.TryParse(line[6..], out var port))
+            {
+                throw new InvalidOperationException("Loopback NNTP server did not report a valid READY port.");
+            }
+            return new LoopbackServerProcess(process, countersPath) { Port = port };
         }
-        return new LoopbackServerProcess(process, countersPath) { Port = port };
+        catch
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+                await process.WaitForExitAsync().ConfigureAwait(false);
+            }
+            var error = await process.StandardError.ReadToEndAsync().ConfigureAwait(false);
+            process.Dispose();
+            throw new InvalidOperationException(
+                $"Loopback NNTP server did not become ready: {error}");
+        }
     }
 
     public async Task<NntpLoopbackServerSnapshot> StopAndGetSnapshotAsync()

--- a/backend.Benchmarks/NntpWholePathReport.cs
+++ b/backend.Benchmarks/NntpWholePathReport.cs
@@ -1,0 +1,515 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text.Json;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Connections;
+using NzbWebDAV.Models;
+using NzbWebDAV.Streams;
+using UsenetSharp.Clients;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Benchmarks;
+
+/// <summary>
+/// Provider-independent whole-path NNTP report. The socket server is a child process
+/// so yEnc encoding, TLS (when introduced), and server writes do not affect client CPU.
+/// It is intentionally a measurement harness; it does not change the product path.
+/// </summary>
+internal static class NntpWholePathReport
+{
+    internal const string ReportName = "nntp-whole-path";
+    private const int CorpusSeed = 1025;
+    private const int TimedRepetitions = 3;
+
+    public static async Task RunAsync(
+        string? jsonPath,
+        string scenarioSet,
+        string? scenarioName = null)
+    {
+        var selected = NntpWholePathScenario.ForSet(scenarioSet)
+            .Where(scenario => scenarioName is null ||
+                               scenario.Name.Equals(scenarioName, StringComparison.Ordinal))
+            .ToArray();
+        if (selected.Length == 0)
+            throw new ArgumentException($"No scenario named '{scenarioName}' exists in set '{scenarioSet}'.");
+
+        var snapshots = new Dictionary<string, ScenarioSnapshot>(StringComparer.Ordinal);
+        foreach (var scenario in selected)
+        {
+            // Tiered JIT and native dispatch setup are intentionally discarded.
+            await ExecuteAsync(scenario, verifyHash: false, httpLike: scenario.Layer == NntpWholePathLayer.HttpLike)
+                .ConfigureAwait(false);
+            var correctness = await ExecuteAsync(scenario, verifyHash: true, httpLike: scenario.Layer == NntpWholePathLayer.HttpLike)
+                .ConfigureAwait(false);
+
+            NntpWholePathTiming? total = null;
+            for (var repetition = 0; repetition < TimedRepetitions; repetition++)
+            {
+                var timed = await ExecuteAsync(scenario, verifyHash: false, httpLike: scenario.Layer == NntpWholePathLayer.HttpLike)
+                    .ConfigureAwait(false);
+                total = total is null ? timed.Timing : Add(total, timed.Timing);
+            }
+
+            var timing = Divide(total!, TimedRepetitions);
+            var deterministic = correctness.Deterministic;
+            snapshots[scenario.Name] = new ScenarioSnapshot(
+                new Dictionary<string, long>(StringComparer.Ordinal)
+                {
+                    ["expectedBytes"] = deterministic.ExpectedBytes,
+                    ["actualBytes"] = deterministic.ActualBytes,
+                    ["sha256Match"] = deterministic.Sha256Match,
+                    ["bodyCommands"] = deterministic.BodyCommands,
+                    ["responses"] = deterministic.Responses,
+                    ["retrievedCallbacks"] = deterministic.RetrievedCallbacks,
+                    ["cancelledCallbacks"] = deterministic.CancelledCallbacks,
+                    ["notFoundCallbacks"] = deterministic.NotFoundCallbacks,
+                    ["notRetrievedCallbacks"] = deterministic.NotRetrievedCallbacks,
+                    ["finalArticleBudgetBytes"] = deterministic.FinalArticleBudgetBytes,
+                    ["finalPipeBufferedBytes"] = deterministic.FinalPipeBufferedBytes,
+                    ["outstandingPermits"] = deterministic.OutstandingPermits,
+                },
+                PerformanceReportJson.WholePathTiming(
+                    timing.WallSeconds,
+                    timing.ClientCpuSeconds,
+                    timing.ServerCpuSeconds,
+                    timing.ClientCpuSecondsPerGb,
+                    timing.ThroughputMbps,
+                    timing.ClientAllocatedBytes,
+                    timing.Gen0Collections,
+                    timing.Gen1Collections,
+                    timing.Gen2Collections));
+
+            Console.WriteLine(
+                $"{scenario.Name} bytes={deterministic.ActualBytes} sha256_match={deterministic.Sha256Match} " +
+                $"body_commands={deterministic.BodyCommands} peak_connections={deterministic.PeakActiveConnections} " +
+                $"wall_s={timing.WallSeconds:F3} " +
+                $"throughput_mb_s={timing.ThroughputMbps:F3} client_cpu_s={timing.ClientCpuSeconds:F3}");
+        }
+
+        if (jsonPath is not null)
+            PerformanceReportJson.Write(jsonPath, ReportName, snapshots);
+    }
+
+    public static async Task RunChildServerAsync(LoopbackServerArguments arguments)
+    {
+        var corpus = NntpLoopbackCorpus.Create(arguments.ArticleCount, arguments.DecodedArticleBytes, arguments.Seed);
+        await using var server = await NntpLoopbackServer.StartAsync(
+                corpus,
+                arguments.RoundTripDelayMs,
+                arguments.BandwidthBytesPerSecond,
+                arguments.MissingIds)
+            .ConfigureAwait(false);
+        Console.WriteLine($"READY {server.Port}");
+        await Console.Out.FlushAsync().ConfigureAwait(false);
+        await Console.In.ReadLineAsync().ConfigureAwait(false);
+        await server.WriteSnapshotAsync(arguments.CountersPath, CancellationToken.None).ConfigureAwait(false);
+    }
+
+    private static async Task<NntpWholePathResult> ExecuteAsync(
+        NntpWholePathScenario scenario,
+        bool verifyHash,
+        bool httpLike)
+    {
+        if (scenario.UseTls)
+            throw new NotSupportedException(
+                "Validated TLS loopback scenarios are deferred until a test-CA trust mechanism is available.");
+
+        var corpus = NntpLoopbackCorpus.Create(
+            scenario.ArticleCount,
+            scenario.DecodedArticleBytes,
+            CorpusSeed);
+        var countersPath = Path.Combine(Path.GetTempPath(), $"nntp-loopback-{Guid.NewGuid():N}.json");
+        await using var server = await LoopbackServerProcess.StartAsync(scenario, countersPath).ConfigureAwait(false);
+        var callbackCounts = new CallbackCounts();
+        var budget = new InFlightArticleBudget(corpus.ExpectedBytes + scenario.DecodedArticleBytes);
+        var oldBudget = InFlightArticleBudget.Current;
+        InFlightArticleBudget.Current = budget;
+        try
+        {
+            var process = Process.GetCurrentProcess();
+            process.Refresh();
+            var cpuBefore = process.TotalProcessorTime;
+            var allocatedBefore = GC.GetTotalAllocatedBytes(precise: false);
+            var collectionCounts = new[] { GC.CollectionCount(0), GC.CollectionCount(1), GC.CollectionCount(2) };
+            var started = Stopwatch.StartNew();
+            var bytes = scenario.Layer switch
+            {
+                NntpWholePathLayer.Transport => await ReadTransportAsync(
+                    scenario, server.Port, corpus, callbackCounts, verifyHash).ConfigureAwait(false),
+                NntpWholePathLayer.Provider => await ReadProviderAsync(
+                    scenario, server.Port, corpus, callbackCounts, verifyHash).ConfigureAwait(false),
+                NntpWholePathLayer.BufferedStream or NntpWholePathLayer.HttpLike =>
+                    await ReadBufferedStreamAsync(
+                        scenario, server.Port, corpus, callbackCounts, budget, verifyHash, httpLike)
+                    .ConfigureAwait(false),
+                _ => throw new ArgumentOutOfRangeException(nameof(scenario)),
+            };
+            started.Stop();
+            process.Refresh();
+
+            var serverSnapshot = await server.StopAndGetSnapshotAsync().ConfigureAwait(false);
+            var shaMatches = bytes.Sha256 is null || bytes.Sha256.Equals(corpus.ExpectedSha256, StringComparison.Ordinal);
+            if (verifyHash && (!shaMatches || bytes.Count != corpus.ExpectedBytes))
+                throw new InvalidOperationException(
+                    $"Whole-path output did not match corpus: {bytes.Count}/{corpus.ExpectedBytes}, hash={bytes.Sha256}.");
+            if (budget.LeasedBytes != 0)
+                throw new InvalidOperationException($"Article budget leaked {budget.LeasedBytes} bytes.");
+
+            var elapsed = Math.Max(started.Elapsed.TotalSeconds, double.Epsilon);
+            var clientCpu = (process.TotalProcessorTime - cpuBefore).TotalSeconds;
+            var serverCpu = server.ProcessCpuSeconds;
+            return new NntpWholePathResult(
+                scenario,
+                new NntpWholePathDeterministic(
+                    corpus.ExpectedBytes,
+                    bytes.Count,
+                    shaMatches ? 1 : 0,
+                    serverSnapshot.BodyCommands,
+                    serverSnapshot.Responses,
+                    callbackCounts.Retrieved,
+                    callbackCounts.Cancelled,
+                    callbackCounts.NotFound,
+                    callbackCounts.NotRetrieved,
+                    budget.LeasedBytes,
+                    0,
+                    0,
+                    serverSnapshot.PeakActiveConnections),
+                new NntpWholePathTiming(
+                    started.Elapsed.TotalSeconds,
+                    clientCpu,
+                    serverCpu,
+                    clientCpu / (bytes.Count / 1_000_000_000d),
+                    bytes.Count / elapsed / 1_000_000d,
+                    GC.GetTotalAllocatedBytes(precise: false) - allocatedBefore,
+                    GC.CollectionCount(0) - collectionCounts[0],
+                    GC.CollectionCount(1) - collectionCounts[1],
+                    GC.CollectionCount(2) - collectionCounts[2]));
+        }
+        finally
+        {
+            InFlightArticleBudget.Current = oldBudget;
+            File.Delete(countersPath);
+        }
+    }
+
+    private static async Task<ReadResult> ReadTransportAsync(
+        NntpWholePathScenario scenario,
+        int port,
+        NntpLoopbackCorpus corpus,
+        CallbackCounts counts,
+        bool verifyHash)
+    {
+        await using var client = new UsenetClient(CreateOptions(scenario));
+        await client.ConnectAsync("127.0.0.1", port, useSsl: false, CancellationToken.None).ConfigureAwait(false);
+        await client.AuthenticateAsync("benchmark", "benchmark", CancellationToken.None).ConfigureAwait(false);
+        return await ReadBatchesAsync(
+            corpus.Articles.Select(article => new SegmentId(article.SegmentId)).ToArray(),
+            scenario.BatchWidth,
+            (ids, callback) => client.DecodedBodiesAsync(ids, callback, CancellationToken.None),
+            counts,
+            verifyHash).ConfigureAwait(false);
+    }
+
+    private static async Task<ReadResult> ReadProviderAsync(
+        NntpWholePathScenario scenario,
+        int port,
+        NntpLoopbackCorpus corpus,
+        CallbackCounts counts,
+        bool verifyHash)
+    {
+        using var provider = CreateProvider(scenario, port);
+        return await ReadBatchesAsync(
+            corpus.Articles.Select(article => new SegmentId(article.SegmentId)).ToArray(),
+            scenario.BatchWidth,
+            (ids, callback) => provider.DecodedBodiesAsync(ids, callback, CancellationToken.None),
+            counts,
+            verifyHash).ConfigureAwait(false);
+    }
+
+    private static async Task<ReadResult> ReadBufferedStreamAsync(
+        NntpWholePathScenario scenario,
+        int port,
+        NntpLoopbackCorpus corpus,
+        CallbackCounts counts,
+        InFlightArticleBudget budget,
+        bool verifyHash,
+        bool httpLike)
+    {
+        using var provider = CreateProvider(scenario, port);
+        var ids = corpus.Articles.Select(article => article.SegmentId).ToArray();
+        var sizes = Enumerable.Repeat((long)scenario.DecodedArticleBytes, scenario.ArticleCount).ToArray();
+        await using var stream = MultiSegmentStream.Create(
+            ids.AsMemory(),
+            provider,
+            articleBufferSize: Math.Max(scenario.BatchWidth * 2, 4),
+            estimatedSegmentSize: scenario.DecodedArticleBytes,
+            failFastOnFirstSegment: true,
+            usePipelinedBodyRequests: true,
+            cancellationToken: CancellationToken.None,
+            fileName: "loopback.bin",
+            exactSegmentSizes: sizes,
+            inFlightArticleBudget: budget,
+            bodyPipelineBatchWidth: scenario.BatchWidth);
+
+        if (verifyHash)
+            return await CopyAndHashAsync(stream, CancellationToken.None).ConfigureAwait(false);
+        if (httpLike)
+        {
+            var sink = new HttpLikeCountingSink();
+            await sink.CopyFromAsync(stream, CancellationToken.None).ConfigureAwait(false);
+            return new ReadResult(sink.BytesWritten, null);
+        }
+
+        await stream.CopyToAsync(Stream.Null, CancellationToken.None).ConfigureAwait(false);
+        return new ReadResult(corpus.ExpectedBytes, null);
+    }
+
+#pragma warning disable CA2000 // MultiProviderNntpClient owns and disposes its MultiConnectionNntpClient and pool.
+    private static MultiProviderNntpClient CreateProvider(NntpWholePathScenario scenario, int port)
+    {
+        var pool = new ConnectionPool<INntpClient>(
+            scenario.ConnectionCount,
+            async cancellationToken =>
+            {
+                var client = new BaseNntpClient(new UsenetClient(CreateOptions(scenario)));
+                await client.ConnectAsync("127.0.0.1", port, useSsl: false, cancellationToken).ConfigureAwait(false);
+                await client.AuthenticateAsync("benchmark", "benchmark", cancellationToken).ConfigureAwait(false);
+                return client;
+            },
+            diagnosticName: "loopback");
+        var connection = new MultiConnectionNntpClient(
+            pool,
+            ProviderType.Pooled,
+            new ProviderCircuitBreaker("loopback"),
+            "loopback",
+            pipeliningDepth: scenario.BatchWidth,
+            maxTransferConnections: scenario.ConnectionCount);
+        return new MultiProviderNntpClient([connection]);
+    }
+#pragma warning restore CA2000
+
+    private static UsenetClientOptions CreateOptions(NntpWholePathScenario scenario) => new()
+    {
+        CrcValidation = scenario.CrcValidation,
+        ReadTimeout = TimeSpan.FromSeconds(30),
+        MaxPipelineDepth = Math.Max(scenario.BatchWidth, 8),
+    };
+
+    private static async Task<ReadResult> ReadBatchesAsync(
+        SegmentId[] ids,
+        int width,
+        Func<IReadOnlyList<SegmentId>, ArticleBodyCompletionHandler, Task<UsenetDecodedBodyBatch>> readBatch,
+        CallbackCounts counts,
+        bool verifyHash)
+    {
+        using var hash = verifyHash ? IncrementalHash.CreateHash(HashAlgorithmName.SHA256) : null;
+        long total = 0;
+        for (var start = 0; start < ids.Length; start += width)
+        {
+            var batchIds = ids.Skip(start).Take(Math.Min(width, ids.Length - start)).ToArray();
+            var batch = await readBatch(batchIds, counts.Record).ConfigureAwait(false);
+            foreach (var responseTask in batch.Responses)
+            {
+                var response = await responseTask.ConfigureAwait(false);
+                if (!response.Success || response.Stream is null)
+                    throw new InvalidOperationException($"Loopback BODY failed with {response.ResponseCode}.");
+                await using var stream = response.Stream;
+                total += await DrainAsync(stream, hash, CancellationToken.None).ConfigureAwait(false);
+            }
+            await batch.Completion.ConfigureAwait(false);
+        }
+        return new ReadResult(total, hash is null ? null : Convert.ToHexString(hash.GetHashAndReset()).ToLowerInvariant());
+    }
+
+    private static async Task<ReadResult> CopyAndHashAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        var buffer = new byte[64 * 1024];
+        long total = 0;
+        while (true)
+        {
+            var read = await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+                break;
+            hash.AppendData(buffer, 0, read);
+            total += read;
+        }
+        return new ReadResult(total, Convert.ToHexString(hash.GetHashAndReset()).ToLowerInvariant());
+    }
+
+    private static async Task<int> DrainAsync(Stream stream, IncrementalHash? hash, CancellationToken cancellationToken)
+    {
+        var buffer = new byte[64 * 1024];
+        var total = 0;
+        while (true)
+        {
+            var read = await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+                return total;
+            hash?.AppendData(buffer, 0, read);
+            total += read;
+        }
+    }
+
+    private static NntpWholePathTiming Add(NntpWholePathTiming left, NntpWholePathTiming right) => new(
+        left.WallSeconds + right.WallSeconds,
+        left.ClientCpuSeconds + right.ClientCpuSeconds,
+        left.ServerCpuSeconds + right.ServerCpuSeconds,
+        left.ClientCpuSecondsPerGb + right.ClientCpuSecondsPerGb,
+        left.ThroughputMbps + right.ThroughputMbps,
+        left.ClientAllocatedBytes + right.ClientAllocatedBytes,
+        left.Gen0Collections + right.Gen0Collections,
+        left.Gen1Collections + right.Gen1Collections,
+        left.Gen2Collections + right.Gen2Collections);
+
+    private static NntpWholePathTiming Divide(NntpWholePathTiming value, int divisor) => new(
+        value.WallSeconds / divisor,
+        value.ClientCpuSeconds / divisor,
+        value.ServerCpuSeconds / divisor,
+        value.ClientCpuSecondsPerGb / divisor,
+        value.ThroughputMbps / divisor,
+        value.ClientAllocatedBytes / divisor,
+        value.Gen0Collections / divisor,
+        value.Gen1Collections / divisor,
+        value.Gen2Collections / divisor);
+
+    private readonly record struct ReadResult(long Count, string? Sha256);
+
+    private sealed class CallbackCounts
+    {
+        private long _retrieved;
+        private long _cancelled;
+        private long _notFound;
+        private long _notRetrieved;
+
+        public long Retrieved => Interlocked.Read(ref _retrieved);
+        public long Cancelled => Interlocked.Read(ref _cancelled);
+        public long NotFound => Interlocked.Read(ref _notFound);
+        public long NotRetrieved => Interlocked.Read(ref _notRetrieved);
+
+        public void Record(ArticleBodyResult result, string? failureReason)
+        {
+            _ = failureReason;
+            switch (result)
+            {
+                case ArticleBodyResult.Retrieved:
+                    Interlocked.Increment(ref _retrieved);
+                    break;
+                case ArticleBodyResult.Cancelled:
+                    Interlocked.Increment(ref _cancelled);
+                    break;
+                case ArticleBodyResult.NotFound:
+                    Interlocked.Increment(ref _notFound);
+                    break;
+                case ArticleBodyResult.NotRetrieved:
+                    Interlocked.Increment(ref _notRetrieved);
+                    break;
+            }
+        }
+    }
+}
+
+internal sealed record LoopbackServerArguments(
+    int ArticleCount,
+    int DecodedArticleBytes,
+    int Seed,
+    int RoundTripDelayMs,
+    long? BandwidthBytesPerSecond,
+    string CountersPath,
+    IReadOnlyList<string> MissingIds);
+
+internal sealed class LoopbackServerProcess : IAsyncDisposable
+{
+    private readonly Process _process;
+    private readonly string _countersPath;
+    private readonly TimeSpan _cpuBefore;
+
+    private LoopbackServerProcess(Process process, string countersPath)
+    {
+        _process = process;
+        _countersPath = countersPath;
+        _cpuBefore = process.TotalProcessorTime;
+    }
+
+    public int Port { get; private init; }
+    public double ProcessCpuSeconds { get; private set; }
+
+    public static async Task<LoopbackServerProcess> StartAsync(
+        NntpWholePathScenario scenario,
+        string countersPath)
+    {
+        var processPath = Environment.ProcessPath ?? "dotnet";
+        var startInfo = new ProcessStartInfo(processPath)
+        {
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        if (Path.GetFileNameWithoutExtension(processPath).Equals("dotnet", StringComparison.OrdinalIgnoreCase))
+            startInfo.ArgumentList.Add(typeof(NntpWholePathReport).Assembly.Location);
+        startInfo.ArgumentList.Add("--nntp-loopback-server");
+        startInfo.ArgumentList.Add("--articles");
+        startInfo.ArgumentList.Add(scenario.ArticleCount.ToString());
+        startInfo.ArgumentList.Add("--article-bytes");
+        startInfo.ArgumentList.Add(scenario.DecodedArticleBytes.ToString());
+        startInfo.ArgumentList.Add("--seed");
+        startInfo.ArgumentList.Add("1025");
+        startInfo.ArgumentList.Add("--rtt-ms");
+        startInfo.ArgumentList.Add(scenario.RoundTripDelayMs.ToString());
+        if (scenario.BandwidthBytesPerSecond is { } bandwidth)
+        {
+            startInfo.ArgumentList.Add("--bandwidth-bps");
+            startInfo.ArgumentList.Add(bandwidth.ToString());
+        }
+        startInfo.ArgumentList.Add("--counters-out");
+        startInfo.ArgumentList.Add(countersPath);
+
+        var process = Process.Start(startInfo) ??
+                      throw new InvalidOperationException("Could not start loopback NNTP server process.");
+        var line = await process.StandardOutput.ReadLineAsync().WaitAsync(TimeSpan.FromSeconds(15)).ConfigureAwait(false);
+        if (line is null || !line.StartsWith("READY ", StringComparison.Ordinal) ||
+            !int.TryParse(line[6..], out var port))
+        {
+            var error = await process.StandardError.ReadToEndAsync().ConfigureAwait(false);
+            process.Kill(entireProcessTree: true);
+            throw new InvalidOperationException($"Loopback NNTP server did not become ready: {error}");
+        }
+        return new LoopbackServerProcess(process, countersPath) { Port = port };
+    }
+
+    public async Task<NntpLoopbackServerSnapshot> StopAndGetSnapshotAsync()
+    {
+        var cpuAfter = _cpuBefore;
+        if (!_process.HasExited)
+        {
+            _process.Refresh();
+            cpuAfter = _process.TotalProcessorTime;
+        }
+        if (!_process.HasExited)
+        {
+            await _process.StandardInput.WriteLineAsync("STOP").ConfigureAwait(false);
+            await _process.StandardInput.FlushAsync().ConfigureAwait(false);
+            await _process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(15)).ConfigureAwait(false);
+        }
+        ProcessCpuSeconds = Math.Max(0, (cpuAfter - _cpuBefore).TotalSeconds);
+        if (_process.ExitCode != 0)
+        {
+            var error = await _process.StandardError.ReadToEndAsync().ConfigureAwait(false);
+            throw new InvalidOperationException($"Loopback NNTP server exited with {_process.ExitCode}: {error}");
+        }
+        var json = await File.ReadAllTextAsync(_countersPath).ConfigureAwait(false);
+        return JsonSerializer.Deserialize<NntpLoopbackServerSnapshot>(json) ??
+               throw new InvalidDataException("Loopback server did not write counters.");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (!_process.HasExited)
+        {
+            _process.Kill(entireProcessTree: true);
+            await _process.WaitForExitAsync().ConfigureAwait(false);
+        }
+        _process.Dispose();
+    }
+}

--- a/backend.Benchmarks/NntpWholePathResult.cs
+++ b/backend.Benchmarks/NntpWholePathResult.cs
@@ -16,8 +16,6 @@ internal sealed record NntpWholePathDeterministic(
     long NotFoundCallbacks,
     long NotRetrievedCallbacks,
     long FinalArticleBudgetBytes,
-    long FinalPipeBufferedBytes,
-    long OutstandingPermits,
     long PeakActiveConnections);
 
 internal sealed record NntpWholePathTiming(

--- a/backend.Benchmarks/NntpWholePathResult.cs
+++ b/backend.Benchmarks/NntpWholePathResult.cs
@@ -1,0 +1,32 @@
+namespace NzbWebDAV.Benchmarks;
+
+internal sealed record NntpWholePathResult(
+    NntpWholePathScenario Scenario,
+    NntpWholePathDeterministic Deterministic,
+    NntpWholePathTiming Timing);
+
+internal sealed record NntpWholePathDeterministic(
+    long ExpectedBytes,
+    long ActualBytes,
+    long Sha256Match,
+    long BodyCommands,
+    long Responses,
+    long RetrievedCallbacks,
+    long CancelledCallbacks,
+    long NotFoundCallbacks,
+    long NotRetrievedCallbacks,
+    long FinalArticleBudgetBytes,
+    long FinalPipeBufferedBytes,
+    long OutstandingPermits,
+    long PeakActiveConnections);
+
+internal sealed record NntpWholePathTiming(
+    double WallSeconds,
+    double ClientCpuSeconds,
+    double ServerCpuSeconds,
+    double ClientCpuSecondsPerGb,
+    double ThroughputMbps,
+    long ClientAllocatedBytes,
+    int Gen0Collections,
+    int Gen1Collections,
+    int Gen2Collections);

--- a/backend.Benchmarks/NntpWholePathScenario.cs
+++ b/backend.Benchmarks/NntpWholePathScenario.cs
@@ -1,0 +1,48 @@
+using UsenetSharp.Clients;
+
+namespace NzbWebDAV.Benchmarks;
+
+internal enum NntpWholePathLayer
+{
+    Transport,
+    Provider,
+    BufferedStream,
+    HttpLike,
+}
+
+internal sealed record NntpWholePathScenario(
+    string Name,
+    NntpWholePathLayer Layer,
+    bool UseTls,
+    int ArticleCount,
+    int DecodedArticleBytes,
+    int ConnectionCount,
+    int BatchWidth,
+    int RoundTripDelayMs,
+    long? BandwidthBytesPerSecond,
+    YencCrcValidationMode CrcValidation)
+{
+    public static IReadOnlyList<NntpWholePathScenario> Quick =>
+    [
+        new("plain-transport-w4", NntpWholePathLayer.Transport, false, 8, 256 * 1024, 1, 4, 0, null, YencCrcValidationMode.Require),
+        new("plain-provider-w4", NntpWholePathLayer.Provider, false, 8, 256 * 1024, 4, 4, 0, null, YencCrcValidationMode.Require),
+        new("plain-buffered-w1", NntpWholePathLayer.BufferedStream, false, 8, 256 * 1024, 4, 1, 0, null, YencCrcValidationMode.Require),
+        new("plain-buffered-w4", NntpWholePathLayer.BufferedStream, false, 8, 256 * 1024, 4, 4, 0, null, YencCrcValidationMode.Require),
+        new("plain-http-like-w4", NntpWholePathLayer.HttpLike, false, 8, 256 * 1024, 4, 4, 0, null, YencCrcValidationMode.Require),
+    ];
+
+    public static IReadOnlyList<NntpWholePathScenario> Sustained =>
+    [
+        new("plain-buffered-w1", NntpWholePathLayer.BufferedStream, false, 256, 4 * 1024 * 1024, 20, 1, 0, null, YencCrcValidationMode.Require),
+        new("plain-buffered-w2", NntpWholePathLayer.BufferedStream, false, 256, 4 * 1024 * 1024, 20, 2, 0, null, YencCrcValidationMode.Require),
+        new("plain-buffered-w4", NntpWholePathLayer.BufferedStream, false, 256, 4 * 1024 * 1024, 20, 4, 0, null, YencCrcValidationMode.Require),
+        new("plain-buffered-w8", NntpWholePathLayer.BufferedStream, false, 256, 4 * 1024 * 1024, 20, 8, 0, null, YencCrcValidationMode.Require),
+    ];
+
+    public static IReadOnlyList<NntpWholePathScenario> ForSet(string set) =>
+        set.Equals("quick", StringComparison.OrdinalIgnoreCase)
+            ? Quick
+            : set.Equals("sustained", StringComparison.OrdinalIgnoreCase)
+                ? Sustained
+                : throw new ArgumentException("--set must be either 'quick' or 'sustained'.", nameof(set));
+}

--- a/backend.Benchmarks/PerformanceReportCli.cs
+++ b/backend.Benchmarks/PerformanceReportCli.cs
@@ -64,7 +64,7 @@ internal static class PerformanceReportCli
                 continue;
             }
 
-            if (report is not null || jsonPath is not null)
+            if (report is not null || jsonPath is not null || scenarioName is not null || scenarioSet != "quick")
                 throw new ArgumentException($"Unexpected argument '{arg}'.");
             return false;
         }
@@ -78,7 +78,8 @@ internal static class PerformanceReportCli
         if (report is null)
         {
             if (jsonPath is not null)
-                throw new ArgumentException("--json requires --streaming-report or --sab-api-report.");
+                throw new ArgumentException(
+                    "--json requires --streaming-report, --sab-api-report, or --nntp-whole-path-report.");
             if (scenarioName is not null || scenarioSet != "quick")
                 throw new ArgumentException("--set and --scenario require --nntp-whole-path-report.");
             return false;
@@ -108,7 +109,7 @@ internal static class PerformanceReportCli
     {
         var articleCount = 0;
         var articleBytes = 0;
-        var seed = 1025;
+        var seed = NntpWholePathReport.CorpusSeed;
         var roundTripDelayMs = 0;
         long? bandwidthBytesPerSecond = null;
         string? countersPath = null;

--- a/backend.Benchmarks/PerformanceReportCli.cs
+++ b/backend.Benchmarks/PerformanceReportCli.cs
@@ -9,16 +9,32 @@ internal static class PerformanceReportCli
 
         string? report = null;
         string? jsonPath = null;
+        string scenarioSet = "quick";
+        string? scenarioName = null;
+        LoopbackServerArguments? serverArguments = null;
         for (var i = 0; i < args.Length;)
         {
             var arg = args[i];
-            if (arg is "--streaming-report" or "--sab-api-report")
+            if (arg is "--streaming-report" or "--sab-api-report" or "--nntp-whole-path-report")
             {
                 if (report is not null)
                     throw new ArgumentException("Multiple performance reports in one invocation.");
-                report = arg == "--streaming-report" ? "streaming" : "sab-api";
+                report = arg switch
+                {
+                    "--streaming-report" => "streaming",
+                    "--sab-api-report" => "sab-api",
+                    _ => "nntp-whole-path",
+                };
                 i++;
                 continue;
+            }
+
+            if (arg == "--nntp-loopback-server")
+            {
+                if (report is not null || serverArguments is not null)
+                    throw new ArgumentException("Multiple performance reports in one invocation.");
+                serverArguments = ParseLoopbackServerArguments(args[(i + 1)..]);
+                break;
             }
 
             if (arg == "--json")
@@ -30,15 +46,41 @@ internal static class PerformanceReportCli
                 continue;
             }
 
+            if (arg == "--set")
+            {
+                if (i + 1 >= args.Length)
+                    throw new ArgumentException("--set requires 'quick' or 'sustained'.");
+                scenarioSet = args[i + 1];
+                i += 2;
+                continue;
+            }
+
+            if (arg == "--scenario")
+            {
+                if (i + 1 >= args.Length)
+                    throw new ArgumentException("--scenario requires a scenario name.");
+                scenarioName = args[i + 1];
+                i += 2;
+                continue;
+            }
+
             if (report is not null || jsonPath is not null)
                 throw new ArgumentException($"Unexpected argument '{arg}'.");
             return false;
+        }
+
+        if (serverArguments is not null)
+        {
+            await NntpWholePathReport.RunChildServerAsync(serverArguments).ConfigureAwait(false);
+            return true;
         }
 
         if (report is null)
         {
             if (jsonPath is not null)
                 throw new ArgumentException("--json requires --streaming-report or --sab-api-report.");
+            if (scenarioName is not null || scenarioSet != "quick")
+                throw new ArgumentException("--set and --scenario require --nntp-whole-path-report.");
             return false;
         }
 
@@ -48,9 +90,99 @@ internal static class PerformanceReportCli
             return true;
         }
 
+        if (report == "nntp-whole-path")
+        {
+            await NntpWholePathReport.RunAsync(jsonPath, scenarioSet, scenarioName).ConfigureAwait(false);
+            return true;
+        }
+
+        if (scenarioName is not null || scenarioSet != "quick")
+            throw new ArgumentException("--set and --scenario require --nntp-whole-path-report.");
         if (jsonPath is null)
             throw new ArgumentException("--sab-api-report requires --json <path>.");
         await SabApiReport.RunAsync(jsonPath).ConfigureAwait(false);
         return true;
     }
+
+    private static LoopbackServerArguments ParseLoopbackServerArguments(string[] args)
+    {
+        var articleCount = 0;
+        var articleBytes = 0;
+        var seed = 1025;
+        var roundTripDelayMs = 0;
+        long? bandwidthBytesPerSecond = null;
+        string? countersPath = null;
+        var missingIds = new List<string>();
+
+        for (var i = 0; i < args.Length; i += 2)
+        {
+            if (i + 1 >= args.Length)
+                throw new ArgumentException($"{args[i]} requires a value.");
+            var value = args[i + 1];
+            switch (args[i])
+            {
+                case "--articles":
+                    articleCount = ParsePositiveInt(args[i], value);
+                    break;
+                case "--article-bytes":
+                    articleBytes = ParsePositiveInt(args[i], value);
+                    break;
+                case "--seed":
+                    seed = ParseInt(args[i], value);
+                    break;
+                case "--rtt-ms":
+                    roundTripDelayMs = ParseNonNegativeInt(args[i], value);
+                    break;
+                case "--bandwidth-bps":
+                    bandwidthBytesPerSecond = ParsePositiveLong(args[i], value);
+                    break;
+                case "--counters-out":
+                    countersPath = value;
+                    break;
+                case "--miss":
+                    missingIds.AddRange(value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+                    break;
+                default:
+                    throw new ArgumentException($"Unexpected loopback-server argument '{args[i]}'.");
+            }
+        }
+
+        if (articleCount == 0 || articleBytes == 0 || string.IsNullOrWhiteSpace(countersPath))
+            throw new ArgumentException(
+                "--nntp-loopback-server requires --articles, --article-bytes, and --counters-out.");
+        return new LoopbackServerArguments(
+            articleCount,
+            articleBytes,
+            seed,
+            roundTripDelayMs,
+            bandwidthBytesPerSecond,
+            countersPath,
+            missingIds);
+    }
+
+    private static int ParsePositiveInt(string name, string value)
+    {
+        var parsed = ParseInt(name, value);
+        if (parsed <= 0)
+            throw new ArgumentException($"{name} must be greater than zero.");
+        return parsed;
+    }
+
+    private static int ParseNonNegativeInt(string name, string value)
+    {
+        var parsed = ParseInt(name, value);
+        if (parsed < 0)
+            throw new ArgumentException($"{name} cannot be negative.");
+        return parsed;
+    }
+
+    private static int ParseInt(string name, string value) =>
+        int.TryParse(value, out var parsed)
+            ? parsed
+            : throw new ArgumentException($"{name} requires an integer.");
+
+    private static long ParsePositiveLong(string name, string value) =>
+        long.TryParse(value, out var parsed) && parsed > 0
+            ? parsed
+            : throw new ArgumentException($"{name} requires a positive integer.");
 }

--- a/backend.Benchmarks/PerformanceReportJson.cs
+++ b/backend.Benchmarks/PerformanceReportJson.cs
@@ -64,6 +64,25 @@ internal static class PerformanceReportJson
             ["cpuSeconds"] = Round(cpuSeconds),
         };
 
+    public static Dictionary<string, double> WholePathTiming(
+        double wallSeconds,
+        double clientCpuSeconds,
+        double serverCpuSeconds,
+        double clientCpuSecondsPerGb,
+        double throughputMbps,
+        long clientAllocatedBytes,
+        int gen0Collections,
+        int gen1Collections,
+        int gen2Collections) =>
+        new(StringComparer.Ordinal)
+        {
+            ["wallSeconds"] = Round(wallSeconds),
+            ["clientCpuSeconds"] = Round(clientCpuSeconds),
+            ["serverCpuSeconds"] = Round(serverCpuSeconds),
+            ["clientCpuSecondsPerGb"] = Round(clientCpuSecondsPerGb),
+            ["throughputMbps"] = Round(throughputMbps),
+        };
+
     public static double Round(double value) =>
         Math.Round(value, 3, MidpointRounding.AwayFromZero);
 

--- a/backend.Benchmarks/PerformanceReportJson.cs
+++ b/backend.Benchmarks/PerformanceReportJson.cs
@@ -81,6 +81,10 @@ internal static class PerformanceReportJson
             ["serverCpuSeconds"] = Round(serverCpuSeconds),
             ["clientCpuSecondsPerGb"] = Round(clientCpuSecondsPerGb),
             ["throughputMbps"] = Round(throughputMbps),
+            ["clientAllocatedBytes"] = Round(clientAllocatedBytes),
+            ["gen0Collections"] = Round(gen0Collections),
+            ["gen1Collections"] = Round(gen1Collections),
+            ["gen2Collections"] = Round(gen2Collections),
         };
 
     public static double Round(double value) =>

--- a/backend.Benchmarks/Properties/AssemblyInfo.cs
+++ b/backend.Benchmarks/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("NzbWebDAV.Tests")]

--- a/backend.Benchmarks/README.md
+++ b/backend.Benchmarks/README.md
@@ -39,6 +39,47 @@ machine and runtime. Timing stays manual and is not a PR gate.
 On macOS, set `RAPIDYENC_LIBRARY_PATH` to the host `librapidyenc.dylib` (see
 `scripts/run-backend.sh`).
 
+## Whole-path loopback NNTP report
+
+```bash
+dotnet run --project backend.Benchmarks -c Release -- \
+  --nntp-whole-path-report --set quick --json /tmp/nntp-whole-path.json
+```
+
+This report fills the gap between the decoded-BODY microbenchmark and a
+provider-backed run. It starts a separate loopback NNTP server process whose
+precomputed yEnc corpus has realistic line wrapping, escaping, dot stuffing,
+multipart headers, CRC trailers, and NNTP terminators. Server CPU is recorded
+separately; client CPU covers socket framing, UsenetSharp decode/CRC and pipe
+handling, the connection/provider wrappers, `MultiSegmentStream`, pooled
+article buffers, and optionally an HTTP-like 64 KiB response copy.
+
+`--set quick` is the small deterministic PR gate. `--set sustained` uses
+256 × 4 MiB articles, 20 connections, and widths 1/2/4/8; it runs only in the
+scheduled/manual performance workflow. Use `--scenario <name>` to investigate
+one named scenario. Timing and allocation observations are diagnostic, while
+bytes, hashes, BODY counts, callbacks, budget cleanup, and connection cleanup
+are deterministic gates.
+
+The committed sustained baseline begins with conservative bootstrap timing
+envelopes because its 20 GiB local run is intentionally deferred to the
+dedicated benchmark phase. Before treating its timing envelope as a regression
+signal, dispatch **Performance** with `rebaseline: true` on the intended
+runner; that action replaces only the observed timing envelopes while retaining
+the deterministic contract.
+
+The initial loopback scenarios are plaintext. Validated-TLS loopback is
+deliberately deferred: UsenetSharp accepts only platform-default trust or a
+skip-all switch, and the benchmark must not add a permissive certificate
+callback. Its test coverage therefore includes only the negative untrusted TLS
+path until an explicit test-CA trust mechanism is designed.
+
+For Linux provider-backed CPU investigation, use
+`scripts/run-nntp-cpu-profile.sh`. It writes `0700`/`0600` restricted artifacts,
+requires credentials via a private `CURL_CONFIG`, and separates
+uninstrumented results from EventPipe and `perf` diagnostics. Profiles and
+response bodies can contain sensitive information; do not upload raw artifacts.
+
 ## Tool decision
 
 Issue [#854](https://github.com/infinidysk/infinidysk/issues/854) asked to
@@ -80,7 +121,7 @@ database (same setup as the SAB limit-zero tests) with a fixed 50-queue /
 
 ## Regression layers
 
-1. **PR-blocking (no clocks):** xUnit exact-count coverage plus both reports
+1. **PR-blocking (no clocks):** xUnit exact-count coverage plus every report
    compared with `scripts/check-performance-baseline.py --deterministic-only`
    against `backend.Benchmarks/Baselines/*.json`. An intentional
    transport-contract or query-shape change must update the baseline JSON in

--- a/scripts/build-rapidyenc.sh
+++ b/scripts/build-rapidyenc.sh
@@ -7,6 +7,11 @@
 #   scripts/build-rapidyenc.sh              # host RID (linux-x64, osx-arm64, …)
 #   scripts/build-rapidyenc.sh linux-x64
 #   TARGET_RIDS="linux-x64 osx-arm64" scripts/build-rapidyenc.sh
+#   scripts/build-rapidyenc.sh --symbols linux-x64
+#
+# --symbols is a Linux diagnostic mode. It keeps Release optimization, adds GNU
+# debug information/build IDs, and writes split symbols plus a build manifest to
+# libs/RapidYencSharp/symbols/<rid>. Ordinary runtime output is unchanged.
 
 set -euo pipefail
 
@@ -15,6 +20,8 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 RAPIDYENC_DIR="$ROOT_DIR/libs/rapidyenc"
 BUILD_ROOT="$ROOT_DIR/libs/rapidyenc/build"
 OUTPUT_DIR="$ROOT_DIR/libs/RapidYencSharp/runtimes"
+SYMBOLS_DIR="$ROOT_DIR/libs/RapidYencSharp/symbols"
+BUILD_SYMBOLS="${RAPIDYENC_SYMBOLS:-0}"
 
 detect_host_rid() {
   local os arch
@@ -38,8 +45,17 @@ detect_host_rid() {
   echo "${os}-${arch}"
 }
 
-if [[ $# -gt 0 ]]; then
-  TARGET_RIDS=("$@")
+TARGET_ARGS=()
+for arg in "$@"; do
+  if [[ "$arg" == "--symbols" ]]; then
+    BUILD_SYMBOLS=1
+  else
+    TARGET_ARGS+=("$arg")
+  fi
+done
+
+if [[ ${#TARGET_ARGS[@]} -gt 0 ]]; then
+  TARGET_RIDS=("${TARGET_ARGS[@]}")
 elif [[ -n "${TARGET_RIDS:-}" ]]; then
   # shellcheck disable=SC2206
   TARGET_RIDS=($TARGET_RIDS)
@@ -120,6 +136,27 @@ build_target() {
       ;;
   esac
 
+  if [[ "$BUILD_SYMBOLS" == "1" ]]; then
+    case "$rid" in
+      linux-x64|linux-arm64|linux-musl-x64|linux-musl-arm64)
+        for tool in objcopy readelf nm sha256sum; do
+          if ! command -v "$tool" >/dev/null 2>&1; then
+            echo "Error: $tool is required for --symbols." >&2
+            return 1
+          fi
+        done
+        cmake_args+=(
+          "-DCMAKE_CXX_FLAGS_RELEASE=-O3 -DNDEBUG -g"
+          "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--build-id=sha1"
+        )
+        ;;
+      *)
+        echo "Error: --symbols currently supports Linux runtime identifiers only." >&2
+        return 1
+        ;;
+    esac
+  fi
+
   local build_dir="$BUILD_ROOT/$rid"
   rm -rf "$build_dir"
   mkdir -p "$build_dir"
@@ -153,6 +190,31 @@ build_target() {
   fi
   cp "$lib_path" "$output_path/$dest_name"
   echo "Copied $dest_name to $output_path"
+
+  if [[ "$BUILD_SYMBOLS" == "1" ]]; then
+    local symbol_output="$SYMBOLS_DIR/$rid"
+    local debug_path="$symbol_output/$dest_name.debug"
+    local exports
+    mkdir -p "$symbol_output"
+    objcopy --only-keep-debug "$lib_path" "$debug_path"
+    objcopy --add-gnu-debuglink="$(basename "$debug_path")" "$output_path/$dest_name"
+    exports="$(nm -D --defined-only "$output_path/$dest_name")"
+    [[ "$exports" == *rapidyenc_decode_ex* && "$exports" == *rapidyenc_crc* ]] || {
+        echo "Error: expected rapidyenc decoder/CRC exports were not found." >&2
+        return 1
+      }
+    {
+      printf '{\n'
+      printf '  "rid": "%s",\n' "$rid"
+      printf '  "runtimeLibrarySha256": "%s",\n' "$(sha256sum "$output_path/$dest_name" | awk '{print $1}')"
+      printf '  "debugLibrarySha256": "%s",\n' "$(sha256sum "$debug_path" | awk '{print $1}')"
+      printf '  "compiler": "%s",\n' "$(c++ --version | awk 'NR==1 {print}' | sed 's/"/\\"/g')"
+      printf '  "cmakeCacheSha256": "%s",\n' "$(sha256sum "$build_dir/CMakeCache.txt" | awk '{print $1}')"
+      printf '  "buildId": "%s"\n' "$(readelf -n "$output_path/$dest_name" | awk '/Build ID:/ {print $3; exit}')"
+      printf '}\n'
+    } > "$symbol_output/manifest.json"
+    echo "Wrote split symbols and manifest to $symbol_output"
+  fi
 }
 
 for rid in "${TARGET_RIDS[@]}"; do

--- a/scripts/build-rapidyenc.sh
+++ b/scripts/build-rapidyenc.sh
@@ -197,7 +197,7 @@ build_target() {
     local exports
     mkdir -p "$symbol_output"
     objcopy --only-keep-debug "$lib_path" "$debug_path"
-    objcopy --add-gnu-debuglink="$(basename "$debug_path")" "$output_path/$dest_name"
+    objcopy --add-gnu-debuglink="$debug_path" "$output_path/$dest_name"
     exports="$(nm -D --defined-only "$output_path/$dest_name")"
     [[ "$exports" == *rapidyenc_decode_ex* && "$exports" == *rapidyenc_crc* ]] || {
         echo "Error: expected rapidyenc decoder/CRC exports were not found." >&2

--- a/scripts/build-rapidyenc.sh
+++ b/scripts/build-rapidyenc.sh
@@ -197,6 +197,7 @@ build_target() {
     local exports
     mkdir -p "$symbol_output"
     objcopy --only-keep-debug "$lib_path" "$debug_path"
+    objcopy --strip-debug "$output_path/$dest_name"
     objcopy --add-gnu-debuglink="$debug_path" "$output_path/$dest_name"
     exports="$(nm -D --defined-only "$output_path/$dest_name")"
     [[ "$exports" == *rapidyenc_decode_ex* && "$exports" == *rapidyenc_crc* ]] || {

--- a/scripts/check-performance-baseline.py
+++ b/scripts/check-performance-baseline.py
@@ -67,7 +67,7 @@ def classify_timing_field(name: str) -> str:
     lowered = name.lower()
     if "throughput" in lowered:
         return "throughput"
-    if lowered == "cpuseconds":
+    if "cpu" in lowered:
         return "cpu"
     return "latency"
 

--- a/scripts/check-performance-baseline.py
+++ b/scripts/check-performance-baseline.py
@@ -21,6 +21,7 @@ from typing import Any
 
 SCHEMA_VERSION = 1
 LATENCY_FLOOR_MS = 15.0
+SECONDS_FLOOR_S = 0.015
 CPU_FLOOR_S = 0.25
 ENVELOPE_MULTIPLIER = 3.0
 REBASELINE_HINT = (
@@ -69,6 +70,10 @@ def classify_timing_field(name: str) -> str:
         return "throughput"
     if "cpu" in lowered:
         return "cpu"
+    if lowered.endswith("seconds") or lowered.endswith("secondspergb"):
+        return "duration"
+    if "allocated" in lowered or "collection" in lowered:
+        return "cpu"
     return "latency"
 
 
@@ -79,7 +84,13 @@ def timing_envelope(median: float, kind: str) -> dict[str, Any]:
             "floor": round3(median / ENVELOPE_MULTIPLIER),
             "policy": "fail",
         }
-    floor = CPU_FLOOR_S if kind == "cpu" else LATENCY_FLOOR_MS
+    floor = (
+        CPU_FLOOR_S
+        if kind == "cpu"
+        else SECONDS_FLOOR_S
+        if kind == "duration"
+        else LATENCY_FLOOR_MS
+    )
     return {
         "baseline": round3(median),
         "envelope": round3(max(ENVELOPE_MULTIPLIER * median, median + floor)),

--- a/scripts/run-nntp-cpu-profile.sh
+++ b/scripts/run-nntp-cpu-profile.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Collect restricted, reproducible CPU evidence for a provider-backed NNTP range.
+# This script never uploads artifacts. Credentials must be held in CURL_CONFIG.
+set -euo pipefail
+
+usage() {
+  echo "Usage: RANGE_URL=... RANGE_START=... RANGE_END=... CURL_CONFIG=/private/curl.conf $0 {result|trace|counters|perf} [run-id]" >&2
+  exit 64
+}
+
+[[ $# -ge 1 && $# -le 2 ]] || usage
+MODE="$1"
+RUN_ID="${2:-$(date -u +%Y%m%dT%H%M%SZ)-$(git rev-parse --short HEAD)}"
+: "${RANGE_URL:?Set RANGE_URL to the benchmark endpoint.}"
+: "${RANGE_START:?Set RANGE_START to the inclusive byte offset.}"
+: "${RANGE_END:?Set RANGE_END to the inclusive byte offset.}"
+: "${CURL_CONFIG:?Set CURL_CONFIG to a private curl configuration file.}"
+[[ -f "$CURL_CONFIG" ]] || { echo "CURL_CONFIG does not exist: $CURL_CONFIG" >&2; exit 64; }
+[[ "$(stat -c '%a' "$CURL_CONFIG" 2>/dev/null || stat -f '%Lp' "$CURL_CONFIG")" -le 600 ]] ||
+  { echo "CURL_CONFIG must not be group/world-readable." >&2; exit 64; }
+
+RUN_DIR="/var/tmp/infinidysk-cpu/$RUN_ID"
+install -d -m 0700 "$RUN_DIR"
+umask 077
+BACKEND_PID="${BACKEND_PID:-$(pgrep -xo NzbWebDAV || true)}"
+NODE_PID="${NODE_PID:-$(pgrep -xo node || true)}"
+[[ -n "$BACKEND_PID" ]] || { echo "Unable to find NzbWebDAV; set BACKEND_PID." >&2; exit 1; }
+[[ -d "/proc/$BACKEND_PID" ]] || { echo "BACKEND_PID is not visible in this PID namespace." >&2; exit 1; }
+
+cgroup_file() {
+  local name="$1"
+  if [[ -r "/sys/fs/cgroup/$name" ]]; then
+    printf '%s' "/sys/fs/cgroup/$name"
+  fi
+}
+
+copy_if_readable() {
+  local source="$1" destination="$2"
+  [[ -r "$source" ]] && cp "$source" "$destination" || true
+}
+
+snapshot_process() {
+  local label="$1" pid="$2"
+  [[ -n "$pid" && -r "/proc/$pid/stat" ]] || return 0
+  awk '{print $14, $15, $22, $24}' "/proc/$pid/stat" > "$RUN_DIR/${label}-process.txt"
+  copy_if_readable "/proc/$pid/status" "$RUN_DIR/${label}-status.txt"
+  copy_if_readable "/proc/$pid/smaps_rollup" "$RUN_DIR/${label}-smaps-rollup.txt"
+}
+
+snapshot_cgroup() {
+  local label="$1" source
+  for name in cpu.max cpu.stat memory.current memory.peak memory.events memory.pressure; do
+    source="$(cgroup_file "$name")"
+    [[ -n "$source" ]] && cp "$source" "$RUN_DIR/${label}-cgroup-${name//./-}.txt"
+  done
+}
+
+write_manifest() {
+  {
+    printf 'run_id=%s\n' "$RUN_ID"
+    printf 'git_sha=%s\n' "$(git rev-parse HEAD)"
+    printf 'utc=%s\n' "$(date -u +%FT%TZ)"
+    printf 'backend_pid=%s\n' "$BACKEND_PID"
+    printf 'node_pid=%s\n' "$NODE_PID"
+    printf 'kernel=%s\n' "$(uname -srvmo)"
+    printf 'cpu=%s\n' "$(uname -m)"
+    printf 'dotnet=%s\n' "$(dotnet --info | awk 'NR==1 {print}')"
+    printf 'mode=%s\n' "$MODE"
+  } > "$RUN_DIR/manifest.txt"
+}
+
+run_curl() {
+  local prefix="$1"
+  curl --config "$CURL_CONFIG" --fail --silent --show-error \
+    --header "Range: bytes=${RANGE_START}-${RANGE_END}" \
+    --output "$RUN_DIR/${prefix}-body.bin" \
+    --write-out '%{json}\n' "$RANGE_URL" > "$RUN_DIR/${prefix}-curl.json"
+  sha256sum "$RUN_DIR/${prefix}-body.bin" > "$RUN_DIR/${prefix}-body.sha256"
+  wc -c "$RUN_DIR/${prefix}-body.bin" > "$RUN_DIR/${prefix}-body.bytes"
+}
+
+write_manifest
+case "$MODE" in
+  result)
+    snapshot_process result-before "$BACKEND_PID"
+    snapshot_process result-before-node "$NODE_PID"
+    snapshot_cgroup result-before
+    run_curl result
+    snapshot_process result-after "$BACKEND_PID"
+    snapshot_process result-after-node "$NODE_PID"
+    snapshot_cgroup result-after
+    ;;
+  trace)
+    command -v dotnet-trace >/dev/null || { echo "dotnet-trace is required." >&2; exit 127; }
+    dotnet-trace collect --process-id "$BACKEND_PID" --profile cpu-sampling \
+      --duration 00:01:30 --output "$RUN_DIR/diagnostic-trace.nettrace" &
+    TRACE_PID=$!
+    sleep 2
+    run_curl diagnostic-trace
+    wait "$TRACE_PID"
+    ;;
+  counters)
+    command -v dotnet-counters >/dev/null || { echo "dotnet-counters is required." >&2; exit 127; }
+    dotnet-counters collect --process-id "$BACKEND_PID" --refresh-interval 1 \
+      --duration 00:01:30 --counters System.Runtime,Microsoft.AspNetCore.Hosting \
+      --format csv --output "$RUN_DIR/diagnostic-counters.csv" &
+    COUNTERS_PID=$!
+    sleep 2
+    run_curl diagnostic-counters
+    wait "$COUNTERS_PID"
+    ;;
+  perf)
+    command -v perf >/dev/null || { echo "perf is required." >&2; exit 127; }
+    perf stat --pid "$BACKEND_PID" --timeout 90000 \
+      --event task-clock,cycles,instructions,branches,branch-misses,cache-references,cache-misses,context-switches,cpu-migrations,page-faults \
+      --output "$RUN_DIR/diagnostic-perf-stat.txt" &
+    PERF_STAT_PID=$!
+    sleep 2
+    run_curl diagnostic-perf
+    wait "$PERF_STAT_PID"
+    perf record --pid "$BACKEND_PID" --frequency 199 --call-graph dwarf --timeout 90000 \
+      --output "$RUN_DIR/diagnostic-perf.data" &
+    PERF_RECORD_PID=$!
+    sleep 2
+    run_curl diagnostic-perf-record
+    wait "$PERF_RECORD_PID"
+    perf buildid-list --input "$RUN_DIR/diagnostic-perf.data" > "$RUN_DIR/diagnostic-perf-buildids.txt"
+    ;;
+  *) usage ;;
+esac
+
+chmod 0600 "$RUN_DIR"/*
+echo "Restricted profiling artifacts written to $RUN_DIR"

--- a/scripts/run-nntp-cpu-profile.sh
+++ b/scripts/run-nntp-cpu-profile.sh
@@ -16,7 +16,8 @@ RUN_ID="${2:-$(date -u +%Y%m%dT%H%M%SZ)-$(git rev-parse --short HEAD)}"
 : "${RANGE_END:?Set RANGE_END to the inclusive byte offset.}"
 : "${CURL_CONFIG:?Set CURL_CONFIG to a private curl configuration file.}"
 [[ -f "$CURL_CONFIG" ]] || { echo "CURL_CONFIG does not exist: $CURL_CONFIG" >&2; exit 64; }
-[[ "$(stat -c '%a' "$CURL_CONFIG" 2>/dev/null || stat -f '%Lp' "$CURL_CONFIG")" -le 600 ]] ||
+CONFIG_MODE="$(stat -c '%a' "$CURL_CONFIG" 2>/dev/null || stat -f '%Lp' "$CURL_CONFIG")"
+(( (8#$CONFIG_MODE & 077) == 0 )) ||
   { echo "CURL_CONFIG must not be group/world-readable." >&2; exit 64; }
 
 RUN_DIR="/var/tmp/infinidysk-cpu/$RUN_ID"
@@ -27,12 +28,12 @@ NODE_PID="${NODE_PID:-$(pgrep -xo node || true)}"
 [[ -n "$BACKEND_PID" ]] || { echo "Unable to find NzbWebDAV; set BACKEND_PID." >&2; exit 1; }
 [[ -d "/proc/$BACKEND_PID" ]] || { echo "BACKEND_PID is not visible in this PID namespace." >&2; exit 1; }
 
-cgroup_file() {
-  local name="$1"
-  if [[ -r "/sys/fs/cgroup/$name" ]]; then
-    printf '%s' "/sys/fs/cgroup/$name"
-  fi
-}
+BACKEND_CGROUP_PATH="$(awk -F: '$1 == "0" { print $3; exit }' "/proc/$BACKEND_PID/cgroup")"
+[[ -n "$BACKEND_CGROUP_PATH" && "$BACKEND_CGROUP_PATH" != *".."* ]] ||
+  { echo "Unable to resolve the backend cgroup v2 path." >&2; exit 1; }
+BACKEND_CGROUP_DIR="/sys/fs/cgroup${BACKEND_CGROUP_PATH}"
+[[ -d "$BACKEND_CGROUP_DIR" ]] ||
+  { echo "Backend cgroup directory is not mounted: $BACKEND_CGROUP_DIR" >&2; exit 1; }
 
 copy_if_readable() {
   local source="$1" destination="$2"
@@ -50,8 +51,8 @@ snapshot_process() {
 snapshot_cgroup() {
   local label="$1" source
   for name in cpu.max cpu.stat memory.current memory.peak memory.events memory.pressure; do
-    source="$(cgroup_file "$name")"
-    [[ -n "$source" ]] && cp "$source" "$RUN_DIR/${label}-cgroup-${name//./-}.txt"
+    source="$BACKEND_CGROUP_DIR/$name"
+    [[ -r "$source" ]] && cp "$source" "$RUN_DIR/${label}-cgroup-${name//./-}.txt"
   done
 }
 
@@ -61,6 +62,7 @@ write_manifest() {
     printf 'git_sha=%s\n' "$(git rev-parse HEAD)"
     printf 'utc=%s\n' "$(date -u +%FT%TZ)"
     printf 'backend_pid=%s\n' "$BACKEND_PID"
+    printf 'backend_cgroup=%s\n' "$BACKEND_CGROUP_PATH"
     printf 'node_pid=%s\n' "$NODE_PID"
     printf 'kernel=%s\n' "$(uname -srvmo)"
     printf 'cpu=%s\n' "$(uname -m)"

--- a/tests/NzbWebDAV.Tests/Benchmarks/NntpWholePathReportContractTests.cs
+++ b/tests/NzbWebDAV.Tests/Benchmarks/NntpWholePathReportContractTests.cs
@@ -29,7 +29,7 @@ public sealed class NntpWholePathReportContractTests
     public async Task Server_WritesGreetingAndSnapshotThenDisposesConnections()
     {
         var corpus = NntpLoopbackCorpus.Create(articleCount: 1, decodedArticleBytes: 1024, seed: 123);
-        var path = Path.Combine(Path.GetTempPath(), $"nntp-loopback-{Guid.NewGuid():N}.json");
+        var path = Path.Join(Path.GetTempPath(), $"nntp-loopback-{Guid.NewGuid():N}.json");
         try
         {
             await using var server = await NntpLoopbackServer.StartAsync(corpus);
@@ -52,7 +52,7 @@ public sealed class NntpWholePathReportContractTests
     [Fact]
     public void PerformanceReportJson_UsesStableWholePathFields()
     {
-        var path = Path.Combine(Path.GetTempPath(), $"nntp-whole-path-{Guid.NewGuid():N}.json");
+        var path = Path.Join(Path.GetTempPath(), $"nntp-whole-path-{Guid.NewGuid():N}.json");
         try
         {
             PerformanceReportJson.Write(
@@ -72,6 +72,8 @@ public sealed class NntpWholePathReportContractTests
             var scenario = root.GetProperty("scenarios").GetProperty("plain-buffered-w1");
             Assert.Equal(1, scenario.GetProperty("deterministic").GetProperty("sha256Match").GetInt64());
             Assert.True(scenario.GetProperty("timing").TryGetProperty("throughputMbps", out _));
+            Assert.Equal(6d, scenario.GetProperty("timing").GetProperty("clientAllocatedBytes").GetDouble());
+            Assert.Equal(7d, scenario.GetProperty("timing").GetProperty("gen0Collections").GetDouble());
         }
         finally
         {
@@ -100,5 +102,12 @@ public sealed class NntpWholePathReportContractTests
         await Assert.ThrowsAsync<ArgumentException>(() =>
             PerformanceReportCli.TryHandleAsync(
                 ["--nntp-loopback-server", "--articles", "1"]));
+    }
+
+    [Fact]
+    public async Task Cli_DoesNotIgnoreScenarioOptionsBeforeAnUnknownArgument()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            PerformanceReportCli.TryHandleAsync(["--set", "sustained", "--unexpected"]));
     }
 }

--- a/tests/NzbWebDAV.Tests/Benchmarks/NntpWholePathReportContractTests.cs
+++ b/tests/NzbWebDAV.Tests/Benchmarks/NntpWholePathReportContractTests.cs
@@ -1,0 +1,104 @@
+using System.Net.Sockets;
+using System.Text.Json;
+using NzbWebDAV.Benchmarks;
+using UsenetSharp.Clients;
+
+namespace NzbWebDAV.Tests.Benchmarks;
+
+public sealed class NntpWholePathReportContractTests
+{
+    [Fact]
+    public void Corpus_IsDeterministicAndHasExpectedFileHash()
+    {
+        var first = NntpLoopbackCorpus.Create(articleCount: 4, decodedArticleBytes: 4096, seed: 123);
+        var second = NntpLoopbackCorpus.Create(articleCount: 4, decodedArticleBytes: 4096, seed: 123);
+
+        Assert.Equal(first.ExpectedSha256, second.ExpectedSha256);
+        Assert.Equal(first.DecodedFile, second.DecodedFile);
+        Assert.Equal(first.Articles.Select(article => article.WireBody), second.Articles.Select(article => article.WireBody));
+        Assert.All(first.Articles, article =>
+        {
+            Assert.Contains("=ybegin", System.Text.Encoding.ASCII.GetString(article.WireBody));
+            Assert.Contains("=yend", System.Text.Encoding.ASCII.GetString(article.WireBody));
+            Assert.True(first.TryGetArticle($"<{article.SegmentId}>", out var found));
+            Assert.Equal(article, found);
+        });
+    }
+
+    [Fact]
+    public async Task Server_WritesGreetingAndSnapshotThenDisposesConnections()
+    {
+        var corpus = NntpLoopbackCorpus.Create(articleCount: 1, decodedArticleBytes: 1024, seed: 123);
+        var path = Path.Combine(Path.GetTempPath(), $"nntp-loopback-{Guid.NewGuid():N}.json");
+        try
+        {
+            await using var server = await NntpLoopbackServer.StartAsync(corpus);
+            using var client = new TcpClient();
+            await client.ConnectAsync("127.0.0.1", server.Port);
+            await using var stream = client.GetStream();
+            using var reader = new StreamReader(stream);
+            Assert.StartsWith("200 ", await reader.ReadLineAsync());
+            await server.WriteSnapshotAsync(path, CancellationToken.None);
+            var snapshot = JsonSerializer.Deserialize<NntpLoopbackServerSnapshot>(await File.ReadAllTextAsync(path));
+            Assert.NotNull(snapshot);
+            Assert.Equal(0, snapshot.BodyCommands);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void PerformanceReportJson_UsesStableWholePathFields()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"nntp-whole-path-{Guid.NewGuid():N}.json");
+        try
+        {
+            PerformanceReportJson.Write(
+                path,
+                NntpWholePathReport.ReportName,
+                new Dictionary<string, ScenarioSnapshot>
+                {
+                    ["plain-buffered-w1"] = new(
+                        new Dictionary<string, long> { ["expectedBytes"] = 1, ["sha256Match"] = 1 },
+                        PerformanceReportJson.WholePathTiming(1, 2, 3, 4, 5, 6, 7, 8, 9)),
+                });
+
+            using var document = JsonDocument.Parse(File.ReadAllText(path));
+            var root = document.RootElement;
+            Assert.Equal(PerformanceReportJson.SchemaVersion, root.GetProperty("schemaVersion").GetInt32());
+            Assert.Equal(NntpWholePathReport.ReportName, root.GetProperty("report").GetString());
+            var scenario = root.GetProperty("scenarios").GetProperty("plain-buffered-w1");
+            Assert.Equal(1, scenario.GetProperty("deterministic").GetProperty("sha256Match").GetInt64());
+            Assert.True(scenario.GetProperty("timing").TryGetProperty("throughputMbps", out _));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Theory]
+    [InlineData("quick", 5)]
+    [InlineData("sustained", 4)]
+    public void ScenarioSets_AreNamedAndExplicitlyPlaintext(string set, int expectedCount)
+    {
+        var scenarios = NntpWholePathScenario.ForSet(set);
+
+        Assert.Equal(expectedCount, scenarios.Count);
+        Assert.All(scenarios, scenario =>
+        {
+            Assert.False(scenario.UseTls);
+            Assert.Equal(YencCrcValidationMode.Require, scenario.CrcValidation);
+        });
+    }
+
+    [Fact]
+    public async Task Cli_RejectsIncompleteLoopbackServerArguments()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            PerformanceReportCli.TryHandleAsync(
+                ["--nntp-loopback-server", "--articles", "1"]));
+    }
+}

--- a/tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj
+++ b/tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj
@@ -31,6 +31,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\backend\NzbWebDAV.csproj" />
+    <ProjectReference Include="..\..\backend.Benchmarks\NzbWebDAV.Benchmarks.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/UsenetSharp.Tests/Integration/UsenetClientLoopbackBodyTests.cs
+++ b/tests/UsenetSharp.Tests/Integration/UsenetClientLoopbackBodyTests.cs
@@ -1,0 +1,106 @@
+using System.Security.Authentication;
+using UsenetSharp.Clients;
+using UsenetSharp.Models;
+using UsenetSharpTest.Support;
+
+namespace UsenetSharpTest.Protocol;
+
+[TestFixture]
+public sealed class UsenetClientLoopbackBodyTests
+{
+    [TestCase(1)]
+    [TestCase(2)]
+    [TestCase(4)]
+    [TestCase(8)]
+    public async Task DecodedBodiesAsync_PlaintextBatchPreservesOrderAndCompletesOnce(int width)
+    {
+        var expected = Enumerable.Range(0, width)
+            .Select(index => Enumerable.Repeat((byte)(index + 1), 4096 + index).ToArray())
+            .ToArray();
+        var bodies = expected
+            .Select((payload, index) => YencWireBodies.SinglePart(payload, $"loopback-{index}.bin"))
+            .ToArray();
+        var requestIndex = 0;
+        await using var server = new ScriptedNntpServer(async (command, writer, cancellationToken) =>
+        {
+            Assert.That(command, Is.EqualTo($"BODY <loopback-{requestIndex}@example.com>"));
+            var body = bodies[requestIndex++];
+            await writer.WriteLineAsync("222 body follows");
+            await writer.FlushAsync();
+            await writer.BaseStream.WriteAsync(body.Wire, cancellationToken);
+            await writer.BaseStream.FlushAsync(cancellationToken);
+        });
+        await using var client = new UsenetClient(new UsenetClientOptions
+        {
+            CrcValidation = YencCrcValidationMode.Require,
+            MaxPipelineDepth = 8,
+        });
+        await client.ConnectAsync("127.0.0.1", server.Port, false, CancellationToken.None);
+
+        var outcomes = new List<ArticleBodyResult>();
+        var ids = Enumerable.Range(0, width)
+            .Select(index => new SegmentId($"loopback-{index}@example.com"))
+            .ToArray();
+        var batch = await client.DecodedBodiesAsync(
+            ids,
+            (result, _) => outcomes.Add(result),
+            CancellationToken.None);
+
+        for (var index = 0; index < width; index++)
+        {
+            var response = await batch.Responses[index];
+            Assert.That(response.SegmentId.ToString(), Is.EqualTo(ids[index].ToString()));
+            await using var body = response.Stream!;
+            using var output = new MemoryStream();
+            await body.CopyToAsync(output);
+            Assert.That(output.ToArray(), Is.EqualTo(expected[index]));
+        }
+
+        await batch.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(server.Commands.Count(command => command.StartsWith("BODY ", StringComparison.Ordinal)), Is.EqualTo(width));
+            Assert.That(outcomes, Is.EqualTo(new[] { ArticleBodyResult.Retrieved }));
+            Assert.That(client.IsHealthy, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task DecodedBodiesAsync_CleanMissingArticleCompletesNotFound()
+    {
+        await using var server = new ScriptedNntpServer(async (command, writer, _) =>
+        {
+            Assert.That(command, Is.EqualTo("BODY <missing@example.com>"));
+            await writer.WriteLineAsync("430 no such article");
+        });
+        await using var client = new UsenetClient();
+        await client.ConnectAsync("127.0.0.1", server.Port, false, CancellationToken.None);
+
+        var outcome = new TaskCompletionSource<ArticleBodyResult>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var batch = await client.DecodedBodiesAsync(
+            [new SegmentId("missing@example.com")],
+            (result, _) => outcome.TrySetResult(result),
+            CancellationToken.None);
+
+        var response = await batch.Responses[0];
+        var completedOutcome = await outcome.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(response.ResponseCode, Is.EqualTo(430));
+            Assert.That(response.Stream, Is.Null);
+            Assert.That(completedOutcome, Is.EqualTo(ArticleBodyResult.NotFound));
+        });
+        await batch.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ConnectAsync_RejectsUntrustedTlsLoopbackCertificate()
+    {
+        await using var server = ScriptedNntpServer.StartTlsConnectionScript((_, _, _) => Task.CompletedTask);
+        await using var client = new UsenetClient();
+
+        Assert.ThrowsAsync<AuthenticationException>(() =>
+            client.ConnectAsync("127.0.0.1", server.Port, true, CancellationToken.None));
+    }
+}


### PR DESCRIPTION
## Summary
- add a deterministic child-process loopback NNTP whole-path report covering transport, provider, buffered-stream, and HTTP-like layers
- add narrow protocol/contract coverage, PR deterministic gating, scheduled sustained timing, and optional rapidyenc symbols plus restricted profiling collection
- defer trusted-TLS scenarios and provider-backed profiling to the subsequent measurement phase

## Test plan
- [x] `dotnet build tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore -p:SkipRapidYencNativeEnsure=true`
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-build --filter \"FullyQualifiedName~NntpWholePathReportContractTests\"`
- [x] `dotnet test tests/UsenetSharp.Tests/UsenetSharp.Tests.csproj -c Release --no-build --filter \"FullyQualifiedName~UsenetClientLoopbackBodyTests\"`
- [x] `bash scripts/test-performance-baseline-gate.sh`
- [x] quick local loopback deterministic report and baseline comparison
- [ ] run the sustained benchmark rebaseline on the intended Linux runner before treating its bootstrap timing envelope as a regression signal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added quick and sustained NNTP whole-path performance benchmarks.
  * Added deterministic loopback transfer testing with integrity, throughput, timing, and resource metrics.
  * Added benchmark scenario and loopback server command-line options.
  * Added Linux symbol generation and CPU profiling support.

* **Bug Fixes**
  * Improved performance baseline validation for CPU and duration metrics.

* **Documentation**
  * Documented benchmark usage, scenarios, regression gates, and profiling guidance.

* **Tests**
  * Added coverage for transfers, server behavior, report formatting, CLI validation, and integration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->