### PR TITLE
fix(ui): existing installs open Overview after upgrading

### DIFF
--- a/backend/Database/Migrations/20260904120000_Skip-Setup-Wizard-For-Existing-Installs.cs
+++ b/backend/Database/Migrations/20260904120000_Skip-Setup-Wizard-For-Existing-Installs.cs
@@ -1,0 +1,44 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.Migrations;
+
+/// <summary>
+/// Existing installations predate the setup wizard and should continue to open on
+/// Overview. Fresh databases have no account, provider, or library data while
+/// migrations run, so their setup state remains pending. Additive; back up /config
+/// before upgrading.
+/// </summary>
+[DbContext(typeof(DavDatabaseContext))]
+[Migration("20260904120000_Skip-Setup-Wizard-For-Existing-Installs")]
+public partial class SkipSetupWizardForExistingInstalls : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql("""
+            INSERT INTO "SetupWizardStates"
+                ("Id", "WizardVersion", "Disposition", "IngestionMethods", "UpdatedAt")
+            SELECT 1, 1, 2, '[]', unixepoch()
+            WHERE NOT EXISTS (
+                SELECT 1 FROM "SetupWizardStates" WHERE "Id" = 1
+            )
+            AND (
+                EXISTS (SELECT 1 FROM "Accounts")
+                OR EXISTS (
+                    SELECT 1 FROM "ConfigItems" WHERE "ConfigName" = 'usenet.providers'
+                )
+                -- Fresh databases contain five system roots plus /content/uncategorized.
+                OR (SELECT COUNT(*) FROM "DavItems") > 6
+                OR EXISTS (SELECT 1 FROM "QueueItems")
+                OR EXISTS (SELECT 1 FROM "HistoryItems")
+            );
+            """);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        // Keep the compatible skipped state so a downgrade does not force setup.
+    }
+}

--- a/backend/Database/PostgresMigrations/20260904120000_Skip-Setup-Wizard-For-Existing-Installs.cs
+++ b/backend/Database/PostgresMigrations/20260904120000_Skip-Setup-Wizard-For-Existing-Installs.cs
@@ -1,0 +1,44 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.PostgresMigrations;
+
+/// <summary>
+/// Existing installations predate the setup wizard and should continue to open on
+/// Overview. Fresh databases have no account, provider, or library data while
+/// migrations run, so their setup state remains pending. Additive; back up /config
+/// before upgrading.
+/// </summary>
+[DbContext(typeof(PostgresDavDatabaseContext))]
+[Migration("20260904120000_Skip-Setup-Wizard-For-Existing-Installs")]
+public partial class SkipSetupWizardForExistingInstalls : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql("""
+            INSERT INTO "SetupWizardStates"
+                ("Id", "WizardVersion", "Disposition", "IngestionMethods", "UpdatedAt")
+            SELECT 1, 1, 2, '[]', EXTRACT(EPOCH FROM NOW())::bigint
+            WHERE NOT EXISTS (
+                SELECT 1 FROM "SetupWizardStates" WHERE "Id" = 1
+            )
+            AND (
+                EXISTS (SELECT 1 FROM "Accounts")
+                OR EXISTS (
+                    SELECT 1 FROM "ConfigItems" WHERE "ConfigName" = 'usenet.providers'
+                )
+                -- Fresh databases contain five system roots plus /content/uncategorized.
+                OR (SELECT COUNT(*) FROM "DavItems") > 6
+                OR EXISTS (SELECT 1 FROM "QueueItems")
+                OR EXISTS (SELECT 1 FROM "HistoryItems")
+            );
+            """);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        // Keep the compatible skipped state so a downgrade does not force setup.
+    }
+}

--- a/docs/getting-started/first-run.md
+++ b/docs/getting-started/first-run.md
@@ -2,13 +2,14 @@
 
 Open `http://your-server:3000` after the container is healthy.
 
-After the first administrator login on a new or upgraded existing installation,
-InfiniDysk opens the guided **[Setup Guide](setup-guide.md)**
+After the first administrator login on a new installation, InfiniDysk opens the
+guided **[Setup Guide](setup-guide.md)**
 <span class="nzbdav-since">since 1.3.0</span>.
 It configures import strategy, the recommended cache layer, rclone or STRM paths,
 content ingestion, scheduled backups, and Library Directory. You may skip it and
 use the manual Settings sequence below; **Setup Guide** remains available in the
-main navigation.
+main navigation. Existing installations open on **Overview** after upgrading and
+can launch the guide there when wanted.
 
 !!! tip "Headless ConfigItems vs first-run account"
 

--- a/docs/getting-started/setup-guide.md
+++ b/docs/getting-started/setup-guide.md
@@ -5,8 +5,8 @@ description: "Use InfiniDysk's guided setup for Plex symlinks or Emby/Jellyfin S
 # Setup Guide <span class="nzbdav-since">since 1.3.0</span>
 
 InfiniDysk opens **Setup Guide** after the first administrator signs in on a new
-or upgraded installation. Complete it, or choose **Skip setup** to stop the
-automatic prompt. You can run it again at any time from the main navigation.
+installation. Existing installations continue to open on **Overview** after an
+upgrade. You can run the guide at any time from the main navigation.
 
 The guide is worth completing even on a long-running installation: it reviews
 best-practice configuration such as pairing Symlinks with rclone VFS read-ahead

--- a/tests/NzbWebDAV.Tests/Database/SkipSetupWizardForExistingInstallsMigrationTests.cs
+++ b/tests/NzbWebDAV.Tests/Database/SkipSetupWizardForExistingInstallsMigrationTests.cs
@@ -1,0 +1,153 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Tests.Database;
+
+public sealed class SkipSetupWizardForExistingInstallsMigrationTests
+{
+    private const string PriorMigration =
+        "20260903120000_Pin-Segment-Cache-For-Existing-Installs";
+
+    [Fact]
+    public async Task ExistingInstallWithAccount_IsSkipped()
+    {
+        await using var harness = await MigrationHarness.CreateAsync();
+        var context = harness.Context;
+
+        context.Accounts.Add(new Account
+        {
+            Type = Account.AccountType.Admin,
+            Username = "admin",
+            PasswordHash = "hash",
+            RandomSalt = "salt",
+        });
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+
+        await context.Database.MigrateAsync();
+        context.ChangeTracker.Clear();
+
+        var state = await context.SetupWizardStates.AsNoTracking().SingleAsync();
+        Assert.Equal(1, state.WizardVersion);
+        Assert.Equal(SetupWizardDisposition.Skipped, state.Disposition);
+    }
+
+    [Fact]
+    public async Task ExistingAuthDisabledInstallWithProvider_IsSkipped()
+    {
+        await using var harness = await MigrationHarness.CreateAsync();
+        var context = harness.Context;
+
+        context.ConfigItems.Add(new ConfigItem
+        {
+            ConfigName = ConfigKeys.UsenetProviders,
+            ConfigValue = "{\"Providers\":[]}",
+        });
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+
+        await context.Database.MigrateAsync();
+        context.ChangeTracker.Clear();
+
+        Assert.Equal(
+            SetupWizardDisposition.Skipped,
+            (await context.SetupWizardStates.AsNoTracking().SingleAsync()).Disposition);
+    }
+
+    [Fact]
+    public async Task ExistingWizardState_IsNotOverwritten()
+    {
+        await using var harness = await MigrationHarness.CreateAsync();
+        var context = harness.Context;
+
+        context.Accounts.Add(new Account
+        {
+            Type = Account.AccountType.Admin,
+            Username = "admin",
+            PasswordHash = "hash",
+            RandomSalt = "salt",
+        });
+        context.SetupWizardStates.Add(new SetupWizardState
+        {
+            WizardVersion = 1,
+            Disposition = SetupWizardDisposition.Completed,
+            IngestionMethods = "[\"manual\"]",
+            UpdatedAt = DateTimeOffset.FromUnixTimeSeconds(1),
+        });
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+
+        await context.Database.MigrateAsync();
+        context.ChangeTracker.Clear();
+
+        var state = await context.SetupWizardStates.AsNoTracking().SingleAsync();
+        Assert.Equal(SetupWizardDisposition.Completed, state.Disposition);
+        Assert.Equal("[\"manual\"]", state.IngestionMethods);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1), state.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task FreshInstall_RemainsPending()
+    {
+        await using var harness = await MigrationHarness.CreateAsync();
+        var context = harness.Context;
+
+        var accountCount = await context.Accounts.CountAsync();
+        var providerCount = await context.ConfigItems.CountAsync(
+            item => item.ConfigName == ConfigKeys.UsenetProviders);
+        var davItemCount = await context.Items.CountAsync();
+        var queueCount = await context.QueueItems.CountAsync();
+        var historyCount = await context.HistoryItems.CountAsync();
+        Assert.False(
+            accountCount > 0 || providerCount > 0 || davItemCount > 6 ||
+            queueCount > 0 || historyCount > 0,
+            $"accounts={accountCount}, providers={providerCount}, dav={davItemCount}, " +
+            $"queue={queueCount}, history={historyCount}");
+
+        await context.Database.MigrateAsync();
+        context.ChangeTracker.Clear();
+
+        Assert.Empty(await context.SetupWizardStates.AsNoTracking().ToListAsync());
+    }
+
+    private sealed class MigrationHarness : IAsyncDisposable
+    {
+        private readonly string _databasePath;
+
+        private MigrationHarness(string databasePath, DavDatabaseContext context)
+        {
+            _databasePath = databasePath;
+            Context = context;
+        }
+
+        public DavDatabaseContext Context { get; }
+
+        public static async Task<MigrationHarness> CreateAsync()
+        {
+            var databasePath = Path.Join(
+                Path.GetTempPath(),
+                $"nzbdav-setup-skip-mig-{Guid.NewGuid():N}.sqlite");
+            var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite($"Data Source={databasePath}")
+                .AddInterceptors(new SqliteForeignKeyEnabler())
+                .ReplaceService<
+                    IMigrationsSqlGenerator,
+                    SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+                .Options;
+            var context = new DavDatabaseContext(options);
+            await context.Database.MigrateAsync(PriorMigration);
+            return new MigrationHarness(databasePath, context);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.DisposeAsync();
+            File.Delete(_databasePath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- mark the current setup guide as skipped when migration evidence identifies an existing installation
- keep fresh installations pending so onboarding still opens the setup guide
- preserve existing completed or skipped setup state and keep the guide available from navigation
- update first-run and setup-guide documentation

## Test plan

- `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~SkipSetupWizardForExistingInstallsMigrationTests`
- `dotnet format NzbWebDAV.sln --verify-no-changes --include backend/Database/Migrations/20260904120000_Skip-Setup-Wizard-For-Existing-Installs.cs backend/Database/PostgresMigrations/20260904120000_Skip-Setup-Wizard-For-Existing-Installs.cs tests/NzbWebDAV.Tests/Database/SkipSetupWizardForExistingInstallsMigrationTests.cs`
- `zensical build --clean --strict`

## Upgrade note

This includes an additive database migration. Back up `/config` before upgrading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Existing installations with setup-related data now skip the Setup Guide after upgrading.
  - New installations continue to open the Setup Guide after the first administrator sign-in.
  - Upgraded installations open on the Overview page and can launch the guide from there.

- **Documentation**
  - Updated first-run and setup-guide guidance to reflect the revised behavior.

- **Tests**
  - Added coverage for existing installations, fresh installations, and preserved setup-guide state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->