### PR TITLE
fix(sab): deleting a queue item that is failing at the same moment no longer returns HTTP 500

### DIFF
--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -287,7 +287,7 @@ public class QueueItemProcessor(
                         attempt - 1,
                         reason);
                     Log.Debug(e, "Queue item give-up stack for {JobName}", queueItem.JobName);
-                    await MarkQueueItemCompleted(startTime, error: e.Message).ConfigureAwait(false);
+                    await MarkQueueItemFailedAsync(startTime, e.Message).ConfigureAwait(false);
                     return;
                 }
 
@@ -354,7 +354,7 @@ public class QueueItemProcessor(
 
             try
             {
-                await MarkQueueItemCompleted(startTime, error: e.Message).ConfigureAwait(false);
+                await MarkQueueItemFailedAsync(startTime, e.Message).ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is DbUpdateException or InvalidOperationException)
             {
@@ -371,6 +371,28 @@ public class QueueItemProcessor(
                         .ConfigureAwait(false);
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Writes the failed-history row for an item that is already on its failure
+    /// path. Runs inside a <c>catch</c> block, so the outer cancellation handler
+    /// cannot see a cancel that lands here: a concurrent SAB/UI remove (or
+    /// shutdown) cancels the worker token mid-finalize, and that must read as an
+    /// ordinary cancel — the remover owns the row — not as a worker fault.
+    /// </summary>
+    private async Task MarkQueueItemFailedAsync(DateTime startTime, string error)
+    {
+        try
+        {
+            await MarkQueueItemCompleted(startTime, error).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex.IsCancellationException() && ex is not OutOfMemoryException)
+        {
+            Log.Information(
+                "Processing of queue item {JobName} was cancelled while recording its failure",
+                queueItem.JobName);
+            dbClient.Ctx.ClearChangeTracker();
         }
     }
 

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -382,7 +382,13 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
             await item.ProcessingTask.ConfigureAwait(false);
         }
 #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
-        catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
+        catch (Exception e) when (e.IsCancellationException())
+        {
+            // The worker was cancelled by this remove/pause; a cancellation that
+            // escaped the processor (e.g. mid-finalize) must not fail the caller.
+            Log.Debug("Queue item {QueueItemId} stopped on cancel", item.QueueItem.Id);
+        }
+        catch (Exception e) when (e is not OutOfMemoryException)
 #pragma warning restore CA2016
         {
             Log.Debug(e, "Queue item {QueueItemId} exited with error after cancel", item.QueueItem.Id);
@@ -947,7 +953,13 @@ public sealed class QueueManager : IQueueCoordinator, IDisposable
                 await item.ProcessingTask.ConfigureAwait(false);
             }
 #pragma warning disable CA2016 // CA2016: classify cancellation regardless of the ambient token -- forwarding it would misclassify cancellations from internal timeout/child tokens
-            catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
+            catch (Exception e) when (e.IsCancellationException())
+            {
+                // Cancelled workers (remove/pause/shutdown) are an expected stop;
+                // letting this escape would abort the reap and leak the worker.
+                Log.Debug("Queue worker for {QueueItemId} stopped on cancel", item.QueueItem.Id);
+            }
+            catch (Exception e) when (e is not OutOfMemoryException)
 #pragma warning restore CA2016
             {
                 Log.Error(e, "Queue worker for {QueueItemId} faulted", item.QueueItem.Id);

--- a/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/QueueStuckWatchdogTests.cs
@@ -685,6 +685,85 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task RemoveQueueItemsAsync_WorkerCancelledMidFailureFinalize_RemovesRowWithoutThrowing()
+    {
+        // Race: the worker is already failing the item (finalize path) when a SAB
+        // delete cancels it. The cancellation must read as an ordinary stop — the
+        // delete succeeds, the row is gone, and no failed-history row is written —
+        // rather than escaping as a worker fault that turns the delete into a 500.
+        _queueManager.StuckItemThreshold = TimeSpan.FromHours(1);
+        var item = CreateQueueItem("empty.nzb", "movies", "EmptyNzbJob");
+
+        await using (var ctx = new DavDatabaseContext(_options))
+        {
+            ctx.QueueItems.Add(item);
+            await ctx.SaveChangesAsync();
+        }
+
+        // An EOF stream is an invalid NZB, which fails the item into history.
+        _queueManager.GetTopQueueItemOverride = async (exclude, ct) =>
+        {
+            await using var ctx = new DavDatabaseContext(_options);
+            var client = new DavDatabaseClient(ctx);
+            var (claimed, _) = await client.GetTopQueueItem(exclude, ct);
+            if (claimed is null) return (null, null);
+            ctx.ChangeTracker.Clear();
+            return (claimed, Stream.Null);
+        };
+
+        // Hold the finalize lock so the failing worker parks in the finalize
+        // wait, then cancel it there via remove.
+        var finalizeLock = GetFinalizeLock();
+        await finalizeLock.WaitAsync();
+        var finalizeHeld = true;
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var loop = _queueManager.ProcessQueueAsync(cts.Token);
+        try
+        {
+            object? inProgress = await WaitForInProgress(item.Id, TimeSpan.FromSeconds(5));
+            Assert.NotNull(inProgress);
+
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+            while (DateTime.UtcNow < deadline && GetCurrentStage(inProgress!) != "finalize-lock-wait")
+                await Task.Delay(20);
+            Assert.Equal("finalize-lock-wait", GetCurrentStage(inProgress!));
+
+            IReadOnlyList<Guid> stillRunning;
+            await using (var ctx = new DavDatabaseContext(_options))
+            {
+                stillRunning = await _queueManager.RemoveQueueItemsAsync(
+                    [item.Id], new DavDatabaseClient(ctx), CancellationToken.None);
+            }
+
+            Assert.Empty(stillRunning);
+            Assert.True(GetProcessingTask(inProgress!).IsCompleted);
+
+            finalizeLock.Release();
+            finalizeHeld = false;
+
+            await using (var ctx = new DavDatabaseContext(_options))
+            {
+                Assert.Equal(0, await ctx.QueueItems.CountAsync());
+                Assert.Equal(0, await ctx.HistoryItems.CountAsync());
+            }
+        }
+        finally
+        {
+            if (finalizeHeld) finalizeLock.Release();
+            await cts.CancelAsync();
+            try
+            {
+                await loop.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            catch (OperationCanceledException) when (cts.IsCancellationRequested)
+            {
+                // Expected when shutdown cancels an in-flight claim.
+            }
+        }
+    }
+
+    [Fact]
     public async Task RemoveQueueItemsAsync_HungWorker_QuarantinesAndReturnsWithinGrace()
     {
         // A worker ignoring cancellation must not hang a SAB delete: the call
@@ -1194,6 +1273,22 @@ public sealed class QueueStuckWatchdogTests : IAsyncLifetime
             "CancellationTokenSource",
             BindingFlags.Instance | BindingFlags.Public);
         return (CancellationTokenSource)prop!.GetValue(inProgressItem)!;
+    }
+
+    private static string GetCurrentStage(object inProgressItem)
+    {
+        var prop = inProgressItem.GetType().GetProperty(
+            "CurrentStage",
+            BindingFlags.Instance | BindingFlags.Public);
+        return (string)prop!.GetValue(inProgressItem)!;
+    }
+
+    private SemaphoreSlim GetFinalizeLock()
+    {
+        var field = typeof(QueueManager).GetField(
+            "_finalizeLock",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        return (SemaphoreSlim)field!.GetValue(_queueManager)!;
     }
 
     private static void SetProgressPercentage(object inProgressItem, int value)


### PR DESCRIPTION
## Summary

Reported against 1.3.0-rc.1: when Sonarr deletes a queue item at the same moment InfiniDysk is failing/completing it, the SAB `mode=queue&name=delete` request returned HTTP 500 with a `TaskCanceledException` stack at `QueueItemProcessor.MarkQueueItemCompleted`, followed by Sonarr queue `NotFound` errors.

**Root cause.** The worker was already on its failure path (inside the processor's `catch` block) writing the failed-history row when the remove cancelled the worker token. The cancellation thrown from `MarkQueueItemCompleted` could not be caught by the sibling cancellation handler, so the worker task ended `Canceled`. `ObserveStoppedWorkerAsync` (remove/pause path) and `ReapCompletedWorkersAsync` (coordinator path) only swallowed *non*-cancellation exceptions, so the cancellation escaped `RemoveQueueItemsAsync` and became a 500.

**Fix.**
- `QueueItemProcessor`: failure-path finalizes go through `MarkQueueItemFailedAsync`, which treats a cancel as an ordinary stop (one Information line, change tracker cleared) — the remover owns the row.
- `QueueManager`: `ObserveStoppedWorkerAsync` and `ReapCompletedWorkersAsync` treat a cancelled worker task as the expected outcome of a cancel (Debug log) instead of re-throwing; unexpected faults keep their stack.

The SAB delete now succeeds idempotently, the row is removed, and no failed-history row is written for a job the user deleted.

## Test plan

- [x] New `RemoveQueueItemsAsync_WorkerCancelledMidFailureFinalize_RemovesRowWithoutThrowing` parks a failing worker in the finalize-lock wait, removes it, and asserts no exception, empty still-running list, no queue row, no history row. Fails on `main` with `OperationCanceledException` escaping `RemoveQueueItemsAsync`; passes with the fix.
- [x] `dotnet test --filter FullyQualifiedName~NzbWebDAV.Tests.Queue` — 263 passed, no analyzer warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queue worker shutdown and cancellation handling to prevent expected cancellations from being reported as processing failures.
  * Ensured failed queue items are finalized safely, preserving items when cancellation interrupts failure recording.
  * Prevented queue item removal from throwing when a worker is cancelled during failure finalization.
  * Added regression coverage for cancellation during queue cleanup and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->