### PR TITLE
fix(db): container no longer dumps a stack trace per file when local streaming metadata is corrupt

### DIFF
--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -220,6 +220,16 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx, IBlobStore? blobSt
     /// the exception is rethrown so callers see the real corruption instead of a false
     /// "missing payload" result.
     /// </summary>
+    /// <summary>
+    /// Reads a typed blob from the blob store, recovering from a legacy database row
+    /// if the blob is corrupted and a fallback is available.
+    /// </summary>
+    /// <typeparam name="T">The deserialized payload type.</typeparam>
+    /// <param name="davItem">The DAV item owning this blob.</param>
+    /// <param name="blobId">The blob identifier to read.</param>
+    /// <param name="readLegacyRow">A callback to query the legacy database row when the blob is corrupted.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The deserialized payload, fallback row, or throws if the blob is corrupted and no fallback exists.</returns>
     private async Task<T?> ReadTypedBlobOrFallbackAsync<T>(
         DavItem davItem,
         Guid blobId,

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Services;
 using Serilog;
@@ -142,11 +143,14 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx, IBlobStore? blobSt
 
     public async Task<DavNzbFile?> GetDavNzbFileAsync(DavItem davItem, CancellationToken ct = default)
     {
-        // attempt to read from blob-store
         var blobId = davItem.FileBlobId;
         if (blobId.HasValue)
         {
-            var blob = await BlobStore.ReadBlob<DavNzbFile>(blobId.Value).ConfigureAwait(false);
+            var blob = await ReadTypedBlobOrFallbackAsync(
+                davItem,
+                blobId.Value,
+                fallbackCt => ctx.NzbFiles.AsNoTracking().FirstOrDefaultAsync(x => x.Id == davItem.Id, fallbackCt),
+                ct).ConfigureAwait(false);
             if (blob is not null) return blob;
         }
 
@@ -159,11 +163,14 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx, IBlobStore? blobSt
 
     public async Task<DavRarFile?> GetDavRarFileAsync(DavItem davItem, CancellationToken ct = default)
     {
-        // attempt to read from blob-store
         var blobId = davItem.FileBlobId;
         if (blobId.HasValue)
         {
-            var blob = await BlobStore.ReadBlob<DavRarFile>(blobId.Value).ConfigureAwait(false);
+            var blob = await ReadTypedBlobOrFallbackAsync(
+                davItem,
+                blobId.Value,
+                fallbackCt => ctx.RarFiles.AsNoTracking().FirstOrDefaultAsync(x => x.Id == davItem.Id, fallbackCt),
+                ct).ConfigureAwait(false);
             if (blob is not null) return blob;
         }
 
@@ -178,11 +185,14 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx, IBlobStore? blobSt
     {
         DavMultipartFile? multipartFile = null;
 
-        // attempt to read from blob-store
         var blobId = davItem.FileBlobId;
         if (blobId.HasValue)
         {
-            multipartFile = await BlobStore.ReadBlob<DavMultipartFile>(blobId.Value).ConfigureAwait(false);
+            multipartFile = await ReadTypedBlobOrFallbackAsync(
+                davItem,
+                blobId.Value,
+                fallbackCt => ctx.MultipartFiles.AsNoTracking().FirstOrDefaultAsync(x => x.Id == davItem.Id, fallbackCt),
+                ct).ConfigureAwait(false);
         }
 
         // read from database
@@ -201,6 +211,37 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx, IBlobStore? blobSt
         }
 
         return multipartFile;
+    }
+
+    /// <summary>
+    /// Reads a typed blob-store record, falling back to its legacy SQL row only when the
+    /// blob is unreadable (<see cref="CorruptedBlobPayloadException"/>) rather than absent.
+    /// A recovered legacy row is logged once as a handled Warning; if no legacy row exists,
+    /// the exception is rethrown so callers see the real corruption instead of a false
+    /// "missing payload" result.
+    /// </summary>
+    private async Task<T?> ReadTypedBlobOrFallbackAsync<T>(
+        DavItem davItem,
+        Guid blobId,
+        Func<CancellationToken, Task<T?>> readLegacyRow,
+        CancellationToken ct)
+    {
+        try
+        {
+            return await (blobStore ?? BlobStore.Current).ReadBlob<T>(blobId).ConfigureAwait(false);
+        }
+        catch (CorruptedBlobPayloadException e)
+        {
+            var legacy = await readLegacyRow(ct).ConfigureAwait(false);
+            if (legacy is null) throw;
+
+            Log.Warning(
+                "Streaming metadata blob {BlobId} for {Path} is unreadable; recovered from the legacy " +
+                "database row instead. Reason: {Reason}",
+                blobId, davItem.Path, e.Message);
+            Log.Debug(e, "Unreadable streaming metadata blob stack for {Path}", davItem.Path);
+            return legacy;
+        }
     }
 
     // queue

--- a/backend/Database/FileBlobStore.cs
+++ b/backend/Database/FileBlobStore.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using MemoryPack;
 using Microsoft.Extensions.Caching.Memory;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
 using ZstdSharp;
 
 namespace NzbWebDAV.Database;
@@ -131,9 +132,22 @@ public sealed class FileBlobStore : IBlobStore, IDisposable
 
         var stream = ReadBlob(id);
         if (stream == null) return default;
-        await using var fileStream = stream;
-        await using var decompressionStream = new DecompressionStream(fileStream);
-        var blob = await MemoryPackSerializer.DeserializeAsync<T>(decompressionStream).ConfigureAwait(false);
+        var blobPath = GetBlobPath(id);
+        T? blob;
+        try
+        {
+            await using var fileStream = stream;
+            await using var decompressionStream = new DecompressionStream(fileStream);
+            blob = await MemoryPackSerializer.DeserializeAsync<T>(decompressionStream).ConfigureAwait(false);
+        }
+        catch (Exception e) when (
+            e is MemoryPackSerializationException or ZstdException or EndOfStreamException)
+        {
+            // Truncated/corrupt on-disk blob (unclean shutdown, partial restore):
+            // the payload exists but cannot be decoded, distinct from a missing file.
+            throw new CorruptedBlobPayloadException(id, blobPath, typeof(T), e);
+        }
+
         if (blob is not null)
         {
             _metadataCache.Set(id, blob, new MemoryCacheEntryOptions()

--- a/backend/Database/FileBlobStore.cs
+++ b/backend/Database/FileBlobStore.cs
@@ -126,6 +126,15 @@ public sealed class FileBlobStore : IBlobStore, IDisposable
         }
     }
 
+    /// <summary>
+    /// Reads and deserializes a blob by identifier, checking the process-local metadata cache first.
+    /// Wraps deserialization failures (truncated/corrupt blobs) in <see cref="CorruptedBlobPayloadException"/>
+    /// with blob identity and path metadata. Does not cache failed reads.
+    /// </summary>
+    /// <typeparam name="T">The deserialized payload type.</typeparam>
+    /// <param name="id">The blob identifier.</param>
+    /// <returns>The deserialized payload, null if the blob file is missing, or throws if truncated/corrupt.</returns>
+    /// <exception cref="CorruptedBlobPayloadException">When the blob file exists but fails deserialization.</exception>
     public async Task<T?> ReadBlob<T>(Guid id)
     {
         if (_metadataCache.TryGetValue(id, out T? cached)) return cached;

--- a/backend/Exceptions/CorruptedBlobPayloadException.cs
+++ b/backend/Exceptions/CorruptedBlobPayloadException.cs
@@ -11,8 +11,8 @@ public class CorruptedBlobPayloadException : Exception
 {
     public CorruptedBlobPayloadException(Guid blobId, string blobPath, Type payloadType, Exception inner)
         : base($"The local streaming metadata blob '{blobId}' ({payloadType.Name}) at '{blobPath}' " +
-               $"could not be read ({inner.GetType().Name}: {inner.Message}). Restore a backup of " +
-               "the blobs/ folder that matches the database, or remove and re-download the release.",
+               "is unreadable. Restore a backup of the blobs/ folder that matches the database, " +
+               "or remove and re-download the release.",
             inner)
     {
         BlobId = blobId;

--- a/backend/Exceptions/CorruptedBlobPayloadException.cs
+++ b/backend/Exceptions/CorruptedBlobPayloadException.cs
@@ -1,0 +1,26 @@
+namespace NzbWebDAV.Exceptions;
+
+/// <summary>
+/// A blob-store record exists on disk but failed to decompress/deserialize
+/// (truncated write, unclean shutdown, restore without a matching blob).
+/// The payload itself is present but unreadable — distinct from
+/// <see cref="MissingFilePayloadException"/> — and never implicates the
+/// release's Usenet articles, so this must never trigger Arr repair.
+/// </summary>
+public class CorruptedBlobPayloadException : Exception
+{
+    public CorruptedBlobPayloadException(Guid blobId, string blobPath, Type payloadType, Exception inner)
+        : base($"The local streaming metadata blob '{blobId}' ({payloadType.Name}) at '{blobPath}' " +
+               $"could not be read ({inner.GetType().Name}: {inner.Message}). Restore a backup of " +
+               "the blobs/ folder that matches the database, or remove and re-download the release.",
+            inner)
+    {
+        BlobId = blobId;
+        BlobPath = blobPath;
+        PayloadType = payloadType;
+    }
+
+    public Guid BlobId { get; }
+    public string BlobPath { get; }
+    public Type PayloadType { get; }
+}

--- a/backend/Extensions/ExceptionExtensions.cs
+++ b/backend/Extensions/ExceptionExtensions.cs
@@ -168,6 +168,24 @@ public static class ExceptionExtensions
     }
 
     /// <summary>
+    /// True when the exception chain contains a <see cref="CorruptedBlobPayloadException"/> —
+    /// a local streaming-metadata blob that exists but failed to decode. Checked ahead of
+    /// the general transport/download walk because its inner exception is often itself a
+    /// known type (e.g. <see cref="EndOfStreamException"/>), which would otherwise overwrite
+    /// this exception's more actionable message.
+    /// </summary>
+    public static bool IsCorruptedBlobPayloadException(this Exception exception)
+    {
+        for (var current = exception; current != null; current = current.InnerException)
+        {
+            if (current is CorruptedBlobPayloadException)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Returns a human-readable message for known/expected failures (transport,
     /// download, and database corruption) so callers can log a single line without
     /// a stack dump. Walks the exception chain and prefers the innermost matching
@@ -181,6 +199,15 @@ public static class ExceptionExtensions
         {
             reason = DatabaseCorruptionReason;
             return true;
+        }
+
+        for (var current = exception; current != null; current = current.InnerException)
+        {
+            if (current is CorruptedBlobPayloadException)
+            {
+                reason = current.Message;
+                return true;
+            }
         }
 
         if (exception.IsTransientDatabaseException() || exception.IsKnownSqliteDiskException())

--- a/backend/Extensions/ExceptionExtensions.cs
+++ b/backend/Extensions/ExceptionExtensions.cs
@@ -172,24 +172,20 @@ public static class ExceptionExtensions
     /// a local streaming-metadata blob that exists but failed to decode. Checked ahead of
     /// the general transport/download walk because its inner exception is often itself a
     /// known type (e.g. <see cref="EndOfStreamException"/>), which would otherwise overwrite
-    /// this exception's more actionable message.
+    /// this exception's more actionable message. Searches for wrapped instances including those inside
+    /// <see cref="AggregateException"/>.
     /// </summary>
     public static bool IsCorruptedBlobPayloadException(this Exception exception)
     {
-        for (var current = exception; current != null; current = current.InnerException)
-        {
-            if (current is CorruptedBlobPayloadException)
-                return true;
-        }
-
-        return false;
+        return exception.TryGetCausingException<CorruptedBlobPayloadException>(out _);
     }
 
     /// <summary>
     /// Returns a human-readable message for known/expected failures (transport,
     /// download, and database corruption) so callers can log a single line without
     /// a stack dump. Walks the exception chain and prefers the innermost matching
-    /// message. Unexpected exceptions return false so full stack traces are preserved.
+    /// message. Searches for wrapped instances including those inside <see cref="AggregateException"/>.
+    /// Unexpected exceptions return false so full stack traces are preserved.
     /// </summary>
     public static bool TryGetKnownErrorMessage(this Exception exception, out string reason)
     {
@@ -201,13 +197,10 @@ public static class ExceptionExtensions
             return true;
         }
 
-        for (var current = exception; current != null; current = current.InnerException)
+        if (exception.TryGetCausingException<CorruptedBlobPayloadException>(out var corrupted))
         {
-            if (current is CorruptedBlobPayloadException)
-            {
-                reason = current.Message;
-                return true;
-            }
+            reason = corrupted!.Message;
+            return true;
         }
 
         if (exception.IsTransientDatabaseException() || exception.IsKnownSqliteDiskException())

--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -329,6 +329,44 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
 
             AbortStartedResponse(context);
         }
+        catch (Exception e) when (e.TryGetCausingException<CorruptedBlobPayloadException>(out var corrupted))
+        {
+            // Handle wrapped CorruptedBlobPayloadException (e.g., inside AggregateException).
+            // The local streaming metadata blob exists but failed to decode (truncated
+            // write, unclean shutdown): a client-visible data problem, not a server
+            // fault, and never a reason to blocklist the release. Reuses the
+            // missing-payload wire classification so existing clients still treat this
+            // as terminal rather than retryable.
+            if (!context.Response.HasStarted)
+            {
+                context.Response.Clear();
+                context.Response.StatusCode = 404;
+                context.Response.Headers["X-InfiniDysk-Stream-Error"] = "missing-file-payload";
+                context.Response.ContentType = "text/plain; charset=utf-8";
+                await context.Response.WriteAsync(
+                    "This file's streaming metadata is present but unreadable. " +
+                    "Restore a backup of the blobs/ folder that matches the database, " +
+                    "or remove and re-download the release.",
+                    context.RequestAborted).ConfigureAwait(false);
+            }
+
+            var filePath = GetRequestFilePath(context);
+            var dedupeKey = $"{filePath}|{corrupted!.BlobId}";
+            LogWithDedup(RecentReadErrors, dedupeKey, suppressed =>
+            {
+                if (suppressed > 0)
+                    Log.Warning(
+                        "File {FilePath} cannot be served: its streaming metadata blob {BlobId} ({PayloadType}) is unreadable (suppressed {SuppressedCount} duplicates in last 60s)",
+                        filePath, corrupted.BlobId, corrupted.PayloadType.Name, suppressed);
+                else
+                    Log.Warning(
+                        "File {FilePath} cannot be served: its streaming metadata blob {BlobId} ({PayloadType}) is unreadable",
+                        filePath, corrupted.BlobId, corrupted.PayloadType.Name);
+            });
+            Log.Debug(e, "Unreadable streaming metadata blob stack for {FilePath}", filePath);
+
+            AbortStartedResponse(context);
+        }
         catch (CorruptedBlobPayloadException e)
         {
             // The local streaming metadata blob exists but failed to decode (truncated

--- a/backend/Middlewares/ExceptionMiddleware.cs
+++ b/backend/Middlewares/ExceptionMiddleware.cs
@@ -329,6 +329,43 @@ public class ExceptionMiddleware(RequestDelegate next, ConfigManager configManag
 
             AbortStartedResponse(context);
         }
+        catch (CorruptedBlobPayloadException e)
+        {
+            // The local streaming metadata blob exists but failed to decode (truncated
+            // write, unclean shutdown): a client-visible data problem, not a server
+            // fault, and never a reason to blocklist the release. Reuses the
+            // missing-payload wire classification so existing clients still treat this
+            // as terminal rather than retryable.
+            if (!context.Response.HasStarted)
+            {
+                context.Response.Clear();
+                context.Response.StatusCode = 404;
+                context.Response.Headers["X-InfiniDysk-Stream-Error"] = "missing-file-payload";
+                context.Response.ContentType = "text/plain; charset=utf-8";
+                await context.Response.WriteAsync(
+                    "This file's streaming metadata is present but unreadable. " +
+                    "Restore a backup of the blobs/ folder that matches the database, " +
+                    "or remove and re-download the release.",
+                    context.RequestAborted).ConfigureAwait(false);
+            }
+
+            var filePath = GetRequestFilePath(context);
+            var dedupeKey = $"{filePath}|{e.BlobId}";
+            LogWithDedup(RecentReadErrors, dedupeKey, suppressed =>
+            {
+                if (suppressed > 0)
+                    Log.Warning(
+                        "File {FilePath} cannot be served: its streaming metadata blob {BlobId} ({PayloadType}) is unreadable (suppressed {SuppressedCount} duplicates in last 60s)",
+                        filePath, e.BlobId, e.PayloadType.Name, suppressed);
+                else
+                    Log.Warning(
+                        "File {FilePath} cannot be served: its streaming metadata blob {BlobId} ({PayloadType}) is unreadable",
+                        filePath, e.BlobId, e.PayloadType.Name);
+            });
+            Log.Debug(e, "Unreadable streaming metadata blob stack for {FilePath}", filePath);
+
+            AbortStartedResponse(context);
+        }
         catch (MissingFilePayloadException e)
         {
             // The local streaming payload is gone (commonly a database-only

--- a/backend/Services/Benchmark/BenchmarkCorpusProvider.cs
+++ b/backend/Services/Benchmark/BenchmarkCorpusProvider.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.Models.Nzb;
 using Serilog;
 
@@ -40,7 +41,7 @@ public sealed class BenchmarkCorpusProvider(DavDatabaseClient db)
         {
             // A corpus hiccup shouldn't sink the whole benchmark — degrade to
             // whatever we managed to gather (possibly latency-only).
-            Log.Warning(e, "Benchmark corpus gathering failed; using {Count} segments.", pool.Count);
+            e.LogWarningKnownOrStack("Benchmark corpus gathering failed; using {Count} segments.", pool.Count);
         }
 
         Shuffle(pool);

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -59,6 +59,10 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             MissingPayloadMessagePrefix,
             StringComparison.Ordinal) == true;
 
+    /// <summary>
+    /// True when the message starts with the unreadable payload prefix, indicating a
+    /// prior check detected a corrupted blob.
+    /// </summary>
     internal static bool IsUnreadablePayloadMessage(string? message) =>
         message?.StartsWith(
             UnreadablePayloadMessagePrefix,
@@ -70,6 +74,14 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
         CancellationToken ct) =>
         GetPayloadConfirmationAsync(context, davItemId, IsMissingPayloadMessage, ct);
 
+    /// <summary>
+    /// Counts recent health check results for this DAV item that reported an unreadable
+    /// streaming metadata blob. Used to detect persistent corruption and escalate actions.
+    /// </summary>
+    /// <param name="context">Database context.</param>
+    /// <param name="davItemId">The DAV item identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The count of consecutive unreadable confirmations.</returns>
     internal static Task<int> GetUnreadablePayloadConfirmationAsync(
         DavDatabaseContext context,
         Guid davItemId,

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -39,6 +39,7 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
 {
     private const int MaximumMissingSegmentIds = 100_000;
     internal const string MissingPayloadMessagePrefix = "Streaming payload missing.";
+    internal const string UnreadablePayloadMessagePrefix = "Streaming payload unreadable.";
     private const int MissingPayloadConfirmationsRequired = 3;
     private static readonly TimeSpan MissingPayloadInitialRecheck = TimeSpan.FromDays(1);
     private static readonly TimeSpan MissingPayloadConfirmedRecheck = TimeSpan.FromDays(7);
@@ -58,9 +59,27 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             MissingPayloadMessagePrefix,
             StringComparison.Ordinal) == true;
 
-    internal static async Task<int> GetMissingPayloadConfirmationAsync(
+    internal static bool IsUnreadablePayloadMessage(string? message) =>
+        message?.StartsWith(
+            UnreadablePayloadMessagePrefix,
+            StringComparison.Ordinal) == true;
+
+    internal static Task<int> GetMissingPayloadConfirmationAsync(
         DavDatabaseContext context,
         Guid davItemId,
+        CancellationToken ct) =>
+        GetPayloadConfirmationAsync(context, davItemId, IsMissingPayloadMessage, ct);
+
+    internal static Task<int> GetUnreadablePayloadConfirmationAsync(
+        DavDatabaseContext context,
+        Guid davItemId,
+        CancellationToken ct) =>
+        GetPayloadConfirmationAsync(context, davItemId, IsUnreadablePayloadMessage, ct);
+
+    private static async Task<int> GetPayloadConfirmationAsync(
+        DavDatabaseContext context,
+        Guid davItemId,
+        Func<string?, bool> isMatchingPriorMessage,
         CancellationToken ct)
     {
         var recentMessages = await context.HealthCheckResults
@@ -74,7 +93,7 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             .ConfigureAwait(false);
 
         return recentMessages
-            .TakeWhile(IsMissingPayloadMessage)
+            .TakeWhile(isMatchingPriorMessage)
             .Count() + 1;
     }
 
@@ -1237,6 +1256,46 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                     "The file's streaming data is missing from the server",
                     "(often a database restore without the blobs/ folder).",
                     "Remove and re-download the release, or restore from a backup that includes blobs.",
+                    state,
+                ]), ct).ConfigureAwait(false);
+        }
+        catch (CorruptedBlobPayloadException e)
+        {
+            // The local streaming metadata blob exists but failed to decode (truncated
+            // write, unclean shutdown). This is not evidence of a bad release, so surface
+            // it for operator action instead of deleting or blocklisting through Arr.
+            CompleteHealthProgress(davItem.Id);
+            var confirmations = await GetUnreadablePayloadConfirmationAsync(
+                dbClient.Ctx,
+                davItem.Id,
+                ct).ConfigureAwait(false);
+            var utcNow = _timeProvider.GetUtcNow();
+            var delay = GetMissingPayloadRecheckDelay(confirmations);
+            davItem.LastHealthCheck = utcNow;
+            davItem.NextHealthCheck = utcNow + delay;
+            Log.Warning(
+                "Health check cannot run for {Path}: {Reason} " +
+                "(confirmation {Count}/{Threshold}; next check in {Delay})",
+                davItem.Path,
+                e.Message,
+                confirmations,
+                MissingPayloadConfirmationsRequired,
+                delay);
+            Log.Debug(e, "Unreadable streaming metadata blob stack for {Path}", davItem.Path);
+            var state = confirmations >= MissingPayloadConfirmationsRequired
+                ? "The payload has been unreadable for at least 3 consecutive checks; " +
+                  "this DavItem is orphaned and will be rechecked weekly."
+                : "The file will be rechecked daily.";
+            await RecordHealthResult(
+                dbClient, davItem,
+                HealthCheckResult.HealthResult.Unhealthy,
+                HealthCheckResult.RepairAction.ActionNeeded,
+                string.Join(" ", [
+                    UnreadablePayloadMessagePrefix,
+                    "The file's local streaming metadata is present but unreadable",
+                    "(often a truncated write or unclean shutdown).",
+                    "Restore a backup of the blobs/ folder that matches the database,",
+                    "or remove and re-download the release.",
                     state,
                 ]), ct).ConfigureAwait(false);
         }

--- a/backend/Services/PreflightOrchestrator.cs
+++ b/backend/Services/PreflightOrchestrator.cs
@@ -219,6 +219,15 @@ public class PreflightOrchestrator(
         {
             throw;
         }
+        catch (CorruptedBlobPayloadException e)
+        {
+            // Local streaming metadata is unreadable, not the release's Usenet
+            // articles — surface it instead of silently dropping the pre-warm.
+            Log.Warning(
+                "Preflight lazy pre-warm skipped for {Title}: streaming metadata blob {BlobId} is unreadable.",
+                candidate.Title, e.BlobId);
+            Log.Debug(e, "Unreadable streaming metadata blob stack for {Title}", candidate.Title);
+        }
         catch (Exception e) when (e is not OutOfMemoryException)
         {
             Log.Debug(e, "Preflight lazy pre-warm failed for {Title}", candidate.Title);

--- a/backend/Services/Repair/DavNzbFileBlobUpdater.cs
+++ b/backend/Services/Repair/DavNzbFileBlobUpdater.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
+using Serilog;
 
 namespace NzbWebDAV.Services.Repair;
 
@@ -64,7 +66,23 @@ internal static class DavNzbFileBlobUpdater
                 : davItem.FileBlobId;
             DavNzbFile? current = null;
             if (blobId is { } id)
-                current = await BlobStore.ReadBlob<DavNzbFile>(id).ConfigureAwait(false);
+            {
+                try
+                {
+                    current = await BlobStore.ReadBlob<DavNzbFile>(id).ConfigureAwait(false);
+                }
+                catch (CorruptedBlobPayloadException e)
+                {
+                    // The current blob is unreadable; the caller's fallback (the
+                    // last known-good in-memory copy) lets this mutation still
+                    // succeed and overwrite the damaged blob.
+                    Log.Warning(
+                        "Streaming metadata blob {BlobId} for {Path} is unreadable during a repair " +
+                        "mutation; using the caller's fallback copy instead.",
+                        id, davItem.Path);
+                    Log.Debug(e, "Unreadable streaming metadata blob stack for {Path}", davItem.Path);
+                }
+            }
             current ??= fallback;
             if (current is null)
                 return;

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -502,6 +502,15 @@ public class Par2RepairService : BackgroundService
             {
                 throw;
             }
+            catch (CorruptedBlobPayloadException e)
+            {
+                // Local streaming metadata is unreadable, not the release's Usenet
+                // articles — surface it instead of silently dropping the trigger.
+                Log.Warning(
+                    "PAR2 zero-fill trigger skipped for {Path}: its streaming metadata blob {BlobId} is unreadable.",
+                    evt.Path, e.BlobId);
+                Log.Debug(e, "Unreadable streaming metadata blob stack for {Path}", evt.Path);
+            }
             catch (Exception e) when (e is not OutOfMemoryException)
             {
                 Log.Debug(e, "PAR2 zero-fill trigger failed for {Path}", evt.Path);

--- a/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
@@ -5,6 +5,7 @@ using NzbWebDAV.Database.Interceptors;
 using NzbWebDAV.Database.MigrationHelpers;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Config;
+using NzbWebDAV.Exceptions;
 using NzbWebDAV.Queue;
 using NzbWebDAV.Services;
 using NzbWebDAV.Tests.Fakes;
@@ -128,6 +129,102 @@ public sealed class DavDatabaseClientTests : IAsyncLifetime
 
         Assert.NotNull(loaded);
         Assert.Equal(1_234, loaded!.Metadata.ExpectedFileSize);
+    }
+
+    [Fact]
+    public async Task GetDavNzbFileAsync_CorruptBlobWithLegacyRow_FallsBackWithoutThrowing()
+    {
+        var blobId = Guid.NewGuid();
+        var item = NewFile(DavItem.ItemSubType.NzbFile, blobId);
+        _context.Items.Add(item);
+        _context.NzbFiles.Add(new DavNzbFile { Id = item.Id, SegmentIds = ["<legacy@example>"] });
+        await _context.SaveChangesAsync();
+        var client = new DavDatabaseClient(_context, new ThrowingBlobStore(blobId));
+
+        var loaded = await client.GetDavNzbFileAsync(item);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(["<legacy@example>"], loaded!.SegmentIds);
+    }
+
+    [Fact]
+    public async Task GetDavRarFileAsync_CorruptBlobWithLegacyRow_FallsBackWithoutThrowing()
+    {
+        var blobId = Guid.NewGuid();
+        var item = NewFile(DavItem.ItemSubType.RarFile, blobId);
+        _context.Items.Add(item);
+        _context.RarFiles.Add(new DavRarFile { Id = item.Id });
+        await _context.SaveChangesAsync();
+        var client = new DavDatabaseClient(_context, new ThrowingBlobStore(blobId));
+
+        var loaded = await client.GetDavRarFileAsync(item);
+
+        Assert.NotNull(loaded);
+    }
+
+    [Fact]
+    public async Task GetDavMultipartFileAsync_CorruptBlobWithLegacyRow_FallsBackWithoutThrowing()
+    {
+        var blobId = Guid.NewGuid();
+        var item = NewFile(DavItem.ItemSubType.MultipartFile, blobId);
+        _context.Items.Add(item);
+        _context.MultipartFiles.Add(new DavMultipartFile { Id = item.Id, Metadata = new DavMultipartFile.Meta() });
+        await _context.SaveChangesAsync();
+        var client = new DavDatabaseClient(_context, new ThrowingBlobStore(blobId));
+
+        var loaded = await client.GetDavMultipartFileAsync(item);
+
+        Assert.NotNull(loaded);
+    }
+
+    [Fact]
+    public async Task GetDavMultipartFileAsync_CorruptBlobWithoutLegacyRow_RethrowsCorruptedBlobPayloadException()
+    {
+        var blobId = Guid.NewGuid();
+        var item = NewFile(DavItem.ItemSubType.MultipartFile, blobId);
+        _context.Items.Add(item);
+        await _context.SaveChangesAsync();
+        var client = new DavDatabaseClient(_context, new ThrowingBlobStore(blobId));
+
+        var ex = await Assert.ThrowsAsync<CorruptedBlobPayloadException>(
+            () => client.GetDavMultipartFileAsync(item));
+
+        Assert.Equal(blobId, ex.BlobId);
+    }
+
+    private static DavItem NewFile(DavItem.ItemSubType subType, Guid blobId)
+    {
+        var id = Guid.NewGuid();
+        return DavItem.New(
+            id, DavItem.Root, $"{id:N}.mkv", 100,
+            DavItem.ItemType.UsenetFile, subType,
+            null, null, null, blobId);
+    }
+
+    /// <summary>
+    /// A fake <see cref="IBlobStore"/> whose typed reads throw
+    /// <see cref="CorruptedBlobPayloadException"/> for one configured blob id,
+    /// simulating a truncated/corrupt on-disk blob without touching the filesystem.
+    /// </summary>
+    private sealed class ThrowingBlobStore(Guid corruptedBlobId) : IBlobStore
+    {
+        public Task WriteBlob(Guid id, Stream stream, CancellationToken cancellationToken = default) =>
+            Task.FromException(new NotSupportedException());
+
+        public Task WriteBlob<T>(Guid id, T blob, CancellationToken cancellationToken = default) =>
+            Task.FromException(new NotSupportedException());
+
+        public Stream? ReadBlob(Guid id) => null;
+
+        public Task<T?> ReadBlob<T>(Guid id) =>
+            id == corruptedBlobId
+                ? Task.FromException<T?>(new CorruptedBlobPayloadException(
+                    id, "/config/blobs/fake", typeof(T), new IOException("simulated corrupt read")))
+                : Task.FromResult<T?>(default);
+
+        public bool Exists(Guid id) => false;
+
+        public bool Delete(Guid id) => false;
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Database/FileBlobStoreTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/FileBlobStoreTests.cs
@@ -1,4 +1,8 @@
+using MemoryPack;
 using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
+using ZstdSharp;
 
 namespace NzbWebDAV.Tests.Database;
 
@@ -78,5 +82,73 @@ public sealed class FileBlobStoreTests : IDisposable
 
         Assert.Equal(1, results.Count(result => result));
         Assert.Null(_store.ReadBlob(id));
+    }
+
+    [Fact]
+    public async Task ReadBlobOfT_ThrowsCorrupted_WhenBlobFileIsEmpty()
+    {
+        var id = Guid.NewGuid();
+        await _store.WriteBlob(id, new MemoryStream());
+
+        var ex = await Assert.ThrowsAsync<CorruptedBlobPayloadException>(
+            () => _store.ReadBlob<DavNzbFile>(id));
+
+        Assert.Equal(id, ex.BlobId);
+        Assert.Equal(typeof(DavNzbFile), ex.PayloadType);
+        Assert.IsType<MemoryPackSerializationException>(ex.InnerException);
+    }
+
+    [Fact]
+    public async Task ReadBlobOfT_ThrowsCorrupted_WhenDataIsNotValidZstd()
+    {
+        var id = Guid.NewGuid();
+        await _store.WriteBlob(id, new MemoryStream([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]));
+
+        var ex = await Assert.ThrowsAsync<CorruptedBlobPayloadException>(
+            () => _store.ReadBlob<DavNzbFile>(id));
+
+        Assert.Equal(id, ex.BlobId);
+        Assert.IsType<ZstdException>(ex.InnerException);
+    }
+
+    [Fact]
+    public async Task ReadBlobOfT_ThrowsCorrupted_WhenZstdFrameIsTruncated()
+    {
+        var id = Guid.NewGuid();
+        var original = new DavNzbFile
+        {
+            Id = id,
+            SegmentIds = Enumerable.Range(0, 500).Select(i => $"<segment-{i}@example>").ToArray(),
+        };
+
+        using var compressed = new MemoryStream();
+        await using (var compressionStream = new CompressionStream(compressed, leaveOpen: true))
+            await MemoryPackSerializer.SerializeAsync(compressionStream, original);
+        var fullBytes = compressed.ToArray();
+        var truncated = fullBytes[..(fullBytes.Length / 2)];
+        await _store.WriteBlob(id, new MemoryStream(truncated));
+
+        var ex = await Assert.ThrowsAsync<CorruptedBlobPayloadException>(
+            () => _store.ReadBlob<DavNzbFile>(id));
+
+        Assert.Equal(id, ex.BlobId);
+        Assert.IsType<EndOfStreamException>(ex.InnerException);
+    }
+
+    [Fact]
+    public async Task ReadBlobOfT_DoesNotCache_AfterCorruptedRead()
+    {
+        var id = Guid.NewGuid();
+        await _store.WriteBlob(id, new MemoryStream());
+
+        await Assert.ThrowsAsync<CorruptedBlobPayloadException>(() => _store.ReadBlob<DavNzbFile>(id));
+
+        // A subsequent write with valid data must not be shadowed by a cached failure.
+        var replacement = new DavNzbFile { Id = id, SegmentIds = ["<ok@example>"] };
+        await _store.WriteBlob(id, replacement);
+        var recovered = await _store.ReadBlob<DavNzbFile>(id);
+
+        Assert.NotNull(recovered);
+        Assert.Equal(replacement.SegmentIds, recovered!.SegmentIds);
     }
 }

--- a/tests/NzbWebDAV.Tests/Extensions/ExceptionExtensionsTests.cs
+++ b/tests/NzbWebDAV.Tests/Extensions/ExceptionExtensionsTests.cs
@@ -29,6 +29,19 @@ public class ExceptionExtensionsTests
     }
 
     [Fact]
+    public void TryGetKnownErrorMessage_CorruptedBlobPayload_PrefersWrapperOverInnerEndOfStream()
+    {
+        // The inner EndOfStreamException is itself a known IOException; the wrapper's
+        // more actionable restore/re-download guidance must win, not the raw EOF text.
+        var inner = new EndOfStreamException("Premature end of stream");
+        var ex = new CorruptedBlobPayloadException(Guid.NewGuid(), "/config/blobs/aa/bb/id", typeof(object), inner);
+
+        Assert.True(ex.TryGetKnownErrorMessage(out var reason));
+        Assert.Equal(ex.Message, reason);
+        Assert.DoesNotContain("Premature end of stream", reason);
+    }
+
+    [Fact]
     public void TryGetKnownErrorMessage_RecognizesUsenetUnexpectedResponse()
     {
         var ex = new UsenetUnexpectedResponseException("<seg@example>", "400 too much time between commands");

--- a/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/ExceptionMiddlewareTests.cs
@@ -458,6 +458,76 @@ public class ExceptionMiddlewareTests
         Assert.Equal(0, failureTracker.GetFailureCount(davItem.Id));
     }
 
+    [Fact]
+    public async Task CorruptedBlobPayloadBeforeResponseStarted_ReturnsTyped404WithoutAborting()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateContext(hasStarted: false, lifetimeFeature);
+        var middleware = CreateMiddleware(_ => throw CreateCorruptedBlobPayloadException());
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+        Assert.Equal("missing-file-payload", context.Response.Headers["X-InfiniDysk-Stream-Error"].ToString());
+        Assert.False(lifetimeFeature.Aborted);
+    }
+
+    [Fact]
+    public async Task CorruptedBlobPayloadAfterResponseStarted_Aborts()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateContext(hasStarted: true, lifetimeFeature);
+        var middleware = CreateMiddleware(_ => throw CreateCorruptedBlobPayloadException());
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(lifetimeFeature.Aborted);
+    }
+
+    [Fact]
+    public async Task CorruptedBlobPayload_LogsOneWarningLineWithoutAStackDump()
+    {
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateContext(hasStarted: false, lifetimeFeature);
+        var blobId = Guid.NewGuid();
+        var middleware = CreateMiddleware(_ => throw CreateCorruptedBlobPayloadException(blobId));
+
+        var events = await CaptureLogsAsync(() => middleware.InvokeAsync(context));
+
+        var logged = Assert.Single(events,
+            e => e.Level == LogEventLevel.Warning
+                 && e.RenderMessage().Contains("is unreadable", StringComparison.Ordinal));
+        Assert.Contains(blobId.ToString(), logged.RenderMessage(), StringComparison.Ordinal);
+        Assert.Null(logged.Exception);
+        Assert.DoesNotContain(events, e => e.Level >= LogEventLevel.Error);
+    }
+
+    [Fact]
+    public async Task CorruptedBlobPayloadWithDavItem_DoesNotRecordStreamingFailure()
+    {
+        // Local blob corruption is not evidence of a bad release; feeding it to
+        // the failure tracker would eventually trigger Arr remove-and-blocklist.
+        var lifetimeFeature = new TestHttpRequestLifetimeFeature();
+        var context = CreateDavItemContext(hasStarted: false, lifetimeFeature);
+        var failureTracker = new StreamingFailureTracker();
+        var middleware = CreateMiddleware(
+            _ => throw CreateCorruptedBlobPayloadException(),
+            CreateRepairEnabledConfig(),
+            failureTracker);
+
+        await middleware.InvokeAsync(context);
+
+        var davItem = Assert.IsType<DavItem>(context.Items["DavItem"]);
+        Assert.Equal(0, failureTracker.GetFailureCount(davItem.Id));
+    }
+
+    private static CorruptedBlobPayloadException CreateCorruptedBlobPayloadException(Guid? blobId = null) =>
+        new(
+            blobId ?? Guid.NewGuid(),
+            "/config/blobs/fake",
+            typeof(DavMultipartFile),
+            new IOException("simulated truncated blob"));
+
     private static MissingFilePayloadException CreateMissingPayloadException(Guid? payloadId = null)
     {
         var id = Guid.NewGuid();

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
@@ -22,6 +22,9 @@ using NzbWebDAV.Services.StreamTrace;
 using NzbWebDAV.Tests.Database;
 using NzbWebDAV.Tests.Fakes;
 using NzbWebDAV.Websocket;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
 using UsenetSharp.Models;
 
 namespace NzbWebDAV.Tests.Services;
@@ -789,6 +792,41 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
         Assert.True(persisted.NextHealthCheck > DateTimeOffset.UtcNow.AddHours(23));
     }
 
+    [Fact]
+    public async Task CorruptedBlobPayload_IsDeferredAsUnreadableWithoutRepairOrStack()
+    {
+        var segments = NewSegmentIds(4);
+        var (item, _) = await AddVideoFileAsync("movie.mkv", segments, [10_000, 10_000, 10_000, 10_000]);
+        var (service, par2) = await NewServiceAsync(NewFakeClient(segments, missing: []), par2Outcome: false);
+        var previousStore = BlobStore.Current;
+        BlobStore.Use(new ThrowingCorruptedBlobStore());
+        IReadOnlyList<LogEvent> events;
+        try
+        {
+            events = await CaptureLogsAsync(
+                () => service.PerformHealthCheck(item, _dbClient, concurrency: 4, CancellationToken.None));
+        }
+        finally
+        {
+            BlobStore.Use(previousStore);
+        }
+
+        var row = Assert.Single(GetHealthRows(item.Id));
+        Assert.Equal(HealthCheckResult.HealthResult.Unhealthy, row.Result);
+        Assert.Equal(HealthCheckResult.RepairAction.ActionNeeded, row.RepairStatus);
+        Assert.Contains("unreadable", row.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(par2.Requests);
+
+        var warning = Assert.Single(events, e => e.Level == LogEventLevel.Warning);
+        Assert.Null(warning.Exception);
+        Assert.Contains("unreadable", warning.RenderMessage(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(events, e => e.Level >= LogEventLevel.Error);
+
+        var persisted = ReloadItem(item.Id);
+        Assert.Equal(item.Id, persisted.Id);
+        Assert.True(persisted.NextHealthCheck > DateTimeOffset.UtcNow.AddHours(23));
+    }
+
     private static string[] NewSegmentIds(int count) =>
         Enumerable.Range(0, count).Select(i => $"seg{i}-{Guid.NewGuid():N}@test").ToArray();
 
@@ -970,6 +1008,58 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
     {
         using var context = new DavDatabaseContext(_options);
         return context.Items.AsNoTracking().Single(x => x.Id == itemId);
+    }
+
+    /// <summary>
+    /// A fake <see cref="IBlobStore"/> whose typed reads always throw
+    /// <see cref="CorruptedBlobPayloadException"/>, simulating a truncated/corrupt
+    /// on-disk blob without touching the filesystem.
+    /// </summary>
+    private sealed class ThrowingCorruptedBlobStore : IBlobStore
+    {
+        public Task WriteBlob(Guid id, Stream stream, CancellationToken cancellationToken = default) =>
+            Task.FromException(new NotSupportedException());
+
+        public Task WriteBlob<T>(Guid id, T blob, CancellationToken cancellationToken = default) =>
+            Task.FromException(new NotSupportedException());
+
+        public Stream? ReadBlob(Guid id) => null;
+
+        public Task<T?> ReadBlob<T>(Guid id) =>
+            Task.FromException<T?>(new CorruptedBlobPayloadException(
+                id, "/config/blobs/fake", typeof(T), new IOException("simulated truncated blob")));
+
+        public bool Exists(Guid id) => false;
+
+        public bool Delete(Guid id) => throw new NotSupportedException();
+    }
+
+    private static async Task<IReadOnlyList<LogEvent>> CaptureLogsAsync(Func<Task> act)
+    {
+        var sink = new CollectingSink();
+        var previous = Log.Logger;
+        var logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        Log.Logger = logger;
+        try
+        {
+            await act().ConfigureAwait(false);
+        }
+        finally
+        {
+            Log.Logger = previous;
+            logger.Dispose();
+        }
+
+        return sink.Events;
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        public List<LogEvent> Events { get; } = [];
+        public void Emit(LogEvent logEvent) => Events.Add(logEvent);
     }
 
     private static byte[] Box(string type, int payloadSize)

--- a/tests/NzbWebDAV.Tests/Services/Repair/DavNzbFileCorruptionRecordTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/DavNzbFileCorruptionRecordTests.cs
@@ -102,6 +102,29 @@ public sealed class DavNzbFileCorruptionRecordTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task MutateAsync_WithCorruptedCurrentBlobAndFallback_WritesReplacementFromFallback()
+    {
+        var segments = NewSegmentIds(3);
+        var (item, blobId) = await AddFileAsync(segments, containerClass: 1);
+
+        // Simulate an unreadable current blob (truncated write / unclean shutdown):
+        // raw non-generic WriteBlob skips compression, so this file decompresses to nothing.
+        await BlobStore.WriteBlob(blobId, new MemoryStream());
+        var fallback = new DavNzbFile { Id = item.Id, SegmentIds = segments, ContainerClass = 1 };
+
+        await DavNzbFileBlobUpdater.MutateAsync(item, current =>
+        {
+            current.CorruptSegmentIndices = [1];
+            return current;
+        }, fallback: fallback);
+
+        Assert.NotEqual(blobId, item.FileBlobId);
+        var blob = await BlobStore.ReadBlob<DavNzbFile>(item.FileBlobId!.Value);
+        Assert.Equal([1], blob!.CorruptSegmentIndices!);
+        Assert.Equal(segments, blob.SegmentIds);
+    }
+
+    [Fact]
     public async Task Consumer_EnqueuesPar2OnlyWhenPar2Enabled()
     {
         var segments = NewSegmentIds(3);


### PR DESCRIPTION
## Summary

A truncated/corrupt on-disk blob (unclean shutdown, partial `/config` restore, etc.) crashed health checks with an unhandled `MemoryPack.MemoryPackSerializationException` stack, once per affected file — a whole season sweeping together looked like dozens of "crashes" in the logs. The same failure would also 500 a WebDAV read instead of the existing clean 404, and could dump raw stacks in a few background repair/benchmark paths.

This PR treats an unreadable local blob as its own classified, handled failure — parallel to the existing `MissingFilePayloadException` handling, but with an accurate message (the payload is present but undecodable, not missing).

## What changed

- **`FileBlobStore.ReadBlob<T>`**: catches confirmed zstd/MemoryPack decode failures (`MemoryPackSerializationException`, `ZstdSharp.ZstdException`, `EndOfStreamException` for a truncated frame) and rethrows a new typed `CorruptedBlobPayloadException` carrying the blob id/path/payload type. Ordinary I/O, permission, and cancellation failures are untouched.
- **`DavDatabaseClient`**: the three typed getters (`GetDavNzbFileAsync`/`GetDavRarFileAsync`/`GetDavMultipartFileAsync`) now read through the injected `IBlobStore` and fall back to the legacy SQL row when the blob is unreadable — logging one handled Warning. If no legacy row exists, the exception is rethrown (never silently converted into a `null` "missing" result).
- **`ExceptionExtensions.TryGetKnownErrorMessage`**: classifies `CorruptedBlobPayloadException` early (before the general transport/download walk), so its actionable message isn't overwritten by an inner known exception like `EndOfStreamException`.
- **`HealthCheckService`**: a dedicated catch records `Unhealthy` + `ActionNeeded` with restore/re-download guidance, using the same daily→weekly recheck cadence as missing payloads, and never touches STAT/PAR2/Arr repair.
- **`ExceptionMiddleware`**: a dedicated catch returns 404 (reusing the existing `missing-file-payload` wire classification so the Explore player's terminal/no-retry state still applies) with a deduped, no-stack Warning.
- **Secondary readers** (`DavNzbFileBlobUpdater`, `BenchmarkCorpusProvider`, PAR2 zero-fill trigger, preflight pre-warm) recover via their existing fallback or log a handled Warning instead of an unhandled/undifferentiated stack.

## Test plan

- `FileBlobStoreTests`: empty, malformed-zstd, and truncated-zstd-frame blobs each become `CorruptedBlobPayloadException` with the right id/type/inner exception; a corrupted read is never cached and a later valid write recovers.
- `ExceptionExtensionsTests`: a wrapper whose inner exception is `EndOfStreamException` still surfaces the wrapper's actionable message.
- `DavDatabaseClientTests`: corrupt blob + legacy row falls back without throwing (Nzb/Rar/Multipart); corrupt blob with no legacy row rethrows `CorruptedBlobPayloadException`.
- `HealthCheckDegradedClassificationTests`: a corrupted blob with no legacy row records `Unhealthy`/`ActionNeeded`, logs exactly one Warning with no attached exception, no Error, and never contacts PAR2.
- `ExceptionMiddlewareTests`: typed 404 + header before response start, abort after start, one deduped no-stack Warning, and no streaming-failure/repair record.
- `DavNzbFileCorruptionRecordTests`: `DavNzbFileBlobUpdater.MutateAsync` recovers via the caller's fallback and writes a replacement blob when the current one is unreadable.

Per `AGENTS.md`, PR CI covers backend build/analyzers/tests — not re-run locally.

## Notes

- No database migration or docs page needed.
- `StreamingPayloadExistsAsync` / `RemoveMissingPayloadsTask` are intentionally unchanged (existence-only checks) so this never causes automatic deletion of recoverable data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unreadable streaming metadata.
  * Automatically uses legacy data when available.
  * Reports unrecoverable payloads as actionable 404 errors with recovery guidance.
  * Prevents corrupted data from being cached and allows repair workflows to continue safely.
  * Health checks defer unreadable payloads without removing or blocklisting affected items.

* **Tests**
  * Added coverage for corrupted, truncated, and invalid payloads across retrieval, error handling, health checks, and repair workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->