### PR TITLE
fix(webdav): prevent PostgreSQL listing failures without buffering directories

### DIFF
--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -9,7 +9,10 @@ using Serilog;
 
 namespace NzbWebDAV.Database;
 
-public sealed class DavDatabaseClient(DavDatabaseContext ctx, IBlobStore? blobStore = null)
+public sealed class DavDatabaseClient(
+    DavDatabaseContext ctx,
+    IBlobStore? blobStore = null,
+    IDbContextFactory<DavDatabaseContext>? dbContextFactory = null)
 {
     public DavDatabaseContext Ctx => ctx;
 
@@ -36,18 +39,10 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx, IBlobStore? blobSt
         return GetDirectoryChildrenQuery(dirId).ToListAsync(ct);
     }
 
-    public async IAsyncEnumerable<DavItem> GetDirectoryChildrenEnumerableAsync(
+    public IAsyncEnumerable<DavItem> GetDirectoryChildrenEnumerableAsync(
         Guid dirId,
-        [EnumeratorCancellation] CancellationToken ct = default)
-    {
-        await foreach (var child in GetDirectoryChildrenQuery(dirId)
-                           .AsAsyncEnumerable()
-                           .WithCancellation(ct)
-                           .ConfigureAwait(false))
-        {
-            yield return child;
-        }
-    }
+        CancellationToken ct = default) =>
+        StreamQueryAsync(streamingContext => GetDirectoryChildrenQuery(streamingContext, dirId), ct);
 
     public async Task<List<DavItem>> GetItemsByIdsBatchedAsync(
         IEnumerable<Guid> ids, int batchSize = 500, CancellationToken ct = default)
@@ -64,12 +59,41 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx, IBlobStore? blobSt
             .FirstOrDefaultAsync(x => x.ParentId == dirId && x.Name == childName, ct);
     }
 
-    private IQueryable<DavItem> GetDirectoryChildrenQuery(Guid dirId)
+    private IQueryable<DavItem> GetDirectoryChildrenQuery(Guid dirId) => GetDirectoryChildrenQuery(ctx, dirId);
+
+    private static IQueryable<DavItem> GetDirectoryChildrenQuery(DavDatabaseContext context, Guid dirId)
     {
-        return ctx.Items
+        return context.Items
             .AsNoTracking()
             .Where(x => x.ParentId == dirId)
             .OrderBy(x => x.Name);
+    }
+
+    private async IAsyncEnumerable<DavItem> StreamQueryAsync(
+        Func<DavDatabaseContext, IQueryable<DavItem>> queryFactory,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        // NWebDav may query the scoped context while consuming this stream, so keep the
+        // reader on a factory-owned context when one is available through production DI.
+        var streamingContext = dbContextFactory is null
+            ? ctx
+            : await dbContextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+
+        try
+        {
+            await foreach (var item in queryFactory(streamingContext)
+                               .AsAsyncEnumerable()
+                               .WithCancellation(ct)
+                               .ConfigureAwait(false))
+            {
+                yield return item;
+            }
+        }
+        finally
+        {
+            if (!ReferenceEquals(streamingContext, ctx))
+                await streamingContext.DisposeAsync().ConfigureAwait(false);
+        }
     }
 
     // Resolves a persisted item by its absolute virtual path in a single indexed lookup,
@@ -851,27 +875,25 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx, IBlobStore? blobSt
         return GetCompletedSymlinkCategoryChildrenQuery(category).ToListAsync(ct);
     }
 
-    public async IAsyncEnumerable<DavItem> GetCompletedSymlinkCategoryChildrenEnumerableAsync(
+    public IAsyncEnumerable<DavItem> GetCompletedSymlinkCategoryChildrenEnumerableAsync(
         string category,
-        [EnumeratorCancellation] CancellationToken ct = default)
-    {
-        await foreach (var child in GetCompletedSymlinkCategoryChildrenQuery(category)
-                           .AsAsyncEnumerable()
-                           .WithCancellation(ct)
-                           .ConfigureAwait(false))
-        {
-            yield return child;
-        }
-    }
+        CancellationToken ct = default) =>
+        StreamQueryAsync(streamingContext =>
+            GetCompletedSymlinkCategoryChildrenQuery(streamingContext, category), ct);
 
-    private IQueryable<DavItem> GetCompletedSymlinkCategoryChildrenQuery(string category)
+    private IQueryable<DavItem> GetCompletedSymlinkCategoryChildrenQuery(string category) =>
+        GetCompletedSymlinkCategoryChildrenQuery(ctx, category);
+
+    private static IQueryable<DavItem> GetCompletedSymlinkCategoryChildrenQuery(
+        DavDatabaseContext context,
+        string category)
     {
-        var query = from historyItem in Ctx.HistoryItems
+        var query = from historyItem in context.HistoryItems
             .AsNoTracking()
                     where historyItem.Category == category
                           && historyItem.DownloadStatus == HistoryItem.DownloadStatusOption.Completed
                           && historyItem.DownloadDirId != null
-                    join davItem in Ctx.Items.AsNoTracking() on historyItem.DownloadDirId equals davItem.Id
+                    join davItem in context.Items.AsNoTracking() on historyItem.DownloadDirId equals davItem.Id
                     where davItem.Type == DavItem.ItemType.Directory
                     select davItem;
         return query.Distinct().OrderBy(x => x.Name);

--- a/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
@@ -83,6 +83,36 @@ public sealed class DavDatabaseClientTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task GetDirectoryChildrenEnumerableAsync_DisposesStreamingContextWhenStoppedEarly()
+    {
+        var directory = DavItem.New(
+            Guid.NewGuid(), DavItem.Root, "shows", null,
+            DavItem.ItemType.Directory, DavItem.ItemSubType.Directory,
+            null, null, null, null);
+        _context.Items.AddRange(
+            directory,
+            DavItem.New(
+                Guid.NewGuid(), directory, "episode1.mkv", 100,
+                DavItem.ItemType.UsenetFile, DavItem.ItemSubType.NzbFile,
+                null, null, null, null),
+            DavItem.New(
+                Guid.NewGuid(), directory, "episode2.mkv", 100,
+                DavItem.ItemType.UsenetFile, DavItem.ItemSubType.NzbFile,
+                null, null, null, null));
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        await foreach (var child in _client.GetDirectoryChildrenEnumerableAsync(directory.Id))
+        {
+            Assert.Equal("episode1.mkv", child.Name);
+            Assert.False(_contextFactory.LastCreatedContext!.IsDisposed);
+            break;
+        }
+
+        Assert.True(_contextFactory.LastCreatedContext!.IsDisposed);
+    }
+
+    [Fact]
     public async Task GetDavMultipartFileAsync_BackfillsExpectedSizeForLegacyLazyMetadata()
     {
         var id = Guid.NewGuid();

--- a/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
@@ -1,4 +1,7 @@
+using System.Collections;
+using System.Data.Common;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Migrations;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Interceptors;
@@ -17,6 +20,7 @@ public sealed class DavDatabaseClientTests : IAsyncLifetime
 {
     private readonly string _databasePath =
         Path.Join(Path.GetTempPath(), $"nzbdav-tests-{Guid.NewGuid():N}.sqlite");
+    private readonly RowCountingDbCommandInterceptor _rowCounter = new();
     private DavDatabaseContext _context = null!;
     private TrackingDbContextFactory _contextFactory = null!;
     private DavDatabaseClient _client = null!;
@@ -25,7 +29,7 @@ public sealed class DavDatabaseClientTests : IAsyncLifetime
     {
         var options = new DbContextOptionsBuilder<DavDatabaseContext>()
             .UseSqlite($"Data Source={_databasePath}")
-            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .AddInterceptors(new SqliteForeignKeyEnabler(), _rowCounter)
             .ReplaceService<
                 IMigrationsSqlGenerator,
                 SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
@@ -83,7 +87,7 @@ public sealed class DavDatabaseClientTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task GetDirectoryChildrenEnumerableAsync_DisposesStreamingContextWhenStoppedEarly()
+    public async Task GetDirectoryChildrenEnumerableAsync_StreamsOneRowAndDisposesWhenStoppedEarly()
     {
         var directory = DavItem.New(
             Guid.NewGuid(), DavItem.Root, "shows", null,
@@ -102,14 +106,20 @@ public sealed class DavDatabaseClientTests : IAsyncLifetime
         await _context.SaveChangesAsync();
         _context.ChangeTracker.Clear();
 
-        await foreach (var child in _client.GetDirectoryChildrenEnumerableAsync(directory.Id))
+        _rowCounter.Reset();
+        await using (var enumerator = _client.GetDirectoryChildrenEnumerableAsync(directory.Id).GetAsyncEnumerator())
         {
-            Assert.Equal("episode1.mkv", child.Name);
+            Assert.True(await enumerator.MoveNextAsync());
+            Assert.Equal("episode1.mkv", enumerator.Current.Name);
+            Assert.Equal(1, _rowCounter.SuccessfulReads);
             Assert.False(_contextFactory.LastCreatedContext!.IsDisposed);
-            break;
         }
 
         Assert.True(_contextFactory.LastCreatedContext!.IsDisposed);
+
+        _rowCounter.Reset();
+        Assert.Equal(2, (await _client.GetDirectoryChildrenAsync(directory.Id)).Count);
+        Assert.Equal(2, _rowCounter.SuccessfulReads);
     }
 
     [Fact]
@@ -522,6 +532,98 @@ public sealed class DavDatabaseClientTests : IAsyncLifetime
         public override async ValueTask DisposeAsync()
         {
             IsDisposed = true;
+            await base.DisposeAsync();
+        }
+    }
+
+    private sealed class RowCountingDbCommandInterceptor : DbCommandInterceptor
+    {
+        private int _successfulReads;
+
+        public int SuccessfulReads => Volatile.Read(ref _successfulReads);
+
+        public void Reset() => Interlocked.Exchange(ref _successfulReads, 0);
+
+        public override DbDataReader ReaderExecuted(
+            DbCommand command,
+            CommandExecutedEventData eventData,
+            DbDataReader result) => new RowCountingDbDataReader(result, RecordRead);
+
+        public override ValueTask<DbDataReader> ReaderExecutedAsync(
+            DbCommand command,
+            CommandExecutedEventData eventData,
+            DbDataReader result,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult<DbDataReader>(new RowCountingDbDataReader(result, RecordRead));
+
+        private void RecordRead(bool hasRow)
+        {
+            if (hasRow) Interlocked.Increment(ref _successfulReads);
+        }
+    }
+
+    private sealed class RowCountingDbDataReader(DbDataReader inner, Action<bool> recordRead) : DbDataReader
+    {
+        public override object this[int ordinal] => inner[ordinal];
+        public override object this[string name] => inner[name];
+        public override int Depth => inner.Depth;
+        public override int FieldCount => inner.FieldCount;
+        public override bool HasRows => inner.HasRows;
+        public override bool IsClosed => inner.IsClosed;
+        public override int RecordsAffected => inner.RecordsAffected;
+
+        public override bool Read()
+        {
+            var hasRow = inner.Read();
+            recordRead(hasRow);
+            return hasRow;
+        }
+
+        public override async Task<bool> ReadAsync(CancellationToken cancellationToken)
+        {
+            var hasRow = await inner.ReadAsync(cancellationToken);
+            recordRead(hasRow);
+            return hasRow;
+        }
+
+        public override bool NextResult() => inner.NextResult();
+        public override Task<bool> NextResultAsync(CancellationToken cancellationToken) =>
+            inner.NextResultAsync(cancellationToken);
+        public override string GetName(int ordinal) => inner.GetName(ordinal);
+        public override string GetDataTypeName(int ordinal) => inner.GetDataTypeName(ordinal);
+        public override Type GetFieldType(int ordinal) => inner.GetFieldType(ordinal);
+        public override object GetValue(int ordinal) => inner.GetValue(ordinal);
+        public override int GetValues(object[] values) => inner.GetValues(values);
+        public override int GetOrdinal(string name) => inner.GetOrdinal(name);
+        public override bool GetBoolean(int ordinal) => inner.GetBoolean(ordinal);
+        public override byte GetByte(int ordinal) => inner.GetByte(ordinal);
+        public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length) =>
+            inner.GetBytes(ordinal, dataOffset, buffer, bufferOffset, length);
+        public override char GetChar(int ordinal) => inner.GetChar(ordinal);
+        public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length) =>
+            inner.GetChars(ordinal, dataOffset, buffer, bufferOffset, length);
+        public override Guid GetGuid(int ordinal) => inner.GetGuid(ordinal);
+        public override short GetInt16(int ordinal) => inner.GetInt16(ordinal);
+        public override int GetInt32(int ordinal) => inner.GetInt32(ordinal);
+        public override long GetInt64(int ordinal) => inner.GetInt64(ordinal);
+        public override float GetFloat(int ordinal) => inner.GetFloat(ordinal);
+        public override double GetDouble(int ordinal) => inner.GetDouble(ordinal);
+        public override string GetString(int ordinal) => inner.GetString(ordinal);
+        public override decimal GetDecimal(int ordinal) => inner.GetDecimal(ordinal);
+        public override DateTime GetDateTime(int ordinal) => inner.GetDateTime(ordinal);
+        public override bool IsDBNull(int ordinal) => inner.IsDBNull(ordinal);
+        public override IEnumerator GetEnumerator() => ((IEnumerable)inner).GetEnumerator();
+
+        public override void Close() => inner.Close();
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) inner.Dispose();
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await inner.DisposeAsync();
             await base.DisposeAsync();
         }
     }

--- a/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/DavDatabaseClientTests.cs
@@ -18,6 +18,7 @@ public sealed class DavDatabaseClientTests : IAsyncLifetime
     private readonly string _databasePath =
         Path.Join(Path.GetTempPath(), $"nzbdav-tests-{Guid.NewGuid():N}.sqlite");
     private DavDatabaseContext _context = null!;
+    private TrackingDbContextFactory _contextFactory = null!;
     private DavDatabaseClient _client = null!;
 
     public async Task InitializeAsync()
@@ -31,7 +32,8 @@ public sealed class DavDatabaseClientTests : IAsyncLifetime
             .Options;
         _context = new DavDatabaseContext(options);
         await _context.Database.MigrateAsync();
-        _client = new DavDatabaseClient(_context);
+        _contextFactory = new TrackingDbContextFactory(options);
+        _client = new DavDatabaseClient(_context, dbContextFactory: _contextFactory);
     }
 
     [Fact]
@@ -70,6 +72,8 @@ public sealed class DavDatabaseClientTests : IAsyncLifetime
         Assert.Equal(
             new[] { "first.mkv", "science-fiction" },
             streamedChildren.Select(item => item.Name));
+        Assert.NotSame(_context, _contextFactory.LastCreatedContext);
+        Assert.True(_contextFactory.LastCreatedContext!.IsDisposed);
 
         Assert.Equal(350, await _client.GetRecursiveSize(directory.Id));
         Assert.Equal(firstFile.Id, (await _client.GetFileById(firstFile.Id.ToString()))?.Id);
@@ -463,5 +467,32 @@ public sealed class DavDatabaseClientTests : IAsyncLifetime
     {
         await _context.DisposeAsync();
         File.Delete(_databasePath);
+    }
+
+    private sealed class TrackingDbContextFactory(DbContextOptions<DavDatabaseContext> options)
+        : IDbContextFactory<DavDatabaseContext>
+    {
+        public TrackingDavDatabaseContext? LastCreatedContext { get; private set; }
+
+        public DavDatabaseContext CreateDbContext()
+        {
+            LastCreatedContext = new TrackingDavDatabaseContext(options);
+            return LastCreatedContext;
+        }
+
+        public Task<DavDatabaseContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(CreateDbContext());
+    }
+
+    private sealed class TrackingDavDatabaseContext(DbContextOptions<DavDatabaseContext> options)
+        : DavDatabaseContext(options)
+    {
+        public bool IsDisposed { get; private set; }
+
+        public override async ValueTask DisposeAsync()
+        {
+            IsDisposed = true;
+            await base.DisposeAsync();
+        }
     }
 }

--- a/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/PostgresMigrationTests.cs
@@ -358,6 +358,85 @@ public sealed class PostgresMigrationTests
         }
     }
 
+    [SkippableFact]
+    public async Task StreamedDirectoryQueries_AllowInterleavedScopedContextQueries()
+    {
+        Skip.IfNot(
+            DatabaseProviderConfig.IsPostgres,
+            "PostgreSQL migration tests require DATABASE_PROVIDER=postgres.");
+
+        var schema = $"nzbdav_streaming_{Guid.NewGuid():N}";
+        var connectionString = DatabaseProviderConfig.PostgresConnectionString;
+        await using var adminConnection = new NpgsqlConnection(connectionString);
+        await adminConnection.OpenAsync();
+        await ExecuteAsync(adminConnection, $"CREATE SCHEMA \"{schema}\"");
+
+        try
+        {
+            var scopedConnectionString = new NpgsqlConnectionStringBuilder(connectionString)
+            {
+                SearchPath = schema
+            }.ConnectionString;
+            var options = new DbContextOptionsBuilder<PostgresDavDatabaseContext>()
+                .UseNpgsql(scopedConnectionString)
+                .Options;
+
+            await using var context = new PostgresDavDatabaseContext(options);
+            using var migrationTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await context.Database.MigrateAsync(migrationTimeout.Token);
+
+            var directory = DavItem.New(
+                Guid.NewGuid(), DavItem.Root, "shows", null,
+                DavItem.ItemType.Directory, DavItem.ItemSubType.Directory,
+                null, null, null, null);
+            var firstFile = DavItem.New(
+                Guid.NewGuid(), directory, "episode1.mkv", 100,
+                DavItem.ItemType.UsenetFile, DavItem.ItemSubType.NzbFile,
+                null, null, null, null);
+            var secondFile = DavItem.New(
+                Guid.NewGuid(), directory, "episode2.mkv", 100,
+                DavItem.ItemType.UsenetFile, DavItem.ItemSubType.NzbFile,
+                null, null, null, null);
+            context.Items.AddRange(directory, firstFile, secondFile);
+            context.HistoryItems.Add(new HistoryItem
+            {
+                Id = Guid.NewGuid(),
+                CreatedAt = DateTime.Now,
+                FileName = "shows.nzb",
+                JobName = "shows",
+                Category = "tv",
+                DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+                DownloadDirId = directory.Id,
+            });
+            await context.SaveChangesAsync();
+            context.ChangeTracker.Clear();
+
+            var contextFactory = new PostgresTestDbContextFactory(options);
+            var client = new DavDatabaseClient(context, dbContextFactory: contextFactory);
+
+            var children = new List<DavItem>();
+            await foreach (var child in client.GetDirectoryChildrenEnumerableAsync(directory.Id))
+            {
+                children.Add(child);
+                Assert.NotNull(await client.GetDirectoryChildAsync(directory.Id, child.Name));
+            }
+            Assert.Equal(2, children.Count);
+
+            var completedDirectories = new List<DavItem>();
+            await foreach (var child in client.GetCompletedSymlinkCategoryChildrenEnumerableAsync("tv"))
+            {
+                completedDirectories.Add(child);
+                Assert.NotNull(await client.GetDirectoryChildAsync(DavItem.Root.Id, child.Name));
+            }
+            Assert.Single(completedDirectories);
+            Assert.Equal(2, contextFactory.CreatedCount);
+        }
+        finally
+        {
+            await ExecuteAsync(adminConnection, $"DROP SCHEMA IF EXISTS \"{schema}\" CASCADE");
+        }
+    }
+
     private static DavItem CreateItem(string name, DateTime createdAt)
     {
         var id = Guid.NewGuid();
@@ -441,6 +520,21 @@ public sealed class PostgresMigrationTests
     {
         await using var command = new NpgsqlCommand(commandText, connection);
         await command.ExecuteNonQueryAsync();
+    }
+
+    private sealed class PostgresTestDbContextFactory(
+        DbContextOptions<PostgresDavDatabaseContext> options) : IDbContextFactory<DavDatabaseContext>
+    {
+        public int CreatedCount { get; private set; }
+
+        public DavDatabaseContext CreateDbContext()
+        {
+            CreatedCount++;
+            return new PostgresDavDatabaseContext(options);
+        }
+
+        public Task<DavDatabaseContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(CreateDbContext());
     }
 
     private sealed class SabControllerFixture : IAsyncDisposable


### PR DESCRIPTION
## Summary
- stream WebDAV directory listings from a factory-owned `DavDatabaseContext`
- keep nested NWebDav lookups on the request-scoped context, preventing active Npgsql reader collisions
- preserve lazy row delivery instead of buffering entire directories with `ToListAsync()`
- cover both regular and completed-symlink directory queries in the existing PostgreSQL CI test class

This addresses the failure reported in #1331 while retaining the streaming behavior introduced by `perf(webdav): stream and order directory listings from SQL` (`425b9ccf`). It is intended to supersede #1331's eager-materialization approach.

## Credit

Thanks to @job-bot-ai for identifying the production failure and proving the reader collision against real PostgreSQL in #1331. That diagnosis and reproduction directly informed this implementation; the author is credited as a co-author in commit `3ec2519f`.

## Test plan
- `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~DavDatabaseClientTests" -p:SkipRapidYencNativeEnsure=true` (16 passed)
- PostgreSQL 17: `DATABASE_PROVIDER=postgres DATABASE_CONNECTION_STRING=... dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~PostgresMigrationTests" -p:SkipRapidYencNativeEnsure=true` (7 passed)
- focused live-Npgsql regression (1 passed)
- editor diagnostics clean for all changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when browsing directories and completed items while other database operations are running.
  - Streaming results now avoid conflicts with concurrent lookups, helping pages and lists load more consistently.
  - Improved handling when users stop browsing before a directory or completed-items list finishes loading.
  - Verified reliable behavior across supported database scenarios, including PostgreSQL, during simultaneous streaming and lookup operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->