### PR TITLE
chore(test): enable constrained streaming CPU profiles

### DIFF
--- a/backend.Benchmarks/HealthCheckConnectionGateBenchmarks.cs
+++ b/backend.Benchmarks/HealthCheckConnectionGateBenchmarks.cs
@@ -8,7 +8,7 @@ using NzbWebDAV.Services;
 namespace NzbWebDAV.Benchmarks;
 
 [MemoryDiagnoser]
-public sealed class HealthCheckConnectionGateBenchmarks : IDisposable
+public class HealthCheckConnectionGateBenchmarks : IDisposable
 {
     private const int OperationsPerRun = 256;
     private HealthCheckConnectionGate _gate = null!;
@@ -75,8 +75,19 @@ public sealed class HealthCheckConnectionGateBenchmarks : IDisposable
     }
 
     [GlobalCleanup]
+    public void Cleanup() => Dispose();
+
     public void Dispose()
     {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposing)
+            return;
+
         _gate?.Dispose();
         _gate = null!;
     }

--- a/backend.Benchmarks/NntpWholePathScenario.cs
+++ b/backend.Benchmarks/NntpWholePathScenario.cs
@@ -39,10 +39,19 @@ internal sealed record NntpWholePathScenario(
         new("plain-buffered-w8", NntpWholePathLayer.BufferedStream, false, 256, 4 * 1024 * 1024, 20, 8, 0, null, YencCrcValidationMode.Require),
     ];
 
+    public static IReadOnlyList<NntpWholePathScenario> Profile =>
+    [
+        new("plain-http-like-w4", NntpWholePathLayer.HttpLike, false, 64, 4 * 1024 * 1024, 20, 4, 0, null, YencCrcValidationMode.Require),
+    ];
+
     public static IReadOnlyList<NntpWholePathScenario> ForSet(string set) =>
         set.Equals("quick", StringComparison.OrdinalIgnoreCase)
             ? Quick
             : set.Equals("sustained", StringComparison.OrdinalIgnoreCase)
                 ? Sustained
-                : throw new ArgumentException("--set must be either 'quick' or 'sustained'.", nameof(set));
+                : set.Equals("profile", StringComparison.OrdinalIgnoreCase)
+                    ? Profile
+                    : throw new ArgumentException(
+                        "--set must be 'quick', 'sustained', or 'profile'.",
+                        nameof(set));
 }

--- a/backend.Benchmarks/PerformanceReportCli.cs
+++ b/backend.Benchmarks/PerformanceReportCli.cs
@@ -49,7 +49,7 @@ internal static class PerformanceReportCli
             if (arg == "--set")
             {
                 if (i + 1 >= args.Length)
-                    throw new ArgumentException("--set requires 'quick' or 'sustained'.");
+                    throw new ArgumentException("--set requires 'quick', 'sustained', or 'profile'.");
                 scenarioSet = args[i + 1];
                 i += 2;
                 continue;

--- a/backend.Benchmarks/Program.cs
+++ b/backend.Benchmarks/Program.cs
@@ -234,7 +234,7 @@ namespace NzbWebDAV.Benchmarks
     }
 
     [MemoryDiagnoser]
-    public sealed class SegmentStreamBenchmarks : IDisposable
+    public class SegmentStreamBenchmarks : IDisposable
     {
         private const int SegmentSize = 256 * 1024;
         private BenchmarkNntpClient _client = null!;
@@ -322,11 +322,24 @@ namespace NzbWebDAV.Benchmarks
             await stream.CopyToAsync(Stream.Null);
         }
 
+        [GlobalCleanup]
+        public void Cleanup() => Dispose();
+
         public void Dispose()
         {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposing || _client is null)
+                return;
+
             _client.Dispose();
             _missingClient.Dispose();
-            GC.SuppressFinalize(this);
+            _client = null!;
+            _missingClient = null!;
         }
     }
 

--- a/backend.Benchmarks/ProviderSelectionBenchmarks.cs
+++ b/backend.Benchmarks/ProviderSelectionBenchmarks.cs
@@ -8,7 +8,7 @@ using NzbWebDAV.Services.Metrics;
 namespace NzbWebDAV.Benchmarks;
 
 [MemoryDiagnoser]
-public sealed class ProviderSelectionBenchmarks : IDisposable
+public class ProviderSelectionBenchmarks : IDisposable
 {
     private CancellationTokenSource _activityCancellation = null!;
     private MultiProviderNntpClient _router = null!;
@@ -59,9 +59,17 @@ public sealed class ProviderSelectionBenchmarks : IDisposable
         _router.SelectProviderForBenchmark(NntpOperation.Body)?.MetricsKey;
 
     [GlobalCleanup]
+    public void Cleanup() => Dispose();
+
     public void Dispose()
     {
-        if (_activityCancellation is null)
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposing || _activityCancellation is null)
             return;
 
         _activityCancellation.Cancel();

--- a/backend.Benchmarks/README.md
+++ b/backend.Benchmarks/README.md
@@ -61,6 +61,10 @@ one named scenario. Timing and allocation observations are diagnostic, while
 bytes, hashes, BODY counts, callbacks, budget cleanup, and connection cleanup
 are deterministic gates.
 
+`--set profile` uses 64 × 4 MiB articles, 20 connections, width 4, CRC, and the
+HTTP-like sink copy. It is small enough to profile under a 2-core, roughly 8 GB
+container without the client/server loopback corpora exhausting the cgroup.
+
 The committed sustained baseline begins with conservative bootstrap timing
 envelopes because its 20 GiB local run is intentionally deferred to the
 dedicated benchmark phase. Before treating its timing envelope as a regression

--- a/scripts/run-nntp-cpu-profile.sh
+++ b/scripts/run-nntp-cpu-profile.sh
@@ -94,7 +94,7 @@ case "$MODE" in
     ;;
   trace)
     command -v dotnet-trace >/dev/null || { echo "dotnet-trace is required." >&2; exit 127; }
-    dotnet-trace collect --process-id "$BACKEND_PID" --profile cpu-sampling \
+    dotnet-trace collect --process-id "$BACKEND_PID" --profile dotnet-sampled-thread-time \
       --duration 00:01:30 --output "$RUN_DIR/diagnostic-trace.nettrace" &
     TRACE_PID=$!
     sleep 2

--- a/tests/NzbWebDAV.Tests/Benchmarks/NntpWholePathReportContractTests.cs
+++ b/tests/NzbWebDAV.Tests/Benchmarks/NntpWholePathReportContractTests.cs
@@ -84,6 +84,7 @@ public sealed class NntpWholePathReportContractTests
     [Theory]
     [InlineData("quick", 5)]
     [InlineData("sustained", 4)]
+    [InlineData("profile", 1)]
     public void ScenarioSets_AreNamedAndExplicitlyPlaintext(string set, int expectedCount)
     {
         var scenarios = NntpWholePathScenario.ForSet(set);


### PR DESCRIPTION
## Summary

- add a memory-bounded 256 MiB whole-path profile scenario for two-core containers
- make BenchmarkDotNet lifecycle classes compatible with 0.15.8 generated subclasses
- use the current managed CPU sampling profile in the provider-backed profiling script

## Test plan

- `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-build` (4,799 passed, 15 skipped)
- architecture 3/3; RapidYencSharp 39/39; UsenetSharp non-live 419/419
- SharpCompress regular 2,137 passed; stress 1/1
- frontend Vitest 944/944; lint, typecheck, browser/server builds, Prettier passed
- streaming, SAB, quick NNTP, and sustained NNTP deterministic gates passed
- SAB and quick timing gates passed; sustained gate passed with bootstrap CPU/allocation warnings
- Linux ARM64 profile under 2 CPUs / 7,600 MiB: exact 256 MiB hash, 64/64 BODY responses, zero budget leak, 0.536-0.603 CPU-s/GB

## Timing note

The local streaming timing envelope failed twice for `pipelined-cold-read` (retry median 757.863 MiB/s vs 796.178 MiB/s floor). Deterministic fields passed. The committed timing metadata predates this scenario and later cache/startup path changes, so it should be re-measured on the intended performance runner rather than rewritten from macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `profile` benchmark scenario set for loopback NNTP performance testing.
  - The new profile configuration supports HTTP-like output and resource-constrained environments.
  - Updated command-line validation to recognize the `profile` scenario set.

- **Documentation**
  - Documented the profile benchmark configuration and its key settings.

- **Bug Fixes**
  - Improved benchmark resource cleanup and disposal reliability.
  - Updated trace profiling to use sampled thread-time analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->