### PR TITLE
feat(ui): warn when Segment Cache duplicates rclone VFS read-ahead

### DIFF
--- a/docs/configuration/streaming.md
+++ b/docs/configuration/streaming.md
@@ -65,6 +65,21 @@ path) is local SSD/NVMe or other storage that can safely absorb the extra writes
 Disable the cache for slow disks, network mounts, or flash storage with limited
 write endurance; alternatively, point **Cache path** at suitable local storage.
 
+### Segment Cache and rclone read-ahead
+
+Symlink libraries stream through an rclone mount. When that mount runs with
+`--vfs-read-ahead`, rclone already buffers ahead of playback, and Segment Cache only
+adds disk writes without improving seeks. Keep one or the other: the
+[Setup Guide](../getting-started/setup-guide.md) disables Segment Cache for Symlinks
+and recommends the bounded rclone VFS cache instead.
+
+InfiniDysk cannot always inspect the mount, so the Streaming tab shows a dismissable
+warning whenever Segment Cache is on for a Symlinks library. Dismissal is remembered
+per browser. When the [rclone RC connection test](rclone.md) can read VFS statistics
+and confirms read-ahead is enabled, the Rclone tab shows a definitive warning instead.
+Re-run the Setup Guide from the main navigation to review this and other recommended
+settings, even on an existing installation.
+
 ## Article buffer and adaptive prefetch
 
 `usenet.article-buffer-size` bounds how many decoded articles a stream may keep

--- a/docs/getting-started/setup-guide.md
+++ b/docs/getting-started/setup-guide.md
@@ -8,6 +8,10 @@ InfiniDysk opens **Setup Guide** after the first administrator signs in on a new
 or upgraded installation. Complete it, or choose **Skip setup** to stop the
 automatic prompt. You can run it again at any time from the main navigation.
 
+The guide is worth completing even on a long-running installation: it reviews
+best-practice configuration such as pairing Symlinks with rclone VFS read-ahead
+rather than Segment Cache, and stages only the settings you approve.
+
 The guide stages changes until **Review and apply**. Skip applies nothing, and a
 validation failure does not save a partial configuration. Settings controlled by
 `NZBDAV_CONFIG__...` remain read-only and name the environment variable to change.

--- a/frontend/app/routes/settings/rclone/rclone.test.tsx
+++ b/frontend/app/routes/settings/rclone/rclone.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { createElement, useState } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RcloneSettings } from "./rclone";
+
+const fetchMock = vi.fn<typeof fetch>();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const baseConfig: Record<string, string> = {
+  "rclone.rc-enabled": "true",
+  "rclone.host": "http://rclone:5572",
+  "rclone.user": "",
+  "rclone.pass": "",
+  "usenet.segment-cache.enabled": "true",
+};
+
+let latestSetConfig: ((next: Record<string, string>) => void) | null = null;
+
+function Harness({ initial }: { initial: Record<string, string> }) {
+  const [config, setNewConfig] = useState(initial);
+  latestSetConfig = (next) => setNewConfig(next);
+  return createElement(RcloneSettings, { config, setNewConfig });
+}
+
+const successBody = {
+  status: true,
+  connected: true,
+  readAheadBytes: 128 * 1024 * 1024,
+};
+
+async function flushPromises(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+describe("RcloneSettings connection test", () => {
+  it("shows the Segment Cache read-ahead warning after a successful test", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(successBody));
+    render(createElement(Harness, { initial: baseConfig }));
+
+    act(() => {
+      screen.getByRole("button", { name: "Test Conn" }).click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Connection test successful")).toBeTruthy();
+    });
+    expect(screen.getByText(/VFS read-ahead enabled while Segment Cache/)).toBeTruthy();
+  });
+
+  it("ignores a stale test response when the host changes while the test is pending", async () => {
+    let resolveFetch: ((response: Response) => void) | null = null;
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    render(createElement(Harness, { initial: baseConfig }));
+
+    act(() => {
+      screen.getByRole("button", { name: "Test Conn" }).click();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      latestSetConfig?.({ ...baseConfig, "rclone.host": "http://other-rclone:5572" });
+    });
+
+    act(() => {
+      resolveFetch?.(jsonResponse(successBody));
+    });
+    await flushPromises();
+
+    expect(screen.queryByText("Connection test successful")).toBeNull();
+    expect(screen.queryByText(/VFS read-ahead enabled while Segment Cache/)).toBeNull();
+    expect(screen.getByRole("button", { name: "Test Conn" })).toBeTruthy();
+  });
+});

--- a/frontend/app/routes/settings/rclone/rclone.tsx
+++ b/frontend/app/routes/settings/rclone/rclone.tsx
@@ -28,6 +28,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
   const [testError, setTestError] = useState<string | null>(null);
   const [invalidationError, setInvalidationError] = useState<string | null>(null);
   const [invalidationErrorAt, setInvalidationErrorAt] = useState<string | null>(null);
+  const [readAheadBytes, setReadAheadBytes] = useState<number | null>(null);
 
   const rcloneHost = config["rclone.host"];
   const rcloneUser = config["rclone.user"];
@@ -37,6 +38,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
     setTestError(null);
     setInvalidationError(null);
     setInvalidationErrorAt(null);
+    setReadAheadBytes(null);
   }, [rcloneHost, rcloneUser, rclonePass]);
 
   const testConnection = useCallback(async () => {
@@ -49,6 +51,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
     setTestError(null);
     setInvalidationError(null);
     setInvalidationErrorAt(null);
+    setReadAheadBytes(null);
 
     try {
       const formData = new FormData();
@@ -66,6 +69,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
         status?: boolean;
         connected?: boolean;
         error?: string;
+        readAheadBytes?: number | null;
         lastInvalidationError?: string | null;
         lastInvalidationErrorAt?: string | null;
       };
@@ -73,6 +77,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
       if (result.status && result.connected) {
         setConnectionState("success");
         setTestError(null);
+        setReadAheadBytes(result.readAheadBytes ?? null);
         setInvalidationError(result.lastInvalidationError ?? null);
         setInvalidationErrorAt(result.lastInvalidationErrorAt ?? null);
       } else {
@@ -84,6 +89,12 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
       setTestError(error instanceof Error ? error.message : "Connection test failed");
     }
   }, [config]);
+
+  const readAheadConflictsWithSegmentCache =
+    connectionState === "success" &&
+    readAheadBytes !== null &&
+    readAheadBytes > 0 &&
+    config["usenet.segment-cache.enabled"] === "true";
 
   return (
     <SettingsPage>
@@ -177,6 +188,26 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
               {connectionState === "success" && (
                 <Alert variant="success" className="text-xs py-2">
                   Connection test successful
+                </Alert>
+              )}
+              {readAheadConflictsWithSegmentCache && (
+                <Alert variant="warning" className="text-xs py-2">
+                  This rclone mount has VFS read-ahead enabled while Segment Cache is also on. Both
+                  buffer ahead for playback, so the Segment Cache only adds disk writes. Disable it
+                  under{" "}
+                  <a className="link font-medium" href={withUrlBase("/settings?tab=streaming")}>
+                    Streaming
+                  </a>{" "}
+                  or re-run the{" "}
+                  <a
+                    className="link font-medium"
+                    href={withUrlBase(
+                      `/setup?returnTo=${encodeURIComponent("/settings?tab=rclone")}`,
+                    )}
+                  >
+                    Setup Guide
+                  </a>{" "}
+                  to apply the recommended configuration.
                 </Alert>
               )}
               {connectionState === "success" && invalidationError && (

--- a/frontend/app/routes/settings/rclone/rclone.tsx
+++ b/frontend/app/routes/settings/rclone/rclone.tsx
@@ -3,7 +3,14 @@ import { Alert, Spinner, Tooltip } from "~/components/ui/feedback";
 import { ManagedSetting, SettingsCard, SettingsIntro, SettingsPage } from "~/components/ui";
 import { Input, Toggle } from "~/components/ui/form";
 import { Icon } from "~/components/ui/icon";
-import { type Dispatch, type SetStateAction, useState, useCallback, useEffect } from "react";
+import {
+  type Dispatch,
+  type SetStateAction,
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+} from "react";
 import { withUrlBase } from "~/utils/url-base";
 
 function formatTimeAgo(isoDate: string): string {
@@ -29,11 +36,14 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
   const [invalidationError, setInvalidationError] = useState<string | null>(null);
   const [invalidationErrorAt, setInvalidationErrorAt] = useState<string | null>(null);
   const [readAheadBytes, setReadAheadBytes] = useState<number | null>(null);
+  // Bumped whenever connection inputs change so in-flight test responses are discarded.
+  const testGeneration = useRef(0);
 
   const rcloneHost = config["rclone.host"];
   const rcloneUser = config["rclone.user"];
   const rclonePass = config["rclone.pass"];
   useEffect(() => {
+    testGeneration.current += 1;
     setConnectionState("idle");
     setTestError(null);
     setInvalidationError(null);
@@ -47,6 +57,7 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
       return;
     }
 
+    const generation = ++testGeneration.current;
     setConnectionState("testing");
     setTestError(null);
     setInvalidationError(null);
@@ -74,6 +85,10 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
         lastInvalidationErrorAt?: string | null;
       };
 
+      if (generation !== testGeneration.current) {
+        return;
+      }
+
       if (result.status && result.connected) {
         setConnectionState("success");
         setTestError(null);
@@ -85,6 +100,9 @@ export function RcloneSettings({ config, setNewConfig }: RcloneSettingsProps) {
         setTestError(result.error || "Connection test failed");
       }
     } catch (error) {
+      if (generation !== testGeneration.current) {
+        return;
+      }
       setConnectionState("error");
       setTestError(error instanceof Error ? error.message : "Connection test failed");
     }

--- a/frontend/app/routes/settings/streaming/streaming.test.ts
+++ b/frontend/app/routes/settings/streaming/streaming.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-/* global HTMLInputElement, HTMLSelectElement */
+/* global HTMLInputElement, HTMLSelectElement, localStorage */
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createElement, useState } from "react";
@@ -11,6 +11,8 @@ vi.mock("~/utils/shared-websocket", () => ({
 import {
   isStreamingSettingsUpdated,
   isStreamingSettingsValid,
+  SEGMENT_CACHE_READ_AHEAD_WARNING_KEY,
+  shouldWarnSegmentCacheReadAhead,
   StreamingSettings,
 } from "./streaming";
 
@@ -43,10 +45,17 @@ const validConfig = {
   "usenet.shared-streams.small-range-max-mb": "",
 };
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
 
-function StreamingHarness() {
-  const [config, setConfig] = useState<Record<string, string>>(validConfig);
+function StreamingHarness({
+  initialConfig = validConfig,
+}: {
+  initialConfig?: Record<string, string>;
+}) {
+  const [config, setConfig] = useState<Record<string, string>>(initialConfig);
   return createElement(StreamingSettings, {
     config,
     setNewConfig: setConfig,
@@ -55,6 +64,49 @@ function StreamingHarness() {
 }
 
 describe("Streaming settings", () => {
+  it("warns about rclone read-ahead only for symlink libraries with Segment Cache on", () => {
+    expect(
+      shouldWarnSegmentCacheReadAhead({ ...validConfig, "api.import-strategy": "symlinks" }),
+    ).toBe(true);
+    expect(shouldWarnSegmentCacheReadAhead({ ...validConfig, "api.import-strategy": "strm" })).toBe(
+      false,
+    );
+    expect(
+      shouldWarnSegmentCacheReadAhead({
+        ...validConfig,
+        "api.import-strategy": "symlinks",
+        "usenet.segment-cache.enabled": "false",
+      }),
+    ).toBe(false);
+  });
+
+  it("shows a dismissable read-ahead warning that stays dismissed", async () => {
+    const user = userEvent.setup();
+    const symlinksConfig = { ...validConfig, "api.import-strategy": "symlinks" };
+    const { unmount } = render(createElement(StreamingHarness, { initialConfig: symlinksConfig }));
+
+    expect(screen.getByTestId("segment-cache-read-ahead-warning")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Setup Guide" }).getAttribute("href")).toBe(
+      "/setup?returnTo=%2Fsettings%3Ftab%3Dstreaming",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Dismiss read-ahead notice" }));
+    expect(screen.queryByTestId("segment-cache-read-ahead-warning")).toBeNull();
+    expect(localStorage.getItem(SEGMENT_CACHE_READ_AHEAD_WARNING_KEY)).toBe("true");
+
+    unmount();
+    render(createElement(StreamingHarness, { initialConfig: symlinksConfig }));
+    expect(screen.queryByTestId("segment-cache-read-ahead-warning")).toBeNull();
+  });
+
+  it("does not show the read-ahead warning for STRM libraries", () => {
+    render(
+      createElement(StreamingHarness, {
+        initialConfig: { ...validConfig, "api.import-strategy": "strm" },
+      }),
+    );
+    expect(screen.queryByTestId("segment-cache-read-ahead-warning")).toBeNull();
+  });
   it("updates connection allocation and conditional controls", async () => {
     const user = userEvent.setup();
     render(createElement(StreamingHarness));

--- a/frontend/app/routes/settings/streaming/streaming.tsx
+++ b/frontend/app/routes/settings/streaming/streaming.tsx
@@ -1,7 +1,9 @@
-import { type Dispatch, type SetStateAction, useState } from "react";
+import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
 import {
   Alert,
   Badge,
+  Button,
+  Icon,
   Input,
   InputGroup,
   Label,
@@ -15,7 +17,17 @@ import {
 } from "~/components/ui";
 import { className } from "~/utils/styling";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
+import { withUrlBase } from "~/utils/url-base";
 import { isPositiveInteger } from "../validation";
+
+export const SEGMENT_CACHE_READ_AHEAD_WARNING_KEY = "segment-cache-read-ahead-warning-dismissed";
+
+export function shouldWarnSegmentCacheReadAhead(config: Record<string, string>): boolean {
+  return (
+    config["usenet.segment-cache.enabled"] === "true" &&
+    config["api.import-strategy"] === "symlinks"
+  );
+}
 
 type StreamingSettingsProps = {
   config: Record<string, string>;
@@ -43,6 +55,28 @@ export function StreamingSettings({
       // Ignore malformed frames; the next tick replaces them.
     }
   });
+
+  // Starts hidden so a previously dismissed notice does not flash during hydration.
+  const [readAheadWarningDismissed, setReadAheadWarningDismissed] = useState(true);
+  useEffect(() => {
+    try {
+      setReadAheadWarningDismissed(
+        globalThis.localStorage?.getItem(SEGMENT_CACHE_READ_AHEAD_WARNING_KEY) === "true",
+      );
+    } catch {
+      setReadAheadWarningDismissed(false);
+    }
+  }, []);
+  const dismissReadAheadWarning = () => {
+    setReadAheadWarningDismissed(true);
+    try {
+      globalThis.localStorage?.setItem(SEGMENT_CACHE_READ_AHEAD_WARNING_KEY, "true");
+    } catch {
+      /* ignore quota / private mode */
+    }
+  };
+  const showReadAheadWarning =
+    !readAheadWarningDismissed && shouldWarnSegmentCacheReadAhead(config);
 
   const bandwidthLimit = config["usenet.bandwidth-limit-mbps"] ?? "";
   const parsedBandwidthLimit = Number(bandwidthLimit);
@@ -251,6 +285,38 @@ export function StreamingSettings({
               or set Cache path to local SSD/NVMe or other storage where the additional writes are
               acceptable.
             </Alert>
+            {showReadAheadWarning && (
+              <Alert
+                className="alert-soft items-start justify-between gap-3 text-xs"
+                variant="warning"
+                data-testid="segment-cache-read-ahead-warning"
+              >
+                <span>
+                  Your library uses Symlinks, which stream through an rclone mount. If that mount
+                  runs with <code>--vfs-read-ahead</code>, rclone already buffers ahead and Segment
+                  Cache duplicates that work with extra disk writes. InfiniDysk cannot always detect
+                  whether read-ahead is enabled, so disable Segment Cache if it is. The{" "}
+                  <a
+                    className="link font-medium"
+                    href={withUrlBase(
+                      `/setup?returnTo=${encodeURIComponent("/settings?tab=streaming")}`,
+                    )}
+                  >
+                    Setup Guide
+                  </a>{" "}
+                  reviews this and other recommended settings, even for existing installations.
+                </span>
+                <Button
+                  variant="ghost"
+                  size="rounded"
+                  className="shrink-0"
+                  aria-label="Dismiss read-ahead notice"
+                  onClick={dismissReadAheadWarning}
+                >
+                  <Icon name="close" className="!text-[18px]" />
+                </Button>
+              </Alert>
+            )}
             {config["usenet.segment-cache.enabled"] === "true" && (
               <div className="grid gap-4 border-l border-base-content/10 pl-4 sm:grid-cols-2">
                 <label className="flex flex-col gap-2 text-sm text-base-content/80">


### PR DESCRIPTION
## Summary

Users running a **Symlinks** library stream through an rclone mount. When that mount uses `--vfs-read-ahead`, rclone already buffers ahead of playback, so InfiniDysk's Segment Cache only adds disk writes. InfiniDysk cannot always inspect the mount, so this PR adds guidance instead of silently changing behavior:

- **Streaming tab** — a dismissable warning appears when Segment Cache is on and `api.import-strategy` is `symlinks`. Dismissal is remembered per browser (`localStorage`).
- **Rclone tab** — when the RC connection test can read VFS statistics and confirms read-ahead is enabled while Segment Cache is on, a definitive (non-dismissable, per-test) warning is shown.
- Both warnings link to the **Setup Guide** with a `returnTo`, and the copy encourages existing installations to re-run it since it reviews recommended configuration.
- Docs: new "Segment Cache and rclone read-ahead" section in `docs/configuration/streaming.md`; Setup Guide intro now notes it is worth completing on long-running installs.

No config keys or backend changes; setup wizard version is unchanged (advisory-only UI).

## Test plan

- [x] `vitest` — new tests cover the warning predicate, the dismiss button persisting to `localStorage` and staying hidden on remount, and no warning for STRM libraries
- [x] ESLint (zero warnings), Prettier, `tsc -b` on the frontend
- [ ] Manual: Settings → Streaming with a Symlinks library and Segment Cache on shows the notice; dismiss survives reload
- [ ] Manual: Settings → Rclone → Test Conn against a mount with `--vfs-read-ahead` shows the read-ahead warning when Segment Cache is on


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added warnings in Streaming and Rclone settings when Segment Cache and rclone read-ahead are enabled together for Symlink libraries.
  - Warnings link to Streaming settings and the Setup Guide and can be dismissed with the choice remembered.
  - Warnings are hidden for STRM libraries and during initial page loading.
  - Rclone connection results now reflect the detected read-ahead configuration.

- **Documentation**
  - Added guidance on configuring Segment Cache and rclone read-ahead.
  - Updated the setup guide with recommendations for existing installations and approved settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->