### PR TITLE
feat(usenet): add memory ownership telemetry

### DIFF
--- a/backend.Benchmarks/NntpLoopbackServer.cs
+++ b/backend.Benchmarks/NntpLoopbackServer.cs
@@ -158,9 +158,10 @@ internal sealed class NntpLoopbackServer : IAsyncDisposable
                 }
             }
         }
-        catch (IOException) when (_stop.IsCancellationRequested)
+        catch (Exception ex) when (_stop.IsCancellationRequested &&
+            ex is IOException or OperationCanceledException or ObjectDisposedException)
         {
-            // A peer may close while the server is stopping.
+            // Client close and shutdown cancellation both tear down the read loop.
         }
         finally
         {
@@ -217,8 +218,21 @@ internal sealed class NntpLoopbackServer : IAsyncDisposable
         {
             // Cancellation is the expected listener shutdown path.
         }
-        await Task.WhenAll(_connectionTasks.ToArray()).ConfigureAwait(false);
+
+        await Task.WhenAll(_connectionTasks.Select(ObserveShutdownAsync)).ConfigureAwait(false);
         _stop.Dispose();
+    }
+
+    private static async Task ObserveShutdownAsync(Task task)
+    {
+        try
+        {
+            await task.ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is OperationCanceledException or IOException or ObjectDisposedException)
+        {
+            // Connection tasks observe the shutdown token or a closed peer.
+        }
     }
 }
 

--- a/backend/Api/Controllers/GetMemoryComponents/GetMemoryComponentsController.cs
+++ b/backend/Api/Controllers/GetMemoryComponents/GetMemoryComponentsController.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Services.Diagnostics;
+
+namespace NzbWebDAV.Api.Controllers.GetMemoryComponents;
+
+/// <summary>
+/// Authenticated low-overhead owner-attribution snapshot for benchmark sampling.
+/// </summary>
+[ApiController]
+[Route("api/memory-components")]
+public sealed class GetMemoryComponentsController(
+    MemoryComponentSnapshotBuilder snapshotBuilder) : GetOnlyApiController
+{
+    protected override Task<IActionResult> HandleRequest() =>
+        Task.FromResult<IActionResult>(Ok(snapshotBuilder.Capture()));
+}

--- a/backend/Api/Controllers/GetMemoryComponents/GetMemoryComponentsController.cs
+++ b/backend/Api/Controllers/GetMemoryComponents/GetMemoryComponentsController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Services.Diagnostics;
 
@@ -8,6 +9,7 @@ namespace NzbWebDAV.Api.Controllers.GetMemoryComponents;
 /// </summary>
 [ApiController]
 [Route("api/memory-components")]
+[ProducesResponseType(typeof(MemoryComponentSnapshot), StatusCodes.Status200OK)]
 public sealed class GetMemoryComponentsController(
     MemoryComponentSnapshotBuilder snapshotBuilder) : GetOnlyApiController
 {

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1245,6 +1245,12 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
             : MemoryBudget.DefaultInFlightArticleBudgetMb();
     }
 
+    /// <summary>Whether the effective article budget originates from a valid persisted value.</summary>
+    public bool IsInFlightArticleBudgetExplicit() =>
+        int.TryParse(
+            StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetInFlightArticleBudgetMb)),
+            out _);
+
     public long GetInFlightArticleBudgetBytes() =>
         (long)GetInFlightArticleBudgetMb() * 1024L * 1024L;
 

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -285,7 +285,9 @@ public sealed partial class Program
                 {
                     var cfg = sp.GetRequiredService<ConfigManager>();
                     var budgetMb = cfg.GetInFlightArticleBudgetMb();
-                    MemoryBudget.LogInFlightBudget(budgetMb);
+                    MemoryBudget.LogInFlightBudget(
+                        budgetMb,
+                        cfg.IsInFlightArticleBudgetExplicit());
                     var budget = new InFlightArticleBudget(
                         cfg.GetInFlightArticleBudgetBytes(),
                         sp.GetRequiredService<ProviderLatencyTracker>());
@@ -329,6 +331,7 @@ public sealed partial class Program
                 .AddSingleton<StreamingFailureTracker>()
                 .AddSingleton<HealthCheckConnectionGate>()
                 .AddSingleton<SegmentCacheStatistics>()
+                .AddSingleton<MemoryComponentSnapshotBuilder>()
                 .AddSingleton<UsenetStreamingClient>()
                 .AddSingleton<StreamingCapacitySnapshotProvider>()
                 .AddHostedService<ProviderRecoveryProbeService>()
@@ -1085,7 +1088,10 @@ public sealed partial class Program
             PooledBufferStream.DefaultPool = SharedArrayPoolAdapter.Instance;
             Log.Information(
                 "Segment buffer pool override active: using ArrayPool<byte>.Shared " +
-                "(NZBDAV_SEGMENT_BUFFER_POOL=shared).");
+                "(NZBDAV_SEGMENT_BUFFER_POOL=shared); sharedRingConfiguredMaxBytes={SharedRingConfiguredMaxBytes} " +
+                "cacheWriter={CacheWriter}.",
+                (long)configManager.GetSharedStreamsMaxEntries() * configManager.GetSharedStreamsRingBytes(),
+                "unsupported");
             return;
         }
 
@@ -1098,9 +1104,12 @@ public sealed partial class Program
             : SegmentBufferRetentionPolicy.Legacy;
         PooledBufferStream.DefaultPool = new SegmentBufferPool(maxIdleBytes, retention);
         Log.Information(
-            "Segment buffer pool mode={Mode} maxIdleBytes={MaxIdleBytes}",
+            "Segment buffer pool mode={Mode} maxIdleBytes={MaxIdleBytes} " +
+            "sharedRingConfiguredMaxBytes={SharedRingConfiguredMaxBytes} cacheWriter={CacheWriter}",
             SegmentBufferPoolSelector.ToLogValue(poolMode),
-            maxIdleBytes);
+            maxIdleBytes,
+            (long)configManager.GetSharedStreamsMaxEntries() * configManager.GetSharedStreamsRingBytes(),
+            "unsupported");
     }
 
     private static async Task<bool> IsDatabaseStartupVacuumEnabledAsync()

--- a/backend/Services/Diagnostics/GcDiagnosticsStore.cs
+++ b/backend/Services/Diagnostics/GcDiagnosticsStore.cs
@@ -162,6 +162,7 @@ public sealed record GcSnapshot(
     public long MemoryLoadBytes { get; init; }
     public long HighMemoryLoadThresholdBytes { get; init; }
     public long? WorkingSetBytes { get; init; }
+    public TimeSpan TotalPauseDuration { get; init; }
 }
 
 public sealed record GcGenerationInfo(

--- a/backend/Services/Diagnostics/GcSnapshotBuilder.cs
+++ b/backend/Services/Diagnostics/GcSnapshotBuilder.cs
@@ -36,6 +36,7 @@ internal static class GcSnapshotBuilder
             MemoryLoadBytes = info.MemoryLoadBytes,
             HighMemoryLoadThresholdBytes = info.HighMemoryLoadThresholdBytes,
             WorkingSetBytes = TryGetWorkingSetBytes(),
+            TotalPauseDuration = GC.GetTotalPauseDuration(),
         };
     }
 

--- a/backend/Services/Diagnostics/MemoryComponentSnapshot.cs
+++ b/backend/Services/Diagnostics/MemoryComponentSnapshot.cs
@@ -1,0 +1,144 @@
+using System.Diagnostics;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Services;
+using NzbWebDAV.Streams;
+
+namespace NzbWebDAV.Services.Diagnostics;
+
+/// <summary>
+/// Versioned, privacy-safe, point-in-time ownership counters for correlating
+/// backend memory with external process and cgroup sampling. Component values
+/// intentionally overlap GC/runtime views and must not be summed in product code.
+/// </summary>
+public sealed record MemoryComponentSnapshot(
+    int SchemaVersion,
+    DateTimeOffset CapturedAtUtc,
+    long MonotonicTimestamp,
+    long CaptureDurationMicroseconds,
+    long? BackendWorkingSetBytes,
+    GcSnapshot Gc,
+    InFlightArticleMemorySnapshot InFlightArticles,
+    SegmentBufferMemorySnapshot? SegmentBuffers,
+    SharedStreamMemorySnapshot SharedStreams,
+    SegmentCacheWriterMemorySnapshot CacheWriter,
+    MemoryActivitySnapshot Activity);
+
+public readonly record struct SharedStreamMemorySnapshot(
+    long RingLogicalBytes,
+    long RingRentedCapacityBytes,
+    long RingRentedCapacityBytesPeak,
+    long PumpScratchRentedCapacityBytes,
+    long PumpScratchRentedCapacityBytesPeak,
+    long ConfiguredRingMaximumBytes,
+    long LiveEntries,
+    long DrainingEntries,
+    long LaggingReaders);
+
+/// <summary>
+/// Null fields indicate that asynchronous cache write-behind is unsupported,
+/// rather than claiming an unavailable owner has zero bytes.
+/// </summary>
+public readonly record struct SegmentCacheWriterMemorySnapshot(
+    bool Supported,
+    long? WriteBudgetBytes,
+    long? QueuedWriteBytes,
+    long? PeakQueuedWriteBytes,
+    long? QueuedJobs,
+    long? ActiveJobs,
+    long? CapacitySkipsTotal);
+
+public readonly record struct MemoryActivitySnapshot(
+    long ActiveReads,
+    long CurrentInFlightSegmentFetches);
+
+/// <summary>
+/// Assembles one cheap snapshot from existing domain counters. It neither forces
+/// collection nor enumerates per-path, per-segment, or per-size-class state.
+/// </summary>
+public sealed class MemoryComponentSnapshotBuilder(
+    InFlightArticleBudget inFlightArticleBudget,
+    ConfigManager configManager,
+    ConcurrentReadTracker concurrentReadTracker,
+    ActiveReadRegistry activeReads,
+    SegmentCacheStatistics segmentCacheStatistics)
+{
+    public const int CurrentSchemaVersion = 1;
+
+    public MemoryComponentSnapshot Capture()
+    {
+        var timestamp = Stopwatch.GetTimestamp();
+        var capturedAtUtc = DateTimeOffset.UtcNow;
+
+        var gc = GcSnapshotBuilder.Capture();
+        var articleBudget = inFlightArticleBudget.SnapshotMemory();
+        var bufferPool = BufferPoolDiagnostics.Shared.Snapshot();
+        var segmentPool = (PooledBufferStream.DefaultPool as SegmentBufferPool)?.MemorySnapshot();
+        var reads = concurrentReadTracker.Snapshot();
+        var cache = segmentCacheStatistics.GetSnapshot();
+
+        SegmentBufferMemorySnapshot? segmentBuffers = segmentPool is { } pool
+            ? new SegmentBufferMemorySnapshot(
+                pool.Mode,
+                pool.CheckedOutCapacityBytes,
+                pool.IdleCapacityBytes,
+                pool.MaxIdleBytes,
+                pool.RentCount,
+                pool.ReturnCount,
+                pool.RejectedReturnCount,
+                bufferPool.RequestedBytes,
+                bufferPool.RentedBytes,
+                bufferPool.BucketWasteBytes)
+            : null;
+
+        var sharedStreams = new SharedStreamMemorySnapshot(
+            reads.SharedStreamRingLogicalBytes,
+            reads.SharedStreamRingRetainedBytes,
+            reads.SharedStreamRingRetainedBytesPeak,
+            reads.SharedStreamPumpScratchRentedBytes,
+            reads.SharedStreamPumpScratchRentedBytesPeak,
+            (long)configManager.GetSharedStreamsMaxEntries() *
+                configManager.GetSharedStreamsRingBytes(),
+            reads.SharedStreamLiveEntries,
+            reads.SharedStreamDrainingEntries,
+            reads.SharedStreamLaggingReaders);
+
+        var cacheWriter = new SegmentCacheWriterMemorySnapshot(
+            Supported: cache.QueuedWriteBytes.HasValue || cache.PeakQueuedWriteBytes.HasValue,
+            WriteBudgetBytes: null,
+            QueuedWriteBytes: cache.QueuedWriteBytes,
+            PeakQueuedWriteBytes: cache.PeakQueuedWriteBytes,
+            QueuedJobs: null,
+            ActiveJobs: null,
+            CapacitySkipsTotal: null);
+
+        return new MemoryComponentSnapshot(
+            CurrentSchemaVersion,
+            capturedAtUtc,
+            timestamp,
+            Stopwatch.GetElapsedTime(timestamp).Ticks / 10,
+            gc.WorkingSetBytes,
+            gc,
+            articleBudget,
+            segmentBuffers,
+            sharedStreams,
+            cacheWriter,
+            new MemoryActivitySnapshot(activeReads.Count, reads.CurrentInFlightSegmentFetches));
+    }
+}
+
+/// <summary>
+/// Aggregate segment-pool counters. A null <see cref="MemoryComponentSnapshot.SegmentBuffers"/>
+/// means the process is using ArrayPool.Shared, whose retained capacity is not observable here.
+/// </summary>
+public readonly record struct SegmentBufferMemorySnapshot(
+    string Mode,
+    long CheckedOutCapacityBytes,
+    long IdleCapacityBytes,
+    long MaxIdleBytes,
+    long RentCount,
+    long ReturnCount,
+    long RejectedReturnCount,
+    long RequestedBytesTotal,
+    long RentedCapacityBytesTotal,
+    long BucketWasteBytesTotal);

--- a/backend/Services/Diagnostics/OomDiagnostics.cs
+++ b/backend/Services/Diagnostics/OomDiagnostics.cs
@@ -21,6 +21,7 @@ internal static class OomDiagnostics
             var addressSpace = AddressSpaceDiagnostics.Capture();
             var pool = PooledBufferStream.DefaultPool as SegmentBufferPool;
             var poolSnapshot = pool?.SnapshotForOom();
+            var articleBudget = InFlightArticleBudget.Current;
             long lohSize = -1;
             long lohFragmentation = -1;
             if (info.GenerationInfo.Length > 3)
@@ -42,7 +43,8 @@ internal static class OomDiagnostics
                 "PoolAllocationAttempts={PoolAllocationAttempts:N0} " +
                 "PoolAllocationFailures={PoolAllocationFailures:N0} " +
                 "PoolAllocations={PoolAllocations:N0} PoolTrimmed={PoolTrimmed:N0} " +
-                "InFlight={InFlight:N0} Cap={Cap:N0} Virtual={Virtual:N0} " +
+                "InFlight={InFlight:N0} DecodedPipe={DecodedPipe:N0} ArticleWaiters={ArticleWaiters:N0} " +
+                "Cap={Cap:N0} Virtual={Virtual:N0} " +
                 "RLIMIT_AS={AddressSpaceLimit:N0} RegionRange={RegionRange:N0} " +
                 "HeapHardLimit={HeapHardLimit:N0} LohHardLimit={LohHardLimit:N0} " +
                 "LohHardLimitPercent={LohHardLimitPercent:N0}",
@@ -66,8 +68,10 @@ internal static class OomDiagnostics
                 poolSnapshot?.AllocationFailureCount ?? -1,
                 poolSnapshot?.AllocationCount ?? -1,
                 poolSnapshot?.TrimmedBytes ?? -1,
-                InFlightArticleBudget.Current?.LeasedBytes ?? -1,
-                InFlightArticleBudget.Current?.CapBytes ?? -1,
+                articleBudget?.LeasedBytes ?? -1,
+                articleBudget?.DecodedPipeBytes ?? -1,
+                articleBudget?.WaiterCount ?? -1,
+                articleBudget?.CapBytes ?? -1,
                 addressSpace.VirtualMemoryBytes ?? -1,
                 addressSpace.AddressSpaceLimitBytes ?? -1,
                 addressSpace.GcRegionRangeBytes ?? -1,

--- a/backend/Services/Observability/PrometheusMetrics.cs
+++ b/backend/Services/Observability/PrometheusMetrics.cs
@@ -1,6 +1,7 @@
 using Prometheus;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Services.Diagnostics;
 using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Streams;
 
@@ -20,7 +21,13 @@ public sealed class PrometheusMetrics
     private readonly Gauge _inFlightSegmentFetches;
     private readonly Gauge _articleBudgetBytes;
     private readonly Gauge _articleBudgetCapBytes;
+    private readonly Gauge _articleDestinationBytes;
+    private readonly Gauge _decodedBodyPipeBytes;
+    private readonly Gauge _articleBudgetWaiters;
     private readonly Counter _articleBudgetThrottleEvents;
+    private readonly Gauge _segmentBufferCheckedOutBytes;
+    private readonly Gauge _segmentBufferIdleBytes;
+    private readonly Gauge _segmentBufferMaxIdleBytes;
     private readonly Gauge _metricsQueueLength;
     private readonly Counter _metricsDropped;
     private readonly Gauge _poolConnections;
@@ -96,9 +103,30 @@ public sealed class PrometheusMetrics
         _inFlightSegmentFetches = metrics.CreateGauge("nzbdav_concurrent_in_flight_segment_fetches", "Current in-flight segment fetches.");
         _articleBudgetBytes = metrics.CreateGauge("nzbdav_inflight_article_bytes", "Article bytes currently leased.");
         _articleBudgetCapBytes = metrics.CreateGauge("nzbdav_inflight_article_budget_bytes", "Configured in-flight article byte budget.");
+        _articleDestinationBytes = metrics.CreateGauge(
+            "nzbdav_inflight_article_destination_bytes",
+            "Logical decoded article destination bytes currently leased.");
+        _decodedBodyPipeBytes = metrics.CreateGauge(
+            "nzbdav_decoded_body_pipe_bytes",
+            "Decoded BODY bytes currently unread in NNTP pipes.");
+        _articleBudgetWaiters = metrics.CreateGauge(
+            "nzbdav_inflight_article_waiters",
+            "Current FIFO waiters for in-flight article memory.");
         _articleBudgetThrottleEvents = metrics.CreateCounter(
             "nzbdav_inflight_article_throttle_events_total",
             "Article RAM lease requests that encountered budget backpressure.");
+        _segmentBufferCheckedOutBytes = metrics.CreateGauge(
+            "nzbdav_segment_buffer_checked_out_bytes",
+            "Actual capacity of custom segment buffers currently checked out.");
+        _segmentBufferIdleBytes = metrics.CreateGauge(
+            "nzbdav_segment_buffer_idle_bytes",
+            "Actual capacity retained idle by the custom segment-buffer pool.");
+        _segmentBufferMaxIdleBytes = metrics.CreateGauge(
+            "nzbdav_segment_buffer_max_idle_bytes",
+            "Configured maximum idle capacity for the custom segment-buffer pool.");
+        _segmentBufferCheckedOutBytes.Unpublish();
+        _segmentBufferIdleBytes.Unpublish();
+        _segmentBufferMaxIdleBytes.Unpublish();
         _metricsQueueLength = metrics.CreateGauge("nzbdav_metrics_queue_length", "Queued internal metric rows.", new GaugeConfiguration { LabelNames = ["queue"] });
         _metricsDropped = metrics.CreateCounter("nzbdav_metrics_dropped_total", "Dropped internal metric rows.", new CounterConfiguration { LabelNames = ["queue"] });
         _poolConnections = metrics.CreateGauge("nzbdav_nntp_pool_connections", "NNTP pool connection and admitted-operation state.", new GaugeConfiguration { LabelNames = ["provider_key", "state"] });
@@ -321,13 +349,45 @@ public sealed class PrometheusMetrics
         _segmentCacheTemporaryFilesCleaned.IncTo(snapshot.TemporaryFilesCleaned);
     }
 
+    /// <summary>
+    /// Projects one owner-attribution snapshot without adding GC metrics that
+    /// prometheus-net's DotNetStats collector already exposes.
+    /// </summary>
+    public void SetMemoryComponents(MemoryComponentSnapshot snapshot)
+    {
+        var articles = snapshot.InFlightArticles;
+        _articleBudgetBytes.Set(articles.TotalAccountedBytes);
+        _articleBudgetCapBytes.Set(articles.CapBytes);
+        _articleDestinationBytes.Set(articles.ArticleDestinationLogicalBytes);
+        _decodedBodyPipeBytes.Set(articles.DecodedPipeBytes);
+        _articleBudgetWaiters.Set(articles.WaiterCount);
+        _articleBudgetThrottleEvents.IncTo(articles.ThrottleEvents);
+
+        if (snapshot.SegmentBuffers is { } pool)
+        {
+            _segmentBufferCheckedOutBytes.Publish();
+            _segmentBufferIdleBytes.Publish();
+            _segmentBufferMaxIdleBytes.Publish();
+            _segmentBufferCheckedOutBytes.Set(pool.CheckedOutCapacityBytes);
+            _segmentBufferIdleBytes.Set(pool.IdleCapacityBytes);
+            _segmentBufferMaxIdleBytes.Set(pool.MaxIdleBytes);
+        }
+        else
+        {
+            _segmentBufferCheckedOutBytes.Unpublish();
+            _segmentBufferIdleBytes.Unpublish();
+            _segmentBufferMaxIdleBytes.Unpublish();
+        }
+    }
+
     public void Refresh(
+        MemoryComponentSnapshot memoryComponents,
         ActiveReadRegistry activeReads,
         ConcurrentReadTracker concurrentReads,
-        InFlightArticleBudget articleBudget,
         MetricsWriter metricsWriter,
         UsenetStreamingClient usenetClient)
     {
+        SetMemoryComponents(memoryComponents);
         _activeReads.Set(activeReads.Count);
         _bytesServed.IncTo(activeReads.TotalBytesServed);
 
@@ -355,10 +415,6 @@ public sealed class PrometheusMetrics
         _sharedStreamPressureReaps.IncTo(reads.SharedStreamPressureReaps);
         _overlappingPaths.Set(reads.CurrentOverlappingPaths);
         _inFlightSegmentFetches.Set(reads.CurrentInFlightSegmentFetches);
-
-        _articleBudgetBytes.Set(articleBudget.LeasedBytes);
-        _articleBudgetCapBytes.Set(articleBudget.CapBytes);
-        _articleBudgetThrottleEvents.IncTo(articleBudget.ThrottleEvents);
 
         var writer = metricsWriter.Stats;
         _metricsQueueLength.WithLabels("fetches").Set(writer.QueuedFetches);

--- a/backend/Services/Observability/PrometheusMetricsCollector.cs
+++ b/backend/Services/Observability/PrometheusMetricsCollector.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Services.Diagnostics;
 using NzbWebDAV.Services.Metrics;
 using NzbWebDAV.Services.Repair;
 using NzbWebDAV.Streams;
@@ -15,7 +16,8 @@ public sealed class PrometheusMetricsCollector(
     UsenetStreamingClient usenetClient,
     RepairPatchStore repairPatchStore,
     HealthCheckConnectionGate healthCheckConnectionGate,
-    SegmentCacheStatistics segmentCacheStatistics) : BackgroundService
+    SegmentCacheStatistics segmentCacheStatistics,
+    MemoryComponentSnapshotBuilder memorySnapshotBuilder) : BackgroundService
 {
     private static readonly TimeSpan Interval = TimeSpan.FromSeconds(5);
 
@@ -29,7 +31,12 @@ public sealed class PrometheusMetricsCollector(
                 {
                     if (InFlightArticleBudget.Current is { } budget)
                     {
-                        metrics.Refresh(activeReads, concurrentReads, budget, metricsWriter, usenetClient);
+                        metrics.Refresh(
+                            memorySnapshotBuilder.Capture(),
+                            activeReads,
+                            concurrentReads,
+                            metricsWriter,
+                            usenetClient);
                         metrics.SetPar2PatchStoreBytes(repairPatchStore.CurrentBytes);
                     }
                     metrics.SetHealthCheckGate(healthCheckConnectionGate.GetSnapshot());

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -39,7 +39,8 @@ public sealed class SupportPackService(
     HealthCheckConnectionGate healthCheckConnectionGate,
     ConcurrentReadTracker? concurrentReadTracker = null,
     IQueueCoordinator? queueCoordinator = null,
-    SegmentCacheStatistics? segmentCacheStatistics = null)
+    SegmentCacheStatistics? segmentCacheStatistics = null,
+    MemoryComponentSnapshotBuilder? memoryComponentSnapshotBuilder = null)
 {
     private const long MinuteMs = 60_000;
     private const long HourMs = 60 * MinuteMs;
@@ -405,6 +406,7 @@ public sealed class SupportPackService(
         var bufferPool = BufferPoolDiagnostics.Shared.Snapshot();
         var segmentPool = (PooledBufferStream.DefaultPool as SegmentBufferPool)?.Snapshot();
         var addressSpace = AddressSpaceDiagnostics.Capture();
+        var memoryComponents = memoryComponentSnapshotBuilder?.Capture();
         var cpu = await BuildCpuDiagnosticsAsync(usage, uptime, cancellationToken).ConfigureAwait(false);
 
         return new
@@ -489,6 +491,7 @@ public sealed class SupportPackService(
                 segmentBufferRequestedBytes = bufferPool.RequestedBytes,
                 segmentBufferRentedBytes = bufferPool.RentedBytes,
                 segmentBufferBucketWasteBytes = bufferPool.BucketWasteBytes,
+                memoryComponents,
                 timeZone = TimeZoneInfo.Local.Id,
             },
             segmentBufferPool = segmentPool is null ? null : new

--- a/backend/Streams/InFlightArticleBudget.cs
+++ b/backend/Streams/InFlightArticleBudget.cs
@@ -15,6 +15,7 @@ namespace NzbWebDAV.Streams;
 public sealed class InFlightArticleBudget
 {
     private long _leased;
+    private long _decodedPipeBytes;
     private long _capBytes;
     private long _throttleEvents;
     private long _lastWarningTicks;
@@ -37,16 +38,59 @@ public sealed class InFlightArticleBudget
     }
 
     public long LeasedBytes => Interlocked.Read(ref _leased);
+    /// <summary>Decoded BODY bytes currently unread in UsenetSharp pipes.</summary>
+    public long DecodedPipeBytes => Interlocked.Read(ref _decodedPipeBytes);
     public long CapBytes => Interlocked.Read(ref _capBytes);
     /// <summary>Number of leases that encountered Article RAM backpressure.</summary>
     public long ThrottleEvents => Interlocked.Read(ref _throttleEvents);
+    /// <summary>Current FIFO article-memory admission waiters.</summary>
+    public int WaiterCount => Volatile.Read(ref _waiterCount);
 
     /// <summary>
     /// True when at least one caller is blocked in <see cref="LeaseAsync"/>.
     /// Used by the streaming write watchdog to reclaim leases from a trickle
     /// reader only while other streams are waiting on the cap.
     /// </summary>
-    public bool HasWaiters => Volatile.Read(ref _waiterCount) > 0;
+    public bool HasWaiters => WaiterCount > 0;
+
+    /// <summary>
+    /// Captures the logical article and decoded-pipe portions of current admission
+    /// accounting without changing admission behavior.
+    /// </summary>
+    public InFlightArticleMemorySnapshot SnapshotMemory()
+    {
+        // Pipe observer callbacks and lease releases are concurrent. Retry a few
+        // times so regular snapshots retain their accounting identity without
+        // blocking either hot path.
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            var total = LeasedBytes;
+            var pipe = DecodedPipeBytes;
+            var destination = total - pipe;
+            if (destination >= 0)
+            {
+                return new InFlightArticleMemorySnapshot(
+                    total,
+                    destination,
+                    pipe,
+                    CapBytes,
+                    WaiterCount,
+                    ThrottleEvents,
+                    IsConsistent: true);
+            }
+        }
+
+        var finalTotal = LeasedBytes;
+        var finalPipe = DecodedPipeBytes;
+        return new InFlightArticleMemorySnapshot(
+            finalTotal,
+            Math.Max(0, finalTotal - finalPipe),
+            finalPipe,
+            CapBytes,
+            WaiterCount,
+            ThrottleEvents,
+            IsConsistent: false);
+    }
 
     /// <summary>
     /// Updates the cap (e.g. after a settings change). Wakes waiters when the cap grows.
@@ -212,6 +256,7 @@ public sealed class InFlightArticleBudget
     {
         if (delta > 0)
         {
+            Interlocked.Add(ref _decodedPipeBytes, delta);
             AccountExtra(delta);
             return;
         }
@@ -222,7 +267,7 @@ public sealed class InFlightArticleBudget
         long released;
         while (true)
         {
-            var current = Interlocked.Read(ref _leased);
+            var current = Interlocked.Read(ref _decodedPipeBytes);
             if (current <= 0)
             {
                 released = 0;
@@ -230,12 +275,13 @@ public sealed class InFlightArticleBudget
             }
 
             released = Math.Min(current, requested);
-            if (Interlocked.CompareExchange(ref _leased, current - released, current) == current)
+            if (Interlocked.CompareExchange(
+                    ref _decodedPipeBytes, current - released, current) == current)
                 break;
         }
 
         if (released > 0)
-            SignalWaiters();
+            Release(released);
 
         if (released < requested)
             MaybeWarnPipeOverRelease(requested, released);
@@ -290,6 +336,19 @@ public sealed class InFlightArticleBudget
             Tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 }
+
+/// <summary>
+/// Point-in-time logical ownership inside <see cref="InFlightArticleBudget"/>.
+/// Destination bytes are a logical lease and overlap checked-out segment capacity.
+/// </summary>
+public readonly record struct InFlightArticleMemorySnapshot(
+    long TotalAccountedBytes,
+    long ArticleDestinationLogicalBytes,
+    long DecodedPipeBytes,
+    long CapBytes,
+    int WaiterCount,
+    long ThrottleEvents,
+    bool IsConsistent);
 
 /// <summary>
 /// Holds <see cref="InFlightArticleBudget"/> credits for one drained segment.

--- a/backend/Streams/InFlightArticleBudget.cs
+++ b/backend/Streams/InFlightArticleBudget.cs
@@ -16,11 +16,13 @@ public sealed class InFlightArticleBudget
 {
     private long _leased;
     private long _decodedPipeBytes;
+    private long _pipeAccountingVersion;
     private long _capBytes;
     private long _throttleEvents;
     private long _lastWarningTicks;
     private long _lastPipeOverReleaseWarningTicks;
     private int _waiterCount;
+    private int _pipeAccountingUpdates;
     private readonly ProviderLatencyTracker? _latencyTracker;
     private readonly object _gate = new();
     private readonly LinkedList<Waiter> _waiters = new();
@@ -59,15 +61,22 @@ public sealed class InFlightArticleBudget
     /// </summary>
     public InFlightArticleMemorySnapshot SnapshotMemory()
     {
-        // Pipe observer callbacks and lease releases are concurrent. Retry a few
-        // times so regular snapshots retain their accounting identity without
-        // blocking either hot path.
+        // Pipe observer callbacks update two counters. Retry only snapshots that
+        // overlap an update or saw a completed update between their reads; neither
+        // hot path blocks for this diagnostic capture.
         for (var attempt = 0; attempt < 3; attempt++)
         {
+            var versionBefore = Interlocked.Read(ref _pipeAccountingVersion);
+            var updatesBefore = Volatile.Read(ref _pipeAccountingUpdates);
             var total = LeasedBytes;
             var pipe = DecodedPipeBytes;
             var destination = total - pipe;
-            if (destination >= 0)
+            var updatesAfter = Volatile.Read(ref _pipeAccountingUpdates);
+            var versionAfter = Interlocked.Read(ref _pipeAccountingVersion);
+            if (destination >= 0 &&
+                updatesBefore == 0 &&
+                updatesAfter == 0 &&
+                versionBefore == versionAfter)
             {
                 return new InFlightArticleMemorySnapshot(
                     total,
@@ -254,37 +263,46 @@ public sealed class InFlightArticleBudget
     /// </summary>
     public void AccountBufferedPipeBytes(long delta)
     {
-        if (delta > 0)
-        {
-            Interlocked.Add(ref _decodedPipeBytes, delta);
-            AccountExtra(delta);
-            return;
-        }
-
         if (delta == 0) return;
 
-        var requested = -delta;
-        long released;
-        while (true)
+        Interlocked.Increment(ref _pipeAccountingUpdates);
+        try
         {
-            var current = Interlocked.Read(ref _decodedPipeBytes);
-            if (current <= 0)
+            if (delta > 0)
             {
-                released = 0;
-                break;
+                Interlocked.Add(ref _decodedPipeBytes, delta);
+                AccountExtra(delta);
+                return;
             }
 
-            released = Math.Min(current, requested);
-            if (Interlocked.CompareExchange(
-                    ref _decodedPipeBytes, current - released, current) == current)
-                break;
+            var requested = -delta;
+            long released;
+            while (true)
+            {
+                var current = Interlocked.Read(ref _decodedPipeBytes);
+                if (current <= 0)
+                {
+                    released = 0;
+                    break;
+                }
+
+                released = Math.Min(current, requested);
+                if (Interlocked.CompareExchange(
+                        ref _decodedPipeBytes, current - released, current) == current)
+                    break;
+            }
+
+            if (released > 0)
+                Release(released);
+
+            if (released < requested)
+                MaybeWarnPipeOverRelease(requested, released);
         }
-
-        if (released > 0)
-            Release(released);
-
-        if (released < requested)
-            MaybeWarnPipeOverRelease(requested, released);
+        finally
+        {
+            Interlocked.Increment(ref _pipeAccountingVersion);
+            Interlocked.Decrement(ref _pipeAccountingUpdates);
+        }
     }
 
     /// <summary>

--- a/backend/Streams/InFlightArticleBudget.cs
+++ b/backend/Streams/InFlightArticleBudget.cs
@@ -270,8 +270,8 @@ public sealed class InFlightArticleBudget
         {
             if (delta > 0)
             {
-                Interlocked.Add(ref _decodedPipeBytes, delta);
                 AccountExtra(delta);
+                Interlocked.Add(ref _decodedPipeBytes, delta);
                 return;
             }
 

--- a/backend/Streams/SegmentBufferPool.cs
+++ b/backend/Streams/SegmentBufferPool.cs
@@ -221,6 +221,27 @@ public sealed class SegmentBufferPool : ISegmentBufferPool
         }
     }
 
+    /// <summary>
+    /// Allocation-free aggregate ownership counters for frequent attribution
+    /// sampling. Per-size-class diagnostics remain available from <see cref="Snapshot"/>.
+    /// </summary>
+    public SegmentBufferPoolMemorySnapshot MemorySnapshot()
+    {
+        lock (_gate)
+        {
+            return new SegmentBufferPoolMemorySnapshot(
+                _retentionPolicy == SegmentBufferRetentionPolicy.Legacy
+                    ? SegmentBufferPoolSelector.BoundedLegacyValue
+                    : SegmentBufferPoolSelector.BoundedCapacityValue,
+                _checkedOutBytes,
+                _idleBytes,
+                _maxIdleBytes,
+                _rentCount,
+                _returnCount,
+                _rejectedReturnCount);
+        }
+    }
+
     internal SegmentBufferPoolOomSnapshot SnapshotForOom()
     {
         lock (_gate)
@@ -506,6 +527,18 @@ public readonly record struct SegmentBufferPoolClassSnapshot(
     int BufferSize,
     int BufferCount,
     long IdleBytes);
+
+/// <summary>
+/// Cheap aggregate ownership snapshot for memory attribution sampling.
+/// </summary>
+public readonly record struct SegmentBufferPoolMemorySnapshot(
+    string Mode,
+    long CheckedOutCapacityBytes,
+    long IdleCapacityBytes,
+    long MaxIdleBytes,
+    long RentCount,
+    long ReturnCount,
+    long RejectedReturnCount);
 
 public readonly record struct SegmentBufferPoolLifetimeClassSnapshot(
     int BufferSize,

--- a/backend/Utils/MemoryBudget.cs
+++ b/backend/Utils/MemoryBudget.cs
@@ -86,14 +86,14 @@ public static class MemoryBudget
     };
 
     /// <summary>One startup line saying what unset defaults the box affords.</summary>
-    public static void LogInFlightBudget(int effectiveBudgetMb)
+    public static void LogInFlightBudget(int effectiveBudgetMb, bool isExplicit)
     {
         var addressSpace = AddressSpaceDiagnostics.Capture();
         Log.Information(
             "[MemoryBudget] Heap limit {HeapMB}MB, GC hard limit {GcHardLimitMB}MB, region range {RegionRangeMB}MB, " +
             "region size {RegionSizeMB}MB, committed heap {CommittedMB}MB, virtual memory {VirtualMemoryMB}MB, " +
             "RLIMIT_AS {AddressSpaceLimitMB}MB -> in-flight article budget {BudgetMB}MB " +
-            "(derived when unset; explicit usenet.in-flight-article-budget-mb still wins).",
+            "from {BudgetSource}.",
             HeapLimitBytes / Mb,
             ToMegabytes(addressSpace.GcHeapHardLimitBytes),
             ToMegabytes(addressSpace.GcRegionRangeBytes),
@@ -101,7 +101,8 @@ public static class MemoryBudget
             ToMegabytes(addressSpace.GcCommittedBytes),
             ToMegabytes(addressSpace.VirtualMemoryBytes),
             ToMegabytes(addressSpace.AddressSpaceLimitBytes),
-            effectiveBudgetMb);
+            effectiveBudgetMb,
+            isExplicit ? "explicit configuration" : "derived heap limit");
     }
 
     private static long? ToMegabytes(long? bytes) => bytes / Mb;

--- a/contracts/openapi/admin-v1.json
+++ b/contracts/openapi/admin-v1.json
@@ -119,6 +119,181 @@
         ],
         "type": "object"
       },
+      "GcGenerationInfo": {
+        "properties": {
+          "fragmentationAfterBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "sizeAfterBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          }
+        },
+        "required": [
+          "fragmentationAfterBytes",
+          "name",
+          "sizeAfterBytes"
+        ],
+        "type": "object"
+      },
+      "GcSnapshot": {
+        "properties": {
+          "compacted": {
+            "type": "boolean"
+          },
+          "concurrent": {
+            "type": "boolean"
+          },
+          "fragmentationBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "gen0Collections": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "gen1Collections": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "gen2Collections": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "generation": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "generations": {
+            "items": {
+              "$ref": "#/components/schemas/GcGenerationInfo"
+            },
+            "type": "array"
+          },
+          "heapSizeBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "highMemoryLoadThresholdBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "index": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "memoryLoadBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "pauseTimePercentage": {
+            "format": "double",
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": [
+              "number",
+              "string"
+            ]
+          },
+          "totalAllocatedBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "totalAvailableMemoryBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "totalCommittedBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "totalPauseDuration": {
+            "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$",
+            "type": "string"
+          },
+          "workingSetBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "null",
+              "string"
+            ]
+          }
+        },
+        "required": [
+          "fragmentationBytes",
+          "gen0Collections",
+          "gen1Collections",
+          "gen2Collections",
+          "generations",
+          "heapSizeBytes",
+          "pauseTimePercentage",
+          "totalAllocatedBytes",
+          "totalAvailableMemoryBytes",
+          "totalCommittedBytes"
+        ],
+        "type": "object"
+      },
       "HistoryCleanupRequest": {
         "properties": {
           "confirm": {
@@ -131,6 +306,62 @@
         "required": [
           "confirm"
         ],
+        "type": "object"
+      },
+      "InFlightArticleMemorySnapshot": {
+        "properties": {
+          "articleDestinationLogicalBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "capBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "decodedPipeBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "isConsistent": {
+            "type": "boolean"
+          },
+          "throttleEvents": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "totalAccountedBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "waiterCount": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          }
+        },
         "type": "object"
       },
       "IncludeRequest": {
@@ -151,6 +382,107 @@
         "required": [
           "included",
           "storeRefs"
+        ],
+        "type": "object"
+      },
+      "MemoryActivitySnapshot": {
+        "properties": {
+          "activeReads": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "currentInFlightSegmentFetches": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "MemoryComponentSnapshot": {
+        "properties": {
+          "activity": {
+            "$ref": "#/components/schemas/MemoryActivitySnapshot"
+          },
+          "backendWorkingSetBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "null",
+              "string"
+            ]
+          },
+          "cacheWriter": {
+            "$ref": "#/components/schemas/SegmentCacheWriterMemorySnapshot"
+          },
+          "captureDurationMicroseconds": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "capturedAtUtc": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "gc": {
+            "$ref": "#/components/schemas/GcSnapshot"
+          },
+          "inFlightArticles": {
+            "$ref": "#/components/schemas/InFlightArticleMemorySnapshot"
+          },
+          "monotonicTimestamp": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "schemaVersion": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "segmentBuffers": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SegmentBufferMemorySnapshot"
+              }
+            ]
+          },
+          "sharedStreams": {
+            "$ref": "#/components/schemas/SharedStreamMemorySnapshot"
+          }
+        },
+        "required": [
+          "activity",
+          "backendWorkingSetBytes",
+          "cacheWriter",
+          "captureDurationMicroseconds",
+          "capturedAtUtc",
+          "gc",
+          "inFlightArticles",
+          "monotonicTimestamp",
+          "schemaVersion",
+          "segmentBuffers",
+          "sharedStreams"
         ],
         "type": "object"
       },
@@ -189,6 +521,225 @@
           "traceId",
           "type"
         ],
+        "type": "object"
+      },
+      "SegmentBufferMemorySnapshot": {
+        "properties": {
+          "bucketWasteBytesTotal": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "checkedOutCapacityBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "idleCapacityBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "maxIdleBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "mode": {
+            "type": "string"
+          },
+          "rejectedReturnCount": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "rentCount": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "rentedCapacityBytesTotal": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "requestedBytesTotal": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "returnCount": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "SegmentCacheWriterMemorySnapshot": {
+        "properties": {
+          "activeJobs": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "null",
+              "string"
+            ]
+          },
+          "capacitySkipsTotal": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "null",
+              "string"
+            ]
+          },
+          "peakQueuedWriteBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "null",
+              "string"
+            ]
+          },
+          "queuedJobs": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "null",
+              "string"
+            ]
+          },
+          "queuedWriteBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "null",
+              "string"
+            ]
+          },
+          "supported": {
+            "type": "boolean"
+          },
+          "writeBudgetBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "SharedStreamMemorySnapshot": {
+        "properties": {
+          "configuredRingMaximumBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "drainingEntries": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "laggingReaders": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "liveEntries": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "pumpScratchRentedCapacityBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "pumpScratchRentedCapacityBytesPeak": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "ringLogicalBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "ringRentedCapacityBytes": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "ringRentedCapacityBytesPeak": {
+            "format": "int64",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ]
+          }
+        },
         "type": "object"
       },
       "SymlinkApplyRequest": {
@@ -3711,6 +4262,23 @@
         "operationId": "get-api-memory-components",
         "responses": {
           "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryComponentSnapshot"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryComponentSnapshot"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryComponentSnapshot"
+                }
+              }
+            },
             "description": "OK"
           },
           "400": {

--- a/contracts/openapi/admin-v1.json
+++ b/contracts/openapi/admin-v1.json
@@ -3706,6 +3706,80 @@
         ]
       }
     },
+    "/api/memory-components": {
+      "get": {
+        "operationId": "get-api-memory-components",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Bad request."
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Unauthorized."
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Forbidden."
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Not found."
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Conflict."
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Unexpected server error. Detail is sanitized; use traceId."
+          }
+        },
+        "summary": "Get Memory Components",
+        "tags": [
+          "GetMemoryComponents"
+        ]
+      }
+    },
     "/api/migration/altmount/categories": {
       "get": {
         "operationId": "get-api-migration-altmount-categories",
@@ -10502,6 +10576,9 @@
     },
     {
       "name": "GetOverviewStats"
+    },
+    {
+      "name": "GetMemoryComponents"
     },
     {
       "name": "GetLogs"

--- a/tests/NzbWebDAV.Tests/Services/Diagnostics/MemoryComponentSnapshotTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Diagnostics/MemoryComponentSnapshotTests.cs
@@ -1,0 +1,59 @@
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Services;
+using NzbWebDAV.Services.Diagnostics;
+using NzbWebDAV.Streams;
+
+namespace NzbWebDAV.Tests.Services.Diagnostics;
+
+public sealed class MemoryComponentSnapshotTests
+{
+    [Fact]
+    public async Task Capture_UsesRawByteUnitsAndSeparatesLogicalArticleBytes()
+    {
+        var budget = new InFlightArticleBudget(10_000);
+        using var lease = await budget.LeaseAsync(1_000, CancellationToken.None);
+        budget.AccountBufferedPipeBytes(500);
+        var builder = CreateBuilder(budget);
+
+        var snapshot = builder.Capture();
+
+        Assert.Equal(MemoryComponentSnapshotBuilder.CurrentSchemaVersion, snapshot.SchemaVersion);
+        Assert.NotEqual(default, snapshot.CapturedAtUtc);
+        Assert.True(snapshot.MonotonicTimestamp > 0);
+        Assert.True(snapshot.CaptureDurationMicroseconds >= 0);
+        Assert.Equal(1_500, snapshot.InFlightArticles.TotalAccountedBytes);
+        Assert.Equal(1_000, snapshot.InFlightArticles.ArticleDestinationLogicalBytes);
+        Assert.Equal(500, snapshot.InFlightArticles.DecodedPipeBytes);
+        Assert.True(snapshot.InFlightArticles.IsConsistent);
+        Assert.False(snapshot.CacheWriter.Supported);
+        Assert.Null(snapshot.CacheWriter.WriteBudgetBytes);
+        Assert.Null(snapshot.CacheWriter.QueuedWriteBytes);
+
+        budget.AccountBufferedPipeBytes(-500);
+    }
+
+    [Fact]
+    public void Capture_QuiescentOwnersAreInternallyConsistent()
+    {
+        var snapshot = CreateBuilder(new InFlightArticleBudget(10_000)).Capture();
+
+        Assert.Equal(0, snapshot.InFlightArticles.TotalAccountedBytes);
+        Assert.Equal(0, snapshot.InFlightArticles.ArticleDestinationLogicalBytes);
+        Assert.Equal(0, snapshot.InFlightArticles.DecodedPipeBytes);
+        Assert.Equal(0, snapshot.InFlightArticles.WaiterCount);
+        Assert.Equal(0, snapshot.Activity.ActiveReads);
+        Assert.Equal(0, snapshot.Activity.CurrentInFlightSegmentFetches);
+    }
+
+    private static MemoryComponentSnapshotBuilder CreateBuilder(InFlightArticleBudget budget)
+    {
+        var config = new ConfigManager();
+        return new MemoryComponentSnapshotBuilder(
+            budget,
+            config,
+            new ConcurrentReadTracker(configManager: config),
+            new ActiveReadRegistry(),
+            new SegmentCacheStatistics());
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Observability/PrometheusMetricsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Observability/PrometheusMetricsTests.cs
@@ -111,9 +111,9 @@ public sealed class PrometheusMetricsTests
         var exposition = await ExportAsync(registry);
 
         Assert.Contains("nzbdav_inflight_article_destination_bytes", exposition);
-        Assert.DoesNotContain("nzbdav_segment_buffer_checked_out_bytes", exposition);
-        Assert.DoesNotContain("nzbdav_segment_buffer_idle_bytes", exposition);
-        Assert.DoesNotContain("nzbdav_segment_buffer_max_idle_bytes", exposition);
+        Assert.DoesNotContain("\nnzbdav_segment_buffer_checked_out_bytes ", exposition);
+        Assert.DoesNotContain("\nnzbdav_segment_buffer_idle_bytes ", exposition);
+        Assert.DoesNotContain("\nnzbdav_segment_buffer_max_idle_bytes ", exposition);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Services/Observability/PrometheusMetricsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Observability/PrometheusMetricsTests.cs
@@ -4,7 +4,9 @@ using NzbWebDAV.Clients.Usenet.Connections;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Models;
 using NzbWebDAV.Services;
+using NzbWebDAV.Services.Diagnostics;
 using NzbWebDAV.Services.Observability;
+using NzbWebDAV.Streams;
 using Prometheus;
 
 namespace NzbWebDAV.Tests.Services.Observability;
@@ -76,6 +78,42 @@ public sealed class PrometheusMetricsTests
         Assert.Contains("nzbdav_shared_stream_lagging_readers", exposition);
         Assert.Contains("nzbdav_shared_stream_pressure_detaches_total", exposition);
         Assert.Contains("nzbdav_shared_stream_pressure_reaps_total", exposition);
+    }
+
+    [Fact]
+    public async Task MemoryComponentMetrics_ProjectAggregateOwnersWithoutLabels()
+    {
+        var registry = new CollectorRegistry();
+        var metrics = new PrometheusMetrics(registry);
+        metrics.SetMemoryComponents(MemoryComponents(
+            segmentBuffers: new SegmentBufferMemorySnapshot(
+                "bounded-legacy", 100, 200, 300, 4, 3, 0, 100, 128, 28)));
+
+        var exposition = await ExportAsync(registry);
+
+        Assert.Contains("nzbdav_inflight_article_destination_bytes 100", exposition);
+        Assert.Contains("nzbdav_decoded_body_pipe_bytes 20", exposition);
+        Assert.Contains("nzbdav_inflight_article_waiters 2", exposition);
+        Assert.Contains("nzbdav_segment_buffer_checked_out_bytes 100", exposition);
+        Assert.Contains("nzbdav_segment_buffer_idle_bytes 200", exposition);
+        Assert.Contains("nzbdav_segment_buffer_max_idle_bytes 300", exposition);
+        Assert.DoesNotContain("nzbdav_inflight_article_destination_bytes{", exposition);
+        Assert.DoesNotContain("nzbdav_segment_buffer_checked_out_bytes{", exposition);
+    }
+
+    [Fact]
+    public async Task MemoryComponentMetrics_UnpublishCustomPoolGaugesWhenUnsupported()
+    {
+        var registry = new CollectorRegistry();
+        var metrics = new PrometheusMetrics(registry);
+        metrics.SetMemoryComponents(MemoryComponents(segmentBuffers: null));
+
+        var exposition = await ExportAsync(registry);
+
+        Assert.Contains("nzbdav_inflight_article_destination_bytes", exposition);
+        Assert.DoesNotContain("nzbdav_segment_buffer_checked_out_bytes", exposition);
+        Assert.DoesNotContain("nzbdav_segment_buffer_idle_bytes", exposition);
+        Assert.DoesNotContain("nzbdav_segment_buffer_max_idle_bytes", exposition);
     }
 
     [Fact]
@@ -264,6 +302,28 @@ public sealed class PrometheusMetricsTests
             TemporaryFilesCleaned: 0,
             QueuedWriteBytes: null,
             PeakQueuedWriteBytes: null);
+
+    private static MemoryComponentSnapshot MemoryComponents(
+        SegmentBufferMemorySnapshot? segmentBuffers) =>
+        new(
+            SchemaVersion: 1,
+            CapturedAtUtc: DateTimeOffset.UtcNow,
+            MonotonicTimestamp: 1,
+            CaptureDurationMicroseconds: 0,
+            BackendWorkingSetBytes: 1000,
+            Gc: new GcSnapshot([], 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            InFlightArticles: new InFlightArticleMemorySnapshot(
+                TotalAccountedBytes: 120,
+                ArticleDestinationLogicalBytes: 100,
+                DecodedPipeBytes: 20,
+                CapBytes: 1000,
+                WaiterCount: 2,
+                ThrottleEvents: 3,
+                IsConsistent: true),
+            SegmentBuffers: segmentBuffers,
+            SharedStreams: new SharedStreamMemorySnapshot(0, 0, 0, 0, 0, 0, 0, 0, 0),
+            CacheWriter: new SegmentCacheWriterMemorySnapshot(false, null, null, null, null, null, null),
+            Activity: new MemoryActivitySnapshot(0, 0));
 
     private static SegmentCacheSnapshot ReadySnapshot() =>
         new(

--- a/tests/NzbWebDAV.Tests/Services/OomDiagnosticsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/OomDiagnosticsTests.cs
@@ -32,6 +32,8 @@ public sealed class OomDiagnosticsTests
         Assert.True(entry.Properties.ContainsKey("LohHardLimit"));
         Assert.True(entry.Properties.ContainsKey("LohHardLimitPercent"));
         Assert.True(entry.Properties.ContainsKey("PoolOutstanding"));
+        Assert.True(entry.Properties.ContainsKey("DecodedPipe"));
+        Assert.True(entry.Properties.ContainsKey("ArticleWaiters"));
         Assert.Contains(events, e =>
             e.Level == LogEventLevel.Debug &&
             e.MessageTemplate.Text.Contains("OutOfMemoryException stack") &&

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -301,6 +301,28 @@ public sealed class SupportPackContentsTests : IDisposable
     }
 
     [Fact]
+    public async Task Pack_ProjectsVersionedMemoryComponentsWithoutSensitiveIdentifiers()
+    {
+        var entries = await ReadPackEntriesAsync(
+            new LogBufferSink(10),
+            new WarningLogBuffer(new LogBufferSink(50)));
+
+        using var environment = JsonDocument.Parse(entries["environment.json"]);
+        var memory = environment.RootElement
+            .GetProperty("runtime")
+            .GetProperty("memoryComponents");
+
+        Assert.Equal(1, memory.GetProperty("schemaVersion").GetInt32());
+        Assert.True(memory.TryGetProperty("capturedAtUtc", out _));
+        Assert.True(memory.TryGetProperty("inFlightArticles", out _));
+        Assert.True(memory.TryGetProperty("sharedStreams", out _));
+        Assert.True(memory.TryGetProperty("cacheWriter", out _));
+        Assert.DoesNotContain("path", memory.GetRawText(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("message", memory.GetRawText(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("provider", memory.GetRawText(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task Pack_ReportsNullSegmentBufferPoolWhenOverrideUsesSharedPool()
     {
         var previous = PooledBufferStream.DefaultPool;
@@ -953,6 +975,7 @@ public sealed class SupportPackContentsTests : IDisposable
     {
         configManager ??= new ConfigManager();
         var websocketManager = new WebsocketManager();
+        var activeReads = new ActiveReadRegistry();
         var usenet = new UsenetStreamingClient(
             configManager,
             websocketManager,
@@ -960,7 +983,7 @@ public sealed class SupportPackContentsTests : IDisposable
             new MetricsWriter(),
             new ProviderBytesTracker(),
             streamTraceBuffer,
-            new ActiveReadRegistry());
+            activeReads);
 
         using var gcDiagnosticsStore = new GcDiagnosticsStore();
         var repairDir = Path.Join(Path.GetTempPath(), "nzbdav-support-test-" + Guid.NewGuid().ToString("N"));
@@ -968,6 +991,14 @@ public sealed class SupportPackContentsTests : IDisposable
         await repairPatchStore.EnsureCatalogLoadedAsync(CancellationToken.None);
         var par2RepairService = new Par2RepairService(configManager, usenet, repairPatchStore);
         using var healthCheckConnectionGate = new HealthCheckConnectionGate(configManager);
+        var budget = new InFlightArticleBudget(64 * 1024 * 1024);
+        var cacheStatistics = segmentCacheStatistics ?? new SegmentCacheStatistics();
+        var snapshotBuilder = new MemoryComponentSnapshotBuilder(
+            budget,
+            configManager,
+            concurrentReadTracker ?? new ConcurrentReadTracker(configManager: configManager),
+            activeReads,
+            cacheStatistics);
         var service = new SupportPackService(
             logBuffer,
             warningBuffer,
@@ -977,7 +1008,7 @@ public sealed class SupportPackContentsTests : IDisposable
             new ProviderLatencyTracker(),
             usenet,
             new ArticleMissNegativeCache(configManager),
-            new InFlightArticleBudget(64 * 1024 * 1024),
+            budget,
             streamTraceBuffer,
             runtimeUsage ?? new RuntimeUsageTracker(),
             gcDiagnosticsStore,
@@ -986,7 +1017,8 @@ public sealed class SupportPackContentsTests : IDisposable
             healthCheckConnectionGate,
             concurrentReadTracker,
             queueCoordinator: null,
-            segmentCacheStatistics);
+            cacheStatistics,
+            snapshotBuilder);
 
         using var memory = new MemoryStream();
         await service.WriteAsync(memory, CancellationToken.None);

--- a/tests/NzbWebDAV.Tests/Streams/InFlightArticleBudgetTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/InFlightArticleBudgetTests.cs
@@ -196,7 +196,7 @@ public class InFlightArticleBudgetTests
         var waiter = budget.LeaseAsync(50, CancellationToken.None).AsTask();
         await WaitUntil(() => budget.WaiterCount == 1);
 
-        held.Adjust(-150);
+        held.Adjust(-100);
         await Task.Delay(25);
         Assert.False(waiter.IsCompleted);
 

--- a/tests/NzbWebDAV.Tests/Streams/InFlightArticleBudgetTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/InFlightArticleBudgetTests.cs
@@ -39,6 +39,31 @@ public class InFlightArticleBudgetTests
     }
 
     [Fact]
+    public async Task Snapshot_SeparatesArticleDestinationPipeAndWaiterBytesAtQuiescence()
+    {
+        var budget = new InFlightArticleBudget(1_000);
+        using var lease = await budget.LeaseAsync(400, CancellationToken.None);
+        budget.AccountBufferedPipeBytes(300);
+
+        var snapshot = budget.SnapshotMemory();
+
+        Assert.True(snapshot.IsConsistent);
+        Assert.Equal(700, snapshot.TotalAccountedBytes);
+        Assert.Equal(400, snapshot.ArticleDestinationLogicalBytes);
+        Assert.Equal(300, snapshot.DecodedPipeBytes);
+        Assert.Equal(0, snapshot.WaiterCount);
+
+        budget.AccountBufferedPipeBytes(-300);
+        lease.Dispose();
+
+        snapshot = budget.SnapshotMemory();
+        Assert.True(snapshot.IsConsistent);
+        Assert.Equal(0, snapshot.TotalAccountedBytes);
+        Assert.Equal(0, snapshot.ArticleDestinationLogicalBytes);
+        Assert.Equal(0, snapshot.DecodedPipeBytes);
+    }
+
+    [Fact]
     public async Task AccountBufferedPipeBytes_PipeChargeSaturation_WakesFifoWaiterOnNegativeDelta()
     {
         const long cap = 1_000;
@@ -125,6 +150,73 @@ public class InFlightArticleBudgetTests
         newcomerLease.Dispose();
         held.Dispose();
         Assert.Equal(0, budget.LeasedBytes);
+    }
+
+    [Fact]
+    public async Task LeaseAsync_CancelledHead_WakesNextFifoWaiter()
+    {
+        var budget = new InFlightArticleBudget(100);
+        using var held = await budget.LeaseAsync(100, CancellationToken.None);
+        using var cancelled = new CancellationTokenSource();
+        var head = budget.LeaseAsync(100, cancelled.Token).AsTask();
+        await WaitUntil(() => budget.WaiterCount == 1);
+        var next = budget.LeaseAsync(50, CancellationToken.None).AsTask();
+        await WaitUntil(() => budget.WaiterCount == 2);
+
+        cancelled.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => head);
+        held.Dispose();
+
+        using var nextLease = await next.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(50, budget.LeasedBytes);
+        Assert.Equal(0, budget.WaiterCount);
+    }
+
+    [Fact]
+    public async Task SetCapBytes_GrowthWakesHeadWithoutBarging()
+    {
+        var budget = new InFlightArticleBudget(100);
+        using var held = await budget.LeaseAsync(100, CancellationToken.None);
+        var head = budget.LeaseAsync(200, CancellationToken.None).AsTask();
+        await WaitUntil(() => budget.WaiterCount == 1);
+
+        budget.SetCapBytes(300);
+        using var lease = await head.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.Equal(300, budget.LeasedBytes);
+        Assert.Equal(0, budget.WaiterCount);
+    }
+
+    [Fact]
+    public async Task SetCapBytes_ShrinkBelowCurrentBlocksUntilReleased()
+    {
+        var budget = new InFlightArticleBudget(200);
+        using var held = await budget.LeaseAsync(200, CancellationToken.None);
+        budget.SetCapBytes(100);
+        var waiter = budget.LeaseAsync(50, CancellationToken.None).AsTask();
+        await WaitUntil(() => budget.WaiterCount == 1);
+
+        held.Adjust(-150);
+        await Task.Delay(25);
+        Assert.False(waiter.IsCompleted);
+
+        held.Dispose();
+        using var lease = await waiter.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(50, budget.LeasedBytes);
+    }
+
+    [Fact]
+    public async Task ArticleByteLease_AdjustAndDoubleDispose_CannotOverRelease()
+    {
+        var budget = new InFlightArticleBudget(500);
+        var lease = await budget.LeaseAsync(400, CancellationToken.None);
+
+        lease.Adjust(-100);
+        lease.Dispose();
+        lease.Dispose();
+
+        Assert.Equal(0, budget.LeasedBytes);
+        Assert.Equal(0, budget.SnapshotMemory().ArticleDestinationLogicalBytes);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolTests.cs
@@ -111,6 +111,28 @@ public class SegmentBufferPoolTests
     }
 
     [Fact]
+    public void MemorySnapshot_MatchesFullSnapshotAtQuiescence()
+    {
+        var pool = new SegmentBufferPool(maxIdleBytes: 1024 * 1024);
+        var checkedOut = pool.Rent(300_000);
+        var returned = pool.Rent(300_000);
+        pool.Return(returned);
+
+        var memory = pool.MemorySnapshot();
+        var full = pool.Snapshot();
+
+        Assert.Equal("bounded-legacy", memory.Mode);
+        Assert.Equal(full.CheckedOutBytes, memory.CheckedOutCapacityBytes);
+        Assert.Equal(full.IdleBytes, memory.IdleCapacityBytes);
+        Assert.Equal(full.MaxIdleBytes, memory.MaxIdleBytes);
+        Assert.Equal(full.RentCount, memory.RentCount);
+        Assert.Equal(full.ReturnCount, memory.ReturnCount);
+        Assert.Equal(full.RejectedReturnCount, memory.RejectedReturnCount);
+
+        pool.Return(checkedOut);
+    }
+
+    [Fact]
     public void LeakedBuffer_IsNotRootedByThePool()
     {
         var pool = new SegmentBufferPool(maxIdleBytes: 1024 * 1024);


### PR DESCRIPTION
## Summary
- expose a versioned authenticated memory-component snapshot for benchmark attribution
- split in-flight accounting into destination and decoded-pipe ownership, and publish low-cardinality metrics
- include the same snapshot in support packs and add owner-attribution test coverage without changing memory limits or retention policies

## Test plan
- [x] `dotnet build backend/NzbWebDAV.csproj -c Release --no-restore`
- [x] `dotnet build tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore`
- [ ] Focused automated tests deferred at requester instruction; PR CI will run the full suite
- [ ] External memory benchmark/attribution campaign deferred to its later work item

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated endpoint for capturing memory-component snapshots.
  * Expanded diagnostics with GC pause duration, memory usage, article budgets, stream buffers, waiters, and cache-writer status.
  * Added memory-component metrics to Prometheus and support packs.
  * Budget logs now identify whether limits are explicitly configured or derived.
* **Bug Fixes**
  * Improved byte accounting to prevent over-release and maintain consistent memory totals.
  * Added clearer handling for unsupported segment-buffer metrics.
  * Improved expected shutdown handling for benchmark connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->