### PR TITLE
fix(webdav): directory listings no longer fail with HTTP 500 when a filename contains XML-invalid characters

### DIFF
--- a/backend/Utils/PathSanitizer.cs
+++ b/backend/Utils/PathSanitizer.cs
@@ -35,7 +35,7 @@ public static class PathSanitizer
             return SanitizeMinimal(name);
 
         var sb = new StringBuilder(name.Length);
-        foreach (var ch in name)
+        foreach (var ch in XmlTextUtil.ReplaceInvalidXmlChars(name, '_'))
         {
             if (ch < 0x20 || WindowsInvalidChars.Contains(ch))
                 sb.Append('_');
@@ -67,13 +67,14 @@ public static class PathSanitizer
     }
 
     /// <summary>
-    /// Minimal sanitization when Windows-safe paths are disabled: only '/' and NUL.
+    /// Minimal sanitization when Windows-safe paths are disabled: only '/', NUL, and
+    /// characters XML 1.0 forbids (they would break every WebDAV listing of the parent).
     /// Still length-capped so a sanitized name can never overflow DavItem.Name (255).
     /// </summary>
     private static string SanitizeMinimal(string name)
     {
         var sb = new StringBuilder(name.Length);
-        foreach (var ch in name)
+        foreach (var ch in XmlTextUtil.ReplaceInvalidXmlChars(name, '_'))
         {
             if (ch is '/' or '\0')
                 sb.Append('_');

--- a/backend/Utils/XmlTextUtil.cs
+++ b/backend/Utils/XmlTextUtil.cs
@@ -1,0 +1,60 @@
+using System.Xml;
+
+namespace NzbWebDAV.Utils;
+
+/// <summary>
+/// XML 1.0 forbids U+FFFE, U+FFFF, lone surrogates, and most C0 controls. Names
+/// carrying those (e.g. mis-decoded NZB subjects) make XmlWriter throw while
+/// serializing a PROPFIND response, which turns the whole listing into a 500.
+/// </summary>
+public static class XmlTextUtil
+{
+    public const char ReplacementChar = '\uFFFD';
+
+    public static bool ContainsInvalidXmlChars(string text)
+    {
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (XmlConvert.IsXmlChar(text[i]))
+                continue;
+
+            if (i + 1 < text.Length && XmlConvert.IsXmlSurrogatePair(text[i + 1], text[i]))
+            {
+                i++;
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public static string ReplaceInvalidXmlChars(string text, char replacement = ReplacementChar)
+    {
+        if (!ContainsInvalidXmlChars(text))
+            return text;
+
+        var buffer = new char[text.Length];
+        for (var i = 0; i < text.Length; i++)
+        {
+            var ch = text[i];
+            if (XmlConvert.IsXmlChar(ch))
+            {
+                buffer[i] = ch;
+            }
+            else if (i + 1 < text.Length && XmlConvert.IsXmlSurrogatePair(text[i + 1], ch))
+            {
+                buffer[i] = ch;
+                buffer[i + 1] = text[i + 1];
+                i++;
+            }
+            else
+            {
+                buffer[i] = replacement;
+            }
+        }
+
+        return new string(buffer);
+    }
+}

--- a/backend/WebDav/Base/BaseStoreCollectionPropertyManager.cs
+++ b/backend/WebDav/Base/BaseStoreCollectionPropertyManager.cs
@@ -2,6 +2,7 @@ using System.Xml.Linq;
 using NWebDav.Server;
 using NWebDav.Server.Props;
 using NWebDav.Server.Stores;
+using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.WebDav.Base;
 
@@ -30,7 +31,7 @@ public class BaseStoreCollectionPropertyManager() : PropertyManager<BaseStoreCol
     [
         new DavDisplayName<BaseStoreCollection>
         {
-            Getter = collection => collection.Name
+            Getter = collection => XmlTextUtil.ReplaceInvalidXmlChars(collection.Name)
         },
         new DavGetResourceType<BaseStoreCollection>
         {

--- a/backend/WebDav/Base/BaseStoreItemPropertyManager.cs
+++ b/backend/WebDav/Base/BaseStoreItemPropertyManager.cs
@@ -11,7 +11,7 @@ public class BaseStoreItemPropertyManager() : PropertyManager<BaseStoreItem>(Dav
     [
         new DavDisplayName<BaseStoreItem>
         {
-            Getter = item => item.Name
+            Getter = item => XmlTextUtil.ReplaceInvalidXmlChars(item.Name)
         },
         new DavGetContentLength<BaseStoreItem>
         {

--- a/tests/NzbWebDAV.Tests/Utils/PathSanitizerTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/PathSanitizerTests.cs
@@ -26,6 +26,19 @@ public class PathSanitizerTests
     }
 
     [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SanitizeComponent_ReplacesXmlInvalidChars(bool windowsSafe)
+    {
+        Assert.Equal(
+            "Pi_\uE0C3\uE0B1ata.mkv",
+            PathSanitizer.SanitizeComponent("Pi\uFFFE\uE0C3\uE0B1ata.mkv", windowsSafe));
+        Assert.Equal("a_b", PathSanitizer.SanitizeComponent("a\uFFFFb", windowsSafe));
+        Assert.Equal("a_b", PathSanitizer.SanitizeComponent("a\uD800b", windowsSafe));
+        Assert.Equal("Piñata é.mkv", PathSanitizer.SanitizeComponent("Piñata é.mkv", windowsSafe));
+    }
+
+    [Theory]
     [InlineData("Season 01.", "Season 01")]
     [InlineData("name.  ", "name")]
     [InlineData("name.. ", "name")]

--- a/tests/NzbWebDAV.Tests/Utils/XmlTextUtilTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/XmlTextUtilTests.cs
@@ -1,0 +1,48 @@
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Tests.Utils;
+
+public class XmlTextUtilTests
+{
+    [Theory]
+    [InlineData("plain.mkv")]
+    [InlineData("Piñata é à û.mkv")]
+    [InlineData("tab\tnewline\ncr\r")]
+    [InlineData("emoji \U0001F600.mkv")]
+    [InlineData("private use \uE0C3\uE0B1.mkv")]
+    public void ValidText_IsReturnedUnchanged(string input)
+    {
+        Assert.False(XmlTextUtil.ContainsInvalidXmlChars(input));
+        Assert.Same(input, XmlTextUtil.ReplaceInvalidXmlChars(input));
+    }
+
+    [Theory]
+    [InlineData("Pi\uFFFE\uE0C3\uE0B1ata.mkv", "Pi\uFFFD\uE0C3\uE0B1ata.mkv")]
+    [InlineData("a\uFFFFb", "a\uFFFDb")]
+    [InlineData("a\u0001b\u001Fc", "a\uFFFDb\uFFFDc")]
+    [InlineData("\uFFFE", "\uFFFD")]
+    public void InvalidChars_AreReplaced(string input, string expected)
+    {
+        Assert.True(XmlTextUtil.ContainsInvalidXmlChars(input));
+        Assert.Equal(expected, XmlTextUtil.ReplaceInvalidXmlChars(input));
+    }
+
+    // Built at runtime: xUnit theory data is round-tripped through UTF-8, which mangles lone surrogates.
+    [Fact]
+    public void LoneSurrogates_AreReplaced()
+    {
+        var loneHigh = "lone" + '\uD800' + "high";
+        var loneLow = "lone" + '\uDC00' + "low";
+
+        Assert.True(XmlTextUtil.ContainsInvalidXmlChars(loneHigh));
+        Assert.True(XmlTextUtil.ContainsInvalidXmlChars(loneLow));
+        Assert.Equal("lone\uFFFDhigh", XmlTextUtil.ReplaceInvalidXmlChars(loneHigh));
+        Assert.Equal("lone\uFFFDlow", XmlTextUtil.ReplaceInvalidXmlChars(loneLow));
+    }
+
+    [Fact]
+    public void CustomReplacement_IsUsed()
+    {
+        Assert.Equal("a_b", XmlTextUtil.ReplaceInvalidXmlChars("a\uFFFEb", '_'));
+    }
+}

--- a/tests/NzbWebDAV.Tests/WebDav/DisplayNamePropertyTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/DisplayNamePropertyTests.cs
@@ -61,13 +61,15 @@ public class DisplayNamePropertyTests
 
     private sealed class StubStoreItem(string name) : BaseStoreReadonlyItem
     {
+        private static readonly Stream EmptyReadableStream = Stream.Null;
+
         public override string Name => name;
         public override string UniqueKey => "stub-item";
         public override long FileSize => 0;
         public override DateTime CreatedAt => DateTime.UnixEpoch;
 
         public override Task<Stream> GetReadableStreamAsync(CancellationToken cancellationToken)
-            => Task.FromResult<Stream>(new MemoryStream([]));
+            => Task.FromResult(EmptyReadableStream);
     }
 
     private sealed class StubStoreCollection(string name) : BaseStoreReadonlyCollection

--- a/tests/NzbWebDAV.Tests/WebDav/DisplayNamePropertyTests.cs
+++ b/tests/NzbWebDAV.Tests/WebDav/DisplayNamePropertyTests.cs
@@ -1,0 +1,90 @@
+using System.Runtime.CompilerServices;
+using System.Xml;
+using System.Xml.Linq;
+using NWebDav.Server;
+using NWebDav.Server.Props;
+using NWebDav.Server.Stores;
+using NzbWebDAV.WebDav.Base;
+using NzbWebDAV.WebDav.Requests;
+
+namespace NzbWebDAV.Tests.WebDav;
+
+// Regression for infinidysk/infinidysk#1308: a single stored name containing
+// U+FFFE made XmlWriter throw while serializing PROPFIND, 500-ing the whole listing.
+public class DisplayNamePropertyTests
+{
+    private const string MojibakeName = "Mucha.Lucha.S02E20.Pi\uFFFE\uE0C3\uE0B1ata.mkv";
+    private const string ExpectedName = "Mucha.Lucha.S02E20.Pi\uFFFD\uE0C3\uE0B1ata.mkv";
+
+    [Fact]
+    public async Task Item_DisplayName_ReplacesXmlInvalidChars()
+    {
+        var item = new StubStoreItem(MojibakeName);
+
+        var value = (string?)await item.PropertyManager!
+            .GetPropertyAsync(item, DavDisplayName<IStoreItem>.PropertyName, skipExpensive: true);
+
+        Assert.Equal(ExpectedName, value);
+        AssertSerializable(value!);
+    }
+
+    [Fact]
+    public async Task Collection_DisplayName_ReplacesXmlInvalidChars()
+    {
+        var collection = new StubStoreCollection(MojibakeName);
+
+        var value = (string?)await collection.PropertyManager!
+            .GetPropertyAsync(collection, DavDisplayName<IStoreItem>.PropertyName, skipExpensive: true);
+
+        Assert.Equal(ExpectedName, value);
+        AssertSerializable(value!);
+    }
+
+    [Fact]
+    public async Task Item_DisplayName_LeavesValidNamesUntouched()
+    {
+        const string name = "Piñata é à û.mkv";
+        var item = new StubStoreItem(name);
+
+        var value = (string?)await item.PropertyManager!
+            .GetPropertyAsync(item, DavDisplayName<IStoreItem>.PropertyName, skipExpensive: true);
+
+        Assert.Equal(name, value);
+    }
+
+    private static void AssertSerializable(string displayName)
+    {
+        var document = new XDocument(new XElement(WebDavNamespaces.DavNs + "displayname", displayName));
+        using var writer = XmlWriter.Create(Stream.Null);
+        document.Save(writer);
+    }
+
+    private sealed class StubStoreItem(string name) : BaseStoreReadonlyItem
+    {
+        public override string Name => name;
+        public override string UniqueKey => "stub-item";
+        public override long FileSize => 0;
+        public override DateTime CreatedAt => DateTime.UnixEpoch;
+
+        public override Task<Stream> GetReadableStreamAsync(CancellationToken cancellationToken)
+            => Task.FromResult<Stream>(new MemoryStream([]));
+    }
+
+    private sealed class StubStoreCollection(string name) : BaseStoreReadonlyCollection
+    {
+        public override string Name => name;
+        public override string UniqueKey => "stub-collection";
+        public override DateTime CreatedAt => DateTime.UnixEpoch;
+
+        protected override Task<IStoreItem?> GetItemAsync(GetItemRequest request)
+            => Task.FromResult<IStoreItem?>(null);
+
+        protected override async IAsyncEnumerable<IStoreItem> GetAllItemsAsync(
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.CompletedTask.ConfigureAwait(false);
+            yield break;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1308.

A single stored filename containing a character XML 1.0 forbids (U+FFFE, U+FFFF, lone surrogates, C0 controls) made `XmlWriter` throw while serializing the PROPFIND multistatus body. The whole directory listing became a 500 — rclone surfaced it as `IO error: couldn't list files`, and importers could not read healthy sibling files.

- **Response-time fix:** `displayname` for items and collections now runs through a new `XmlTextUtil.ReplaceInvalidXmlChars` (replaces with U+FFFD), so existing corrupted entries list correctly without a DB migration. `href` was already safe (percent-encoded via `Uri.AbsoluteUri`).
- **Ingest fix:** `PathSanitizer.SanitizeComponent` strips XML-invalid characters (as `_`) in both Windows-safe and minimal modes, so mis-decoded NZB subjects (e.g. `Pi\uFFFE\uE0C3\uE0B1ata`) never enter storage with them again.

## Test plan

- [x] New `XmlTextUtilTests` (valid text untouched, U+FFFE/U+FFFF/C0/lone surrogates replaced, surrogate pairs preserved)
- [x] New `DisplayNamePropertyTests` — property managers return a sanitized `displayname` that serializes through `XmlWriter`
- [x] `PathSanitizerTests` extended for both modes
- [x] Existing `PropFindHandlerPatchTests` / `WebDavContractTests` still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid XML characters in sanitized paths and WebDAV item and collection display names.
  * Prevented malformed display names from causing XML serialization issues.
  * Preserved valid Unicode characters, including valid surrogate pairs.

* **Tests**
  * Added coverage for invalid characters, unpaired surrogates, custom replacements, and successful XML serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->