### PR TITLE
fix(health): clarify which folder Library Directory requires

### DIFF
--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -2838,9 +2838,11 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                     ])
                     : string.Join(" ", [
                         "File failed health validation.",
-                        "Could not find a corresponding symlink or strm-file within Library Dir.",
+                        "No corresponding imported symlink or .strm file was found in Library Directory.",
                         "The library scan may be incomplete, so the webdav-file was left in place.",
-                        "Use Remove Orphaned Files for deliberate unlinked-item cleanup."
+                        "Verify Library Directory points to the parent of your Radarr/Sonarr root folders",
+                        "that contains imported symlinks or .strm files, not the rclone mount or a folder",
+                        "of regular media files, before running Remove Orphaned Files."
                     ]);
                 await RecordHealthResult(
                     dbClient, davItem,

--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -166,7 +166,10 @@ public class RemoveUnlinkedFilesTask : BaseTask
         {
             _allRemovedPaths.Clear();
             Complete(
-                "Aborted: There are less than five linked files found in your library. " +
+                $"Aborted: Library Directory scan found {linkedIdCount} WebDAV files referenced by imported " +
+                "symlinks or .strm files; at least five are required before cleanup. Verify Library Directory " +
+                "points to the parent of your Radarr/Sonarr root folders containing imported symlinks or .strm " +
+                "files, not the rclone mount or a folder of regular media files. " +
                 "Cancelling operation to prevent accidental bulk deletion.");
             return;
         }

--- a/frontend/app/routes/health/components/health-stats/health-stats.test.tsx
+++ b/frontend/app/routes/health/components/health-stats/health-stats.test.tsx
@@ -23,4 +23,15 @@ describe("HealthStats", () => {
 
     expect(markup).toContain("Degraded (0%)");
   });
+
+  it("distinguishes recent check results from library configuration validation", () => {
+    const markup = render([
+      { result: 0, repairStatus: 0, count: 87 },
+      { result: 1, repairStatus: 3, count: 13 },
+    ]);
+
+    expect(markup).toContain("Healthy (87%)");
+    expect(markup).toContain("A file can appear more than once");
+    expect(markup).toContain("do not verify the Library Directory setting");
+  });
 });

--- a/frontend/app/routes/health/components/health-stats/health-stats.tsx
+++ b/frontend/app/routes/health/components/health-stats/health-stats.tsx
@@ -39,9 +39,15 @@ export function HealthStats({ stats }: HealthStatsProps) {
   return (
     <section className="card w-full border border-base-content/10 bg-base-100 shadow-sm">
       <div className="card-body gap-4 p-4 md:p-6">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <h2 className="card-title text-xl">Overview</h2>
-          <Badge className="badge-ghost badge-sm">Last 30 days</Badge>
+        <div className="space-y-1.5">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <h2 className="card-title text-xl">Overview</h2>
+            <Badge className="badge-ghost badge-sm">Last 30 days</Badge>
+          </div>
+          <p className="text-xs leading-relaxed text-base-content/55">
+            These are health-check results recorded during this period. A file can appear more than
+            once, and these totals do not verify the Library Directory setting.
+          </p>
         </div>
 
         <div className="stats stats-vertical w-full bg-base-200/40 sm:stats-horizontal">

--- a/frontend/app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.tsx
+++ b/frontend/app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.tsx
@@ -102,8 +102,8 @@ export function RemoveUnlinkedFiles({ savedConfig }: RemoveUnlinkedFilesProps) {
       )}
       <div className="space-y-4">
         <p className="text-sm leading-relaxed text-base-content/70">
-          Scan the organized media library for symlink and STRM references, then remove WebDAV files
-          that are no longer linked from the library.
+          Scan the configured Library Directory for imported symlink and STRM references, then
+          remove WebDAV files that are no longer linked from those references.
         </p>
 
         <div className="rounded-lg border border-base-content/10 bg-base-200/40 p-3">
@@ -151,7 +151,9 @@ export function RemoveUnlinkedFiles({ savedConfig }: RemoveUnlinkedFilesProps) {
             </div>
           </div>
           <p className="mt-3 border-t border-base-content/10 pt-2.5 text-xs text-base-content/50">
-            Dry Run previews the files that would be removed without changing anything.
+            Dry Run previews the files that would be removed without changing anything. Library
+            Directory must be the parent of your Radarr/Sonarr root folders containing imported
+            links, not the rclone mount or a folder containing regular media files instead of links.
           </p>
         </div>
 

--- a/frontend/app/routes/settings/repairs/repairs.tsx
+++ b/frontend/app/routes/settings/repairs/repairs.tsx
@@ -114,8 +114,9 @@ export function RepairsSettings({ config, setNewConfig }: RepairsSettingsProps) 
                   className="text-[11px] leading-relaxed text-base-content/45"
                   id="library-dir-help"
                 >
-                  The path to your organized media library that contains all your imported symlinks
-                  or *.strm files. Make sure this path is visible to your InfiniDysk container.
+                  Path inside the InfiniDysk container to the parent of your Radarr/Sonarr root
+                  folders. Imported library entries there must be symlinks or *.strm files. Do not
+                  use the rclone mount or a folder containing regular media files instead of links.
                 </p>
               </div>
             </ManagedSetting>

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
@@ -230,7 +230,9 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
         var row = Assert.Single(GetHealthRows(item.Id));
         Assert.Equal(HealthCheckResult.HealthResult.Unhealthy, row.Result);
         Assert.Equal(HealthCheckResult.RepairAction.ActionNeeded, row.RepairStatus);
-        Assert.Contains("symlink or strm-file", row.Message);
+        Assert.Contains("Verify Library Directory", row.Message, StringComparison.Ordinal);
+        Assert.Contains("parent of your Radarr/Sonarr root folders", row.Message, StringComparison.Ordinal);
+        Assert.Contains("before running Remove Orphaned Files", row.Message, StringComparison.Ordinal);
         Assert.Equal(oldBlobId, ReloadItem(item.Id).FileBlobId);
         foreach (var index in new[] { 2, 3, 4 })
             Assert.Throws<UsenetArticleNotFoundException>(

--- a/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
@@ -1017,7 +1017,12 @@ public class RemoveUnlinkedFilesTaskTests
             var progress = websocket.PeekLastMessage(WebsocketTopic.CleanupTaskProgress);
             Assert.NotNull(progress);
             Assert.Contains("Aborted:", progress, StringComparison.Ordinal);
-            Assert.Contains("less than five linked files", progress, StringComparison.Ordinal);
+            Assert.Contains(
+                "found 0 WebDAV files referenced by imported symlinks or .strm files",
+                progress,
+                StringComparison.Ordinal);
+            Assert.Contains("parent of your Radarr/Sonarr root folders", progress, StringComparison.Ordinal);
+            Assert.Contains("not the rclone mount or a folder of regular media files", progress, StringComparison.Ordinal);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- define Library Directory as the container-visible parent of Radarr/Sonarr root folders containing imported symlinks or `.strm` files
- make missing-link health results and low-link cleanup aborts verify that path before recommending deletion
- clarify that the Health overview aggregates recent check results, not unique files or Library Directory validation
- preserve the existing linked-file, ratio, and rclone-mount deletion safeguards

## Test plan
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~NzbWebDAV.Tests.Tasks.RemoveUnlinkedFilesTaskTests|FullyQualifiedName~NzbWebDAV.Tests.Services.HealthCheckDegradedClassificationTests"` (65 passed)
- [x] `npm test -- --run app/routes/health/components/health-stats/health-stats.test.tsx` (3 passed)
- [x] `npm run typecheck`
- [x] `npm run format:check`
- [x] focused .NET whitespace verification and `git diff --check`
- [x] desktop and mobile browser checks for overflow, clipping, and overlap

Fixes #1300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Clarified health-check and cleanup messages for missing links, referenced files, and insufficient file references.
  * Added guidance to configure the Library Directory as the parent of the relevant media roots, excluding rclone mounts and regular media folders.
  * Expanded Dry Run instructions and clarified cleanup scope.
  * Health statistics now explain reporting periods, duplicate entries, and configuration checks.
* **Tests**
  * Expanded coverage for health reporting and cleanup diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->