### PR TITLE
feat(ui): setup wizard always suggests rclone RC notifications for symlink installs

### DIFF
--- a/docs/getting-started/setup-guide.md
+++ b/docs/getting-started/setup-guide.md
@@ -34,7 +34,10 @@ requires an InfiniDysk restart.
 The guide shows the recommended bounded sidecar flags, including
 `--vfs-cache-mode=full`, `--buffer-size=0`, a `50G` cache cap, and
 `--vfs-read-ahead=512M`. Rclone's defaults control read chunking.
-It also walks through rclone RC notifications:
+It also walks through rclone RC notifications. The wizard proposes RC
+notifications **on** whenever symlinks are selected, even if they are currently
+disabled; turn the toggle off explicitly if you do not want them. A value pinned
+by `NZBDAV_CONFIG__RCLONE__RC_ENABLED` is left unchanged.
 
 ```text
 --rc

--- a/frontend/app/routes/setup/route.tsx
+++ b/frontend/app/routes/setup/route.tsx
@@ -124,7 +124,6 @@ export default function SetupRoute({ loaderData }: Route.ComponentProps) {
       loaderData.config,
       loaderData.managedEnv,
       loaderData.state.ingestionMethods,
-      loaderData.state.setupRequired,
     ),
   );
   const [attempted, setAttempted] = useState(false);

--- a/frontend/app/routes/setup/route.tsx
+++ b/frontend/app/routes/setup/route.tsx
@@ -120,11 +120,7 @@ export default function SetupRoute({ loaderData }: Route.ComponentProps) {
   const fetcher = useFetcher<typeof action>();
   const [step, setStep] = useState(0);
   const [draft, setDraft] = useState<SetupDraft>(() =>
-    createInitialDraft(
-      loaderData.config,
-      loaderData.managedEnv,
-      loaderData.state.ingestionMethods,
-    ),
+    createInitialDraft(loaderData.config, loaderData.managedEnv, loaderData.state.ingestionMethods),
   );
   const [attempted, setAttempted] = useState(false);
   const [strategyChangeConfirmed, setStrategyChangeConfirmed] = useState(false);

--- a/frontend/app/routes/setup/setup-model.test.ts
+++ b/frontend/app/routes/setup/setup-model.test.ts
@@ -27,6 +27,7 @@ describe("setup model", () => {
     const baseline = { ...SETUP_DEFAULT_CONFIG, "usenet.segment-cache.enabled": "true" };
     const managed = {
       "usenet.segment-cache.enabled": "NZBDAV_CONFIG__USENET__SEGMENT_CACHE__ENABLED",
+      "rclone.rc-enabled": "NZBDAV_CONFIG__RCLONE__RC_ENABLED",
     };
     const draft = applyStrategy(baseline, "symlinks", managed);
 
@@ -34,26 +35,48 @@ describe("setup model", () => {
     expect(changedSetupConfig(baseline, draft, managed)).toEqual({});
   });
 
-  it("defaults pending symlink setup to RC notifications on", () => {
-    const draft = createInitialDraft(SETUP_DEFAULT_CONFIG, {}, [], true);
+  it("defaults symlink setup to RC notifications on regardless of stored config", () => {
+    const draft = createInitialDraft(
+      { ...SETUP_DEFAULT_CONFIG, "rclone.rc-enabled": "false" },
+      {},
+      [],
+    );
 
     expect(draft.config["rclone.rc-enabled"]).toBe("true");
     expect(draft.config["usenet.segment-cache.enabled"]).toBe("false");
   });
 
+  it("re-enables RC notifications when switching to symlinks but leaves STRM untouched", () => {
+    const strm = applyStrategy(
+      { ...SETUP_DEFAULT_CONFIG, "api.import-strategy": "strm", "rclone.rc-enabled": "false" },
+      "strm",
+      {},
+    );
+    expect(strm["rclone.rc-enabled"]).toBe("false");
+
+    expect(applyStrategy(strm, "symlinks", {})["rclone.rc-enabled"]).toBe("true");
+  });
+
+  it("keeps environment-managed RC notifications untouched", () => {
+    const managed = { "rclone.rc-enabled": "NZBDAV_CONFIG__RCLONE__RC_ENABLED" };
+    const draft = createInitialDraft(SETUP_DEFAULT_CONFIG, managed, []);
+
+    expect(draft.config["rclone.rc-enabled"]).toBe("false");
+  });
+
   it("includes selected branch defaults in the completion payload", () => {
-    const draft = createInitialDraft(SETUP_DEFAULT_CONFIG, {}, ["manual"], false);
+    const draft = createInitialDraft(SETUP_DEFAULT_CONFIG, {}, ["manual"]);
 
     expect(completionSetupConfig(SETUP_DEFAULT_CONFIG, draft, {})).toMatchObject({
       "rclone.mount-dir": "/mnt/nzbdav",
-      "rclone.rc-enabled": "false",
+      "rclone.rc-enabled": "true",
       "backup.schedule-enabled": "false",
       "media.library-dir": "",
     });
   });
 
   it("requires read-ahead confirmation and a valid RC host for symlinks", () => {
-    const draft = createInitialDraft(SETUP_DEFAULT_CONFIG, {}, ["manual"], true);
+    const draft = createInitialDraft(SETUP_DEFAULT_CONFIG, {}, ["manual"]);
 
     expect(validateSetupStep(1, draft, {}, false, "symlinks")).toEqual([
       "Enter a valid http(s) rclone RC host.",
@@ -71,7 +94,6 @@ describe("setup model", () => {
       },
       {},
       ["manual"],
-      false,
     );
 
     expect(validateSetupStep(4, draft, {}, false, "strm")).toEqual([]);

--- a/frontend/app/routes/setup/setup-model.ts
+++ b/frontend/app/routes/setup/setup-model.ts
@@ -71,13 +71,9 @@ export function createInitialDraft(
   config: Record<string, string>,
   managedEnv: ManagedEnvMap,
   ingestionMethods: string[],
-  setupRequired: boolean,
 ): SetupDraft {
   const strategy = normalizeStrategy(config["api.import-strategy"]);
   const next = applyStrategy(config, strategy, managedEnv);
-  if (setupRequired && strategy === "symlinks" && !("rclone.rc-enabled" in managedEnv)) {
-    next["rclone.rc-enabled"] = "true";
-  }
 
   return {
     config: next,
@@ -97,6 +93,10 @@ export function applyStrategy(
   }
   if (!("usenet.segment-cache.enabled" in managedEnv)) {
     next["usenet.segment-cache.enabled"] = strategy === "strm" ? "true" : "false";
+  }
+  // The wizard always proposes RC notifications for symlinks; the user must opt out explicitly.
+  if (strategy === "symlinks" && !("rclone.rc-enabled" in managedEnv)) {
+    next["rclone.rc-enabled"] = "true";
   }
   return next;
 }

--- a/frontend/app/routes/setup/setup-steps.test.tsx
+++ b/frontend/app/routes/setup/setup-steps.test.tsx
@@ -16,7 +16,7 @@ afterEach(cleanup);
 
 describe("setup wizard controls", () => {
   it("uses named radios for the exclusive library strategy", () => {
-    const draft = createInitialDraft(SETUP_DEFAULT_CONFIG, {}, ["manual"], false);
+    const draft = createInitialDraft(SETUP_DEFAULT_CONFIG, {}, ["manual"]);
     render(
       <ManagedEnvProvider value={{}}>
         <LibraryTypeStep draft={draft} managedEnv={{}} updateDraft={vi.fn()} />
@@ -36,7 +36,7 @@ describe("setup wizard controls", () => {
   });
 
   it("uses checkboxes for independent ingestion choices", () => {
-    const draft = createInitialDraft(SETUP_DEFAULT_CONFIG, {}, ["search", "manual"], false);
+    const draft = createInitialDraft(SETUP_DEFAULT_CONFIG, {}, ["search", "manual"]);
     render(
       <ManagedEnvProvider value={{}}>
         <IngestionStep draft={draft} updateDraft={vi.fn()} />
@@ -53,7 +53,7 @@ describe("setup wizard controls", () => {
   });
 
   it("uses a toggle and disabled fieldset for an off backup schedule", () => {
-    const draft = createInitialDraft(SETUP_DEFAULT_CONFIG, {}, ["manual"], false);
+    const draft = createInitialDraft(SETUP_DEFAULT_CONFIG, {}, ["manual"]);
     render(
       <ManagedEnvProvider value={{}}>
         <BackupStep draft={draft} updateDraft={vi.fn()} mainDatabaseProvider="sqlite" />
@@ -76,7 +76,7 @@ describe("setup wizard controls", () => {
   });
 
   it("shows rclone sidecar configuration expanded by default", () => {
-    const draft = createInitialDraft(SETUP_DEFAULT_CONFIG, {}, ["manual"], true);
+    const draft = createInitialDraft(SETUP_DEFAULT_CONFIG, {}, ["manual"]);
     render(
       <ManagedEnvProvider value={{}}>
         <PlaybackStep draft={draft} updateDraft={vi.fn()} />


### PR DESCRIPTION
## Summary
- The setup wizard now proposes **Enable rclone RC notifications = on** whenever the symlinks strategy is selected, regardless of the currently stored value. Users must intentionally toggle it off during the wizard if they do not want it.
- Environment-managed values (`NZBDAV_CONFIG__RCLONE__RC_ENABLED`) are still left untouched.
- STRM installs are unaffected; switching back to symlinks re-proposes RC on.
- Docs: setup guide notes the new default.

Setup-wizard impact review: no new config key, no wizard version bump (existing option, changed default proposal only).

## Test plan
- [x] `npx vitest run app/routes/setup` (27 tests, incl. new cases for stored-off config, strategy switch, and managed env)
- [x] `tsc --noEmit` and eslint on `app/routes/setup`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The setup wizard now proposes enabling rclone notifications by default when Symlinks is selected.
  * Switching to Symlinks re-enables the proposed notification setting, while STRM preserves the stored value.
  * Environment-managed notification settings remain unchanged.
  * Users can explicitly disable the proposed notification setting.

* **Documentation**
  * Updated setup guidance to explain the default notification behavior and configuration override.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->