### PR TITLE
feat(usenet): let segment cache writes run behind playback

### DIFF
--- a/backend/Clients/Usenet/SegmentCacheNntpClient.cs
+++ b/backend/Clients/Usenet/SegmentCacheNntpClient.cs
@@ -33,6 +33,8 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
     private readonly object[] _commitStripes = CreateCommitStripes();
     private readonly Func<IEnumerable<string>> _enumerateCacheFiles;
     private readonly Func<string, SegmentCacheDeleteResult?>? _tryDelete;
+    private readonly SegmentCacheWriteBehind? _writeBehind;
+    private readonly Func<CancellationToken, Task>? _beforeWriteBehindPersist;
     private long _currentBytes;
     private int _catalogReady;
     private int _catalogDegraded;
@@ -58,7 +60,9 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         MetricsWriter? metricsWriter,
         Func<IEnumerable<string>>? enumerateCacheFiles,
         SegmentCacheStatistics? statistics = null,
-        Func<string, SegmentCacheDeleteResult?>? tryDelete = null) : base(inner)
+        Func<string, SegmentCacheDeleteResult?>? tryDelete = null,
+        long writeBehindBytes = 0,
+        Func<CancellationToken, Task>? beforeWriteBehindPersist = null) : base(inner)
     {
         _dir = cacheDir;
         _maxBytes = maxBytes;
@@ -70,12 +74,23 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         _enumerateCacheFiles = enumerateCacheFiles
                                ?? (() => Directory.EnumerateFiles(_dir, "*", SearchOption.AllDirectories));
         _tryDelete = tryDelete;
+        _beforeWriteBehindPersist = beforeWriteBehindPersist;
+        if (writeBehindBytes > 0)
+        {
+            _writeBehind = new SegmentCacheWriteBehind(
+                writeBehindBytes,
+                PersistWriteBehindAsync,
+                WarnCacheWriteFailure,
+                _generation.SetWriterSnapshot);
+        }
         CatalogLoadTask = Task.Run(LoadIndex);
     }
 
     public bool IsCatalogReady => Volatile.Read(ref _catalogReady) != 0;
     internal Task CatalogLoadTask { get; }
     internal long CurrentBytes => Interlocked.Read(ref _currentBytes);
+    internal Task DrainWriteBehindForTestsAsync() =>
+        _writeBehind?.DrainForTestsAsync() ?? Task.CompletedTask;
 
     internal static string ClassifyCachePath(string path) =>
         string.Equals(path, DefaultCachePath, StringComparison.Ordinal)
@@ -230,6 +245,50 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
 
         var hash = Hash(requestedId.ToString());
         var attempt = _statistics.BeginWriteAttempt();
+        if (_writeBehind is not null)
+        {
+            PooledBufferStream? body = null;
+            long reservedCapacity = 0;
+            if (header.PartSize > int.MaxValue)
+            {
+                attempt.Complete(SegmentCacheWriteOutcome.Skipped, 0);
+                return response;
+            }
+
+            try
+            {
+#pragma warning disable CA2000 // The finally releases ownership unless it is transferred to ValidatedCacheBufferingStream.
+                if (!_writeBehind.TryRentBuffer(
+                        (int)header.PartSize,
+                        out body,
+                        out reservedCapacity))
+#pragma warning restore CA2000
+                {
+                    attempt.Complete(SegmentCacheWriteOutcome.Skipped, 0);
+                    return response;
+                }
+
+                var stream = new ValidatedCacheBufferingStream(
+                    response.Stream,
+                    header,
+                    hash,
+                    body,
+                    reservedCapacity,
+                    _writeBehind,
+                    attempt);
+                body = null;
+                return response with { Stream = stream };
+            }
+            finally
+            {
+                if (body is not null)
+                {
+                    await body.DisposeAsync().ConfigureAwait(false);
+                    _writeBehind.ReleaseReservation(reservedCapacity);
+                }
+            }
+        }
+
         return response with
         {
             Stream = new ValidatedCacheWriteStream(
@@ -241,6 +300,66 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
                 attempt,
                 WarnCacheWriteFailure),
         };
+    }
+
+    private async Task<SegmentCacheCommitResult> PersistWriteBehindAsync(
+        PendingSegmentCacheWrite write,
+        CancellationToken cancellationToken)
+    {
+        if (_beforeWriteBehindPersist is not null)
+            await _beforeWriteBehindPersist(cancellationToken).ConfigureAwait(false);
+
+        var blobPath = BlobPath(write.Hash);
+        var unique = Guid.NewGuid().ToString("N");
+        var blobTempPath = blobPath + "." + unique + ".tmp";
+        var headerTempPath = blobPath + ".h." + unique + ".tmp";
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(blobPath)!);
+            await using (var stream = new FileStream(
+                             blobTempPath,
+                             new FileStreamOptions
+                             {
+                                 Mode = FileMode.CreateNew,
+                                 Access = FileAccess.Write,
+                                 Share = FileShare.None,
+                                 Options = FileOptions.Asynchronous | FileOptions.SequentialScan,
+                                 BufferSize = 81920,
+                                 PreallocationSize = write.Header.PartSize,
+                             }))
+            {
+                await stream.WriteAsync(write.Body.WrittenMemory, cancellationToken).ConfigureAwait(false);
+            }
+
+            await File.WriteAllTextAsync(
+                    headerTempPath,
+                    JsonSerializer.Serialize(write.Header, HeaderJsonOptions),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return CommitPublishedPair(
+                write.Hash,
+                blobTempPath,
+                headerTempPath,
+                write.Header,
+                write.Body.Length);
+        }
+        finally
+        {
+            TryDelete(blobTempPath);
+            TryDelete(headerTempPath);
+        }
+    }
+
+    internal override void Retire()
+    {
+        _writeBehind?.Retire();
+        base.Retire();
+    }
+
+    public override void Dispose()
+    {
+        _writeBehind?.Dispose();
+        base.Dispose();
     }
 
     internal static bool IsCoherentHeader(UsenetYencHeader header)
@@ -820,6 +939,136 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
     {
         public long Size;
         public long LastAccessTicks;
+    }
+
+    private sealed class ValidatedCacheBufferingStream : YencStream
+    {
+        private readonly YencStream _source;
+        private readonly UsenetYencHeader _header;
+        private readonly string _hash;
+        private readonly PooledBufferStream _body;
+        private readonly long _reservedCapacity;
+        private readonly SegmentCacheWriteBehind _writer;
+        private readonly SegmentCacheWriteAttempt _attempt;
+        private long _readBytes;
+        private bool _eof;
+        private int _completed;
+        private int _disposed;
+
+        internal ValidatedCacheBufferingStream(
+            YencStream source,
+            UsenetYencHeader header,
+            string hash,
+            PooledBufferStream body,
+            long reservedCapacity,
+            SegmentCacheWriteBehind writer,
+            SegmentCacheWriteAttempt attempt) : base(Null)
+        {
+            _source = source;
+            _header = header;
+            _hash = hash;
+            _body = body;
+            _reservedCapacity = reservedCapacity;
+            _writer = writer;
+            _attempt = attempt;
+        }
+
+        public override ValueTask<UsenetYencHeader?> GetYencHeadersAsync(
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<UsenetYencHeader?>(_header);
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            var read = await _source.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+            {
+                _eof = true;
+                return 0;
+            }
+
+            var previous = _readBytes;
+            _readBytes = checked(_readBytes + read);
+            var remaining = Math.Max(0, _header.PartSize - previous);
+            var retained = (int)Math.Min(read, remaining);
+            if (retained > 0)
+                _body.Write(buffer.Span[..retained]);
+            return read;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!disposing)
+                return;
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                base.Dispose(disposing);
+                return;
+            }
+
+            Exception? sourceFailure = null;
+            try
+            {
+                _source.Dispose();
+            }
+            catch (Exception exception) when (exception is not OutOfMemoryException)
+            {
+                sourceFailure = exception;
+                throw;
+            }
+            finally
+            {
+                Complete(sourceFailure is null);
+                base.Dispose(disposing);
+            }
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                await base.DisposeAsync().ConfigureAwait(false);
+                return;
+            }
+
+            Exception? sourceFailure = null;
+            try
+            {
+                await _source.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception exception) when (exception is not OutOfMemoryException)
+            {
+                sourceFailure = exception;
+                throw;
+            }
+            finally
+            {
+                Complete(sourceFailure is null);
+                await base.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        private void Complete(bool sourceSucceeded)
+        {
+            if (Interlocked.Exchange(ref _completed, 1) != 0)
+                return;
+
+            if (sourceSucceeded && _eof && _readBytes == _header.PartSize &&
+                _writer.TryEnqueue(new PendingSegmentCacheWrite(
+                    _hash,
+                    _header,
+                    _body,
+                    _reservedCapacity,
+                    _attempt)))
+            {
+                return;
+            }
+
+            _body.Dispose();
+            _writer.ReleaseReservation(_reservedCapacity);
+            _attempt.Complete(SegmentCacheWriteOutcome.Skipped, _readBytes);
+        }
     }
 
     private sealed class ValidatedCacheWriteStream : YencStream

--- a/backend/Clients/Usenet/SegmentCacheStatistics.cs
+++ b/backend/Clients/Usenet/SegmentCacheStatistics.cs
@@ -39,7 +39,8 @@ public sealed class SegmentCacheStatistics
                 CatalogLoadDurationMs: null,
                 Entries: 0,
                 CurrentBytes: 0,
-                MaxBytes: effectiveMax);
+                MaxBytes: effectiveMax,
+                Writer: null);
         }
 
         return generation;
@@ -119,8 +120,14 @@ public sealed class SegmentCacheStatistics
             evictions,
             bytesEvicted,
             temporaryFilesCleaned,
-            QueuedWriteBytes: null,
-            PeakQueuedWriteBytes: null);
+            QueuedWriteBytes: gauges.Writer?.ReservedBytes,
+                PeakQueuedWriteBytes: gauges.Writer?.PeakReservedBytes);
+    }
+
+    internal SegmentCacheWriteBehindSnapshot? GetWriterSnapshot()
+    {
+        lock (_gaugeLock)
+            return _gauges.Writer;
     }
 
     internal void SetCatalog(long generationId, bool ready, long? durationMs, long entries, long currentBytes)
@@ -147,6 +154,15 @@ public sealed class SegmentCacheStatistics
         }
     }
 
+    internal void SetWriter(long generationId, SegmentCacheWriteBehindSnapshot snapshot)
+    {
+        lock (_gaugeLock)
+        {
+            if (_gauges.GenerationId != generationId) return;
+            _gauges = _gauges with { Writer = snapshot };
+        }
+    }
+
     private void CompleteWrite(SegmentCacheWriteOutcome outcome, long _)
     {
         switch (outcome)
@@ -170,7 +186,8 @@ public sealed class SegmentCacheStatistics
         long? CatalogLoadDurationMs,
         long Entries,
         long CurrentBytes,
-        long MaxBytes);
+        long MaxBytes,
+        SegmentCacheWriteBehindSnapshot? Writer);
 }
 
 public sealed record SegmentCacheSnapshot(
@@ -218,6 +235,9 @@ internal sealed class SegmentCacheGeneration
 
     internal void SetIndex(long entries, long currentBytes) =>
         _owner.SetIndex(Id, entries, currentBytes);
+
+    internal void SetWriterSnapshot(SegmentCacheWriteBehindSnapshot snapshot) =>
+        _owner.SetWriter(Id, snapshot);
 }
 
 internal enum SegmentCacheWriteOutcome

--- a/backend/Clients/Usenet/SegmentCacheWriteBehind.cs
+++ b/backend/Clients/Usenet/SegmentCacheWriteBehind.cs
@@ -236,6 +236,7 @@ internal sealed class SegmentCacheWriteBehind : IDisposable
         }
         catch (OperationCanceledException) when (_stop.IsCancellationRequested)
         {
+            // Worker stop is expected; the finally block releases all queued reservations.
         }
         finally
         {

--- a/backend/Clients/Usenet/SegmentCacheWriteBehind.cs
+++ b/backend/Clients/Usenet/SegmentCacheWriteBehind.cs
@@ -1,0 +1,287 @@
+using System.Threading.Channels;
+using System.Diagnostics.CodeAnalysis;
+using NzbWebDAV.Streams;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Clients.Usenet;
+
+internal sealed record PendingSegmentCacheWrite(
+    string Hash,
+    UsenetYencHeader Header,
+    PooledBufferStream Body,
+    long ReservedCapacityBytes,
+    SegmentCacheWriteAttempt Attempt);
+
+internal readonly record struct SegmentCacheWriteBehindSnapshot(
+    long BudgetBytes,
+    long ReservedBytes,
+    long PeakReservedBytes,
+    long QueuedJobs,
+    long ActiveJobs,
+    long CapacitySkips);
+
+internal sealed class SegmentCacheWriteBehind : IDisposable
+{
+    internal const int DefaultMaximumJobs = 256;
+    private static readonly TimeSpan DisposeDrainTimeout = TimeSpan.FromSeconds(5);
+    private readonly TimeSpan _disposeDrainTimeout;
+
+    private readonly long _budgetBytes;
+    private readonly int _maximumJobs;
+    private readonly Func<PendingSegmentCacheWrite, CancellationToken, Task<SegmentCacheCommitResult>> _persist;
+    private readonly Action _warnWriteFailure;
+    private readonly Action<SegmentCacheWriteBehindSnapshot>? _publishSnapshot;
+    private readonly Channel<PendingSegmentCacheWrite> _channel;
+    private readonly CancellationTokenSource _stop = new();
+    private readonly Lock _stateLock = new();
+    private readonly Task _worker;
+    private long _reservedBytes;
+    private long _peakReservedBytes;
+    private long _queuedJobs;
+    private long _activeJobs;
+    private long _capacitySkips;
+    private int _reservedJobs;
+    private bool _accepting = true;
+    private int _disposed;
+
+    internal SegmentCacheWriteBehind(
+        long budgetBytes,
+        Func<PendingSegmentCacheWrite, CancellationToken, Task<SegmentCacheCommitResult>> persist,
+        Action warnWriteFailure,
+        Action<SegmentCacheWriteBehindSnapshot>? publishSnapshot = null,
+        int maximumJobs = DefaultMaximumJobs,
+        TimeSpan? disposeDrainTimeout = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(budgetBytes);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumJobs);
+        _budgetBytes = budgetBytes;
+        _maximumJobs = maximumJobs;
+        _persist = persist;
+        _warnWriteFailure = warnWriteFailure;
+        _publishSnapshot = publishSnapshot;
+        _disposeDrainTimeout = disposeDrainTimeout ?? DisposeDrainTimeout;
+        if (_disposeDrainTimeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(disposeDrainTimeout));
+        _channel = Channel.CreateBounded<PendingSegmentCacheWrite>(new BoundedChannelOptions(maximumJobs)
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            FullMode = BoundedChannelFullMode.Wait,
+        });
+        _worker = Task.Run(ProcessAsync);
+        _publishSnapshot?.Invoke(Snapshot());
+    }
+
+    internal bool TryRentBuffer(
+        int capacityHint,
+        [NotNullWhen(true)] out PooledBufferStream? body,
+        out long reservedCapacity)
+    {
+        body = null;
+        reservedCapacity = 0;
+        if (capacityHint <= 0)
+            return false;
+
+        var estimatedCapacity = PooledBufferStream.EstimateDefaultRentedCapacity(capacityHint);
+        lock (_stateLock)
+        {
+            if (!_accepting || _reservedJobs >= _maximumJobs ||
+                estimatedCapacity > _budgetBytes - _reservedBytes)
+            {
+                _capacitySkips++;
+                PublishSnapshotUnderLock();
+                return false;
+            }
+
+            _reservedJobs++;
+            _reservedBytes += estimatedCapacity;
+            _peakReservedBytes = Math.Max(_peakReservedBytes, _reservedBytes);
+            PublishSnapshotUnderLock();
+        }
+
+        PooledBufferStream? candidate = null;
+        try
+        {
+            candidate = new PooledBufferStream(capacityHint);
+            var physicalCapacity = candidate.RentedCapacity;
+            lock (_stateLock)
+            {
+                var adjustment = physicalCapacity - estimatedCapacity;
+                if (adjustment > _budgetBytes - _reservedBytes)
+                {
+                    _capacitySkips++;
+                    _reservedJobs--;
+                    _reservedBytes -= estimatedCapacity;
+                    PublishSnapshotUnderLock();
+                    return false;
+                }
+
+                _reservedBytes += adjustment;
+                _peakReservedBytes = Math.Max(_peakReservedBytes, _reservedBytes);
+                PublishSnapshotUnderLock();
+            }
+
+            body = candidate;
+            candidate = null;
+            reservedCapacity = physicalCapacity;
+            return true;
+        }
+        catch
+        {
+            lock (_stateLock)
+            {
+                _reservedJobs--;
+                _reservedBytes -= estimatedCapacity;
+                PublishSnapshotUnderLock();
+            }
+            throw;
+        }
+        finally
+        {
+            candidate?.Dispose();
+        }
+    }
+
+    internal bool TryEnqueue(PendingSegmentCacheWrite write)
+    {
+        lock (_stateLock)
+        {
+            if (!_accepting || !_channel.Writer.TryWrite(write))
+                return false;
+            _queuedJobs++;
+            PublishSnapshotUnderLock();
+            return true;
+        }
+    }
+
+    internal void ReleaseReservation(long reservedCapacity)
+    {
+        lock (_stateLock)
+        {
+            _reservedJobs--;
+            _reservedBytes -= reservedCapacity;
+            if (_reservedJobs < 0 || _reservedBytes < 0)
+                throw new InvalidOperationException("Segment-cache write-behind reservation underflow.");
+            PublishSnapshotUnderLock();
+        }
+    }
+
+    internal SegmentCacheWriteBehindSnapshot Snapshot()
+    {
+        lock (_stateLock)
+        {
+            return SnapshotUnderLock();
+        }
+    }
+
+    internal void Retire()
+    {
+        lock (_stateLock)
+        {
+            if (!_accepting)
+                return;
+            _accepting = false;
+            _channel.Writer.TryComplete();
+            PublishSnapshotUnderLock();
+        }
+    }
+
+    internal Task DrainForTestsAsync() => _worker;
+
+    private async Task ProcessAsync()
+    {
+        try
+        {
+            await foreach (var write in _channel.Reader.ReadAllAsync(_stop.Token).ConfigureAwait(false))
+            {
+                lock (_stateLock)
+                {
+                    _queuedJobs--;
+                    _activeJobs++;
+                    PublishSnapshotUnderLock();
+                }
+
+                try
+                {
+                    var result = await _persist(write, _stop.Token).ConfigureAwait(false);
+                    write.Attempt.Complete(
+                        result == SegmentCacheCommitResult.Committed
+                            ? SegmentCacheWriteOutcome.Committed
+                            : result is SegmentCacheCommitResult.AlreadyPresent or SegmentCacheCommitResult.InvalidLength
+                                ? SegmentCacheWriteOutcome.Skipped
+                                : SegmentCacheWriteOutcome.Failed,
+                        write.Body.Length);
+                }
+                catch (OperationCanceledException) when (_stop.IsCancellationRequested)
+                {
+                    write.Attempt.Complete(SegmentCacheWriteOutcome.Skipped, write.Body.Length);
+                }
+                catch (Exception exception) when (exception is not OutOfMemoryException)
+                {
+                    write.Attempt.Complete(SegmentCacheWriteOutcome.Failed, write.Body.Length);
+                    if (exception is IOException or UnauthorizedAccessException or DirectoryNotFoundException)
+                        _warnWriteFailure();
+                }
+                finally
+                {
+                    lock (_stateLock)
+                    {
+                        _activeJobs--;
+                        PublishSnapshotUnderLock();
+                    }
+                    await write.Body.DisposeAsync().ConfigureAwait(false);
+                    ReleaseReservation(write.ReservedCapacityBytes);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (_stop.IsCancellationRequested)
+        {
+        }
+        finally
+        {
+            while (_channel.Reader.TryRead(out var write))
+            {
+                lock (_stateLock)
+                {
+                    _queuedJobs--;
+                    PublishSnapshotUnderLock();
+                }
+                write.Attempt.Complete(SegmentCacheWriteOutcome.Skipped, write.Body.Length);
+                await write.Body.DisposeAsync().ConfigureAwait(false);
+                ReleaseReservation(write.ReservedCapacityBytes);
+            }
+        }
+    }
+
+    private SegmentCacheWriteBehindSnapshot SnapshotUnderLock() => new(
+        _budgetBytes,
+        _reservedBytes,
+        _peakReservedBytes,
+        _queuedJobs,
+        _activeJobs,
+        _capacitySkips);
+
+    private void PublishSnapshotUnderLock() =>
+        _publishSnapshot?.Invoke(SnapshotUnderLock());
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        Retire();
+        if (_worker.Wait(_disposeDrainTimeout))
+        {
+            _stop.Dispose();
+            return;
+        }
+
+        _stop.Cancel();
+        _ = _worker.ContinueWith(
+            static (_, state) => ((CancellationTokenSource)state!).Dispose(),
+            _stop,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+}

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -135,7 +135,8 @@ public class UsenetStreamingClient : WrappingNntpClient
                     usageTracker,
                     metricsWriter,
                     enumerateCacheFiles: null,
-                    segmentCacheStatistics
+                    segmentCacheStatistics,
+                    writeBehindBytes: configManager.GetSegmentCacheWriteBehindBytes()
                 );
             }
             catch (Exception e) when (e is IOException or UnauthorizedAccessException or ArgumentException)

--- a/backend/Config/ConfigKeys.cs
+++ b/backend/Config/ConfigKeys.cs
@@ -75,6 +75,7 @@ public static class ConfigKeys
     public const string UsenetSegmentCacheEnabled = "usenet.segment-cache.enabled";
     public const string UsenetSegmentCacheMaxGb = "usenet.segment-cache.max-gb";
     public const string UsenetSegmentCachePath = "usenet.segment-cache.path";
+    public const string UsenetSegmentCacheWriteBehindMb = "usenet.segment-cache.write-behind-mb";
     public const string UsenetStreamingPriority = "usenet.streaming-priority";
     public const string UsenetStreamingSegmentTimeoutSeconds = "usenet.streaming-segment-timeout-seconds";
     public const string UsenetStreamingSegmentRetries = "usenet.streaming-segment-retries";

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -498,6 +498,10 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
                     RequireLongInRange(item.ConfigName, value, 1, 8);
                     break;
 
+                case ConfigKeys.UsenetSegmentCacheWriteBehindMb:
+                    RequireZeroOrLongInRange(item.ConfigName, value, 16, 1024);
+                    break;
+
                 case ConfigKeys.UsenetSharedStreamsMaxEntries:
                     RequireLongInRange(item.ConfigName, value, 1, 32);
                     break;
@@ -648,6 +652,16 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
             if (!long.TryParse(value, out var parsed) || parsed < minimum || parsed > maximum)
                 throw new ArgumentException(
                     $"Config value for '{key}' must be a whole number from {minimum} through {maximum}.");
+        }
+
+        void RequireZeroOrLongInRange(string key, string value, long minimum, long maximum)
+        {
+            if (!long.TryParse(value, out var parsed) ||
+                parsed != 0 && (parsed < minimum || parsed > maximum))
+            {
+                throw new ArgumentException(
+                    $"Config value for '{key}' must be 0 or a whole number from {minimum} through {maximum}.");
+            }
         }
 
         void RequireIndexerMaxResponseBytes(string json, JsonSerializerOptions? options)
@@ -1434,6 +1448,17 @@ public class ConfigManager : IConfigReader, IConfigUpdater, IConfigChangeSource
         var gb = long.TryParse(v, out var n) ? n : 10;
         return Math.Max(1, gb) * 1024L * 1024L * 1024L;
     }
+
+    public int GetSegmentCacheWriteBehindMb()
+    {
+        var configured = StringUtil.EmptyToNull(GetConfigValue(ConfigKeys.UsenetSegmentCacheWriteBehindMb));
+        if (!int.TryParse(configured, out var value) || value <= 0)
+            return 0;
+        return Math.Clamp(value, 16, 1024);
+    }
+
+    public long GetSegmentCacheWriteBehindBytes() =>
+        (long)GetSegmentCacheWriteBehindMb() * 1024L * 1024L;
 
     public bool IsPar2RepairEnabled()
     {

--- a/backend/Config/EffectiveStreamingConfigManifest.cs
+++ b/backend/Config/EffectiveStreamingConfigManifest.cs
@@ -76,7 +76,8 @@ internal static class EffectiveStreamingConfigManifest
                 configManager.GetSharedStreamsSmallRangeMaxBytes()),
             new EffectiveSegmentCacheSettings(
                 configManager.IsSegmentCacheEnabled(),
-                configManager.GetSegmentCacheMaxBytes()),
+                configManager.GetSegmentCacheMaxBytes(),
+                configManager.GetSegmentCacheWriteBehindBytes()),
             new EffectiveRepairSettings(
                 configManager.IsRepairJobEnabled(),
                 configManager.IsPar2RepairEnabled(),
@@ -111,7 +112,8 @@ internal static class EffectiveStreamingConfigManifest
                     Source(configManager, ConfigKeys.UsenetSharedStreamsSmallRangeMaxMb)),
                 new EffectiveSegmentCacheSettingSources(
                     Source(configManager, ConfigKeys.UsenetSegmentCacheEnabled),
-                    Source(configManager, ConfigKeys.UsenetSegmentCacheMaxGb)),
+                    Source(configManager, ConfigKeys.UsenetSegmentCacheMaxGb),
+                    Source(configManager, ConfigKeys.UsenetSegmentCacheWriteBehindMb)),
                 new EffectiveRepairSettingSources(
                     Source(configManager, ConfigKeys.RepairEnable),
                     Source(configManager, ConfigKeys.RepairPar2Enabled),
@@ -175,7 +177,8 @@ internal sealed record EffectiveMemorySettings(
 
 internal sealed record EffectiveSegmentCacheSettings(
     bool Enabled,
-    long MaxBytes);
+    long MaxBytes,
+    long WriteBehindBytes);
 
 internal sealed record EffectiveRepairSettings(
     bool BackgroundEnabled,
@@ -229,7 +232,8 @@ internal sealed record EffectiveMemorySettingSources(
 
 internal sealed record EffectiveSegmentCacheSettingSources(
     EffectiveConfigSource Enabled,
-    EffectiveConfigSource MaxBytes);
+    EffectiveConfigSource MaxBytes,
+    EffectiveConfigSource WriteBehindBytes);
 
 internal sealed record EffectiveRepairSettingSources(
     EffectiveConfigSource BackgroundEnabled,

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1094,7 +1094,7 @@ public sealed partial class Program
                 "(NZBDAV_SEGMENT_BUFFER_POOL=shared); sharedRingConfiguredMaxBytes={SharedRingConfiguredMaxBytes} " +
                 "cacheWriter={CacheWriter}.",
                 (long)configManager.GetSharedStreamsMaxEntries() * configManager.GetSharedStreamsRingBytes(),
-                "unsupported");
+                CacheWriterMode(configManager));
             return;
         }
 
@@ -1112,7 +1112,12 @@ public sealed partial class Program
             SegmentBufferPoolSelector.ToLogValue(poolMode),
             maxIdleBytes,
             (long)configManager.GetSharedStreamsMaxEntries() * configManager.GetSharedStreamsRingBytes(),
-            "unsupported");
+            CacheWriterMode(configManager));
+
+        static string CacheWriterMode(ConfigManager config) =>
+            !config.IsSegmentCacheEnabled()
+                ? "disabled"
+                : config.GetSegmentCacheWriteBehindBytes() > 0 ? "bounded" : "inline";
     }
 
     private static async Task<bool> IsDatabaseStartupVacuumEnabledAsync()

--- a/backend/Services/Diagnostics/MemoryComponentSnapshot.cs
+++ b/backend/Services/Diagnostics/MemoryComponentSnapshot.cs
@@ -75,7 +75,6 @@ public sealed class MemoryComponentSnapshotBuilder(
         var bufferPool = BufferPoolDiagnostics.Shared.Snapshot();
         var segmentPool = (PooledBufferStream.DefaultPool as SegmentBufferPool)?.MemorySnapshot();
         var reads = concurrentReadTracker.Snapshot();
-        var cache = segmentCacheStatistics.GetSnapshot();
         var writer = segmentCacheStatistics.GetWriterSnapshot();
 
         SegmentBufferMemorySnapshot? segmentBuffers = segmentPool is { } pool
@@ -107,8 +106,8 @@ public sealed class MemoryComponentSnapshotBuilder(
         var cacheWriter = new SegmentCacheWriterMemorySnapshot(
             Supported: writer.HasValue,
             WriteBudgetBytes: writer?.BudgetBytes,
-            QueuedWriteBytes: cache.QueuedWriteBytes,
-            PeakQueuedWriteBytes: cache.PeakQueuedWriteBytes,
+            QueuedWriteBytes: writer?.ReservedBytes,
+            PeakQueuedWriteBytes: writer?.PeakReservedBytes,
             QueuedJobs: writer?.QueuedJobs,
             ActiveJobs: writer?.ActiveJobs,
             CapacitySkipsTotal: writer?.CapacitySkips);

--- a/backend/Services/Diagnostics/MemoryComponentSnapshot.cs
+++ b/backend/Services/Diagnostics/MemoryComponentSnapshot.cs
@@ -76,6 +76,7 @@ public sealed class MemoryComponentSnapshotBuilder(
         var segmentPool = (PooledBufferStream.DefaultPool as SegmentBufferPool)?.MemorySnapshot();
         var reads = concurrentReadTracker.Snapshot();
         var cache = segmentCacheStatistics.GetSnapshot();
+        var writer = segmentCacheStatistics.GetWriterSnapshot();
 
         SegmentBufferMemorySnapshot? segmentBuffers = segmentPool is { } pool
             ? new SegmentBufferMemorySnapshot(
@@ -104,13 +105,13 @@ public sealed class MemoryComponentSnapshotBuilder(
             reads.SharedStreamLaggingReaders);
 
         var cacheWriter = new SegmentCacheWriterMemorySnapshot(
-            Supported: cache.QueuedWriteBytes.HasValue || cache.PeakQueuedWriteBytes.HasValue,
-            WriteBudgetBytes: null,
+            Supported: writer.HasValue,
+            WriteBudgetBytes: writer?.BudgetBytes,
             QueuedWriteBytes: cache.QueuedWriteBytes,
             PeakQueuedWriteBytes: cache.PeakQueuedWriteBytes,
-            QueuedJobs: null,
-            ActiveJobs: null,
-            CapacitySkipsTotal: null);
+            QueuedJobs: writer?.QueuedJobs,
+            ActiveJobs: writer?.ActiveJobs,
+            CapacitySkipsTotal: writer?.CapacitySkips);
 
         return new MemoryComponentSnapshot(
             CurrentSchemaVersion,

--- a/backend/Streams/PooledBufferStream.cs
+++ b/backend/Streams/PooledBufferStream.cs
@@ -19,6 +19,22 @@ public sealed class PooledBufferStream : Stream
     /// </summary>
     internal static ISegmentBufferPool DefaultPool { get; set; } = SharedArrayPoolAdapter.Instance;
 
+    internal static int EstimateDefaultRentedCapacity(int minimumLength)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(minimumLength);
+        if (DefaultPool is SegmentBufferPool)
+            return SegmentBufferPool.RoundToSizeClass(minimumLength);
+
+        // ArrayPool.Shared uses power-of-two buckets. This is intentionally
+        // conservative for the supported shared-pool rollback path.
+        var estimate = 16L;
+        while (estimate < minimumLength && estimate <= Array.MaxLength / 2L)
+            estimate *= 2;
+        return estimate >= minimumLength && estimate <= Array.MaxLength
+            ? (int)estimate
+            : minimumLength;
+    }
+
     private readonly ISegmentBufferPool _pool;
     private readonly BufferPoolDiagnostics _diagnostics;
     private byte[]? _buffer;
@@ -51,6 +67,22 @@ public sealed class PooledBufferStream : Stream
     public override bool CanRead => !_disposed;
     public override bool CanSeek => !_disposed;
     public override bool CanWrite => !_disposed;
+    internal ReadOnlyMemory<byte> WrittenMemory
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return _buffer.AsMemory(0, _length);
+        }
+    }
+    internal int RentedCapacity
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return _buffer!.Length;
+        }
+    }
     public override long Length
     {
         get

--- a/docs/configuration/streaming.md
+++ b/docs/configuration/streaming.md
@@ -36,6 +36,7 @@ is saturated.
 | Enable Segment Cache | `usenet.segment-cache.enabled` | off (new installs) | Cache decoded segments on disk; restart required |
 | Cache path | `usenet.segment-cache.path` | `/config/segment-cache` | Segment-cache directory |
 | Maximum size (GB) | `usenet.segment-cache.max-gb` | `10` | Segment-cache size limit |
+| Cache write-behind (MiB) [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since } | `usenet.segment-cache.write-behind-mb` | `0` | Advanced, restart-required RAM budget for asynchronous cache writes. `0` keeps inline writes; nonzero values are 16–1024 MiB |
 | Streaming Segment Timeout | `usenet.streaming-segment-timeout-seconds` | `8` | Per-segment deadline, 2–40 seconds |
 | Streaming Read Timeout [since 0.9.0](https://github.com/infinidysk/infinidysk/releases/tag/v0.9.0){ .nzbdav-since } | `usenet.streaming-read-timeout-seconds` | `30` | Initial 5–120 second wait to open a GET/range |
 | Streaming Write Timeout | `usenet.streaming-write-timeout-seconds` | `60` | Per-write deadline, 0–600 seconds (0 disables); also cancels a stream that transfers less than 64 KB per timeout window while other streams wait on Article RAM |
@@ -77,6 +78,29 @@ files from the cache path in the background so a previously enabled cache does n
 keep occupying disk. Only files matching the cache layout are removed; unrelated
 files placed in that directory are left alone.
 [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since }
+
+### Segment-cache write-behind
+
+With the default value `0`, each decoded segment is written to storage before
+the same bytes continue through the playback drain. On slower bind mounts,
+overlay filesystems, or network storage, that can apply disk backpressure to
+the Usenet socket.
+
+Set `usenet.segment-cache.write-behind-mb` to 16–1024 to copy completed segment
+bodies into bounded pooled memory and publish them from one FIFO background
+writer. This budget is additional to the in-flight article budget. The writer
+also caps queued plus active jobs at 256. When either limit is full, the new
+cache write is skipped rather than delaying playback.
+
+Write-behind makes cache publication asynchronous. An immediate second read can
+miss and fetch the segment again until the writer publishes both body and header.
+Disk failures remain best-effort and do not fail playback. The Support memory
+snapshot reports the configured budget, reserved and peak physical buffer bytes,
+queued/active jobs, and capacity skips.
+
+The setting is advanced-only and has no Settings control. Configure
+`NZBDAV_CONFIG__USENET__SEGMENT_CACHE__WRITE_BEHIND_MB`, then restart the
+container. Set it back to `0` and restart to restore inline writes.
 
 ### Segment Cache and rclone read-ahead
 

--- a/docs/operations/memory-constrained-hosts.md
+++ b/docs/operations/memory-constrained-hosts.md
@@ -83,6 +83,9 @@ glibc-specific; the shipped Alpine image uses musl and does not use
   idle timeout if many pooled sockets are unnecessary.
 - Lower **Streaming body batch width** and set an explicit **In-flight article
   budget** to reduce active decoded-pipe retention.
+- Keep `usenet.segment-cache.write-behind-mb` at `0`, or include its full
+  additional pooled-buffer budget when sizing the container. Under pressure,
+  write-behind skips new cache writes instead of exceeding its byte/job limits.
 - `DOTNET_GCRetainVM=0` is already the .NET default; setting it does not shrink
   the initial regions-GC reservation.
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
@@ -452,7 +452,7 @@ public sealed class SegmentCacheNntpClientTests
             await response.Stream!.CopyToAsync(output);
             await response.Stream.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(1));
             Assert.Equal(content, output.ToArray());
-            await persistStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+            await persistStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
             Assert.Null(await client.TryGetLocalDecodedBodyAsync(segmentId, CancellationToken.None));
             var blocked = statistics.GetSnapshot();
@@ -468,7 +468,8 @@ public sealed class SegmentCacheNntpClientTests
             await client.DrainWriteBehindForTestsAsync().WaitAsync(TimeSpan.FromSeconds(5));
 
             var cached = await client.TryGetLocalDecodedBodyAsync(segmentId, CancellationToken.None);
-            Assert.NotNull(cached?.Stream);
+            Assert.NotNull(cached);
+            Assert.NotNull(cached.Stream);
             await using var cachedOutput = new MemoryStream();
             await cached.Stream.CopyToAsync(cachedOutput);
             Assert.Equal(content, cachedOutput.ToArray());

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Models;
 using NzbWebDAV.Streams;
 using NzbWebDAV.Tests.Fakes;
 using NzbWebDAV.Tests.TestUtils;
@@ -405,6 +406,310 @@ public sealed class SegmentCacheNntpClientTests
             Assert.Equal(1, snapshot.WriteSkipped);
             Assert.Equal(0, snapshot.WriteCommits);
             Assert.Equal(0, snapshot.WriteFailures);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
+    public async Task WriteBehind_BlockedPersistenceDoesNotDelayPlaybackAndPublishesAfterDrain()
+    {
+        var cacheDir = NewCacheDir();
+        const string segmentId = "write-behind-blocked";
+        byte[] content = Enumerable.Repeat((byte)0x5A, 128 * 1024).ToArray();
+        var statistics = new SegmentCacheStatistics();
+        var persistStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePersist = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            var inner = new FakeNntpClient(
+                new Dictionary<string, byte[]> { [segmentId] = content },
+                useCachedYencStreams: true);
+            using var client = new SegmentCacheNntpClient(
+                inner,
+                cacheDir,
+                maxBytes: 1024 * 1024,
+                usageTracker: null,
+                metricsWriter: null,
+                enumerateCacheFiles: null,
+                statistics,
+                writeBehindBytes: 1024 * 1024,
+                beforeWriteBehindPersist: async cancellationToken =>
+                {
+                    persistStarted.TrySetResult();
+                    await releasePersist.Task.WaitAsync(cancellationToken);
+                });
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            await using var output = new MemoryStream();
+            await response.Stream!.CopyToAsync(output);
+            await response.Stream.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(1));
+            Assert.Equal(content, output.ToArray());
+            await persistStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+            Assert.Null(await client.TryGetLocalDecodedBodyAsync(segmentId, CancellationToken.None));
+            var blocked = statistics.GetSnapshot();
+            var blockedWriter = Assert.IsType<SegmentCacheWriteBehindSnapshot>(
+                statistics.GetWriterSnapshot());
+            Assert.Equal(0, blocked.WriteCommits);
+            Assert.Equal(1024 * 1024, blockedWriter.BudgetBytes);
+            Assert.Equal(1, blockedWriter.ActiveJobs);
+            Assert.True(blocked.QueuedWriteBytes >= content.Length);
+
+            releasePersist.TrySetResult();
+            client.Retire();
+            await client.DrainWriteBehindForTestsAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+            var cached = await client.TryGetLocalDecodedBodyAsync(segmentId, CancellationToken.None);
+            Assert.NotNull(cached?.Stream);
+            await using var cachedOutput = new MemoryStream();
+            await cached.Stream.CopyToAsync(cachedOutput);
+            Assert.Equal(content, cachedOutput.ToArray());
+            var drained = statistics.GetSnapshot();
+            var drainedWriter = Assert.IsType<SegmentCacheWriteBehindSnapshot>(
+                statistics.GetWriterSnapshot());
+            Assert.Equal(1, drained.WriteCommits);
+            Assert.Equal(0, drained.QueuedWriteBytes);
+            Assert.Equal(0, drainedWriter.QueuedJobs);
+            Assert.Equal(0, drainedWriter.ActiveJobs);
+        }
+        finally
+        {
+            releasePersist.TrySetResult();
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
+    public async Task WriteBehind_ByteBudgetPressureSkipsCacheWithoutDelayingPlayback()
+    {
+        var cacheDir = NewCacheDir();
+        const string segmentId = "write-behind-pressure";
+        byte[] content = Enumerable.Repeat((byte)0x3C, 64 * 1024).ToArray();
+        var statistics = new SegmentCacheStatistics();
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            var inner = new FakeNntpClient(
+                new Dictionary<string, byte[]> { [segmentId] = content },
+                useCachedYencStreams: true);
+            using var client = new SegmentCacheNntpClient(
+                inner,
+                cacheDir,
+                maxBytes: 1024 * 1024,
+                usageTracker: null,
+                metricsWriter: null,
+                enumerateCacheFiles: null,
+                statistics,
+                writeBehindBytes: 1);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            await using var output = new MemoryStream();
+            await response.Stream!.CopyToAsync(output);
+            await response.Stream.DisposeAsync();
+
+            Assert.Equal(content, output.ToArray());
+            var snapshot = statistics.GetSnapshot();
+            Assert.Equal(1, snapshot.WriteAttempts);
+            Assert.Equal(1, snapshot.WriteSkipped);
+            Assert.Equal(
+                1,
+                Assert.IsType<SegmentCacheWriteBehindSnapshot>(
+                    statistics.GetWriterSnapshot()).CapacitySkips);
+            Assert.Equal(0, snapshot.QueuedWriteBytes);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
+    public async Task WriteBehind_PartialReadReleasesReservation()
+    {
+        var cacheDir = NewCacheDir();
+        const string segmentId = "write-behind-partial";
+        byte[] content = Enumerable.Repeat((byte)0x7E, 64 * 1024).ToArray();
+        var statistics = new SegmentCacheStatistics();
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            var inner = new FakeNntpClient(
+                new Dictionary<string, byte[]> { [segmentId] = content },
+                useCachedYencStreams: true);
+            using var client = new SegmentCacheNntpClient(
+                inner,
+                cacheDir,
+                maxBytes: 1024 * 1024,
+                usageTracker: null,
+                metricsWriter: null,
+                enumerateCacheFiles: null,
+                statistics,
+                writeBehindBytes: 1024 * 1024);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            Assert.Equal(16, await response.Stream!.ReadAsync(new byte[16]));
+            await response.Stream.DisposeAsync();
+
+            var snapshot = statistics.GetSnapshot();
+            Assert.Equal(1, snapshot.WriteAttempts);
+            Assert.Equal(1, snapshot.WriteSkipped);
+            Assert.Equal(0, snapshot.QueuedWriteBytes);
+            var writer = Assert.IsType<SegmentCacheWriteBehindSnapshot>(
+                statistics.GetWriterSnapshot());
+            Assert.Equal(0, writer.QueuedJobs);
+            Assert.Equal(0, writer.ActiveJobs);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
+    public async Task WriteBehind_PersistenceFailureDoesNotFailPlaybackAndReleasesReservation()
+    {
+        var cacheDir = NewCacheDir();
+        const string segmentId = "write-behind-failure";
+        byte[] content = Enumerable.Repeat((byte)0x42, 64 * 1024).ToArray();
+        var statistics = new SegmentCacheStatistics();
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            var inner = new FakeNntpClient(
+                new Dictionary<string, byte[]> { [segmentId] = content },
+                useCachedYencStreams: true);
+            using var client = new SegmentCacheNntpClient(
+                inner,
+                cacheDir,
+                maxBytes: 1024 * 1024,
+                usageTracker: null,
+                metricsWriter: null,
+                enumerateCacheFiles: null,
+                statistics,
+                writeBehindBytes: 1024 * 1024,
+                beforeWriteBehindPersist: _ => throw new IOException("simulated storage failure"));
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            await using var output = new MemoryStream();
+            await response.Stream!.CopyToAsync(output);
+            await response.Stream.DisposeAsync();
+            client.Retire();
+            await client.DrainWriteBehindForTestsAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(content, output.ToArray());
+            Assert.Null(await client.TryGetLocalDecodedBodyAsync(segmentId, CancellationToken.None));
+            var snapshot = statistics.GetSnapshot();
+            Assert.Equal(1, snapshot.WriteFailures);
+            Assert.Equal(0, snapshot.QueuedWriteBytes);
+            var writer = Assert.IsType<SegmentCacheWriteBehindSnapshot>(
+                statistics.GetWriterSnapshot());
+            Assert.Equal(0, writer.QueuedJobs);
+            Assert.Equal(0, writer.ActiveJobs);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
+    public async Task WriteBehind_OverlongBodyIsDrainedButNotPublished()
+    {
+        var cacheDir = NewCacheDir();
+        const string segmentId = "write-behind-overlong";
+        byte[] content = Enumerable.Repeat((byte)0x24, 64 * 1024).ToArray();
+        var declaredRange = new LongRange(0, content.Length / 2);
+        var statistics = new SegmentCacheStatistics();
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            var inner = new FakeNntpClient(
+                new Dictionary<string, byte[]> { [segmentId] = content },
+                useCachedYencStreams: true,
+                segmentRanges: new Dictionary<string, LongRange> { [segmentId] = declaredRange });
+            using var client = new SegmentCacheNntpClient(
+                inner,
+                cacheDir,
+                maxBytes: 1024 * 1024,
+                usageTracker: null,
+                metricsWriter: null,
+                enumerateCacheFiles: null,
+                statistics,
+                writeBehindBytes: 1024 * 1024);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            await using var output = new MemoryStream();
+            await response.Stream!.CopyToAsync(output);
+            await response.Stream.DisposeAsync();
+
+            Assert.Equal(content, output.ToArray());
+            Assert.Null(await client.TryGetLocalDecodedBodyAsync(segmentId, CancellationToken.None));
+            var snapshot = statistics.GetSnapshot();
+            Assert.Equal(1, snapshot.WriteSkipped);
+            Assert.Equal(0, snapshot.WriteCommits);
+            Assert.Equal(0, snapshot.QueuedWriteBytes);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
+    public async Task WriteBehind_SourceValidationFailureIsNotPublishedAndReleasesReservation()
+    {
+        var cacheDir = NewCacheDir();
+        const string segmentId = "write-behind-source-failure";
+        byte[] content = Enumerable.Repeat((byte)0x66, 64 * 1024).ToArray();
+        var statistics = new SegmentCacheStatistics();
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            var inner = new FakeNntpClient(
+                new Dictionary<string, byte[]> { [segmentId] = content },
+                useCachedYencStreams: true,
+                decodedStreamFactory: (_, bytes) => new ThrowOnDisposeMemoryStream(bytes));
+            using var client = new SegmentCacheNntpClient(
+                inner,
+                cacheDir,
+                maxBytes: 1024 * 1024,
+                usageTracker: null,
+                metricsWriter: null,
+                enumerateCacheFiles: null,
+                statistics,
+                writeBehindBytes: 1024 * 1024);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            await response.Stream!.CopyToAsync(Stream.Null);
+            await Assert.ThrowsAsync<IOException>(() => response.Stream.DisposeAsync().AsTask());
+
+            Assert.Null(await client.TryGetLocalDecodedBodyAsync(segmentId, CancellationToken.None));
+            var snapshot = statistics.GetSnapshot();
+            Assert.Equal(1, snapshot.WriteSkipped);
+            Assert.Equal(0, snapshot.WriteCommits);
+            Assert.Equal(0, snapshot.QueuedWriteBytes);
+            var writer = Assert.IsType<SegmentCacheWriteBehindSnapshot>(
+                statistics.GetWriterSnapshot());
+            Assert.Equal(0, writer.QueuedJobs);
+            Assert.Equal(0, writer.ActiveJobs);
         }
         finally
         {
@@ -1245,6 +1550,16 @@ public sealed class SegmentCacheNntpClientTests
     {
         await using (stream)
             await stream.CopyToAsync(Stream.Null);
+    }
+
+    private sealed class ThrowOnDisposeMemoryStream(byte[] bytes) : MemoryStream(bytes, writable: false)
+    {
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (disposing)
+                throw new IOException("simulated source validation failure");
+        }
     }
 
     private static string SegmentHash(string segmentId) =>

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheStatisticsTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheStatisticsTests.cs
@@ -82,6 +82,27 @@ public sealed class SegmentCacheStatisticsTests
     }
 
     [Fact]
+    public void LaterGeneration_IgnoresStaleWriterSnapshots()
+    {
+        var statistics = new SegmentCacheStatistics();
+        var generationA = statistics.BeginGeneration(enabled: true, maxBytes: 100);
+        generationA.SetWriterSnapshot(new SegmentCacheWriteBehindSnapshot(64, 32, 32, 1, 1, 0));
+
+        var generationB = statistics.BeginGeneration(enabled: true, maxBytes: 200);
+        generationB.SetWriterSnapshot(new SegmentCacheWriteBehindSnapshot(128, 16, 24, 2, 1, 3));
+        generationA.SetWriterSnapshot(new SegmentCacheWriteBehindSnapshot(64, 64, 64, 9, 9, 9));
+
+        var snapshot = Assert.IsType<SegmentCacheWriteBehindSnapshot>(
+            statistics.GetWriterSnapshot());
+        Assert.Equal(128, snapshot.BudgetBytes);
+        Assert.Equal(16, snapshot.ReservedBytes);
+        Assert.Equal(24, snapshot.PeakReservedBytes);
+        Assert.Equal(2, snapshot.QueuedJobs);
+        Assert.Equal(1, snapshot.ActiveJobs);
+        Assert.Equal(3, snapshot.CapacitySkips);
+    }
+
+    [Fact]
     public void LateRetiredGeneration_StillContributesOutcomeCounters()
     {
         var statistics = new SegmentCacheStatistics();

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheWriteBehindTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheWriteBehindTests.cs
@@ -1,0 +1,145 @@
+using System.Collections.Concurrent;
+using NzbWebDAV.Clients.Usenet;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public sealed class SegmentCacheWriteBehindTests
+{
+    [Fact]
+    public async Task JobCapacityCountsQueuedAndActiveWrites()
+    {
+        var persistStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePersist = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var writer = new SegmentCacheWriteBehind(
+            budgetBytes: 1024 * 1024,
+            persist: async (_, cancellationToken) =>
+            {
+                persistStarted.TrySetResult();
+                await releasePersist.Task.WaitAsync(cancellationToken);
+                return SegmentCacheCommitResult.Committed;
+            },
+            warnWriteFailure: () => { },
+            maximumJobs: 2);
+
+        Assert.True(writer.TryRentBuffer(1024, out var firstBody, out var firstCapacity));
+        firstBody.Write(new byte[1024]);
+        Assert.True(writer.TryEnqueue(CreateWrite("first", firstBody, firstCapacity)));
+        await persistStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.True(writer.TryRentBuffer(1024, out var secondBody, out var secondCapacity));
+        secondBody.Write(new byte[1024]);
+        Assert.True(writer.TryEnqueue(CreateWrite("second", secondBody, secondCapacity)));
+        Assert.False(writer.TryRentBuffer(1024, out var rejected, out _));
+        Assert.Null(rejected);
+        Assert.Equal(1, writer.Snapshot().CapacitySkips);
+
+        releasePersist.TrySetResult();
+        writer.Retire();
+        await writer.DrainForTestsAsync().WaitAsync(TimeSpan.FromSeconds(1));
+
+        var drained = writer.Snapshot();
+        Assert.Equal(0, drained.ReservedBytes);
+        Assert.Equal(0, drained.QueuedJobs);
+        Assert.Equal(0, drained.ActiveJobs);
+    }
+
+    [Fact]
+    public async Task WorkerPersistsJobsInFifoOrder()
+    {
+        var order = new ConcurrentQueue<string>();
+        using var writer = new SegmentCacheWriteBehind(
+            budgetBytes: 1024 * 1024,
+            persist: (write, _) =>
+            {
+                order.Enqueue(write.Hash);
+                return Task.FromResult(SegmentCacheCommitResult.Committed);
+            },
+            warnWriteFailure: () => { });
+
+        Assert.True(writer.TryRentBuffer(16, out var firstBody, out var firstCapacity));
+        firstBody.Write(new byte[16]);
+        Assert.True(writer.TryRentBuffer(16, out var secondBody, out var secondCapacity));
+        secondBody.Write(new byte[16]);
+        Assert.True(writer.TryEnqueue(CreateWrite("first", firstBody, firstCapacity)));
+        Assert.True(writer.TryEnqueue(CreateWrite("second", secondBody, secondCapacity)));
+
+        writer.Retire();
+        await writer.DrainForTestsAsync().WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(["first", "second"], order.ToArray());
+        Assert.Equal(0, writer.Snapshot().ReservedBytes);
+    }
+
+    [Fact]
+    public void RetireRejectsEnqueueAndCallerReleasesReservation()
+    {
+        using var writer = new SegmentCacheWriteBehind(
+            budgetBytes: 1024 * 1024,
+            persist: (_, _) => Task.FromResult(SegmentCacheCommitResult.Committed),
+            warnWriteFailure: () => { });
+        Assert.True(writer.TryRentBuffer(1024, out var body, out var capacity));
+        body.Write(new byte[1024]);
+
+        writer.Retire();
+        Assert.False(writer.TryEnqueue(CreateWrite("retired", body, capacity)));
+        body.Dispose();
+        writer.ReleaseReservation(capacity);
+
+        var snapshot = writer.Snapshot();
+        Assert.Equal(0, snapshot.ReservedBytes);
+        Assert.Equal(0, snapshot.QueuedJobs);
+        Assert.Equal(0, snapshot.ActiveJobs);
+    }
+
+    [Fact]
+    public async Task DisposeAfterTimeoutCancelsPersistenceAndReleasesOwnership()
+    {
+        var persistStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var writer = new SegmentCacheWriteBehind(
+            budgetBytes: 1024 * 1024,
+            persist: async (_, cancellationToken) =>
+            {
+                persistStarted.TrySetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return SegmentCacheCommitResult.Committed;
+            },
+            warnWriteFailure: () => { },
+            disposeDrainTimeout: TimeSpan.FromMilliseconds(10));
+        Assert.True(writer.TryRentBuffer(1024, out var body, out var capacity));
+        body.Write(new byte[1024]);
+        Assert.True(writer.TryEnqueue(CreateWrite("stuck", body, capacity)));
+        await persistStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        writer.Dispose();
+        await writer.DrainForTestsAsync().WaitAsync(TimeSpan.FromSeconds(1));
+
+        var snapshot = writer.Snapshot();
+        Assert.Equal(0, snapshot.ReservedBytes);
+        Assert.Equal(0, snapshot.QueuedJobs);
+        Assert.Equal(0, snapshot.ActiveJobs);
+    }
+
+    private static PendingSegmentCacheWrite CreateWrite(
+        string hash,
+        NzbWebDAV.Streams.PooledBufferStream body,
+        long reservedCapacity) =>
+        new(
+            hash,
+            new UsenetYencHeader
+            {
+                FileName = "test.bin",
+                FileSize = body.Length,
+                PartOffset = 0,
+                PartSize = body.Length,
+                LineLength = 128,
+                PartNumber = 1,
+                TotalParts = 1,
+            },
+            body,
+            reservedCapacity,
+            new SegmentCacheWriteAttempt((_, _) => { }));
+}

--- a/tests/NzbWebDAV.Tests/Config/EffectiveStreamingConfigManifestTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/EffectiveStreamingConfigManifestTests.cs
@@ -33,6 +33,7 @@ public sealed class EffectiveStreamingConfigManifestTests
         Assert.True(document.Memory.SharedStreamsEnabled);
         Assert.False(document.SegmentCache.Enabled);
         Assert.Equal(10L * 1024 * 1024 * 1024, document.SegmentCache.MaxBytes);
+        Assert.Equal(0, document.SegmentCache.WriteBehindBytes);
         Assert.True(document.Repair.BackgroundEnabled);
         Assert.True(document.Repair.Par2Enabled);
         Assert.True(document.Repair.DegradedToleranceEnabled);
@@ -227,6 +228,7 @@ public sealed class EffectiveStreamingConfigManifestTests
         "segmentCache",
         "segmentCache.enabled",
         "segmentCache.maxBytes",
+        "segmentCache.writeBehindBytes",
         "repair",
         "repair.backgroundEnabled",
         "repair.par2Enabled",
@@ -268,6 +270,7 @@ public sealed class EffectiveStreamingConfigManifestTests
         "source.segmentCache",
         "source.segmentCache.enabled",
         "source.segmentCache.maxBytes",
+        "source.segmentCache.writeBehindBytes",
         "source.repair",
         "source.repair.backgroundEnabled",
         "source.repair.par2Enabled",

--- a/tests/NzbWebDAV.Tests/Config/SegmentCacheWriteBehindConfigTests.cs
+++ b/tests/NzbWebDAV.Tests/Config/SegmentCacheWriteBehindConfigTests.cs
@@ -1,0 +1,67 @@
+using System.Collections;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Config;
+
+public sealed class SegmentCacheWriteBehindConfigTests
+{
+    [Fact]
+    public void Default_PreservesInlineWrites()
+    {
+        var config = new ConfigManager();
+
+        Assert.Equal(0, config.GetSegmentCacheWriteBehindMb());
+        Assert.Equal(0, config.GetSegmentCacheWriteBehindBytes());
+    }
+
+    [Theory]
+    [InlineData("0", 0)]
+    [InlineData("16", 16)]
+    [InlineData("64", 64)]
+    [InlineData("1024", 1024)]
+    public void ValidValues_AreReturnedInMiB(string configured, int expected)
+    {
+        var config = new ConfigManager();
+        var item = new ConfigItem
+        {
+            ConfigName = ConfigKeys.UsenetSegmentCacheWriteBehindMb,
+            ConfigValue = configured,
+        };
+
+        ConfigManager.ValidateConfigItems([item]);
+        config.UpdateValues([item]);
+        Assert.Equal(expected, config.GetSegmentCacheWriteBehindMb());
+    }
+
+    [Theory]
+    [InlineData("-1")]
+    [InlineData("1")]
+    [InlineData("15")]
+    [InlineData("1025")]
+    [InlineData("invalid")]
+    public void Validation_RejectsUnsupportedValues(string configured)
+    {
+        Assert.Throws<ArgumentException>(() => ConfigManager.ValidateConfigItems(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetSegmentCacheWriteBehindMb,
+                ConfigValue = configured,
+            },
+        ]));
+    }
+
+    [Fact]
+    public void EnvironmentOverlay_IsAuthoritative()
+    {
+        var config = new ConfigManager();
+        config.ApplyEnvironmentOverlay(ConfigEnvironmentOverlay.LoadFromEnvironment(new Hashtable
+        {
+            ["NZBDAV_CONFIG__USENET__SEGMENT_CACHE__WRITE_BEHIND_MB"] = "64",
+        }));
+
+        Assert.Equal(64, config.GetSegmentCacheWriteBehindMb());
+        Assert.True(config.IsEnvironmentManaged(ConfigKeys.UsenetSegmentCacheWriteBehindMb));
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/Diagnostics/MemoryComponentSnapshotTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Diagnostics/MemoryComponentSnapshotTests.cs
@@ -46,7 +46,33 @@ public sealed class MemoryComponentSnapshotTests
         Assert.Equal(0, snapshot.Activity.CurrentInFlightSegmentFetches);
     }
 
-    private static MemoryComponentSnapshotBuilder CreateBuilder(InFlightArticleBudget budget)
+    [Fact]
+    public void Capture_ProjectsActiveCacheWriterOwnership()
+    {
+        var statistics = new SegmentCacheStatistics();
+        var generation = statistics.BeginGeneration(enabled: true, maxBytes: 1024);
+        generation.SetWriterSnapshot(new SegmentCacheWriteBehindSnapshot(
+            BudgetBytes: 64,
+            ReservedBytes: 32,
+            PeakReservedBytes: 48,
+            QueuedJobs: 2,
+            ActiveJobs: 1,
+            CapacitySkips: 3));
+
+        var snapshot = CreateBuilder(new InFlightArticleBudget(10_000), statistics).Capture();
+
+        Assert.True(snapshot.CacheWriter.Supported);
+        Assert.Equal(64, snapshot.CacheWriter.WriteBudgetBytes);
+        Assert.Equal(32, snapshot.CacheWriter.QueuedWriteBytes);
+        Assert.Equal(48, snapshot.CacheWriter.PeakQueuedWriteBytes);
+        Assert.Equal(2, snapshot.CacheWriter.QueuedJobs);
+        Assert.Equal(1, snapshot.CacheWriter.ActiveJobs);
+        Assert.Equal(3, snapshot.CacheWriter.CapacitySkipsTotal);
+    }
+
+    private static MemoryComponentSnapshotBuilder CreateBuilder(
+        InFlightArticleBudget budget,
+        SegmentCacheStatistics? statistics = null)
     {
         var config = new ConfigManager();
         return new MemoryComponentSnapshotBuilder(
@@ -54,6 +80,6 @@ public sealed class MemoryComponentSnapshotTests
             config,
             new ConcurrentReadTracker(configManager: config),
             new ActiveReadRegistry(),
-            new SegmentCacheStatistics());
+            statistics ?? new SegmentCacheStatistics());
     }
 }

--- a/tests/NzbWebDAV.Tests/Streams/PooledBufferStreamTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/PooledBufferStreamTests.cs
@@ -10,6 +10,27 @@ namespace NzbWebDAV.Tests.Streams;
 public class PooledBufferStreamTests
 {
     [Fact]
+    public void WrittenMemoryAndRentedCapacity_ExposeLogicalAndPhysicalSizes()
+    {
+        var pool = new OversizedPool(extraBytes: 32);
+        using var stream = new PooledBufferStream(8, pool);
+        stream.Write("payload"u8);
+
+        Assert.Equal("payload"u8.ToArray(), stream.WrittenMemory.ToArray());
+        Assert.Equal(40, stream.RentedCapacity);
+    }
+
+    [Fact]
+    public void WrittenMemoryAndRentedCapacity_AfterDisposeThrow()
+    {
+        var stream = new PooledBufferStream(8);
+        stream.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => _ = stream.WrittenMemory);
+        Assert.Throws<ObjectDisposedException>(() => _ = stream.RentedCapacity);
+    }
+
+    [Fact]
     public async Task CopyToAsync_RoundTripsBytes()
     {
         var sourceBytes = Enumerable.Range(0, 1000).Select(i => (byte)(i % 256)).ToArray();
@@ -271,6 +292,15 @@ public class PooledBufferStreamTests
         }
 
         public void Return(byte[] buffer) => SharedArrayPoolAdapter.Instance.Return(buffer);
+    }
+
+    private sealed class OversizedPool(int extraBytes) : ISegmentBufferPool
+    {
+        public byte[] Rent(int minimumLength) => new byte[minimumLength + extraBytes];
+
+        public void Return(byte[] buffer)
+        {
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- add a bounded single-reader FIFO segment-cache writer that takes storage I/O off the decoded-body playback path
- reserve physical pooled-buffer capacity and queued/active job slots before accepting work; skip cache writes under pressure instead of delaying playback
- preserve the existing commit/pair validation, index publication, eviction, cache races, and legacy inline mode
- expose generation-safe writer memory/job diagnostics and an advanced restart-scoped budget

## Behavior evidence

A deterministic blocked-persistence test parks the background persistence seam after a complete segment is consumed. Playback copies and disposes the source within one second while persistence remains blocked; the cache entry stays invisible until the writer is released and drained, then serves the exact original bytes.

Additional coverage verifies FIFO order, byte and job caps, physical capacity accounting, partial and overlong bodies, source-validation failures, storage failures, retirement rejection, stale-generation gauges, and forced shutdown cancellation. This demonstrates decoupling and bounded ownership, not a deployment throughput multiplier. Live cache-on/inline/write-behind measurements on the target storage are still required before changing the default.

## Rollout and rollback

- `usenet.segment-cache.write-behind-mb=0` remains the default and preserves inline writes
- enable with `NZBDAV_CONFIG__USENET__SEGMENT_CACHE__WRITE_BEHIND_MB=64` (valid nonzero range: 16–1024 MiB), then restart
- the budget is additional to in-flight Article RAM and is based on physical pooled-buffer capacity
- queued plus active writes are capped at 256; pressure skips new cache writes
- immediate rereads may miss until asynchronous publication completes
- restore `0` and restart to roll back

## Setup wizard impact

No setup-wizard UI, completion allowlist, strategy bundle, or wizard-version change. This is an advanced storage-performance experiment; segment cache remains usable with legacy inline writes and new installations do not require this setting.

## Test plan

- exact backend CI command: 4,916 tests total, 0 failed, 4,901 passed, 15 skipped
- 137 focused cache, buffer, config, memory, Prometheus, and support-pack tests
- `dotnet build NzbWebDAV.sln -c Release`
- `zensical build --clean --strict`
- admin OpenAPI compatibility check
- touched-file `dotnet format whitespace` verification
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional bounded asynchronous writes for the segment cache; inline writes remain the default.
  * Added configurable write-behind capacity and cache-writer queue and memory metrics.
* **Documentation**
  * Documented configuration, cache visibility, capacity limits, skipped writes, and memory-sizing guidance.
* **Bug Fixes**
  * Improved cleanup and handling for failed, partial, oversized, or invalid cache responses.
* **Tests**
  * Added coverage for configuration, persistence ordering, capacity limits, failures, shutdown, and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->