### PR TITLE
chore(docs): direct rclone mounts to the backend WebDAV port

### DIFF
--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -68,6 +68,10 @@ There are two Stremio paths:
 | Frontend | `:3000` | Admin UI, auth, proxy for WebDAV + `/api` + `/ws` |
 | Backend | `:8080` (internal) | WebDAV, queue, SAB API, SQLite under `CONFIG_PATH` |
 
+Backend services such as rclone should connect directly to WebDAV on port `8080`
+whenever the backend is reachable. The frontend WebDAV proxy is a fallback for
+clients without network access to the backend and adds avoidable streaming overhead.
+
 Persistent state lives under `/config` (DB, settings, blobs, backups).
 
 ## Related

--- a/docs/guides/mounting-webdav.md
+++ b/docs/guides/mounting-webdav.md
@@ -26,11 +26,19 @@ docker run --rm -it rclone/rclone obscure "<your-webdav-password>"
 ```ini
 [nzbdav]
 type = webdav
-url = http://nzbdav:3000/
+url = http://nzbdav:8080/
 vendor = other
 user = your-webdav-user
 pass = your-obscured-password
 ```
+
+!!! important
+
+  The rclone sidecar is a backend service and shares the Compose network with
+  InfiniDysk. Point it directly at the backend on port `8080`. Sending WebDAV
+  traffic through the frontend on port `3000` adds proxy overhead and reduces
+  streaming performance. Use the frontend URL only when an rclone client cannot
+  access the backend service over the network.
 
 ```bash
 chmod 600 rclone.conf


### PR DESCRIPTION
## Summary

- change the rclone WebDAV example from frontend port `3000` to backend port `8080`
- explain that backend services should connect directly for streaming performance
- reserve the frontend WebDAV proxy for clients without backend network access

## Test plan

- `zensical build --clean --strict`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated WebDAV guidance to recommend connecting directly to the backend service on port 8080 when accessible.
  - Clarified that the frontend proxy remains a fallback for clients without backend network access and may introduce streaming overhead.
  - Updated the rclone configuration example to use the backend WebDAV address, with guidance on sidecar networking requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->