### PR TITLE
feat(usenet): leftover segment-cache files are cleaned up on startup when the cache is disabled

### DIFF
--- a/backend/Clients/Usenet/SegmentCacheNntpClient.cs
+++ b/backend/Clients/Usenet/SegmentCacheNntpClient.cs
@@ -666,8 +666,9 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
     /// <summary>
     /// Deletes every cache artifact under <paramref name="cacheDir"/>. Only files that
     /// match the cache layout (two-hex-char shard directory, hex blob name with optional
-    /// <c>.h</c> / <c>.tmp</c> suffix) are removed so a misconfigured path never loses
-    /// unrelated data. Empty shard directories are removed afterwards.
+    /// <c>.h</c> / writer-generated <c>.tmp</c> suffix) are removed so a misconfigured path
+    /// never loses unrelated data. Symlinked shard directories are ignored. Empty shard
+    /// directories are removed afterwards.
     /// </summary>
     internal static SegmentCachePurgeResult PurgeDirectory(string cacheDir)
     {
@@ -677,6 +678,7 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         foreach (var shard in Directory.EnumerateDirectories(cacheDir))
         {
             if (!IsShardDirectoryName(Path.GetFileName(shard))) continue;
+            if (IsReparsePoint(shard, result)) continue;
 
             foreach (var file in Directory.EnumerateFiles(shard))
             {
@@ -686,13 +688,13 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
                     continue;
                 }
 
-                switch (DeleteCacheFile(file))
+                switch (DeleteCacheFile(file, out var failure))
                 {
                     case SegmentCacheDeleteResult.Deleted:
                         result.Deleted++;
                         break;
                     case SegmentCacheDeleteResult.Failed:
-                        result.Failed++;
+                        result.RecordFailure(failure);
                         break;
                 }
             }
@@ -704,11 +706,24 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
             }
             catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
             {
-                result.Failed++;
+                result.RecordFailure(exception);
             }
         }
 
         return result;
+    }
+
+    private static bool IsReparsePoint(string path, SegmentCachePurgeResult result)
+    {
+        try
+        {
+            return (File.GetAttributes(path) & FileAttributes.ReparsePoint) != 0;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            result.RecordFailure(exception);
+            return true;
+        }
     }
 
     private static bool IsShardDirectoryName(string name) =>
@@ -716,13 +731,25 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
 
     private static bool IsCacheFileName(string name)
     {
-        // <hash>[.h][.<unique>.tmp]
+        // <hash> | <hash>.h | <hash>.<guid:N>.tmp | <hash>.h.<guid:N>.tmp
         var hashEnd = name.IndexOf('.', StringComparison.Ordinal);
         var hash = hashEnd < 0 ? name : name[..hashEnd];
-        if (hash.Length != 64 || !hash.All(Uri.IsHexDigit)) return false;
+        if (!IsHex(hash, 64)) return false;
         if (hashEnd < 0) return true;
-        var suffix = name[hashEnd..];
-        return suffix == ".h" || suffix.EndsWith(".tmp", StringComparison.Ordinal);
+
+        var suffix = name.AsSpan(hashEnd);
+        if (suffix.SequenceEqual(".h")) return true;
+        if (suffix.StartsWith(".h.")) suffix = suffix[2..];
+        if (!suffix.EndsWith(".tmp") || suffix.Length != 1 + 32 + 4) return false;
+        return IsHex(suffix[1..^4], 32);
+    }
+
+    private static bool IsHex(ReadOnlySpan<char> value, int length)
+    {
+        if (value.Length != length) return false;
+        foreach (var c in value)
+            if (!Uri.IsHexDigit(c)) return false;
+        return true;
     }
 
     private static string Hash(string id)
@@ -759,8 +786,11 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         return DeleteCacheFile(path);
     }
 
-    private static SegmentCacheDeleteResult DeleteCacheFile(string path)
+    private static SegmentCacheDeleteResult DeleteCacheFile(string path) => DeleteCacheFile(path, out _);
+
+    private static SegmentCacheDeleteResult DeleteCacheFile(string path, out Exception? failure)
     {
+        failure = null;
         try
         {
             _ = File.GetAttributes(path);
@@ -773,6 +803,7 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         }
         catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
         {
+            failure = exception;
             return SegmentCacheDeleteResult.Failed;
         }
     }
@@ -1023,7 +1054,16 @@ internal sealed class SegmentCachePurgeResult
 {
     public int Deleted { get; set; }
     public int Skipped { get; set; }
-    public int Failed { get; set; }
+    public int Failed { get; private set; }
+
+    /// <summary>First failure's exception type, without paths or messages.</summary>
+    public string? FailureReason { get; private set; }
+
+    public void RecordFailure(Exception? exception)
+    {
+        Failed++;
+        FailureReason ??= exception?.GetType().Name ?? "unknown";
+    }
 }
 
 internal enum SegmentCacheCommitResult

--- a/backend/Clients/Usenet/SegmentCacheNntpClient.cs
+++ b/backend/Clients/Usenet/SegmentCacheNntpClient.cs
@@ -663,6 +663,68 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
 
     private string BlobPath(string hash) => Path.Join(_dir, hash[..2], hash);
 
+    /// <summary>
+    /// Deletes every cache artifact under <paramref name="cacheDir"/>. Only files that
+    /// match the cache layout (two-hex-char shard directory, hex blob name with optional
+    /// <c>.h</c> / <c>.tmp</c> suffix) are removed so a misconfigured path never loses
+    /// unrelated data. Empty shard directories are removed afterwards.
+    /// </summary>
+    internal static SegmentCachePurgeResult PurgeDirectory(string cacheDir)
+    {
+        var result = new SegmentCachePurgeResult();
+        if (!Directory.Exists(cacheDir)) return result;
+
+        foreach (var shard in Directory.EnumerateDirectories(cacheDir))
+        {
+            if (!IsShardDirectoryName(Path.GetFileName(shard))) continue;
+
+            foreach (var file in Directory.EnumerateFiles(shard))
+            {
+                if (!IsCacheFileName(Path.GetFileName(file)))
+                {
+                    result.Skipped++;
+                    continue;
+                }
+
+                switch (DeleteCacheFile(file))
+                {
+                    case SegmentCacheDeleteResult.Deleted:
+                        result.Deleted++;
+                        break;
+                    case SegmentCacheDeleteResult.Failed:
+                        result.Failed++;
+                        break;
+                }
+            }
+
+            try
+            {
+                if (!Directory.EnumerateFileSystemEntries(shard).Any())
+                    Directory.Delete(shard);
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+            {
+                result.Failed++;
+            }
+        }
+
+        return result;
+    }
+
+    private static bool IsShardDirectoryName(string name) =>
+        name.Length == 2 && name.All(Uri.IsHexDigit);
+
+    private static bool IsCacheFileName(string name)
+    {
+        // <hash>[.h][.<unique>.tmp]
+        var hashEnd = name.IndexOf('.', StringComparison.Ordinal);
+        var hash = hashEnd < 0 ? name : name[..hashEnd];
+        if (hash.Length != 64 || !hash.All(Uri.IsHexDigit)) return false;
+        if (hashEnd < 0) return true;
+        var suffix = name[hashEnd..];
+        return suffix == ".h" || suffix.EndsWith(".tmp", StringComparison.Ordinal);
+    }
+
     private static string Hash(string id)
         => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(id)));
 
@@ -955,6 +1017,13 @@ internal enum SegmentCacheDeleteResult
     Absent,
     Deleted,
     Failed,
+}
+
+internal sealed class SegmentCachePurgeResult
+{
+    public int Deleted { get; set; }
+    public int Skipped { get; set; }
+    public int Failed { get; set; }
 }
 
 internal enum SegmentCacheCommitResult

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -331,6 +331,7 @@ public sealed partial class Program
                 .AddSingleton<StreamingFailureTracker>()
                 .AddSingleton<HealthCheckConnectionGate>()
                 .AddSingleton<SegmentCacheStatistics>()
+                .AddHostedService<SegmentCacheCleanupService>()
                 .AddSingleton<MemoryComponentSnapshotBuilder>()
                 .AddSingleton<UsenetStreamingClient>()
                 .AddSingleton<StreamingCapacitySnapshotProvider>()

--- a/backend/Services/SegmentCacheCleanupService.cs
+++ b/backend/Services/SegmentCacheCleanupService.cs
@@ -28,10 +28,19 @@ public sealed class SegmentCacheCleanupService(ConfigManager configManager) : Ba
             var result = SegmentCacheNntpClient.PurgeDirectory(cacheDir);
             if (result.Deleted == 0 && result.Failed == 0) return;
 
+            if (result.Failed > 0)
+            {
+                Log.Warning(
+                    "Segment cache is disabled; some leftover cache files at {PathClass} could not be purged. " +
+                    "Deleted: {Deleted}. Skipped: {Skipped}. Failed: {Failed}. Reason: {Reason}",
+                    pathClass, result.Deleted, result.Skipped, result.Failed, result.FailureReason);
+                return;
+            }
+
             Log.Information(
                 "Segment cache is disabled; purged leftover cache files at {PathClass}. " +
-                "Deleted: {Deleted}. Skipped: {Skipped}. Failed: {Failed}.",
-                pathClass, result.Deleted, result.Skipped, result.Failed);
+                "Deleted: {Deleted}. Skipped: {Skipped}.",
+                pathClass, result.Deleted, result.Skipped);
         }
         catch (Exception e) when (e is IOException or UnauthorizedAccessException)
         {

--- a/backend/Services/SegmentCacheCleanupService.cs
+++ b/backend/Services/SegmentCacheCleanupService.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using Serilog;
+
+namespace NzbWebDAV.Services;
+
+/// <summary>
+/// Removes leftover on-disk segment-cache files at startup when the segment cache is
+/// disabled. The cache wrapper only prunes files while it is active, so a disabled
+/// cache would otherwise keep its last contents on disk indefinitely.
+/// </summary>
+public sealed class SegmentCacheCleanupService(ConfigManager configManager) : BackgroundService
+{
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (configManager.IsSegmentCacheEnabled()) return Task.CompletedTask;
+
+        var cacheDir = configManager.GetSegmentCachePath();
+        return Task.Run(() => Purge(cacheDir), stoppingToken);
+    }
+
+    private static void Purge(string cacheDir)
+    {
+        var pathClass = SegmentCacheNntpClient.ClassifyCachePath(cacheDir);
+        try
+        {
+            var result = SegmentCacheNntpClient.PurgeDirectory(cacheDir);
+            if (result.Deleted == 0 && result.Failed == 0) return;
+
+            Log.Information(
+                "Segment cache is disabled; purged leftover cache files at {PathClass}. " +
+                "Deleted: {Deleted}. Skipped: {Skipped}. Failed: {Failed}.",
+                pathClass, result.Deleted, result.Skipped, result.Failed);
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            Log.Warning(
+                "Segment cache is disabled but leftover cache files at {PathClass} could not be purged. Reason: {Reason}",
+                pathClass, e.Message);
+            Log.Debug(e, "Segment cache purge failure stack");
+        }
+    }
+}

--- a/docs/configuration/streaming.md
+++ b/docs/configuration/streaming.md
@@ -65,6 +65,12 @@ path) is local SSD/NVMe or other storage that can safely absorb the extra writes
 Disable the cache for slow disks, network mounts, or flash storage with limited
 write endurance; alternatively, point **Cache path** at suitable local storage.
 
+When Segment Cache is **disabled** at startup, InfiniDysk purges any leftover cache
+files from the cache path in the background so a previously enabled cache does not
+keep occupying disk. Only files matching the cache layout are removed; unrelated
+files placed in that directory are left alone.
+[since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since }
+
 ### Segment Cache and rclone read-ahead
 
 Symlink libraries stream through an rclone mount. When that mount runs with

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
@@ -1155,12 +1155,15 @@ public sealed class SegmentCacheNntpClientTests
             WriteCacheEntry(cacheDir, "segment-1", "one"u8.ToArray());
             WriteCacheEntry(cacheDir, "segment-2", "two"u8.ToArray());
             var blob = CacheBlobPath(cacheDir, "segment-1");
-            File.WriteAllText(blob + ".abc.tmp", "partial");
-            File.WriteAllText(blob + ".h.abc.tmp", "partial");
+            var unique = Guid.NewGuid().ToString("N");
+            File.WriteAllText(blob + "." + unique + ".tmp", "partial");
+            File.WriteAllText(blob + ".h." + unique + ".tmp", "partial");
 
             var shard = Path.GetDirectoryName(blob)!;
             var unrelated = Path.Join(shard, "notes.txt");
             File.WriteAllText(unrelated, "keep");
+            var foreignTemp = blob + ".notes.tmp";
+            File.WriteAllText(foreignTemp, "keep");
             var otherDir = Path.Join(cacheDir, "backups");
             Directory.CreateDirectory(otherDir);
             File.WriteAllText(Path.Join(otherDir, "db.bak"), "keep");
@@ -1168,9 +1171,11 @@ public sealed class SegmentCacheNntpClientTests
             var result = SegmentCacheNntpClient.PurgeDirectory(cacheDir);
 
             Assert.Equal(6, result.Deleted);
-            Assert.Equal(1, result.Skipped);
+            Assert.Equal(2, result.Skipped);
             Assert.Equal(0, result.Failed);
+            Assert.Null(result.FailureReason);
             Assert.True(File.Exists(unrelated));
+            Assert.True(File.Exists(foreignTemp));
             Assert.True(File.Exists(Path.Join(otherDir, "db.bak")));
             Assert.False(File.Exists(blob));
             Assert.False(File.Exists(CacheBlobPath(cacheDir, "segment-2")));
@@ -1195,6 +1200,45 @@ public sealed class SegmentCacheNntpClientTests
         Assert.Equal(0, result.Deleted);
         Assert.Equal(0, result.Failed);
         Assert.False(Directory.Exists(cacheDir));
+    }
+
+    [Fact]
+    public void PurgeDirectory_IgnoresSymlinkedShardDirectory()
+    {
+        var root = Path.Join(
+            Path.GetTempPath(), "nzbdav-segment-cache-" + Guid.NewGuid().ToString("N"));
+        var cacheDir = Path.Join(root, "cache");
+        var outside = Path.Join(root, "outside");
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            // Layout a real cache entry outside the cache tree, then link a shard name to it.
+            WriteCacheEntry(outside, "segment-1", "one"u8.ToArray());
+            var outsideBlob = CacheBlobPath(outside, "segment-1");
+            var outsideShard = Path.GetDirectoryName(outsideBlob)!;
+            var linkedShard = Path.Join(cacheDir, Path.GetFileName(outsideShard));
+            try
+            {
+                Directory.CreateSymbolicLink(linkedShard, outsideShard);
+            }
+            catch (Exception e) when (e is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+            {
+                return; // symlinks unavailable on this host
+            }
+
+            var result = SegmentCacheNntpClient.PurgeDirectory(cacheDir);
+
+            Assert.Equal(0, result.Deleted);
+            Assert.Equal(0, result.Failed);
+            Assert.True(File.Exists(outsideBlob));
+            Assert.True(File.Exists(outsideBlob + ".h"));
+            Assert.True(Directory.Exists(linkedShard));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
     }
 
     private static async Task ReadAndDisposeAsync(Stream stream)

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
@@ -1145,6 +1145,58 @@ public sealed class SegmentCacheNntpClientTests
         await ReadAndDisposeAsync(response.Stream!);
     }
 
+    [Fact]
+    public void PurgeDirectory_RemovesCacheArtifacts_AndLeavesUnrelatedFiles()
+    {
+        var cacheDir = Path.Join(
+            Path.GetTempPath(), "nzbdav-segment-cache-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            WriteCacheEntry(cacheDir, "segment-1", "one"u8.ToArray());
+            WriteCacheEntry(cacheDir, "segment-2", "two"u8.ToArray());
+            var blob = CacheBlobPath(cacheDir, "segment-1");
+            File.WriteAllText(blob + ".abc.tmp", "partial");
+            File.WriteAllText(blob + ".h.abc.tmp", "partial");
+
+            var shard = Path.GetDirectoryName(blob)!;
+            var unrelated = Path.Join(shard, "notes.txt");
+            File.WriteAllText(unrelated, "keep");
+            var otherDir = Path.Join(cacheDir, "backups");
+            Directory.CreateDirectory(otherDir);
+            File.WriteAllText(Path.Join(otherDir, "db.bak"), "keep");
+
+            var result = SegmentCacheNntpClient.PurgeDirectory(cacheDir);
+
+            Assert.Equal(6, result.Deleted);
+            Assert.Equal(1, result.Skipped);
+            Assert.Equal(0, result.Failed);
+            Assert.True(File.Exists(unrelated));
+            Assert.True(File.Exists(Path.Join(otherDir, "db.bak")));
+            Assert.False(File.Exists(blob));
+            Assert.False(File.Exists(CacheBlobPath(cacheDir, "segment-2")));
+            Assert.False(Directory.Exists(Path.GetDirectoryName(CacheBlobPath(cacheDir, "segment-2"))));
+            Assert.True(Directory.Exists(cacheDir));
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+                Directory.Delete(cacheDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void PurgeDirectory_MissingDirectory_IsNoOp()
+    {
+        var cacheDir = Path.Join(
+            Path.GetTempPath(), "nzbdav-segment-cache-" + Guid.NewGuid().ToString("N"));
+
+        var result = SegmentCacheNntpClient.PurgeDirectory(cacheDir);
+
+        Assert.Equal(0, result.Deleted);
+        Assert.Equal(0, result.Failed);
+        Assert.False(Directory.Exists(cacheDir));
+    }
+
     private static async Task ReadAndDisposeAsync(Stream stream)
     {
         await using (stream)


### PR DESCRIPTION
## Summary

When Segment Cache was turned off, files written while it was enabled stayed on disk forever because only the active cache wrapper ever pruned them. This adds `SegmentCacheCleanupService`, a hosted service that runs once at startup and, if `usenet.segment-cache.enabled` is off, purges the cache directory in the background.

- `SegmentCacheNntpClient.PurgeDirectory` deletes only files that match the cache layout (two-hex shard dir, 64-hex blob name with optional `.h` / `*.tmp` suffix) and removes emptied shard directories, so a misconfigured path never loses unrelated data.
- Logs a single human-friendly Information line with deleted/skipped/failed counts (or a Warning with `{Reason}` on I/O failure); nothing is logged when there is nothing to purge.
- Docs: note in `docs/configuration/streaming.md` with a `since 1.3.0` pill.

No new configuration option; no setup-wizard impact.

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests --filter FullyQualifiedName~SegmentCacheNntpClientTests.PurgeDirectory` — new tests cover purge of blobs/headers/temp files, skipping unrelated files and directories, and no-op on a missing directory.
- [ ] Manual: start with `usenet.segment-cache.enabled=false` and a populated `/config/segment-cache`; confirm the purge log line and empty shard directories removed.

Note: `NzbWebDAV.ArchitectureTests.NonApiCodeDoesNotDependOnControllers` currently fails on `main` (`ExceptionMiddleware` → `SabBaseResponse`); unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Leftover segment-cache files are automatically cleaned up at startup when segment caching is disabled.
  * Cleanup preserves unrelated files and directories, skips linked cache shards, and removes empty shard directories.
  * Cleanup results report deleted, skipped, and failed items.

* **Documentation**
  * Documented startup cleanup behavior for disabled segment caching, available since version 1.3.0.

* **Bug Fixes**
  * Improved handling of missing cache directories and file-access failures during cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->