### PR TITLE
feat(usenet): segment cache is off by default for new installs; existing installs keep their current behavior

### DIFF
--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -1410,8 +1410,9 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
 
     public bool IsSegmentCacheEnabled()
     {
+        // Off by default for new installs; a data migration pins "true" for pre-existing installs.
         var v = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetSegmentCacheEnabled));
-        return v == null || bool.Parse(v);
+        return v != null && bool.Parse(v);
     }
 
     public string GetSegmentCachePath()

--- a/backend/Database/Migrations/20260903120000_Pin-Segment-Cache-For-Existing-Installs.cs
+++ b/backend/Database/Migrations/20260903120000_Pin-Segment-Cache-For-Existing-Installs.cs
@@ -17,6 +17,18 @@ public partial class PinSegmentCacheForExistingInstalls : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder)
     {
+        // ConfigManager treats a blank persisted value as unset, so pin those too.
+        migrationBuilder.Sql("""
+            UPDATE "ConfigItems"
+            SET "ConfigValue" = 'true'
+            WHERE "ConfigName" = 'usenet.segment-cache.enabled'
+            AND ("ConfigValue" IS NULL OR TRIM("ConfigValue") = '')
+            AND EXISTS (
+                SELECT 1 FROM "ConfigItems"
+                WHERE "ConfigName" = 'usenet.providers'
+            );
+            """);
+
         migrationBuilder.Sql("""
             INSERT INTO "ConfigItems" ("ConfigName", "ConfigValue")
             SELECT 'usenet.segment-cache.enabled', 'true'

--- a/backend/Database/Migrations/20260903120000_Pin-Segment-Cache-For-Existing-Installs.cs
+++ b/backend/Database/Migrations/20260903120000_Pin-Segment-Cache-For-Existing-Installs.cs
@@ -22,7 +22,12 @@ public partial class PinSegmentCacheForExistingInstalls : Migration
             UPDATE "ConfigItems"
             SET "ConfigValue" = 'true'
             WHERE "ConfigName" = 'usenet.segment-cache.enabled'
-            AND ("ConfigValue" IS NULL OR TRIM("ConfigValue") = '')
+            AND ("ConfigValue" IS NULL OR TRIM(
+                "ConfigValue",
+                CHAR(9, 10, 11, 12, 13, 32, 133, 160, 5760,
+                     8192, 8193, 8194, 8195, 8196, 8197, 8198, 8199, 8200, 8201, 8202,
+                     8232, 8233, 8239, 8287, 12288)
+            ) = '')
             AND EXISTS (
                 SELECT 1 FROM "ConfigItems"
                 WHERE "ConfigName" = 'usenet.providers'

--- a/backend/Database/Migrations/20260903120000_Pin-Segment-Cache-For-Existing-Installs.cs
+++ b/backend/Database/Migrations/20260903120000_Pin-Segment-Cache-For-Existing-Installs.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.Migrations;
+
+/// <summary>
+/// The segment cache now defaults to off for new installs. Installs that already have
+/// providers configured but never set the option keep their previous effective value
+/// (on) by pinning it explicitly. Fresh databases have no providers row at this point,
+/// so they fall through to the new default. Additive; back up /config before upgrading.
+/// </summary>
+[DbContext(typeof(DavDatabaseContext))]
+[Migration("20260903120000_Pin-Segment-Cache-For-Existing-Installs")]
+public partial class PinSegmentCacheForExistingInstalls : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql("""
+            INSERT INTO "ConfigItems" ("ConfigName", "ConfigValue")
+            SELECT 'usenet.segment-cache.enabled', 'true'
+            WHERE NOT EXISTS (
+                SELECT 1 FROM "ConfigItems"
+                WHERE "ConfigName" = 'usenet.segment-cache.enabled'
+            )
+            AND EXISTS (
+                SELECT 1 FROM "ConfigItems"
+                WHERE "ConfigName" = 'usenet.providers'
+            );
+            """);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        // Intentionally left blank: the pinned value matches the pre-migration
+        // effective default, so it is safe to keep on downgrade.
+    }
+}

--- a/backend/Database/PostgresMigrations/20260903120000_Pin-Segment-Cache-For-Existing-Installs.cs
+++ b/backend/Database/PostgresMigrations/20260903120000_Pin-Segment-Cache-For-Existing-Installs.cs
@@ -17,6 +17,18 @@ public partial class PinSegmentCacheForExistingInstalls : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder)
     {
+        // ConfigManager treats a blank persisted value as unset, so pin those too.
+        migrationBuilder.Sql("""
+            UPDATE "ConfigItems"
+            SET "ConfigValue" = 'true'
+            WHERE "ConfigName" = 'usenet.segment-cache.enabled'
+            AND ("ConfigValue" IS NULL OR TRIM("ConfigValue") = '')
+            AND EXISTS (
+                SELECT 1 FROM "ConfigItems"
+                WHERE "ConfigName" = 'usenet.providers'
+            );
+            """);
+
         migrationBuilder.Sql("""
             INSERT INTO "ConfigItems" ("ConfigName", "ConfigValue")
             SELECT 'usenet.segment-cache.enabled', 'true'

--- a/backend/Database/PostgresMigrations/20260903120000_Pin-Segment-Cache-For-Existing-Installs.cs
+++ b/backend/Database/PostgresMigrations/20260903120000_Pin-Segment-Cache-For-Existing-Installs.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.PostgresMigrations;
+
+/// <summary>
+/// The segment cache now defaults to off for new installs. Installs that already have
+/// providers configured but never set the option keep their previous effective value
+/// (on) by pinning it explicitly. Fresh databases have no providers row at this point,
+/// so they fall through to the new default. Additive; back up /config before upgrading.
+/// </summary>
+[DbContext(typeof(PostgresDavDatabaseContext))]
+[Migration("20260903120000_Pin-Segment-Cache-For-Existing-Installs")]
+public partial class PinSegmentCacheForExistingInstalls : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql("""
+            INSERT INTO "ConfigItems" ("ConfigName", "ConfigValue")
+            SELECT 'usenet.segment-cache.enabled', 'true'
+            WHERE NOT EXISTS (
+                SELECT 1 FROM "ConfigItems"
+                WHERE "ConfigName" = 'usenet.segment-cache.enabled'
+            )
+            AND EXISTS (
+                SELECT 1 FROM "ConfigItems"
+                WHERE "ConfigName" = 'usenet.providers'
+            );
+            """);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        // Intentionally left blank: the pinned value matches the pre-migration
+        // effective default, so it is safe to keep on downgrade.
+    }
+}

--- a/backend/Database/PostgresMigrations/20260903120000_Pin-Segment-Cache-For-Existing-Installs.cs
+++ b/backend/Database/PostgresMigrations/20260903120000_Pin-Segment-Cache-For-Existing-Installs.cs
@@ -22,7 +22,15 @@ public partial class PinSegmentCacheForExistingInstalls : Migration
             UPDATE "ConfigItems"
             SET "ConfigValue" = 'true'
             WHERE "ConfigName" = 'usenet.segment-cache.enabled'
-            AND ("ConfigValue" IS NULL OR TRIM("ConfigValue") = '')
+            AND ("ConfigValue" IS NULL OR BTRIM(
+                "ConfigValue",
+                CHR(9) || CHR(10) || CHR(11) || CHR(12) || CHR(13) || CHR(32) ||
+                CHR(133) || CHR(160) || CHR(5760) ||
+                CHR(8192) || CHR(8193) || CHR(8194) || CHR(8195) || CHR(8196) ||
+                CHR(8197) || CHR(8198) || CHR(8199) || CHR(8200) || CHR(8201) ||
+                CHR(8202) || CHR(8232) || CHR(8233) || CHR(8239) || CHR(8287) ||
+                CHR(12288)
+            ) = '')
             AND EXISTS (
                 SELECT 1 FROM "ConfigItems"
                 WHERE "ConfigName" = 'usenet.providers'

--- a/docs/configuration/streaming.md
+++ b/docs/configuration/streaming.md
@@ -33,7 +33,7 @@ is saturated.
 
 | Control | Config key | Default | Effect |
 |---------|------------|---------|--------|
-| Enable Segment Cache | `usenet.segment-cache.enabled` | on | Cache decoded segments on disk; restart required |
+| Enable Segment Cache | `usenet.segment-cache.enabled` | off (new installs) | Cache decoded segments on disk; restart required |
 | Cache path | `usenet.segment-cache.path` | `/config/segment-cache` | Segment-cache directory |
 | Maximum size (GB) | `usenet.segment-cache.max-gb` | `10` | Segment-cache size limit |
 | Streaming Segment Timeout | `usenet.streaming-segment-timeout-seconds` | `8` | Per-segment deadline, 2–40 seconds |
@@ -58,8 +58,14 @@ values apply on the next provider-config save or process restart.
 
 ### Segment-cache storage
 
-Segment Cache is **enabled by default**. It can improve repeated reads and seeks, but
-also writes decoded segments to the cache path. InfiniDysk does not automatically
+Segment Cache is **off by default on new installs**
+[since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since }.
+Installs upgraded from an earlier release that never changed the setting keep the cache
+**on**: the upgrade pins the previous effective value so behaviour does not change
+silently. Review it under **Settings → Streaming** and turn it off if you do not need it.
+
+When enabled, the cache can improve repeated reads and seeks, but it also writes decoded
+segments to the cache path. InfiniDysk does not automatically
 classify that storage, so verify that `/config/segment-cache` (or your configured
 path) is local SSD/NVMe or other storage that can safely absorb the extra writes.
 Disable the cache for slow disks, network mounts, or flash storage with limited

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -103,7 +103,7 @@ const defaultConfig = {
   "usenet.reconnect-delay-milliseconds": "500",
   "usenet.pipelined-body-requests": "true",
   "usenet.streaming-body-batch-width": "",
-  "usenet.segment-cache.enabled": "true",
+  "usenet.segment-cache.enabled": "false",
   "usenet.segment-cache.path": "/config/segment-cache",
   "usenet.segment-cache.max-gb": "10",
   "usenet.shared-streams.enabled": "true",

--- a/frontend/app/routes/setup/setup-model.ts
+++ b/frontend/app/routes/setup/setup-model.ts
@@ -28,7 +28,7 @@ export const SETUP_DEFAULT_CONFIG: Record<string, string> = {
   "api.completed-downloads-dir": "/data/completed-downloads",
   "api.categories": "movies,tv",
   "api.key": "",
-  "usenet.segment-cache.enabled": "true",
+  "usenet.segment-cache.enabled": "false",
   "rclone.mount-dir": "/mnt/nzbdav",
   "rclone.rc-enabled": "false",
   "rclone.host": "",

--- a/tests/NzbWebDAV.Tests/Api/SetupWizardControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/SetupWizardControllerTests.cs
@@ -62,7 +62,8 @@ public sealed class SetupWizardControllerTests
             await completion.Content.ReadAsStreamAsync());
         Assert.Equal(HttpStatusCode.OK, completion.StatusCode);
         Assert.True(completionJson.RootElement.GetProperty("status").GetBoolean());
-        Assert.True(completionJson.RootElement.GetProperty("restartRequired").GetBoolean());
+        // Fresh installs already default the cache off, so symlinks needs no restart.
+        Assert.False(completionJson.RootElement.GetProperty("restartRequired").GetBoolean());
 
         using var configForm = new MultipartFormDataContent
         {

--- a/tests/NzbWebDAV.Tests/Config/EffectiveStreamingConfigManifestTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/EffectiveStreamingConfigManifestTests.cs
@@ -30,7 +30,7 @@ public sealed class EffectiveStreamingConfigManifestTests
         Assert.True(document.Connections.WarmConnectionsEnabled);
         Assert.Equal(config.GetInFlightArticleBudgetBytes(), document.Memory.InFlightArticleBudgetBytes);
         Assert.True(document.Memory.SharedStreamsEnabled);
-        Assert.True(document.SegmentCache.Enabled);
+        Assert.False(document.SegmentCache.Enabled);
         Assert.Equal(10L * 1024 * 1024 * 1024, document.SegmentCache.MaxBytes);
         Assert.True(document.Repair.BackgroundEnabled);
         Assert.True(document.Repair.Par2Enabled);

--- a/tests/NzbWebDAV.Tests/Config/StreamingPriorityConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/StreamingPriorityConfigTests.cs
@@ -128,22 +128,22 @@ public class StreamingPriorityConfigTests
     }
 
     [Fact]
-    public void IsSegmentCacheEnabled_DefaultsOnUntilExplicitlyDisabled()
+    public void IsSegmentCacheEnabled_DefaultsOffUntilExplicitlyEnabled()
     {
         var config = new ConfigManager();
 
-        Assert.True(config.IsSegmentCacheEnabled());
+        Assert.False(config.IsSegmentCacheEnabled());
 
         config.UpdateValues(
         [
             new ConfigItem
             {
                 ConfigName = ConfigKeys.UsenetSegmentCacheEnabled,
-                ConfigValue = "false",
+                ConfigValue = "true",
             },
         ]);
 
-        Assert.False(config.IsSegmentCacheEnabled());
+        Assert.True(config.IsSegmentCacheEnabled());
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Database/PinSegmentCacheForExistingInstallsMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PinSegmentCacheForExistingInstallsMigrationTests.cs
@@ -65,6 +65,7 @@ public sealed class PinSegmentCacheForExistingInstallsMigrationTests
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
+    [MemberData(nameof(AllDotNetWhitespace))]
     public async Task ExistingInstallWithBlankSetting_IsPinnedOn(string blank)
     {
         await using var harness = await MigrationHarness.CreateAsync();
@@ -91,6 +92,14 @@ public sealed class PinSegmentCacheForExistingInstallsMigrationTests
             .SingleAsync(x => x.ConfigName == ConfigKeys.UsenetSegmentCacheEnabled);
         Assert.Equal("true", pinned.ConfigValue);
     }
+
+    public static TheoryData<string> AllDotNetWhitespace =>
+    [
+        new string(Enumerable.Range(char.MinValue, char.MaxValue + 1)
+            .Select(value => (char)value)
+            .Where(char.IsWhiteSpace)
+            .ToArray()),
+    ];
 
     [Fact]
     public async Task FreshInstall_IsNotPinned_AndDefaultsOff()

--- a/tests/NzbWebDAV.Tests/Database/PinSegmentCacheForExistingInstallsMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PinSegmentCacheForExistingInstallsMigrationTests.cs
@@ -62,6 +62,36 @@ public sealed class PinSegmentCacheForExistingInstallsMigrationTests
         Assert.Equal("false", existing.ConfigValue);
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ExistingInstallWithBlankSetting_IsPinnedOn(string blank)
+    {
+        await using var harness = await MigrationHarness.CreateAsync();
+        var ctx = harness.Context;
+
+        ctx.ConfigItems.AddRange(
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = "{\"Providers\":[]}",
+            },
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetSegmentCacheEnabled,
+                ConfigValue = blank,
+            });
+        await ctx.SaveChangesAsync();
+        ctx.ChangeTracker.Clear();
+
+        await ctx.Database.MigrateAsync();
+        ctx.ChangeTracker.Clear();
+
+        var pinned = await ctx.ConfigItems.AsNoTracking()
+            .SingleAsync(x => x.ConfigName == ConfigKeys.UsenetSegmentCacheEnabled);
+        Assert.Equal("true", pinned.ConfigValue);
+    }
+
     [Fact]
     public async Task FreshInstall_IsNotPinned_AndDefaultsOff()
     {

--- a/tests/NzbWebDAV.Tests/Database/PinSegmentCacheForExistingInstallsMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PinSegmentCacheForExistingInstallsMigrationTests.cs
@@ -1,0 +1,115 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Database;
+
+public sealed class PinSegmentCacheForExistingInstallsMigrationTests
+{
+    private const string PriorMigration = "20260902000809_Add-Setup-Wizard-State";
+
+    [Fact]
+    public async Task ExistingInstallWithoutExplicitSetting_IsPinnedOn()
+    {
+        await using var harness = await MigrationHarness.CreateAsync();
+        var ctx = harness.Context;
+
+        ctx.ConfigItems.Add(new ConfigItem
+        {
+            ConfigName = ConfigKeys.UsenetProviders,
+            ConfigValue = "{\"Providers\":[]}",
+        });
+        await ctx.SaveChangesAsync();
+        ctx.ChangeTracker.Clear();
+
+        await ctx.Database.MigrateAsync();
+        ctx.ChangeTracker.Clear();
+
+        var pinned = await ctx.ConfigItems.AsNoTracking()
+            .SingleAsync(x => x.ConfigName == ConfigKeys.UsenetSegmentCacheEnabled);
+        Assert.Equal("true", pinned.ConfigValue);
+    }
+
+    [Fact]
+    public async Task ExistingInstallWithExplicitSetting_IsLeftUnchanged()
+    {
+        await using var harness = await MigrationHarness.CreateAsync();
+        var ctx = harness.Context;
+
+        ctx.ConfigItems.AddRange(
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = "{\"Providers\":[]}",
+            },
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetSegmentCacheEnabled,
+                ConfigValue = "false",
+            });
+        await ctx.SaveChangesAsync();
+        ctx.ChangeTracker.Clear();
+
+        await ctx.Database.MigrateAsync();
+        ctx.ChangeTracker.Clear();
+
+        var existing = await ctx.ConfigItems.AsNoTracking()
+            .SingleAsync(x => x.ConfigName == ConfigKeys.UsenetSegmentCacheEnabled);
+        Assert.Equal("false", existing.ConfigValue);
+    }
+
+    [Fact]
+    public async Task FreshInstall_IsNotPinned_AndDefaultsOff()
+    {
+        await using var harness = await MigrationHarness.CreateAsync();
+        var ctx = harness.Context;
+
+        await ctx.Database.MigrateAsync();
+        ctx.ChangeTracker.Clear();
+
+        Assert.False(await ctx.ConfigItems.AsNoTracking()
+            .AnyAsync(x => x.ConfigName == ConfigKeys.UsenetSegmentCacheEnabled));
+
+        var config = new ConfigManager();
+        config.UpdateValues(await ctx.ConfigItems.AsNoTracking().ToListAsync());
+        Assert.False(config.IsSegmentCacheEnabled());
+    }
+
+    private sealed class MigrationHarness : IAsyncDisposable
+    {
+        private readonly string _databasePath;
+
+        private MigrationHarness(string databasePath, DavDatabaseContext context)
+        {
+            _databasePath = databasePath;
+            Context = context;
+        }
+
+        public DavDatabaseContext Context { get; }
+
+        public static async Task<MigrationHarness> CreateAsync()
+        {
+            var databasePath = Path.Join(Path.GetTempPath(), $"nzbdav-segcache-mig-{Guid.NewGuid():N}.sqlite");
+            var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite($"Data Source={databasePath}")
+                .AddInterceptors(new SqliteForeignKeyEnabler())
+                .ReplaceService<
+                    IMigrationsSqlGenerator,
+                    SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            var context = new DavDatabaseContext(options);
+            await context.Database.MigrateAsync(PriorMigration);
+            return new MigrationHarness(databasePath, context);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.DisposeAsync();
+            File.Delete(_databasePath);
+        }
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/SetupWizardServiceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SetupWizardServiceTests.cs
@@ -91,7 +91,8 @@ public sealed class SetupWizardServiceTests : IDisposable
         Assert.Equal("symlinks", persisted[ConfigKeys.ApiImportStrategy]);
         Assert.Equal("false", persisted[ConfigKeys.UsenetSegmentCacheEnabled]);
         Assert.False(configManager.IsSegmentCacheEnabled());
-        Assert.True(result.RestartRequired);
+        // Fresh installs already default the cache off, so symlinks needs no restart.
+        Assert.False(result.RestartRequired);
 
         var state = await context.SetupWizardStates.SingleAsync();
         Assert.Equal(SetupWizardDisposition.Completed, state.Disposition);

--- a/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/SupportPack/SupportPackContentsTests.cs
@@ -530,7 +530,7 @@ public sealed class SupportPackContentsTests : IDisposable
         Assert.Equal(40, effective.RootElement.GetProperty("streaming").GetProperty("articleBufferSize").GetInt32());
         Assert.True(effective.RootElement.GetProperty("streaming").GetProperty("pipelinedBodyRequests").GetBoolean());
         Assert.Equal(4, effective.RootElement.GetProperty("streaming").GetProperty("bodyBatchWidth").GetInt32());
-        Assert.True(effective.RootElement.GetProperty("segmentCache").GetProperty("enabled").GetBoolean());
+        Assert.False(effective.RootElement.GetProperty("segmentCache").GetProperty("enabled").GetBoolean());
         Assert.Equal(
             "default",
             effective.RootElement.GetProperty("source").GetProperty("streaming").GetProperty("articleBufferSize").GetString());
@@ -640,6 +640,9 @@ public sealed class SupportPackContentsTests : IDisposable
             new ConfigItem { ConfigName = ConfigKeys.WebdavPass, ConfigValue = "schema" },
             new ConfigItem { ConfigName = ConfigKeys.RclonePass, ConfigValue = "enabled" },
             new ConfigItem { ConfigName = ConfigKeys.WatchtowerProfileToken, ConfigValue = "203.0.113.50" },
+            // Explicitly on so the boolean "enabled" property stays true and proves the
+            // redactor does not rewrite it when a secret value happens to equal "enabled".
+            new ConfigItem { ConfigName = ConfigKeys.UsenetSegmentCacheEnabled, ConfigValue = "true" },
         ]);
 
         var entries = await ReadPackEntriesAsync(


### PR DESCRIPTION
## Summary

Segment Cache is now **off by default for new installs**. Existing installs that never touched the setting keep the cache **on**.

- `ConfigManager.IsSegmentCacheEnabled()` returns `false` when no explicit `usenet.segment-cache.enabled` value exists.
- New data-only EF migration `Pin-Segment-Cache-For-Existing-Installs` (SQLite + PostgreSQL) inserts `usenet.segment-cache.enabled = true` **only** when the key is absent *and* `usenet.providers` already exists — i.e. a pre-existing, configured install. Fresh databases are left untouched and fall through to the new `false` default. Installs that already set the key explicitly are unchanged.
- `NZBDAV_CONFIG__USENET__SEGMENT_CACHE__ENABLED` still wins at read time as before.
- Settings page and setup-wizard fallbacks updated to `"false"`; the wizard continues to write an explicit value (`strm` → on, `symlinks` → off), so `CurrentWizardVersion` was intentionally **not** bumped.
- Docs (`docs/configuration/streaming.md`) updated with a `since 1.3.0` pill describing the new default and the upgrade pin.

Companion to #1321 (purge stale cache files on startup when disabled).

> **Back up `/config` before upgrading.** This release adds a migration that auto-applies on startup. It is additive (inserts one config row for existing installs) and non-destructive.

## Test plan

- [x] `dotnet test tests/NzbWebDAV.Tests` — 4843 passed, 0 failed
  - New `PinSegmentCacheForExistingInstallsMigrationTests`: existing install without explicit key is pinned on; existing install with explicit key is untouched; fresh install is not pinned and defaults off.
  - `StreamingPriorityConfigTests.IsSegmentCacheEnabled_DefaultsOffUntilExplicitlyEnabled`.
  - Setup wizard service/controller tests: symlinks on a fresh install no longer reports `restartRequired`.
  - Effective-streaming manifest and support-pack default assertions flipped to `false`.
- [x] `cd frontend && npx vitest run app/routes/settings app/routes/setup` — 235 passed
- [ ] Manual: upgrade a pre-1.3 `/config` and confirm the Settings page shows Segment Cache **on** with an explicit stored value; fresh `/config` shows **off**.

Note: `NzbWebDAV.ArchitectureTests.NonApiCodeDoesNotDependOnControllers` fails on `main` independently of this change (`ExceptionMiddleware` → `SabBaseResponse`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Segment caching is now disabled by default for new installations.
  * Existing installations with previously enabled or implicitly enabled caching retain it.
  * The setup wizard and settings reflect the disabled default.

* **Documentation**
  * Updated streaming configuration guidance for defaults, upgrades, and storage considerations.

* **Bug Fixes**
  * Fresh installations no longer require a restart to apply the disabled segment-cache setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->