### PR TITLE
perf(usenet): reduce streaming allocation churn by default

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1076,7 +1076,7 @@ public sealed partial class Program
                 "Unknown {Variable} value {Value}; using {Default}.",
                 SegmentBufferPoolSelector.EnvironmentVariableName,
                 poolOverride,
-                SegmentBufferPoolSelector.BoundedLegacyValue);
+                SegmentBufferPoolSelector.DefaultValue);
         }
 
         if (poolMode == SegmentBufferPoolSelector.Mode.Shared)

--- a/backend/Streams/SegmentBufferPoolSelector.cs
+++ b/backend/Streams/SegmentBufferPoolSelector.cs
@@ -5,6 +5,7 @@ internal static class SegmentBufferPoolSelector
     internal const string EnvironmentVariableName = "NZBDAV_SEGMENT_BUFFER_POOL";
     internal const string BoundedLegacyValue = "bounded-legacy";
     internal const string BoundedCapacityValue = "bounded-capacity";
+    internal const string DefaultValue = BoundedCapacityValue;
     internal const string SharedValue = "shared";
 
     internal enum Mode
@@ -18,7 +19,7 @@ internal static class SegmentBufferPoolSelector
     {
         unknownValue = false;
         if (string.IsNullOrWhiteSpace(value))
-            return Mode.BoundedLegacy;
+            return Mode.BoundedCapacity;
 
         value = value.Trim();
         if (value.Equals(SharedValue, StringComparison.OrdinalIgnoreCase))
@@ -29,7 +30,7 @@ internal static class SegmentBufferPoolSelector
             return Mode.BoundedCapacity;
 
         unknownValue = true;
-        return Mode.BoundedLegacy;
+        return Mode.BoundedCapacity;
     }
 
     internal static string ToLogValue(Mode mode) => mode switch
@@ -37,6 +38,6 @@ internal static class SegmentBufferPoolSelector
         Mode.BoundedLegacy => BoundedLegacyValue,
         Mode.BoundedCapacity => BoundedCapacityValue,
         Mode.Shared => SharedValue,
-        _ => BoundedLegacyValue,
+        _ => DefaultValue,
     };
 }

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -97,7 +97,7 @@ or restrict backend capabilities when enforcement is required.
 | `USENET_DISABLE_CRC_VALIDATION` [since 0.8.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.8.0){ .nzbdav-since } | unset | `1` skips yEnc CRC checks (emergency) |
 | `THREADPOOL_MIN_THREADS` | `max(2×CPU, 50)` | Override min worker/IOCP threads |
 | `THREADPOOL_MAX_THREADS` | `max(50×CPU, 1000)` | Override max threads |
-| `NZBDAV_SEGMENT_BUFFER_POOL` [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since } | `bounded-legacy` | Segment-buffer retention. Unset and `bounded-legacy` keep the production age-plus-per-class policy. `bounded-capacity` is a restart-only canary that keeps the same 32–256 MiB idle-byte cap without the two-minute expiry or 64-buffer class ceiling. `shared` uses `ArrayPool<byte>.Shared` as an emergency escape hatch. Unknown values log a Warning and use `bounded-legacy`. |
+| `NZBDAV_SEGMENT_BUFFER_POOL` [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since } | `bounded-capacity` | Segment-buffer retention. Unset and `bounded-capacity` use the production 32–256 MiB idle-byte cap without expiry or a per-class ceiling. `bounded-legacy` restores the previous two-minute expiry and 64-buffer class ceiling as a restart-only rollback. `shared` uses `ArrayPool<byte>.Shared` as an emergency escape hatch. Unknown values log a Warning and use `bounded-capacity`. |
 | `DOTNET_GCHeapHardLimit` | runtime default | .NET managed-heap ceiling; hexadecimal bytes |
 | `DOTNET_GCHeapHardLimitPercent` | runtime/container default | .NET managed-heap ceiling as a hexadecimal percentage |
 | `DOTNET_GCRegionRange` | runtime default | .NET regions-GC virtual reservation; hexadecimal bytes |

--- a/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolAllocationFailureTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SegmentBufferPoolAllocationFailureTests.cs
@@ -104,9 +104,9 @@ public sealed class SegmentBufferPoolAllocationFailureTests
 public sealed class SegmentBufferPoolSelectorTests
 {
     [Theory]
-    [InlineData(null, "bounded-legacy", false)]
-    [InlineData("", "bounded-legacy", false)]
-    [InlineData(" ", "bounded-legacy", false)]
+    [InlineData(null, "bounded-capacity", false)]
+    [InlineData("", "bounded-capacity", false)]
+    [InlineData(" ", "bounded-capacity", false)]
     [InlineData(" bounded-capacity ", "bounded-capacity", false)]
     [InlineData("bounded-legacy", "bounded-legacy", false)]
     [InlineData("BOUNDED-LEGACY", "bounded-legacy", false)]
@@ -114,8 +114,8 @@ public sealed class SegmentBufferPoolSelectorTests
     [InlineData("Bounded-Capacity", "bounded-capacity", false)]
     [InlineData("shared", "shared", false)]
     [InlineData("SHARED", "shared", false)]
-    [InlineData("experimental", "bounded-legacy", true)]
-    [InlineData("legacy", "bounded-legacy", true)]
+    [InlineData("experimental", "bounded-capacity", true)]
+    [InlineData("legacy", "bounded-capacity", true)]
     public void Resolve_CoversDocumentedValuesAndUnknownFallback(
         string? value,
         string expected,


### PR DESCRIPTION
## Summary
- make `bounded-capacity` the segment-buffer retention default for the 1.3.0 RC
- keep `bounded-legacy` as a restart-only rollback and `shared` as the emergency escape hatch
- make unknown override values warn and fall back to the documented default

## Provider-backed evidence
A four-process ABBA comparison used identical 64 MiB and 256 MiB ranges before and after a 130-second idle horizon, with Segment Cache, shared streams, and tracing disabled. All requests returned exact 206 bodies with matching SHA-256 hashes. Capacity-only retention produced:

- 13.3% lower post-idle CPU/GiB
- 73.7% lower pool allocation rate
- 48.8% less managed allocation and half as many Gen 0/1/2 collections
- 19.1% lower median peak RSS despite retaining 48 MiB more idle buffers
- 9.5% higher median throughput and 34% lower median TTFB

The RC should still exercise constrained Linux hosts, normal shared-stream settings, and workloads that pressure the 256 MiB cap. Operators can restore the prior policy with `NZBDAV_SEGMENT_BUFFER_POOL=bounded-legacy` and a restart.

## Test plan
- `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore --filter FullyQualifiedName~SegmentBufferPoolSelectorTests` (12 passed)
- `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-build --filter FullyQualifiedName~SegmentBufferPool` (43 passed)
- startup smoke with `NZBDAV_SEGMENT_BUFFER_POOL` unset confirmed `mode=bounded-capacity`
- provider-backed ABBA comparison described above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the segment buffer pool default to use the bounded-capacity policy.
  * Unknown or missing configuration values now safely fall back to bounded-capacity.

* **Documentation**
  * Clarified configuration defaults and documented bounded-legacy as a restart-only rollback option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->