### PR TITLE
feat(ui): warn when rclone streams through port 3000

### DIFF
--- a/docs/guides/mounting-webdav.md
+++ b/docs/guides/mounting-webdav.md
@@ -26,7 +26,7 @@ docker run --rm -it rclone/rclone obscure "<your-webdav-password>"
 ```ini
 [nzbdav]
 type = webdav
-url = http://nzbdav:3000/
+url = http://nzbdav:8080/
 vendor = other
 user = your-webdav-user
 pass = your-obscured-password
@@ -39,6 +39,19 @@ chmod 600 rclone.conf
 !!! note
 
     Rclone's obscured password is not strong encryption — protect the file.
+
+    Port `8080` is the backend WebDAV endpoint inside the trusted Docker network.
+    Pointing the rclone sidecar there avoids sending streamed bytes through the Node
+    frontend on port `3000`. Do not publish backend port `8080` to an untrusted network;
+    browser and admin traffic should continue to use port `3000`.
+
+### Frontend proxy warning [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since }
+
+If the frontend detects an rclone client on port `3000`, it emits an operator warning
+at most once every 30 minutes and shows a non-dismissible warning in the admin UI.
+Continued proxied traffic keeps the warning active. After rclone is moved to port `8080`,
+the warning clears once the 30-minute observation window expires. An open admin tab
+refreshes this status once per minute.
 
 ## Sidecar Compose service
 

--- a/docs/guides/mounting-webdav.md
+++ b/docs/guides/mounting-webdav.md
@@ -38,7 +38,9 @@ pass = your-obscured-password
   InfiniDysk. Point it directly at the backend on port `8080`. Sending WebDAV
   traffic through the frontend on port `3000` adds proxy overhead and reduces
   streaming performance. Use the frontend URL only when an rclone client cannot
-  access the backend service over the network.
+  access the backend service over the network. Do not publish backend port `8080`
+  to an untrusted network; browser and admin traffic should continue to use port
+  `3000`.
 
 ```bash
 chmod 600 rclone.conf
@@ -47,11 +49,6 @@ chmod 600 rclone.conf
 !!! note
 
     Rclone's obscured password is not strong encryption — protect the file.
-
-    Port `8080` is the backend WebDAV endpoint inside the trusted Docker network.
-    Pointing the rclone sidecar there avoids sending streamed bytes through the Node
-    frontend on port `3000`. Do not publish backend port `8080` to an untrusted network;
-    browser and admin traffic should continue to use port `3000`.
 
 ### Frontend proxy warning [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since }
 

--- a/frontend/app/components/rclone-proxy-warning-banner.test.tsx
+++ b/frontend/app/components/rclone-proxy-warning-banner.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  RcloneProxyWarningBanner,
+  RCLONE_PROXY_STATUS_POLL_MS,
+} from "./rclone-proxy-warning-banner";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("RcloneProxyWarningBanner", () => {
+  it("shows persistent direct-backend guidance after proxied rclone traffic", () => {
+    render(<RcloneProxyWarningBanner active />);
+
+    expect(screen.getByText("rclone is using the frontend proxy")).toBeTruthy();
+    expect(screen.getByText(/backend port/).textContent).toContain("8080");
+    expect(screen.getByText(/backend port/).textContent).toContain("trusted Docker network");
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("renders nothing before a detection", () => {
+    const { container } = render(<RcloneProxyWarningBanner active={false} />);
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("activates and clears from the lightweight status poll", async () => {
+    vi.useFakeTimers();
+    const states = [true, false];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ active: states.shift() }),
+        }),
+      ),
+    );
+    render(<RcloneProxyWarningBanner active={false} />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RCLONE_PROXY_STATUS_POLL_MS);
+    });
+    expect(screen.getByText("rclone is using the frontend proxy")).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RCLONE_PROXY_STATUS_POLL_MS);
+    });
+    expect(screen.queryByText("rclone is using the frontend proxy")).toBeNull();
+  });
+});

--- a/frontend/app/components/rclone-proxy-warning-banner.test.tsx
+++ b/frontend/app/components/rclone-proxy-warning-banner.test.tsx
@@ -61,7 +61,8 @@ describe("RcloneProxyWarningBanner", () => {
     rerender(<RcloneProxyWarningBanner active={false} />);
 
     await act(async () => {
-      resolveStatus?.({ ok: true, json: () => Promise.resolve({ active: true }) });
+      if (!resolveStatus) throw new Error("Expected a pending status request");
+      resolveStatus({ ok: true, json: () => Promise.resolve({ active: true }) });
       await Promise.resolve();
     });
 

--- a/frontend/app/components/rclone-proxy-warning-banner.test.tsx
+++ b/frontend/app/components/rclone-proxy-warning-banner.test.tsx
@@ -40,6 +40,34 @@ describe("RcloneProxyWarningBanner", () => {
     expect(screen.queryByText("rclone is using the frontend proxy")).toBeNull();
   });
 
+  it("ignores a delayed poll response after root-loader revalidation", async () => {
+    vi.useFakeTimers();
+    let resolveStatus:
+      ((value: { ok: true; json: () => Promise<{ active: boolean }> }) => void) | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        () =>
+          new Promise<{ ok: true; json: () => Promise<{ active: boolean }> }>((resolve) => {
+            resolveStatus = resolve;
+          }),
+      ),
+    );
+    const { rerender } = render(<RcloneProxyWarningBanner active />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RCLONE_PROXY_STATUS_POLL_MS);
+    });
+    rerender(<RcloneProxyWarningBanner active={false} />);
+
+    await act(async () => {
+      resolveStatus?.({ ok: true, json: () => Promise.resolve({ active: true }) });
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText("rclone is using the frontend proxy")).toBeNull();
+  });
+
   it("activates and clears from the lightweight status poll", async () => {
     vi.useFakeTimers();
     const states = [true, false];

--- a/frontend/app/components/rclone-proxy-warning-banner.test.tsx
+++ b/frontend/app/components/rclone-proxy-warning-banner.test.tsx
@@ -29,6 +29,17 @@ describe("RcloneProxyWarningBanner", () => {
     expect(container.innerHTML).toBe("");
   });
 
+  it("synchronizes with root-loader revalidation without waiting for the poll", () => {
+    const { rerender } = render(<RcloneProxyWarningBanner active={false} />);
+    expect(screen.queryByText("rclone is using the frontend proxy")).toBeNull();
+
+    rerender(<RcloneProxyWarningBanner active />);
+    expect(screen.getByText("rclone is using the frontend proxy")).toBeTruthy();
+
+    rerender(<RcloneProxyWarningBanner active={false} />);
+    expect(screen.queryByText("rclone is using the frontend proxy")).toBeNull();
+  });
+
   it("activates and clears from the lightweight status poll", async () => {
     vi.useFakeTimers();
     const states = [true, false];

--- a/frontend/app/components/rclone-proxy-warning-banner.tsx
+++ b/frontend/app/components/rclone-proxy-warning-banner.tsx
@@ -1,13 +1,15 @@
 import { Alert, Icon } from "~/components/ui";
 import { withUrlBase } from "~/utils/url-base";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export const RCLONE_PROXY_STATUS_POLL_MS = 60_000;
 
 export function RcloneProxyWarningBanner({ active: initiallyActive }: { active: boolean }) {
   const [active, setActive] = useState(initiallyActive);
+  const requestGeneration = useRef(0);
 
   useEffect(() => {
+    requestGeneration.current += 1;
     setActive(initiallyActive);
   }, [initiallyActive]);
 
@@ -15,13 +17,20 @@ export function RcloneProxyWarningBanner({ active: initiallyActive }: { active: 
     let stopped = false;
     const refresh = async () => {
       if (document.visibilityState === "hidden") return;
+      const generation = ++requestGeneration.current;
       try {
         const response = await fetch(withUrlBase("/rclone-proxy-warning"), {
           headers: { Accept: "application/json" },
         });
         if (!response.ok) return;
         const status = (await response.json()) as { active?: unknown };
-        if (!stopped && typeof status.active === "boolean") setActive(status.active);
+        if (
+          !stopped &&
+          generation === requestGeneration.current &&
+          typeof status.active === "boolean"
+        ) {
+          setActive(status.active);
+        }
       } catch {
         // Keep the last known state while the frontend route is unavailable.
       }

--- a/frontend/app/components/rclone-proxy-warning-banner.tsx
+++ b/frontend/app/components/rclone-proxy-warning-banner.tsx
@@ -1,0 +1,51 @@
+import { Alert, Icon } from "~/components/ui";
+import { withUrlBase } from "~/utils/url-base";
+import { useEffect, useState } from "react";
+
+export const RCLONE_PROXY_STATUS_POLL_MS = 60_000;
+
+export function RcloneProxyWarningBanner({ active: initiallyActive }: { active: boolean }) {
+  const [active, setActive] = useState(initiallyActive);
+
+  useEffect(() => {
+    let stopped = false;
+    const refresh = async () => {
+      if (document.visibilityState === "hidden") return;
+      try {
+        const response = await fetch(withUrlBase("/rclone-proxy-warning"), {
+          headers: { Accept: "application/json" },
+        });
+        if (!response.ok) return;
+        const status = (await response.json()) as { active?: unknown };
+        if (!stopped && typeof status.active === "boolean") setActive(status.active);
+      } catch {
+        // Keep the last known state while the frontend route is unavailable.
+      }
+    };
+
+    const interval = window.setInterval(() => void refresh(), RCLONE_PROXY_STATUS_POLL_MS);
+    return () => {
+      stopped = true;
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  if (!active) return null;
+
+  return (
+    <Alert
+      variant="warning"
+      className="mb-4 grid-cols-[auto_minmax(0,1fr)] items-start gap-3 border border-warning-content/15 text-sm shadow-sm"
+    >
+      <Icon name="lan" className="mt-0.5 shrink-0 !text-[22px]" />
+      <div className="min-w-0">
+        <p className="font-semibold">rclone is using the frontend proxy</p>
+        <p className="mt-0.5 text-warning-content/80">
+          Point the rclone WebDAV remote directly to backend port <code>8080</code> on the trusted
+          Docker network. Port <code>3000</code> proxies every streamed byte through Node and can
+          limit throughput. Do not publish backend port <code>8080</code> to untrusted networks.
+        </p>
+      </div>
+    </Alert>
+  );
+}

--- a/frontend/app/components/rclone-proxy-warning-banner.tsx
+++ b/frontend/app/components/rclone-proxy-warning-banner.tsx
@@ -8,6 +8,10 @@ export function RcloneProxyWarningBanner({ active: initiallyActive }: { active: 
   const [active, setActive] = useState(initiallyActive);
 
   useEffect(() => {
+    setActive(initiallyActive);
+  }, [initiallyActive]);
+
+  useEffect(() => {
     let stopped = false;
     const refresh = async () => {
       if (document.visibilityState === "hidden") return;

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -26,7 +26,9 @@ import { ServiceProviderGate } from "./components/service-provider-gate";
 import { StreamTracingBanner } from "./components/stream-tracing-banner";
 import { LegacyImageBanner } from "./components/legacy-image-banner";
 import { ResetAdminPasswordBanner } from "./components/reset-admin-password-banner";
+import { RcloneProxyWarningBanner } from "./components/rclone-proxy-warning-banner";
 import { isOidcEnabled } from "../server/oidc.server";
+import { isRcloneProxyWarningActive } from "../server/rclone-proxy-warning.server";
 import { getServiceProvider } from "./utils/service-provider.server";
 import { isResetAdminPasswordSet } from "./utils/reset-admin-password.server";
 import { withUrlBase } from "~/utils/url-base";
@@ -44,6 +46,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       useLayout: false,
       serviceProvider: null,
       isResetAdminPasswordSet: resetAdminPasswordSet,
+      rcloneProxyWarningActive: false,
     };
   }
 
@@ -71,6 +74,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     // Baked into images published to the deprecated ghcr.io/nzbdav/nzbdav path.
     isLegacyImage: process.env["NZBDAV_LEGACY_IMAGE"] === "true",
     isResetAdminPasswordSet: resetAdminPasswordSet,
+    rcloneProxyWarningActive: isRcloneProxyWarningActive(),
     version,
     updateAvailable: await checkForUpdate(version),
     isFrontendAuthDisabled: IS_FRONTEND_AUTH_DISABLED,
@@ -138,6 +142,7 @@ export default function App({ loaderData }: Route.ComponentProps) {
     useLayout,
     isLegacyImage,
     isResetAdminPasswordSet,
+    rcloneProxyWarningActive,
     version,
     updateAvailable,
     isFrontendAuthDisabled,
@@ -184,6 +189,7 @@ export default function App({ loaderData }: Route.ComponentProps) {
                     isResetAdminPasswordSet={isResetAdminPasswordSet ?? false}
                   />
                   <LegacyImageBanner isLegacyImage={isLegacyImage ?? false} />
+                  <RcloneProxyWarningBanner active={rcloneProxyWarningActive ?? false} />
                   <StreamTracingBanner isReadOnly={role === "readonly"} />
                 </div>
                 {outlet}

--- a/frontend/app/routes/rclone-proxy-warning/route.test.ts
+++ b/frontend/app/routes/rclone-proxy-warning/route.test.ts
@@ -1,0 +1,20 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  recordRcloneProxyRequest,
+  resetRcloneProxyWarningForTests,
+} from "../../../server/rclone-proxy-warning.server";
+import { loader } from "./route";
+
+describe("rclone proxy warning status route", () => {
+  beforeEach(() => {
+    resetRcloneProxyWarningForTests();
+  });
+
+  it("returns the shared frontend detection state", async () => {
+    expect(await loader().json()).toEqual({ active: false });
+
+    recordRcloneProxyRequest("rclone/v1.70.3");
+
+    expect(await loader().json()).toEqual({ active: true });
+  });
+});

--- a/frontend/app/routes/rclone-proxy-warning/route.tsx
+++ b/frontend/app/routes/rclone-proxy-warning/route.tsx
@@ -1,0 +1,5 @@
+import { isRcloneProxyWarningActive } from "../../../server/rclone-proxy-warning.server";
+
+export function loader() {
+  return Response.json({ active: isRcloneProxyWarningActive() });
+}

--- a/frontend/coverage-thresholds.json
+++ b/frontend/coverage-thresholds.json
@@ -1,7 +1,7 @@
 {
   "global": {
     "branches": 27,
-    "functions": 23,
+    "functions": 26,
     "lines": 31,
     "statements": 30
   },

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -27,6 +27,7 @@ import { backendProxyTimeoutOptions } from "./backend-proxy-options";
 import { handleBackendProxyResponse } from "./backend-proxy-response";
 import { oidcRouter } from "./oidc-routes";
 import { observeRcloneProxyRequest } from "./rclone-proxy-warning.server";
+import { admitAndForwardBackendRequest } from "./backend-proxy-admission";
 import { URL_BASE } from "~/utils/url-base";
 
 export const app = express();
@@ -142,28 +143,33 @@ app.use(credentialRateLimiter);
 
 app.use(async (req, res, next) => {
   if (shouldProxyToBackend(req.method, req.path)) {
-    observeRcloneProxyRequest(req.headers["user-agent"], logger.warn);
-
     const decodedPath = safeDecodePath(req.path);
-    if (decodedPath === "/metrics" && !(await isAuthenticated(req))) {
-      res.status(401).type("text/plain").send("Metrics authentication required.");
-      return;
-    }
-
-    await setApiKeyForAuthenticatedRequests(req, getFrontendRuntimeConfig().frontendBackendApiKey);
-
-    if (isReadOnlyDeniedBackendMutation(req.method, req.path)) {
-      const user = await getSessionUser(req);
-      if (user?.role === "readonly") {
-        res.status(403).json({
-          status: false,
-          error: "Read-only users cannot perform destructive maintenance.",
-        });
-        return;
-      }
-    }
-
-    return forwardToBackend(req, res, next);
+    return admitAndForwardBackendRequest(
+      {
+        requiresMetricsAuthentication: decodedPath === "/metrics",
+        isReadOnlyMutation: isReadOnlyDeniedBackendMutation(req.method, req.path),
+        userAgent: req.headers["user-agent"],
+      },
+      {
+        isAuthenticated: () => isAuthenticated(req),
+        injectApiKey: () =>
+          setApiKeyForAuthenticatedRequests(req, getFrontendRuntimeConfig().frontendBackendApiKey),
+        getRole: async () => (await getSessionUser(req))?.role ?? null,
+        rejectMetrics: () => {
+          res.status(401).type("text/plain").send("Metrics authentication required.");
+        },
+        rejectReadOnlyMutation: () => {
+          res.status(403).json({
+            status: false,
+            error: "Read-only users cannot perform destructive maintenance.",
+          });
+        },
+        observeRclone: (userAgent) => observeRcloneProxyRequest(userAgent, logger.warn),
+        forward: () => {
+          void forwardToBackend(req, res, next);
+        },
+      },
+    );
   }
   next();
 });

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -26,6 +26,7 @@ import { applyCanonicalForwardedHeaders } from "./forwarded-headers";
 import { backendProxyTimeoutOptions } from "./backend-proxy-options";
 import { handleBackendProxyResponse } from "./backend-proxy-response";
 import { oidcRouter } from "./oidc-routes";
+import { observeRcloneProxyRequest } from "./rclone-proxy-warning.server";
 import { URL_BASE } from "~/utils/url-base";
 
 export const app = express();
@@ -141,6 +142,8 @@ app.use(credentialRateLimiter);
 
 app.use(async (req, res, next) => {
   if (shouldProxyToBackend(req.method, req.path)) {
+    observeRcloneProxyRequest(req.headers["user-agent"], logger.warn);
+
     const decodedPath = safeDecodePath(req.path);
     if (decodedPath === "/metrics" && !(await isAuthenticated(req))) {
       res.status(401).type("text/plain").send("Metrics authentication required.");

--- a/frontend/server/backend-proxy-admission.test.ts
+++ b/frontend/server/backend-proxy-admission.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import { admitAndForwardBackendRequest } from "./backend-proxy-admission";
+
+function handlers(overrides: Partial<Parameters<typeof admitAndForwardBackendRequest>[1]> = {}) {
+  return {
+    isAuthenticated: vi.fn(() => Promise.resolve(true)),
+    injectApiKey: vi.fn(() => Promise.resolve()),
+    getRole: vi.fn(() => Promise.resolve<string | null>("admin")),
+    rejectMetrics: vi.fn(),
+    rejectReadOnlyMutation: vi.fn(),
+    observeRclone: vi.fn(),
+    forward: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("backend proxy admission", () => {
+  it("does not observe or forward rejected metrics requests", async () => {
+    const callbacks = handlers({
+      isAuthenticated: vi.fn(() => Promise.resolve(false)),
+    });
+
+    await admitAndForwardBackendRequest(
+      {
+        requiresMetricsAuthentication: true,
+        isReadOnlyMutation: false,
+        userAgent: "rclone/v1.70.3",
+      },
+      callbacks,
+    );
+
+    expect(callbacks.rejectMetrics).toHaveBeenCalledOnce();
+    expect(callbacks.injectApiKey).not.toHaveBeenCalled();
+    expect(callbacks.observeRclone).not.toHaveBeenCalled();
+    expect(callbacks.forward).not.toHaveBeenCalled();
+  });
+
+  it("does not observe or forward rejected read-only mutations", async () => {
+    const callbacks = handlers({
+      getRole: vi.fn(() => Promise.resolve("readonly")),
+    });
+
+    await admitAndForwardBackendRequest(
+      {
+        requiresMetricsAuthentication: false,
+        isReadOnlyMutation: true,
+        userAgent: "rclone/v1.70.3",
+      },
+      callbacks,
+    );
+
+    expect(callbacks.injectApiKey).toHaveBeenCalledOnce();
+    expect(callbacks.rejectReadOnlyMutation).toHaveBeenCalledOnce();
+    expect(callbacks.observeRclone).not.toHaveBeenCalled();
+    expect(callbacks.forward).not.toHaveBeenCalled();
+  });
+
+  it("observes immediately before forwarding admitted requests", async () => {
+    const calls: string[] = [];
+    const callbacks = handlers({
+      observeRclone: vi.fn(() => calls.push("observe")),
+      forward: vi.fn(() => calls.push("forward")),
+    });
+
+    await admitAndForwardBackendRequest(
+      {
+        requiresMetricsAuthentication: false,
+        isReadOnlyMutation: false,
+        userAgent: "rclone/v1.70.3",
+      },
+      callbacks,
+    );
+
+    expect(calls).toEqual(["observe", "forward"]);
+  });
+});

--- a/frontend/server/backend-proxy-admission.ts
+++ b/frontend/server/backend-proxy-admission.ts
@@ -1,0 +1,35 @@
+export type BackendProxyAdmissionRequest = {
+  requiresMetricsAuthentication: boolean;
+  isReadOnlyMutation: boolean;
+  userAgent: string | string[] | undefined;
+};
+
+type BackendProxyAdmissionHandlers = {
+  isAuthenticated: () => Promise<boolean>;
+  injectApiKey: () => Promise<void>;
+  getRole: () => Promise<string | null>;
+  rejectMetrics: () => void;
+  rejectReadOnlyMutation: () => void;
+  observeRclone: (userAgent: string | string[] | undefined) => void;
+  forward: () => void;
+};
+
+export async function admitAndForwardBackendRequest(
+  request: BackendProxyAdmissionRequest,
+  handlers: BackendProxyAdmissionHandlers,
+): Promise<void> {
+  if (request.requiresMetricsAuthentication && !(await handlers.isAuthenticated())) {
+    handlers.rejectMetrics();
+    return;
+  }
+
+  await handlers.injectApiKey();
+
+  if (request.isReadOnlyMutation && (await handlers.getRole()) === "readonly") {
+    handlers.rejectReadOnlyMutation();
+    return;
+  }
+
+  handlers.observeRclone(request.userAgent);
+  handlers.forward();
+}

--- a/frontend/server/rclone-proxy-warning.server.test.ts
+++ b/frontend/server/rclone-proxy-warning.server.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  isRcloneProxyWarningActive,
+  isRcloneUserAgent,
+  observeRcloneProxyRequest,
+  recordRcloneProxyRequest,
+  RCLONE_PROXY_WARNING_INTERVAL_MS,
+  resetRcloneProxyWarningForTests,
+} from "./rclone-proxy-warning.server";
+
+describe("rclone proxy warning", () => {
+  beforeEach(() => {
+    resetRcloneProxyWarningForTests();
+  });
+
+  it.each(["rclone/v1.70.3", "RCLONE/v1.71.0", "rclone test"])(
+    "recognizes the rclone user agent %s",
+    (userAgent) => {
+      expect(isRcloneUserAgent(userAgent)).toBe(true);
+    },
+  );
+
+  it.each([undefined, "", "Mozilla/5.0", "my-rclone-client/1.0"])(
+    "ignores unrelated user agent %s",
+    (userAgent) => {
+      expect(isRcloneUserAgent(userAgent)).toBe(false);
+    },
+  );
+
+  it("logs the first detection and reports suppressed detections after the interval", () => {
+    const now = 1_000_000;
+
+    expect(recordRcloneProxyRequest("rclone/v1.70.3", now)).toEqual({
+      detected: true,
+      shouldLog: true,
+      suppressed: 0,
+    });
+    expect(recordRcloneProxyRequest("rclone/v1.70.3", now + 1)).toEqual({
+      detected: true,
+      shouldLog: false,
+      suppressed: 0,
+    });
+    expect(recordRcloneProxyRequest("rclone/v1.70.3", now + 2)).toEqual({
+      detected: true,
+      shouldLog: false,
+      suppressed: 0,
+    });
+    expect(
+      recordRcloneProxyRequest("rclone/v1.70.3", now + RCLONE_PROXY_WARNING_INTERVAL_MS),
+    ).toEqual({ detected: true, shouldLog: true, suppressed: 2 });
+  });
+
+  it("keeps the warning active while detections continue and expires after the interval", () => {
+    const now = 1_000_000;
+
+    recordRcloneProxyRequest("rclone/v1.70.3", now);
+    expect(isRcloneProxyWarningActive(now + RCLONE_PROXY_WARNING_INTERVAL_MS - 1)).toBe(true);
+
+    recordRcloneProxyRequest("rclone/v1.70.3", now + RCLONE_PROXY_WARNING_INTERVAL_MS - 1);
+    expect(isRcloneProxyWarningActive(now + RCLONE_PROXY_WARNING_INTERVAL_MS * 2 - 2)).toBe(true);
+    expect(isRcloneProxyWarningActive(now + RCLONE_PROXY_WARNING_INTERVAL_MS * 2)).toBe(false);
+  });
+
+  it("does not activate for unrelated clients", () => {
+    expect(recordRcloneProxyRequest("Mozilla/5.0", 1_000_000).detected).toBe(false);
+    expect(isRcloneProxyWarningActive(1_000_000)).toBe(false);
+  });
+
+  it("emits one warning per interval and reports suppressed detections", () => {
+    const warnings: string[] = [];
+    const warn = (message: string) => warnings.push(message);
+    const now = 1_000_000;
+
+    expect(observeRcloneProxyRequest("rclone/v1.70.3", warn, now)).toBe(true);
+    observeRcloneProxyRequest("rclone/v1.70.3", warn, now + 1);
+    observeRcloneProxyRequest("rclone/v1.70.3", warn, now + 2);
+    observeRcloneProxyRequest("rclone/v1.70.3", warn, now + RCLONE_PROXY_WARNING_INTERVAL_MS);
+
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain("frontend proxy on port 3000");
+    expect(warnings[0]).toContain("backend port 8080");
+    expect(warnings[1]).toContain("Suppressed 2 repeated detection(s)");
+  });
+});

--- a/frontend/server/rclone-proxy-warning.server.ts
+++ b/frontend/server/rclone-proxy-warning.server.ts
@@ -1,0 +1,85 @@
+export const RCLONE_PROXY_WARNING_INTERVAL_MS = 30 * 60 * 1000;
+
+export type RcloneProxyObservation = {
+  detected: boolean;
+  shouldLog: boolean;
+  suppressed: number;
+};
+
+type WarnLogger = (message: string) => void;
+
+type RcloneProxyWarningState = {
+  lastDetectedAtMs: number | null;
+  lastLogAtMs: number | null;
+  suppressed: number;
+};
+
+const processState = process as typeof process & {
+  __infinidyskRcloneProxyWarningState?: RcloneProxyWarningState;
+};
+
+function state(): RcloneProxyWarningState {
+  processState.__infinidyskRcloneProxyWarningState ??= {
+    lastDetectedAtMs: null,
+    lastLogAtMs: null,
+    suppressed: 0,
+  };
+  return processState.__infinidyskRcloneProxyWarningState;
+}
+
+export function isRcloneUserAgent(userAgent: string | string[] | undefined): boolean {
+  const value = Array.isArray(userAgent) ? userAgent.join(" ") : userAgent;
+  return /^rclone(?:\/|\s|$)/i.test(value?.trim() ?? "");
+}
+
+export function recordRcloneProxyRequest(
+  userAgent: string | string[] | undefined,
+  nowMs = Date.now(),
+): RcloneProxyObservation {
+  if (!isRcloneUserAgent(userAgent)) {
+    return { detected: false, shouldLog: false, suppressed: 0 };
+  }
+
+  const current = state();
+  current.lastDetectedAtMs = nowMs;
+  if (
+    current.lastLogAtMs !== null &&
+    nowMs - current.lastLogAtMs < RCLONE_PROXY_WARNING_INTERVAL_MS
+  ) {
+    current.suppressed += 1;
+    return { detected: true, shouldLog: false, suppressed: 0 };
+  }
+
+  const suppressed = current.suppressed;
+  current.lastLogAtMs = nowMs;
+  current.suppressed = 0;
+  return { detected: true, shouldLog: true, suppressed };
+}
+
+export function observeRcloneProxyRequest(
+  userAgent: string | string[] | undefined,
+  warn: WarnLogger,
+  nowMs = Date.now(),
+): boolean {
+  const observation = recordRcloneProxyRequest(userAgent, nowMs);
+  if (!observation.shouldLog) return observation.detected;
+
+  const suppressed =
+    observation.suppressed > 0
+      ? ` Suppressed ${observation.suppressed} repeated detection(s) since the previous warning.`
+      : "";
+  warn(
+    "rclone WebDAV traffic is using the frontend proxy on port 3000. Point the rclone sidecar directly at backend port 8080 on the trusted Docker network to avoid proxying streamed bytes." +
+      suppressed,
+  );
+  return true;
+}
+
+export function isRcloneProxyWarningActive(nowMs = Date.now()): boolean {
+  const lastDetectedAtMs = state().lastDetectedAtMs;
+  return lastDetectedAtMs !== null && nowMs - lastDetectedAtMs < RCLONE_PROXY_WARNING_INTERVAL_MS;
+}
+
+export function resetRcloneProxyWarningForTests(): void {
+  delete processState.__infinidyskRcloneProxyWarningState;
+}


### PR DESCRIPTION
## Summary

- detect rclone User-Agent traffic only when the Node frontend actually routes the request to the backend proxy
- emit one operator warning at most every 30 minutes, including the number of suppressed repeated detections on the next warning
- show a persistent, non-dismissible admin banner with direct-backend and trusted-network guidance
- poll one authenticated frontend-local boolean every minute so already-open tabs activate and clear without a navigation
- update the canonical rclone sidecar config to use `http://nzbdav:8080/`

## Behavior

The frontend retains only process-local timestamps and a suppressed-event count; it stores no client IP, path, credentials, or User-Agent. Continued proxied rclone traffic extends the 30-minute observation window. After rclone is moved to backend port 8080, the banner clears automatically after the window expires. Direct backend traffic never traverses Node and therefore cannot trigger the warning.

The warning does not redirect requests and does not recommend publishing port 8080. Browser, admin, Newznab, Stremio, and Prometheus traffic remain on port 3000; only the trusted Docker-network rclone sidecar uses 8080.

## Setup wizard impact

No setup-wizard state, completion allowlist, strategy bundle, or wizard-version change. The existing sidecar setup becomes more accurate through the updated canonical rclone documentation; no persisted configuration is added.

## Test plan

- 108 frontend test files, 998 tests, 0 failures
- detector coverage: User-Agent matching, first warning, 30-minute throttling, suppressed counts, sliding activation, expiry, unrelated clients
- UI coverage: persistent banner, no dismiss control, polling activation and clearing
- authenticated resource-route coverage for shared process state
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build` and `npm run build:server`
- `zensical build --clean --strict`
- Impeccable detector: no findings
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a warning banner when rclone traffic uses the frontend proxy, explaining that direct backend port `8080` access can improve throughput.
  - The warning updates automatically, remains visible while active, and limits repeated alerts.
  - Added safeguards to prevent unauthorized metrics access and disallowed read-only mutations.
- **Documentation**
  - Clarified WebDAV port usage: trusted Docker-network traffic uses port `8080`, while browser and administrative traffic continue using port `3000`.
  - Documented warning behavior, persistence, clearing after migration, and refresh timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->