### PR TITLE
chore(bench): measure HTTP response-copy chunk sizes

### DIFF
--- a/backend.Benchmarks/HttpLikeCountingSink.cs
+++ b/backend.Benchmarks/HttpLikeCountingSink.cs
@@ -1,34 +1,54 @@
 using System.Buffers;
+using System.Diagnostics;
+using System.Security.Cryptography;
 
 namespace NzbWebDAV.Benchmarks;
 
 /// <summary>
-/// Applies the bounded 64 KiB response-copy shape used by the WebDAV handler,
-/// while discarding output so timed benchmark passes do not include hashing.
+/// Applies a bounded response-copy shape while discarding output so timed
+/// benchmark passes do not include hashing unless explicitly requested.
 /// </summary>
-internal sealed class HttpLikeCountingSink
+internal sealed class HttpLikeCountingSink(
+    int bufferBytes,
+    long copyStartedTimestamp,
+    ArrayPool<byte>? bufferPool = null)
 {
-    private const int BufferBytes = 64 * 1024;
+    private readonly int _bufferBytes = bufferBytes > 0
+        ? bufferBytes
+        : throw new ArgumentOutOfRangeException(nameof(bufferBytes));
+    private readonly ArrayPool<byte> _bufferPool = bufferPool ?? ArrayPool<byte>.Shared;
 
     public long BytesWritten { get; private set; }
 
-    public async Task CopyFromAsync(Stream source, CancellationToken cancellationToken)
+    // Measured from whole-path execution start so this matches client-observed
+    // latency, including stream construction and the first segment fetch.
+    public TimeSpan? TimeToFirstByte { get; private set; }
+
+    public async Task<string?> CopyFromAsync(
+        Stream source,
+        bool verifyHash,
+        CancellationToken cancellationToken)
     {
-        var buffer = ArrayPool<byte>.Shared.Rent(BufferBytes);
+        using var hash = verifyHash ? IncrementalHash.CreateHash(HashAlgorithmName.SHA256) : null;
+        var buffer = _bufferPool.Rent(_bufferBytes);
         try
         {
             while (true)
             {
-                var read = await source.ReadAsync(buffer.AsMemory(0, BufferBytes), cancellationToken)
+                var read = await source.ReadAsync(buffer.AsMemory(0, _bufferBytes), cancellationToken)
                     .ConfigureAwait(false);
                 if (read == 0)
-                    return;
+                    return hash is null
+                        ? null
+                        : Convert.ToHexString(hash.GetHashAndReset()).ToLowerInvariant();
+                TimeToFirstByte ??= Stopwatch.GetElapsedTime(copyStartedTimestamp);
+                hash?.AppendData(buffer, 0, read);
                 BytesWritten += read;
             }
         }
         finally
         {
-            ArrayPool<byte>.Shared.Return(buffer);
+            _bufferPool.Return(buffer);
         }
     }
 }

--- a/backend.Benchmarks/HttpResponseCopyChunkReport.cs
+++ b/backend.Benchmarks/HttpResponseCopyChunkReport.cs
@@ -1,0 +1,160 @@
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+
+namespace NzbWebDAV.Benchmarks;
+
+internal static class HttpResponseCopyChunkReport
+{
+    private static readonly int[] ChunkBytes = [64 * 1024, 128 * 1024, 256 * 1024];
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    public static async Task RunAsync(string? jsonPath, string? scenarioName, int repetitions)
+    {
+        var scenario = NntpWholePathScenario.Profile.SingleOrDefault(candidate =>
+            scenarioName is null || candidate.Name.Equals(scenarioName, StringComparison.Ordinal));
+        if (scenario is null)
+            throw new ArgumentException($"No HTTP-like profile scenario named '{scenarioName}'.");
+
+        foreach (var chunkBytes in ChunkBytes)
+        {
+            await NntpWholePathReport.ExecuteForCopyChunkAsync(
+                    scenario, verifyHash: false, chunkBytes)
+                .ConfigureAwait(false);
+            var correctness = await NntpWholePathReport.ExecuteForCopyChunkAsync(
+                    scenario, verifyHash: true, chunkBytes)
+                .ConfigureAwait(false);
+            if (correctness.Deterministic.ActualBytes != correctness.Deterministic.ExpectedBytes ||
+                correctness.Deterministic.Sha256Match != 1)
+            {
+                throw new InvalidOperationException(
+                    $"{chunkBytes / 1024} KiB copy failed correctness verification.");
+            }
+        }
+
+        var samples = new List<HttpCopyChunkSample>(ChunkBytes.Length * repetitions);
+        for (var repetition = 1; repetition <= repetitions; repetition++)
+        {
+            for (var offset = 0; offset < ChunkBytes.Length; offset++)
+            {
+                var chunkBytes = ChunkBytes[(offset + repetition - 1) % ChunkBytes.Length];
+                var result = await NntpWholePathReport.ExecuteForCopyChunkAsync(
+                        scenario, verifyHash: false, chunkBytes)
+                    .ConfigureAwait(false);
+                var timing = result.Timing;
+                var sample = new HttpCopyChunkSample(
+                    chunkBytes / 1024,
+                    repetition,
+                    timing.WallSeconds,
+                    timing.ThroughputMbps,
+                    timing.ClientCpuSeconds,
+                    timing.ClientCpuSecondsPerGb,
+                    timing.ClientAllocatedBytes,
+                    timing.FirstByteMs);
+                samples.Add(sample);
+                Console.WriteLine(
+                    $"chunk_kib={sample.ChunkKiB} repetition={sample.Repetition} " +
+                    $"wall_s={sample.WallSeconds:F6} throughput_mb_s={sample.ThroughputMbps:F3} " +
+                    $"client_cpu_s={sample.ClientCpuSeconds:F6} " +
+                    $"client_cpu_s_per_gb={sample.ClientCpuSecondsPerGb:F6} " +
+                    $"allocated_bytes={sample.ClientAllocatedBytes} first_byte_ms={sample.FirstByteMs:F3}");
+            }
+        }
+
+        var summaries = samples
+            .GroupBy(sample => sample.ChunkKiB)
+            .OrderBy(group => group.Key)
+            .Select(group => Summarize(group.Key, group.ToArray()))
+            .ToArray();
+        foreach (var summary in summaries)
+        {
+            Console.WriteLine(
+                $"summary chunk_kib={summary.ChunkKiB} " +
+                $"throughput_median_mb_s={summary.ThroughputMbps.Median:F3} " +
+                $"throughput_mad={summary.ThroughputMbps.Mad:F3} " +
+                $"cpu_per_gb_median={summary.ClientCpuSecondsPerGb.Median:F6} " +
+                $"cpu_per_gb_mad={summary.ClientCpuSecondsPerGb.Mad:F6} " +
+                $"first_byte_median_ms={summary.FirstByteMs.Median:F3} " +
+                $"first_byte_mad={summary.FirstByteMs.Mad:F3}");
+        }
+
+        if (jsonPath is not null)
+            WriteJson(jsonPath, scenario.Name, samples, summaries);
+    }
+
+    private static HttpCopyChunkSummary Summarize(int chunkKiB, HttpCopyChunkSample[] samples) => new(
+        chunkKiB,
+        Summarize(samples.Select(sample => sample.WallSeconds)),
+        Summarize(samples.Select(sample => sample.ThroughputMbps)),
+        Summarize(samples.Select(sample => sample.ClientCpuSeconds)),
+        Summarize(samples.Select(sample => sample.ClientCpuSecondsPerGb)),
+        Summarize(samples.Select(sample => (double)sample.ClientAllocatedBytes)),
+        Summarize(samples.Select(sample => sample.FirstByteMs)));
+
+    internal static MedianAndMad Summarize(IEnumerable<double> values)
+    {
+        var sorted = values.Order().ToArray();
+        if (sorted.Length == 0)
+            throw new ArgumentException("At least one sample is required.", nameof(values));
+        var median = Median(sorted);
+        var deviations = sorted.Select(value => Math.Abs(value - median)).Order().ToArray();
+        return new MedianAndMad(median, Median(deviations));
+    }
+
+    private static double Median(double[] sorted) =>
+        sorted.Length % 2 == 1
+            ? sorted[sorted.Length / 2]
+            : (sorted[(sorted.Length / 2) - 1] + sorted[sorted.Length / 2]) / 2;
+
+    private static void WriteJson(
+        string path,
+        string scenario,
+        IReadOnlyList<HttpCopyChunkSample> samples,
+        IReadOnlyList<HttpCopyChunkSummary> summaries)
+    {
+        var document = new
+        {
+            schemaVersion = 1,
+            report = "http-response-copy-chunks",
+            meta = new
+            {
+                commit = Environment.GetEnvironmentVariable("GITHUB_SHA") ?? "unknown",
+                generatedAt = DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture),
+                os = RuntimeInformation.OSDescription,
+                dotnet = RuntimeInformation.FrameworkDescription,
+            },
+            scenario,
+            samples,
+            summaries,
+        };
+        File.WriteAllText(
+            path,
+            JsonSerializer.Serialize(document, JsonOptions) +
+            Environment.NewLine);
+    }
+}
+
+internal sealed record HttpCopyChunkSample(
+    int ChunkKiB,
+    int Repetition,
+    double WallSeconds,
+    double ThroughputMbps,
+    double ClientCpuSeconds,
+    double ClientCpuSecondsPerGb,
+    long ClientAllocatedBytes,
+    double FirstByteMs);
+
+internal sealed record HttpCopyChunkSummary(
+    int ChunkKiB,
+    MedianAndMad WallSeconds,
+    MedianAndMad ThroughputMbps,
+    MedianAndMad ClientCpuSeconds,
+    MedianAndMad ClientCpuSecondsPerGb,
+    MedianAndMad ClientAllocatedBytes,
+    MedianAndMad FirstByteMs);
+
+internal sealed record MedianAndMad(double Median, double Mad);

--- a/backend.Benchmarks/NntpWholePathReport.cs
+++ b/backend.Benchmarks/NntpWholePathReport.cs
@@ -19,6 +19,7 @@ internal static class NntpWholePathReport
 {
     internal const string ReportName = "nntp-whole-path";
     internal const int CorpusSeed = 1025;
+    internal const int DefaultResponseCopyChunkBytes = 64 * 1024;
     private const int TimedRepetitions = 3;
 
     public static async Task RunAsync(
@@ -37,15 +38,27 @@ internal static class NntpWholePathReport
         foreach (var scenario in selected)
         {
             // Tiered JIT and native dispatch setup are intentionally discarded.
-            await ExecuteAsync(scenario, verifyHash: false, httpLike: scenario.Layer == NntpWholePathLayer.HttpLike)
+            await ExecuteAsync(
+                    scenario,
+                    verifyHash: false,
+                    httpLike: scenario.Layer == NntpWholePathLayer.HttpLike,
+                    DefaultResponseCopyChunkBytes)
                 .ConfigureAwait(false);
-            var correctness = await ExecuteAsync(scenario, verifyHash: true, httpLike: scenario.Layer == NntpWholePathLayer.HttpLike)
+            var correctness = await ExecuteAsync(
+                    scenario,
+                    verifyHash: true,
+                    httpLike: scenario.Layer == NntpWholePathLayer.HttpLike,
+                    DefaultResponseCopyChunkBytes)
                 .ConfigureAwait(false);
 
             NntpWholePathTiming? total = null;
             for (var repetition = 0; repetition < TimedRepetitions; repetition++)
             {
-                var timed = await ExecuteAsync(scenario, verifyHash: false, httpLike: scenario.Layer == NntpWholePathLayer.HttpLike)
+                var timed = await ExecuteAsync(
+                    scenario,
+                    verifyHash: false,
+                    httpLike: scenario.Layer == NntpWholePathLayer.HttpLike,
+                    DefaultResponseCopyChunkBytes)
                     .ConfigureAwait(false);
                 total = total is null ? timed.Timing : Add(total, timed.Timing);
             }
@@ -107,10 +120,17 @@ internal static class NntpWholePathReport
         await server.WriteSnapshotAsync(arguments.CountersPath, CancellationToken.None).ConfigureAwait(false);
     }
 
+    internal static Task<NntpWholePathResult> ExecuteForCopyChunkAsync(
+        NntpWholePathScenario scenario,
+        bool verifyHash,
+        int responseCopyChunkBytes) =>
+        ExecuteAsync(scenario, verifyHash, httpLike: true, responseCopyChunkBytes);
+
     private static async Task<NntpWholePathResult> ExecuteAsync(
         NntpWholePathScenario scenario,
         bool verifyHash,
-        bool httpLike)
+        bool httpLike,
+        int responseCopyChunkBytes)
     {
         if (scenario.UseTls)
             throw new NotSupportedException(
@@ -133,6 +153,7 @@ internal static class NntpWholePathReport
             var cpuBefore = process.TotalProcessorTime;
             var allocatedBefore = GC.GetTotalAllocatedBytes(precise: false);
             var collectionCounts = new[] { GC.CollectionCount(0), GC.CollectionCount(1), GC.CollectionCount(2) };
+            var startedTimestamp = Stopwatch.GetTimestamp();
             var started = Stopwatch.StartNew();
             var bytes = scenario.Layer switch
             {
@@ -142,7 +163,8 @@ internal static class NntpWholePathReport
                     scenario, server.Port, corpus, callbackCounts, verifyHash).ConfigureAwait(false),
                 NntpWholePathLayer.BufferedStream or NntpWholePathLayer.HttpLike =>
                     await ReadBufferedStreamAsync(
-                        scenario, server.Port, corpus, callbackCounts, budget, verifyHash, httpLike)
+                        scenario, server.Port, corpus, callbackCounts, budget, verifyHash, httpLike,
+                        responseCopyChunkBytes, startedTimestamp)
                     .ConfigureAwait(false),
                 _ => throw new ArgumentOutOfRangeException(nameof(scenario)),
             };
@@ -180,6 +202,7 @@ internal static class NntpWholePathReport
                     serverCpu,
                     clientCpu / (bytes.Count / 1_000_000_000d),
                     bytes.Count / elapsed / 1_000_000d,
+                    bytes.TimeToFirstByte?.TotalMilliseconds ?? 0,
                     serverSnapshot.TimeToPeakActiveMs,
                     GC.GetTotalAllocatedBytes(precise: false) - allocatedBefore,
                     GC.CollectionCount(0) - collectionCounts[0],
@@ -234,7 +257,9 @@ internal static class NntpWholePathReport
         CallbackCounts counts,
         InFlightArticleBudget budget,
         bool verifyHash,
-        bool httpLike)
+        bool httpLike,
+        int responseCopyChunkBytes,
+        long copyStartedTimestamp)
     {
         using var provider = CreateProvider(scenario, port);
         var ids = corpus.Articles.Select(article => article.SegmentId).ToArray();
@@ -261,17 +286,18 @@ internal static class NntpWholePathReport
             inFlightArticleBudget: budget,
             bodyPipelineBatchWidth: scenario.BatchWidth);
 
-        if (verifyHash)
-            return await CopyAndHashAsync(stream, CancellationToken.None).ConfigureAwait(false);
         if (httpLike)
         {
-            var sink = new HttpLikeCountingSink();
-            await sink.CopyFromAsync(stream, CancellationToken.None).ConfigureAwait(false);
-            return new ReadResult(sink.BytesWritten, null);
+            var sink = new HttpLikeCountingSink(responseCopyChunkBytes, copyStartedTimestamp);
+            var sha256 = await sink.CopyFromAsync(stream, verifyHash, CancellationToken.None)
+                .ConfigureAwait(false);
+            return new ReadResult(sink.BytesWritten, sha256, sink.TimeToFirstByte);
         }
+        if (verifyHash)
+            return await CopyAndHashAsync(stream, CancellationToken.None).ConfigureAwait(false);
 
         await stream.CopyToAsync(Stream.Null, CancellationToken.None).ConfigureAwait(false);
-        return new ReadResult(corpus.ExpectedBytes, null);
+        return new ReadResult(corpus.ExpectedBytes, null, null);
     }
 
 #pragma warning disable CA2000 // MultiProviderNntpClient owns and disposes its MultiConnectionNntpClient and pool.
@@ -329,7 +355,10 @@ internal static class NntpWholePathReport
             }
             await batch.Completion.ConfigureAwait(false);
         }
-        return new ReadResult(total, hash is null ? null : Convert.ToHexString(hash.GetHashAndReset()).ToLowerInvariant());
+        return new ReadResult(
+            total,
+            hash is null ? null : Convert.ToHexString(hash.GetHashAndReset()).ToLowerInvariant(),
+            null);
     }
 
     private static async Task<ReadResult> CopyAndHashAsync(Stream stream, CancellationToken cancellationToken)
@@ -345,7 +374,10 @@ internal static class NntpWholePathReport
             hash.AppendData(buffer, 0, read);
             total += read;
         }
-        return new ReadResult(total, Convert.ToHexString(hash.GetHashAndReset()).ToLowerInvariant());
+        return new ReadResult(
+            total,
+            Convert.ToHexString(hash.GetHashAndReset()).ToLowerInvariant(),
+            null);
     }
 
     private static async Task<int> DrainAsync(Stream stream, IncrementalHash? hash, CancellationToken cancellationToken)
@@ -368,6 +400,7 @@ internal static class NntpWholePathReport
         left.ServerCpuSeconds + right.ServerCpuSeconds,
         left.ClientCpuSecondsPerGb + right.ClientCpuSecondsPerGb,
         left.ThroughputMbps + right.ThroughputMbps,
+        left.FirstByteMs + right.FirstByteMs,
         left.TimeToPeakActiveMs + right.TimeToPeakActiveMs,
         left.ClientAllocatedBytes + right.ClientAllocatedBytes,
         left.Gen0Collections + right.Gen0Collections,
@@ -380,13 +413,14 @@ internal static class NntpWholePathReport
         value.ServerCpuSeconds / divisor,
         value.ClientCpuSecondsPerGb / divisor,
         value.ThroughputMbps / divisor,
+        value.FirstByteMs / divisor,
         value.TimeToPeakActiveMs / divisor,
         value.ClientAllocatedBytes / divisor,
         value.Gen0Collections / divisor,
         value.Gen1Collections / divisor,
         value.Gen2Collections / divisor);
 
-    private readonly record struct ReadResult(long Count, string? Sha256);
+    private readonly record struct ReadResult(long Count, string? Sha256, TimeSpan? TimeToFirstByte);
 
     private sealed class CallbackCounts
     {

--- a/backend.Benchmarks/NntpWholePathResult.cs
+++ b/backend.Benchmarks/NntpWholePathResult.cs
@@ -24,6 +24,7 @@ internal sealed record NntpWholePathTiming(
     double ServerCpuSeconds,
     double ClientCpuSecondsPerGb,
     double ThroughputMbps,
+    double FirstByteMs,
     double TimeToPeakActiveMs,
     long ClientAllocatedBytes,
     int Gen0Collections,

--- a/backend.Benchmarks/PerformanceReportCli.cs
+++ b/backend.Benchmarks/PerformanceReportCli.cs
@@ -11,11 +11,12 @@ internal static class PerformanceReportCli
         string? jsonPath = null;
         string scenarioSet = "quick";
         string? scenarioName = null;
+        int? repetitions = null;
         LoopbackServerArguments? serverArguments = null;
         for (var i = 0; i < args.Length;)
         {
             var arg = args[i];
-            if (arg is "--streaming-report" or "--sab-api-report" or "--nntp-whole-path-report")
+            if (arg is "--streaming-report" or "--sab-api-report" or "--nntp-whole-path-report" or "--http-copy-chunk-report")
             {
                 if (report is not null)
                     throw new ArgumentException("Multiple performance reports in one invocation.");
@@ -23,7 +24,8 @@ internal static class PerformanceReportCli
                 {
                     "--streaming-report" => "streaming",
                     "--sab-api-report" => "sab-api",
-                    _ => "nntp-whole-path",
+                    "--nntp-whole-path-report" => "nntp-whole-path",
+                    _ => "http-copy-chunk",
                 };
                 i++;
                 continue;
@@ -64,7 +66,17 @@ internal static class PerformanceReportCli
                 continue;
             }
 
-            if (report is not null || jsonPath is not null || scenarioName is not null || scenarioSet != "quick")
+            if (arg == "--repetitions")
+            {
+                if (i + 1 >= args.Length)
+                    throw new ArgumentException("--repetitions requires a positive integer.");
+                repetitions = ParsePositiveInt(args[i], args[i + 1]);
+                i += 2;
+                continue;
+            }
+
+            if (report is not null || jsonPath is not null || scenarioName is not null ||
+                repetitions is not null || scenarioSet != "quick")
                 throw new ArgumentException($"Unexpected argument '{arg}'.");
             return false;
         }
@@ -82,6 +94,8 @@ internal static class PerformanceReportCli
                     "--json requires --streaming-report, --sab-api-report, or --nntp-whole-path-report.");
             if (scenarioName is not null || scenarioSet != "quick")
                 throw new ArgumentException("--set and --scenario require --nntp-whole-path-report.");
+            if (repetitions is not null)
+                throw new ArgumentException("--repetitions requires --http-copy-chunk-report.");
             return false;
         }
 
@@ -93,11 +107,22 @@ internal static class PerformanceReportCli
 
         if (report == "nntp-whole-path")
         {
+            if (repetitions is not null)
+                throw new ArgumentException("--repetitions requires --http-copy-chunk-report.");
             await NntpWholePathReport.RunAsync(jsonPath, scenarioSet, scenarioName).ConfigureAwait(false);
             return true;
         }
 
-        if (scenarioName is not null || scenarioSet != "quick")
+        if (report == "http-copy-chunk")
+        {
+            if (scenarioSet != "quick")
+                throw new ArgumentException("--set is not used with --http-copy-chunk-report.");
+            await HttpResponseCopyChunkReport.RunAsync(jsonPath, scenarioName, repetitions ?? 5)
+                .ConfigureAwait(false);
+            return true;
+        }
+
+        if (scenarioName is not null || repetitions is not null || scenarioSet != "quick")
             throw new ArgumentException("--set and --scenario require --nntp-whole-path-report.");
         if (jsonPath is null)
             throw new ArgumentException("--sab-api-report requires --json <path>.");

--- a/backend.Benchmarks/README.md
+++ b/backend.Benchmarks/README.md
@@ -65,6 +65,23 @@ are deterministic gates.
 HTTP-like sink copy. It is small enough to profile under a 2-core, roughly 8 GB
 container without the client/server loopback corpora exhausting the cgroup.
 
+To compare HTTP response-copy chunks without changing production behavior, run:
+
+```bash
+dotnet run --project backend.Benchmarks -c Release -- \
+  --http-copy-chunk-report --repetitions 5 --json /tmp/http-copy-chunks.json
+```
+
+The experiment uses the 256 MiB profile scenario and rotates 64, 128, and
+256 KiB candidates across repetitions. It hash-verifies each candidate before
+timing, then records every sample plus median and median absolute deviation for
+wall time, throughput, client CPU, allocations, and time to first byte. On
+macOS, set `RAPIDYENC_LIBRARY_PATH` as described above.
+
+This is a localhost NNTP and HTTP-like sink measurement, not an authoritative
+WebDAV deployment result. Use it to select candidates for direct-backend testing
+on the target deployment; do not infer a universal throughput gain from it.
+
 `--set cold` compares demand-only and read-start-prewarmed scenarios using
 342 × 768 KiB articles (256.5 MiB), 20 connections, width 4,
 a 40-article window, 40 ms BODY-response delay, and a 6 MB/s per-connection

--- a/tests/NzbWebDAV.Tests/Benchmarks/HttpLikeCountingSinkTests.cs
+++ b/tests/NzbWebDAV.Tests/Benchmarks/HttpLikeCountingSinkTests.cs
@@ -1,0 +1,120 @@
+using System.Buffers;
+using System.Diagnostics;
+using System.Security.Cryptography;
+using NzbWebDAV.Benchmarks;
+
+namespace NzbWebDAV.Tests.Benchmarks;
+
+public sealed class HttpLikeCountingSinkTests
+{
+    [Theory]
+    [InlineData(64 * 1024)]
+    [InlineData(128 * 1024)]
+    [InlineData(256 * 1024)]
+    public async Task CopyFromAsync_UsesConfiguredChunkAndReturnsBuffer(int chunkBytes)
+    {
+        var payload = new byte[(chunkBytes * 2) + 17];
+        new Random(42).NextBytes(payload);
+        var pool = new TrackingArrayPool();
+        await using var source = new RecordingReadStream(payload);
+        var sink = new HttpLikeCountingSink(chunkBytes, Stopwatch.GetTimestamp(), pool);
+
+        var hash = await sink.CopyFromAsync(source, verifyHash: true, CancellationToken.None);
+
+        Assert.Equal(payload.Length, sink.BytesWritten);
+        Assert.Equal(chunkBytes, source.MaximumRequestedBytes);
+        Assert.NotNull(sink.TimeToFirstByte);
+        Assert.Equal(Convert.ToHexString(SHA256.HashData(payload)).ToLowerInvariant(), hash);
+        Assert.Equal(1, pool.RentCount);
+        Assert.Equal(1, pool.ReturnCount);
+    }
+
+    [Fact]
+    public async Task CopyFromAsync_ReadFailure_ReturnsBuffer()
+    {
+        var pool = new TrackingArrayPool();
+        await using var source = new ThrowingReadStream(new IOException("read failed"));
+        var sink = new HttpLikeCountingSink(64 * 1024, Stopwatch.GetTimestamp(), pool);
+
+        await Assert.ThrowsAsync<IOException>(() =>
+            sink.CopyFromAsync(source, verifyHash: false, CancellationToken.None));
+
+        Assert.Equal(1, pool.ReturnCount);
+    }
+
+    [Fact]
+    public async Task CopyFromAsync_Cancellation_ReturnsBuffer()
+    {
+        var pool = new TrackingArrayPool();
+        await using var source = new ThrowingReadStream(new OperationCanceledException());
+        var sink = new HttpLikeCountingSink(64 * 1024, Stopwatch.GetTimestamp(), pool);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            sink.CopyFromAsync(source, verifyHash: false, CancellationToken.None));
+
+        Assert.Equal(1, pool.ReturnCount);
+    }
+
+    [Fact]
+    public void Summarize_ComputesMedianAndMedianAbsoluteDeviation()
+    {
+        var summary = HttpResponseCopyChunkReport.Summarize([1, 2, 4, 8, 16]);
+
+        Assert.Equal(4, summary.Median);
+        Assert.Equal(3, summary.Mad);
+    }
+
+    private sealed class TrackingArrayPool : ArrayPool<byte>
+    {
+        public int RentCount { get; private set; }
+        public int ReturnCount { get; private set; }
+
+        public override byte[] Rent(int minimumLength)
+        {
+            RentCount++;
+            return new byte[minimumLength];
+        }
+
+        public override void Return(byte[] array, bool clearArray = false)
+        {
+            _ = array;
+            _ = clearArray;
+            ReturnCount++;
+        }
+    }
+
+    private sealed class RecordingReadStream(byte[] payload) : MemoryStream(payload)
+    {
+        public int MaximumRequestedBytes { get; private set; }
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            MaximumRequestedBytes = Math.Max(MaximumRequestedBytes, buffer.Length);
+            return base.ReadAsync(buffer, cancellationToken);
+        }
+    }
+
+    private sealed class ThrowingReadStream(Exception exception) : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => throw new NotSupportedException();
+        public override int Read(byte[] buffer, int offset, int count) => throw exception;
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default) => ValueTask.FromException<int>(exception);
+    }
+}

--- a/tests/NzbWebDAV.Tests/Benchmarks/NntpWholePathReportContractTests.cs
+++ b/tests/NzbWebDAV.Tests/Benchmarks/NntpWholePathReportContractTests.cs
@@ -172,4 +172,12 @@ public sealed class NntpWholePathReportContractTests
         await Assert.ThrowsAsync<ArgumentException>(() =>
             PerformanceReportCli.TryHandleAsync(["--set", "sustained", "--unexpected"]));
     }
+
+    [Fact]
+    public async Task Cli_RejectsCopyChunkRepetitionsForOtherReports()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            PerformanceReportCli.TryHandleAsync(
+                ["--nntp-whole-path-report", "--repetitions", "3"]));
+    }
 }

--- a/tests/NzbWebDAV.Tests/Utils/StreamingResponseWriteWatchdogTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/StreamingResponseWriteWatchdogTests.cs
@@ -7,6 +7,12 @@ namespace NzbWebDAV.Tests.Utils;
 public class StreamingResponseWriteWatchdogTests
 {
     [Fact]
+    public void CopyChunkBytes_RemainsSixtyFourKiB()
+    {
+        Assert.Equal(64 * 1024, StreamingResponseWriteWatchdog.CopyChunkBytes);
+    }
+
+    [Fact]
     public async Task ObserveWrite_TrickleUnderContention_SignalsReclaim()
     {
         var budget = new InFlightArticleBudget(1_000);


### PR DESCRIPTION
## Summary

- parameterize the HTTP-like whole-path sink for 64, 128, and 256 KiB response-copy chunks
- add raw per-repetition output plus median/MAD summaries for wall time, throughput, client CPU, allocations, and first-byte latency
- retain production response-copy and watchdog behavior at 64 KiB
- cover configured reads, SHA-256 correctness, first byte, pooled-buffer returns, statistics, CLI validation, and the 64 KiB production invariant

## Measurement

Five rotated repetitions of the 256 MiB `plain-http-like-w4` loopback profile on macOS 27.0 / .NET 10.0.11:

| Chunk | Throughput median (MAD) | vs 64 KiB | CPU s/GB median (MAD) | vs 64 KiB | First byte median (MAD) | vs 64 KiB |
|---|---:|---:|---:|---:|---:|---:|
| 64 KiB | 4803.57 MB/s (252.83) | baseline | 1.14098 (0.16577) | baseline | 9.601 ms (0.625) | baseline |
| 128 KiB | 5466.78 MB/s (220.34) | +13.81% | 1.13770 (0.12821) | -0.29% | 10.006 ms (1.429) | +4.22% |
| 256 KiB | 5034.98 MB/s (122.36) | +4.82% | 1.21172 (0.03732) | +6.20% | 9.241 ms (0.128) | -3.75% |

All correctness passes delivered 256 MiB with matching SHA-256 and released the article budget. The 128 KiB loopback median meets the numeric throughput/first-byte thresholds, but variance is material and no real deployment was available. Loopback is supporting evidence only, so this PR deliberately makes no product chunk-size change.

## Test plan

- `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~HttpLikeCountingSinkTests|FullyQualifiedName~NntpWholePathReportContractTests|FullyQualifiedName~StreamingResponseWriteWatchdogTests|FullyQualifiedName~GetAndHeadHandlerRangeTests|FullyQualifiedName~GetWebdavItemRequestRangeTests|FullyQualifiedName~SharedStreamHandlerTests"` (85 passed)
- `dotnet build NzbWebDAV.sln -c Release` (passed)
- changed-file `dotnet format --verify-no-changes` (passed)
- `--http-copy-chunk-report --repetitions 5` (15 timed samples plus per-size warm-up and SHA-256 correctness passes)

## Decision

Keep production at 64 KiB. A target deployment must repeat the 256 MiB direct-backend read before any product change is proposed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an HTTP response copy-chunk benchmark with configurable repetitions and chunk sizes.
  - Reports per-sample results, summary statistics, time to first byte, byte counts, and optional SHA-256 verification.
  - Added optional camelCase JSON output with benchmark metadata and measurements.

- **Bug Fixes**
  - Invalid buffer sizes and unsupported command-line option combinations are now rejected with clear errors.

- **Documentation**
  - Added usage guidance, configuration details, recorded metrics, platform setup, and measurement limitations for the new benchmark.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->