### PR TITLE
chore(ci): frontend mutation runs no longer take 30+ minutes on dependency-only PRs

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -8,13 +8,13 @@ on:
       - frontend/app/clients/**
       - frontend/app/auth/**
       - frontend/stryker.config.json
+      - frontend/package-lock.json
   workflow_dispatch:
     inputs:
       scope:
         description: Mutation scope
         type: choice
         options:
-          - changed
           - queue
           - streams
           - usenet
@@ -41,7 +41,7 @@ env:
 jobs:
   backend:
     name: Backend mutation
-    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && contains(fromJSON('["changed","queue","streams","usenet","range-strm","all"]'), github.event.inputs.scope))
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && contains(fromJSON('["queue","streams","usenet","range-strm","all"]'), github.event.inputs.scope))
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -124,7 +124,7 @@ jobs:
 
   frontend:
     name: Frontend mutation
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON('["changed","frontend","all"]'), github.event.inputs.scope)
+    if: github.event_name != 'workflow_dispatch' || contains(fromJSON('["frontend","all"]'), github.event.inputs.scope)
     runs-on: ubuntu-latest
     timeout-minutes: 40
     permissions:
@@ -176,10 +176,10 @@ jobs:
         with:
           path: frontend/reports/stryker-incremental.json
           # PR caches are not readable from other PRs; the push-to-main run seeds the shared fallback.
-          key: stryker-js-${{ hashFiles('frontend/stryker.config.json') }}-${{ github.ref_name }}-${{ github.sha }}
+          key: stryker-js-${{ hashFiles('frontend/stryker.config.json', 'frontend/package-lock.json') }}-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
-            stryker-js-${{ hashFiles('frontend/stryker.config.json') }}-${{ github.ref_name }}-
-            stryker-js-${{ hashFiles('frontend/stryker.config.json') }}-main-
+            stryker-js-${{ hashFiles('frontend/stryker.config.json', 'frontend/package-lock.json') }}-${{ github.ref_name }}-
+            stryker-js-${{ hashFiles('frontend/stryker.config.json', 'frontend/package-lock.json') }}-main-
 
       - name: Run StrykerJS
         if: github.event_name != 'pull_request' || steps.mutate.outputs.skip != 'true'

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -2,6 +2,12 @@ name: Mutation
 
 on:
   pull_request:
+  push:
+    branches: [main]
+    paths:
+      - frontend/app/clients/**
+      - frontend/app/auth/**
+      - frontend/stryker.config.json
   workflow_dispatch:
     inputs:
       scope:
@@ -35,7 +41,7 @@ env:
 jobs:
   backend:
     name: Backend mutation
-    if: github.event_name != 'workflow_dispatch' || contains(fromJSON('["changed","queue","streams","usenet","range-strm","all"]'), github.event.inputs.scope)
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && contains(fromJSON('["changed","queue","streams","usenet","range-strm","all"]'), github.event.inputs.scope))
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -136,11 +142,11 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          # Dependency bumps are covered by regular CI; only pilot sources and the Stryker config warrant a mutation run.
           if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
             frontend/app/clients \
             frontend/app/auth \
-            frontend/stryker.config.json \
-            frontend/package-lock.json; then
+            frontend/stryker.config.json; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "No frontend mutation-pilot files changed."
           else
@@ -169,14 +175,16 @@ jobs:
         uses: actions/cache@v6
         with:
           path: frontend/reports/stryker-incremental.json
-          key: stryker-js-${{ hashFiles('frontend/stryker.config.json', 'frontend/package-lock.json') }}-${{ github.ref_name }}
+          # PR caches are not readable from other PRs; the push-to-main run seeds the shared fallback.
+          key: stryker-js-${{ hashFiles('frontend/stryker.config.json') }}-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
-            stryker-js-${{ hashFiles('frontend/stryker.config.json', 'frontend/package-lock.json') }}-
+            stryker-js-${{ hashFiles('frontend/stryker.config.json') }}-${{ github.ref_name }}-
+            stryker-js-${{ hashFiles('frontend/stryker.config.json') }}-main-
 
       - name: Run StrykerJS
         if: github.event_name != 'pull_request' || steps.mutate.outputs.skip != 'true'
         working-directory: frontend
-        run: npm exec stryker -- run
+        run: npm exec stryker -- run --concurrency 3
 
       - name: Compare mutation baseline
         if: github.event_name != 'pull_request' || steps.mutate.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

The frontend mutation job in #1316 (a `qs` lockfile bump) ran a full, cold StrykerJS pass. Two causes:

- `frontend/package-lock.json` was in the trigger paths, so every Dependabot npm bump ran mutation testing over the whole `app/clients` + `app/auth` pilot (~1.7k LOC) even though no pilot source changed.
- The incremental cache key was per-`ref_name` (e.g. `1312/merge`) and PR-scoped caches are not readable from other PRs, so each PR started cold. Because the key had no commit component, the cache was also never refreshed after its first save.

Changes:

- Drop `package-lock.json` from the frontend pilot-change detection (regular CI already covers dependency bumps).
- Add a `push` to `main` trigger (frontend pilot paths only) that seeds a `stryker-js-<config-hash>-main-*` incremental cache, and add it as a fallback `restore-key` for PRs. Key now includes `github.sha` so the cache is refreshed on each run.
- Run StrykerJS with `--concurrency 3` on the 4-vCPU runner instead of the config default of `50%` (=2).

The backend job is unchanged on PRs and does not run on the new `push` trigger.

## Test plan

- [x] `mutation.yml` parses as YAML
- [ ] Dependabot npm-only PR: frontend mutation job reports "No frontend mutation-pilot files changed" and skips
- [ ] PR touching `frontend/app/clients/**`: job restores the `-main-` cache once one has been seeded, and total runtime drops

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved automated quality checks for backend and frontend changes.
  - Updated mutation-testing triggers for pull requests, pushes to the main branch, and supported manual workflows.
  - Refined change detection and manual workflow scope options.
  - Improved test result reuse across branches, configurations, and commits.
  - Increased frontend mutation-testing parallelism to complete validation more efficiently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->