### PR TITLE
fix(rclone): improve mount recommendations and RC connection tests

### DIFF
--- a/backend/Api/Controllers/TestRcloneConnection/TestRcloneConnectionController.cs
+++ b/backend/Api/Controllers/TestRcloneConnection/TestRcloneConnectionController.cs
@@ -24,7 +24,7 @@ public class TestRcloneConnectionController(
                 {
                     Status = true,
                     Connected = false,
-                    Error = result.Error,
+                    Error = DescribeConnectionError(request.Host, result.Error),
                 };
             }
 
@@ -59,5 +59,13 @@ public class TestRcloneConnectionController(
         var request = new TestRcloneConnectionRequest(HttpContext, configManager);
         var response = await TestRcloneConnection(request).ConfigureAwait(false);
         return Ok(response);
+    }
+
+    internal static string DescribeConnectionError(string host, string? error)
+    {
+        var reason = string.IsNullOrWhiteSpace(error) ? "Connection test failed" : error.TrimEnd('.');
+        return Uri.TryCreate(host, UriKind.Absolute, out var uri) && uri.IsLoopback
+            ? $"{reason}. Loopback addresses refer to the InfiniDysk container; use the rclone service name unless both processes share a network namespace."
+            : reason;
     }
 }

--- a/backend/Api/Controllers/TestRcloneConnection/TestRcloneConnectionController.cs
+++ b/backend/Api/Controllers/TestRcloneConnection/TestRcloneConnectionController.cs
@@ -49,7 +49,7 @@ public class TestRcloneConnectionController(
             {
                 Status = true,
                 Connected = false,
-                Error = e.Message
+                Error = DescribeConnectionError(request.Host, e.Message)
             };
         }
     }

--- a/backend/Clients/Rclone/Models/VfsStatsResponse.cs
+++ b/backend/Clients/Rclone/Models/VfsStatsResponse.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace NzbWebDAV.Clients.Rclone.Models;
@@ -50,6 +51,7 @@ public class VfsMetadataCache
 public class VfsOptions
 {
     [JsonPropertyName("CacheMode")]
+    [JsonConverter(typeof(RcloneCacheModeConverter))]
     public string? CacheMode { get; set; }
 
     [JsonPropertyName("CacheMaxAge")]
@@ -72,4 +74,28 @@ public class VfsOptions
 
     [JsonPropertyName("ReadOnly")]
     public bool ReadOnly { get; set; }
+}
+
+public sealed class RcloneCacheModeConverter : JsonConverter<string>
+{
+    private static readonly string[] Modes = ["off", "minimal", "writes", "full"];
+
+    public override string Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options) =>
+        reader.TokenType switch
+        {
+            JsonTokenType.String => reader.GetString()!,
+            JsonTokenType.Number when reader.TryGetInt32(out var ordinal) &&
+                ordinal >= 0 && ordinal < Modes.Length => Modes[ordinal],
+            JsonTokenType.Number => "unknown",
+            _ => throw new JsonException($"Unexpected token {reader.TokenType} for rclone CacheMode"),
+        };
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        string value,
+        JsonSerializerOptions options) =>
+        writer.WriteStringValue(value);
 }

--- a/backend/Clients/Rclone/RcloneClient.cs
+++ b/backend/Clients/Rclone/RcloneClient.cs
@@ -332,6 +332,14 @@ public sealed class RcloneClient : IRcloneClient, IDisposable
                 (int)HttpClient.Timeout.TotalSeconds);
             return new T { Success = false, Error = "Request timed out" };
         }
+        catch (JsonException ex)
+        {
+            Log.Warning(
+                "Rclone RC request to {Endpoint} returned an incompatible response. Reason: {Reason}",
+                endpoint,
+                ex.Message);
+            return new T { Success = false, Error = "Rclone returned an incompatible response" };
+        }
     }
 
     private Task<T> Post<T>(string endpoint, object? body, CancellationToken cancellationToken)

--- a/backend/Clients/Rclone/RcloneClient.cs
+++ b/backend/Clients/Rclone/RcloneClient.cs
@@ -311,7 +311,15 @@ public sealed class RcloneClient : IRcloneClient, IDisposable
                 return new T { Success = true };
             }
 
-            var result = JsonSerializer.Deserialize<T>(content, JsonOptions) ?? new T();
+            var result = JsonSerializer.Deserialize<T>(content, JsonOptions);
+            if (result is null)
+            {
+                Log.Warning(
+                    "Rclone RC request to {Endpoint} returned an incompatible response. Reason: response body was null",
+                    endpoint);
+                return new T { Success = false, Error = "Rclone returned an incompatible response" };
+            }
+
             result.Success = true;
             return result;
         }

--- a/docs/getting-started/setup-guide.md
+++ b/docs/getting-started/setup-guide.md
@@ -32,8 +32,8 @@ requires an InfiniDysk restart.
 ## Symlink playback and rclone
 
 The guide shows the recommended bounded sidecar flags, including
-`--vfs-cache-mode=full`, `--buffer-size=0`, chunk growth up to `512M`, a
-`50G` cache cap, and `--vfs-read-ahead=512M`.
+`--vfs-cache-mode=full`, `--buffer-size=0`, a `50G` cache cap, and
+`--vfs-read-ahead=512M`. Rclone's defaults control read chunking.
 It also walks through rclone RC notifications:
 
 ```text

--- a/frontend/app/routes/settings/rclone/rclone.tsx
+++ b/frontend/app/routes/settings/rclone/rclone.tsx
@@ -140,7 +140,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
                   id="rclone-host-input"
                   className="join-item min-w-0 flex-1"
                   aria-describedby="rclone-host-help"
-                  placeholder="http://localhost:5572"
+                  placeholder="http://nzbdav_rclone:5572"
                   value={config["rclone.host"]}
                   onChange={(e) => setNewConfig({ ...config, "rclone.host": e.target.value })}
                 />
@@ -188,7 +188,8 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
                 </Alert>
               )}
               <p className="text-[11px] leading-relaxed text-base-content/45" id="rclone-host-help">
-                The host address of the rclone RC API.
+                Use the rclone container&apos;s service name and RC port. Loopback addresses only
+                work when rclone shares InfiniDysk&apos;s network namespace.
               </p>
             </div>
           </ManagedSetting>

--- a/frontend/app/routes/setup/setup-steps.test.tsx
+++ b/frontend/app/routes/setup/setup-steps.test.tsx
@@ -88,7 +88,7 @@ describe("setup wizard controls", () => {
       true,
     );
     expect(screen.getByText("--poll-interval=0")).toBeTruthy();
-    expect(screen.getByText("--vfs-read-chunk-size-limit=512M")).toBeTruthy();
+    expect(screen.queryByText(/--vfs-read-chunk-/)).toBeNull();
     expect(screen.getByText("--vfs-read-ahead=512M")).toBeTruthy();
     expect(screen.getByText("--rc-addr=:5572")).toBeTruthy();
   });

--- a/frontend/app/routes/setup/setup-steps.tsx
+++ b/frontend/app/routes/setup/setup-steps.tsx
@@ -352,7 +352,10 @@ function SymlinkPlaybackStep({
                 Test
               </Button>
             </div>
-            <p className="validator-hint">Enter an absolute URL for the sidecar RC endpoint.</p>
+            <p className="validator-hint">
+              Enter an absolute URL using the rclone service name. Loopback only works in a shared
+              network namespace.
+            </p>
           </Field>
         </ManagedSetting>
         <ManagedSetting configKey="rclone.user">

--- a/frontend/app/routes/setup/setup-steps.tsx
+++ b/frontend/app/routes/setup/setup-steps.tsx
@@ -179,9 +179,6 @@ function SymlinkPlaybackStep({
 --allow-non-empty
 --vfs-cache-mode=full
 --buffer-size=0
---vfs-read-chunk-streams=1
---vfs-read-chunk-size=1M
---vfs-read-chunk-size-limit=512M
 --vfs-read-ahead=512M
 --vfs-cache-max-size=50G
 --vfs-cache-max-age=1w

--- a/tests/NzbWebDAV.Tests/Api/TestRcloneConnectionControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/TestRcloneConnectionControllerTests.cs
@@ -1,0 +1,29 @@
+using NzbWebDAV.Api.Controllers.TestRcloneConnection;
+
+namespace NzbWebDAV.Tests.Api;
+
+public class TestRcloneConnectionControllerTests
+{
+    [Theory]
+    [InlineData("http://127.0.0.1:5572")]
+    [InlineData("http://localhost:5572")]
+    [InlineData("http://[::1]:5572")]
+    public void DescribeConnectionError_ForLoopbackHost_AddsContainerGuidance(string host)
+    {
+        var result = TestRcloneConnectionController.DescribeConnectionError(
+            host,
+            "Connection refused");
+
+        Assert.Contains("use the rclone service name", result);
+    }
+
+    [Fact]
+    public void DescribeConnectionError_ForServiceHost_PreservesReason()
+    {
+        var result = TestRcloneConnectionController.DescribeConnectionError(
+            "http://nzbdav_rclone:5572",
+            "Connection refused");
+
+        Assert.Equal("Connection refused", result);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Clients/RcloneClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RcloneClientTests.cs
@@ -158,6 +158,21 @@ public class RcloneClientTests : IDisposable
     }
 
     [Fact]
+    public async Task GetVfsStats_WithNullResponse_ReturnsInspectionError()
+    {
+        RcloneClient.TestHandler = CreateHandler(
+            ("POST /vfs/stats", SuccessResponse("null")));
+
+        var result = await RcloneClient.GetVfsStats(
+            "http://rclone.test",
+            "rclone",
+            "secret");
+
+        Assert.False(result.Success);
+        Assert.Equal("Rclone returned an incompatible response", result.Error);
+    }
+
+    [Fact]
     public void SharedHttpClient_HasExplicitTimeout()
     {
         Assert.Equal(TimeSpan.FromSeconds(30), RcloneClient.RequestTimeout);

--- a/tests/NzbWebDAV.Tests/Clients/RcloneClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RcloneClientTests.cs
@@ -143,6 +143,21 @@ public class RcloneClientTests : IDisposable
     }
 
     [Fact]
+    public async Task GetVfsStats_WithIncompatibleCacheMode_ReturnsInspectionError()
+    {
+        RcloneClient.TestHandler = CreateHandler(
+            ("POST /vfs/stats", SuccessResponse("{\"opt\":{\"CacheMode\":true}}")));
+
+        var result = await RcloneClient.GetVfsStats(
+            "http://rclone.test",
+            "rclone",
+            "secret");
+
+        Assert.False(result.Success);
+        Assert.Equal("Rclone returned an incompatible response", result.Error);
+    }
+
+    [Fact]
     public void SharedHttpClient_HasExplicitTimeout()
     {
         Assert.Equal(TimeSpan.FromSeconds(30), RcloneClient.RequestTimeout);

--- a/tests/NzbWebDAV.Tests/Clients/RcloneClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RcloneClientTests.cs
@@ -122,6 +122,26 @@ public class RcloneClientTests : IDisposable
         Assert.Equal("full", result.Options?.CacheMode);
     }
 
+    [Theory]
+    [InlineData(0, "off")]
+    [InlineData(1, "minimal")]
+    [InlineData(2, "writes")]
+    [InlineData(3, "full")]
+    [InlineData(4, "unknown")]
+    public async Task GetVfsStats_WithNumericCacheMode_ReturnsName(int cacheMode, string expected)
+    {
+        RcloneClient.TestHandler = CreateHandler(
+            ("POST /vfs/stats", SuccessResponse($"{{\"opt\":{{\"CacheMode\":{cacheMode}}}}}")));
+
+        var result = await RcloneClient.GetVfsStats(
+            "http://rclone.test",
+            "rclone",
+            "secret");
+
+        Assert.True(result.Success);
+        Assert.Equal(expected, result.Options?.CacheMode);
+    }
+
     [Fact]
     public void SharedHttpClient_HasExplicitTimeout()
     {


### PR DESCRIPTION
## Summary

- let rclone defaults control VFS read chunking instead of recommending conflicting chunk flags
- accept both string and numeric cache modes returned by different rclone versions
- preserve successful RC connectivity when VFS inspection returns an incompatible payload
- explain the container loopback trap and recommend the rclone service hostname

## Test plan

- `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter 'FullyQualifiedName~RcloneClientTests|FullyQualifiedName~TestRcloneConnectionControllerTests'` (18 passed)
- `cd frontend && npm test -- app/routes/setup/setup-steps.test.tsx` (5 passed)
- `cd frontend && npx prettier --check app/routes/settings/rclone/rclone.tsx app/routes/setup/setup-steps.tsx`

## Setup wizard impact

Updates the existing rclone recommendations and RC connection guidance. No new setting, persisted value, or wizard version bump is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rclone connection errors by preserving failure reasons and providing container networking guidance for loopback hosts.
  * Improved handling of incompatible or empty rclone responses with clearer inspection errors.
  * Added support for numeric rclone cache mode values, including safe handling of invalid values.

* **Updates**
  * Removed fixed VFS read-chunk tuning from symlink playback so rclone defaults apply.
  * Updated setup guidance, host validation, and connection placeholders for container-based rclone connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->