### PR TITLE
chore(ci): Discord release announcements now list the rolling image tag

### DIFF
--- a/.github/workflows/cut-prerelease.yml
+++ b/.github/workflows/cut-prerelease.yml
@@ -246,12 +246,13 @@ jobs:
           if [ "${HAS_COMMITS}" = "true" ]; then
             SUMMARY=$(printf '%s' "$CHANGELOG" | bash .github/scripts/summarize-release-notes.sh --type rc --version "$RELEASE_TAG" || true)
           fi
+          IMAGE="ghcr.io/${REPO}:rc"
           if [ -n "${SUMMARY}" ]; then
-            ANNOUNCEMENT_BODY=$(printf '🧪 **Release Candidate Available** (`%s`)\nRelease and downloads: https://github.com/%s/releases/tag/%s\n\n%s' \
-              "${RELEASE_TAG}" "${REPO}" "${RELEASE_TAG}" "${SUMMARY}")
+            ANNOUNCEMENT_BODY=$(printf '🧪 **Release Candidate Available** (`%s`)\nImage: `%s`\nRelease and downloads: https://github.com/%s/releases/tag/%s\n\n%s' \
+              "${RELEASE_TAG}" "${IMAGE}" "${REPO}" "${RELEASE_TAG}" "${SUMMARY}")
           else
-            ANNOUNCEMENT_BODY=$(printf '🧪 **Release Candidate Available** (`%s`)\nRelease and downloads: https://github.com/%s/releases/tag/%s\n\n%s\n%s' \
-              "${RELEASE_TAG}" "${REPO}" "${RELEASE_TAG}" "${BASE_LABEL}" "${CHANGELOG}")
+            ANNOUNCEMENT_BODY=$(printf '🧪 **Release Candidate Available** (`%s`)\nImage: `%s`\nRelease and downloads: https://github.com/%s/releases/tag/%s\n\n%s\n%s' \
+              "${RELEASE_TAG}" "${IMAGE}" "${REPO}" "${RELEASE_TAG}" "${BASE_LABEL}" "${CHANGELOG}")
           fi
 
           MAX_LEN=1900

--- a/.github/workflows/refresh-dev.yml
+++ b/.github/workflows/refresh-dev.yml
@@ -201,12 +201,13 @@ jobs:
           if [ "${HAS_COMMITS}" = "true" ]; then
             SUMMARY=$(printf '%s' "$CHANGELOG" | bash .github/scripts/summarize-release-notes.sh --type dev --version "${DEV_LABEL}" || true)
           fi
+          IMAGE="ghcr.io/${REPO}:dev"
           if [ -n "${SUMMARY}" ]; then
-            ANNOUNCEMENT_BODY=$(printf '🛠️ **Dev Branch Update** (version `%s`)\nRelease and downloads: https://github.com/%s/releases/tag/dev\n\n%s' \
-              "${DEV_LABEL}" "${REPO}" "${SUMMARY}")
+            ANNOUNCEMENT_BODY=$(printf '🛠️ **Dev Branch Update** (version `%s`)\nImage: `%s`\nRelease and downloads: https://github.com/%s/releases/tag/dev\n\n%s' \
+              "${DEV_LABEL}" "${IMAGE}" "${REPO}" "${SUMMARY}")
           else
-            ANNOUNCEMENT_BODY=$(printf '🛠️ **Dev Branch Update** (version `%s`)\nRelease and downloads: https://github.com/%s/releases/tag/dev\n\n%s\n%s' \
-              "${DEV_LABEL}" "${REPO}" "${BASE_LABEL}" "${CHANGELOG}")
+            ANNOUNCEMENT_BODY=$(printf '🛠️ **Dev Branch Update** (version `%s`)\nImage: `%s`\nRelease and downloads: https://github.com/%s/releases/tag/dev\n\n%s\n%s' \
+              "${DEV_LABEL}" "${IMAGE}" "${REPO}" "${BASE_LABEL}" "${CHANGELOG}")
           fi
 
           MAX_LEN=1900

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,11 +383,12 @@ jobs:
             -e 's/, closes \[#[0-9]+\]\(https:\/\/github\.com\/[^)]+\/issues\/[0-9]+\)//g')
 
           SUMMARY=$(printf '%s' "$RELEASE_NOTES" | bash .github/scripts/summarize-release-notes.sh --type stable --version "v${VERSION}" || true)
+          IMAGE="ghcr.io/${REPO}:latest"
           if [ -n "${SUMMARY}" ]; then
-            ANNOUNCEMENT_BODY=$(printf '🚀 **New Release: Version [%s]**\n\n%s\n\nFull changelog: https://github.com/%s/releases/tag/v%s' \
-              "${VERSION}" "${SUMMARY}" "${REPO}" "${VERSION}")
+            ANNOUNCEMENT_BODY=$(printf '🚀 **New Release: Version [%s]**\nImage: `%s`\n\n%s\n\nFull changelog: https://github.com/%s/releases/tag/v%s' \
+              "${VERSION}" "${IMAGE}" "${SUMMARY}" "${REPO}" "${VERSION}")
           else
-            ANNOUNCEMENT_BODY=$(printf '🚀 **New Release: Version [%s]**%s' "${VERSION}" "${RELEASE_NOTES}")
+            ANNOUNCEMENT_BODY=$(printf '🚀 **New Release: Version [%s]**\nImage: `%s`%s' "${VERSION}" "${IMAGE}" "${RELEASE_NOTES}")
           fi
 
           # Discord content is limited to 2000 characters.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -388,7 +388,7 @@ jobs:
             ANNOUNCEMENT_BODY=$(printf '🚀 **New Release: Version [%s]**\nImage: `%s`\n\n%s\n\nFull changelog: https://github.com/%s/releases/tag/v%s' \
               "${VERSION}" "${IMAGE}" "${SUMMARY}" "${REPO}" "${VERSION}")
           else
-            ANNOUNCEMENT_BODY=$(printf '🚀 **New Release: Version [%s]**\nImage: `%s`%s' "${VERSION}" "${IMAGE}" "${RELEASE_NOTES}")
+            ANNOUNCEMENT_BODY=$(printf '🚀 **New Release: Version [%s]**\nImage: `%s`\n%s' "${VERSION}" "${IMAGE}" "${RELEASE_NOTES}")
           fi
 
           # Discord content is limited to 2000 characters.


### PR DESCRIPTION
## Summary
Dev, RC, and stable Discord announcements now include an `Image:` line pointing at the rolling tag (`ghcr.io/infinidysk/infinidysk:dev`, `:rc`, `:latest`) rather than the versioned tag (e.g. `v1.3.0-rc.2`).

## Test plan
- Rendered the RC printf template locally with sample values and confirmed output.
- Workflow-only change; verify on the next Refresh :dev / Cut pre-release run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release, release candidate, and development announcements now include direct references to their corresponding container images.
  - Image references appear consistently in both summarized and unsummarized announcement formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->