### PR TITLE
fix(ui): remove experimental tag from container-aware gap fill

### DIFF
--- a/docs/configuration/streaming.md
+++ b/docs/configuration/streaming.md
@@ -48,7 +48,7 @@ is saturated.
 | Replacement reconnect spacing [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since } | `usenet.reconnect-delay-milliseconds` | `500` | Minimum spacing between replacement handshakes after a poisoned connection is closed, 0–5000 milliseconds. Zero disables ordinary replacement spacing; TCP/TLS/AUTHINFO factory failures still back off from a 500ms floor, doubling up to 60 seconds. Takes effect on the next provider-pool rebuild or restart. |
 | Batched article downloads | `usenet.pipelined-body-requests` | on | Fetch WebDAV BODY requests in small batches |
 | Streaming batch width [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since } | `usenet.streaming-body-batch-width` | `4` | Maximum articles per BODY batch (1–8) |
-| Container-aware gap fill [since 0.10.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.10.0){ .nzbdav-since } | `usenet.container-aware-fill` | on | Experimental MPEG-TS null-packet fill for confirmed gaps |
+| Container-aware gap fill [since 0.10.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.10.0){ .nzbdav-since } | `usenet.container-aware-fill` | on | MPEG-TS null-packet fill for confirmed gaps |
 
 The NNTP stalled-read timeout, streaming segment timeout, streaming read budget, and idle
 connection timeout are separate deadlines. Connect and AUTHINFO use the earliest of caller
@@ -84,7 +84,7 @@ narrowing does not shrink those ceilings — only future batch sizes. Leave the
 width at the default unless you have measured a benefit; wide settings can
 starve other concurrent streams via the shared in-flight article budget.
 
-## Experimental container-aware gap fill
+## Container-aware gap fill
 
 After every provider and fallback Message-ID confirms an article is missing or
 corrupt, InfiniDysk normally emits the same number of zero bytes to preserve

--- a/frontend/app/routes/settings/streaming/streaming.tsx
+++ b/frontend/app/routes/settings/streaming/streaming.tsx
@@ -738,7 +738,7 @@ export function StreamingSettings({
 
         <ManagedSetting configKey="usenet.container-aware-fill">
           <div className="space-y-2">
-            <Tooltip content="Experimental. Applies only after all missing or corrupt article fallbacks are exhausted; transient transport failures still abort so the player can retry the range.">
+            <Tooltip content="Applies only after all missing or corrupt article fallbacks are exhausted; transient transport failures still abort so the player can retry the range.">
               <Toggle
                 id="container-aware-fill"
                 className="cursor-pointer gap-2 p-0"
@@ -749,12 +749,7 @@ export function StreamingSettings({
                     "usenet.container-aware-fill": String(e.target.checked),
                   })
                 }
-                label={
-                  <span className="inline-flex items-center gap-2 text-sm text-base-content">
-                    Container-aware gap fill
-                    <Badge className="badge-warning badge-outline badge-xs">Experimental</Badge>
-                  </span>
-                }
+                label={<span className="text-sm text-base-content">Container-aware gap fill</span>}
               />
             </Tooltip>
             <p className="text-[11px] leading-relaxed text-base-content/45">


### PR DESCRIPTION
## Summary
- remove the Experimental badge and wording from the container-aware gap-fill setting
- update the streaming docs to describe it as a standard feature

## Verification
- 
 RUN  v4.1.10 /Users/anthonyhoivik/projects/nzbdav/frontend

······

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  21:09:32
   Duration  1.10s (transform 55ms, setup 0ms, import 113ms, tests 706ms, environment 230ms)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated streaming configuration documentation to present container-aware gap-fill as a confirmed MPEG-TS null-packet filling feature.

- **Improvements**
  - Removed the “Experimental” label from the container-aware gap-fill setting and tooltip in the streaming settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->