### PR TITLE
fix(webdav): stop healthy playback triggering stalled-stream warnings

### DIFF
--- a/backend/Middlewares/WebDavObservabilityMiddleware.cs
+++ b/backend/Middlewares/WebDavObservabilityMiddleware.cs
@@ -14,12 +14,12 @@ namespace NzbWebDAV.Middlewares;
 /// For GETs the decisive clock runs to the first response byte (path resolution, first
 /// NNTP fetch, decode): a ranged stream's total duration is paced by the client and says
 /// nothing about the server. Metadata methods (PROPFIND, HEAD, ...) keep total-duration
-/// semantics because their responses are small. A GET with a fast first byte whose total
-/// duration exceeds the stall threshold is counted separately as a stalled stream. Slow
+/// semantics because their responses are small. A GET with a fast first byte is stalled
+/// only when no body write is attempted for the stall threshold. Slow
 /// warnings are throttled per category so a busy host cannot flood the warnings ring
 /// that support packs rely on.
 ///
-/// Known limitation: first-byte timing wraps Response.Body and does not observe
+/// Known limitation: response timing wraps Response.Body and does not observe
 /// IHttpResponseBodyFeature sendfile paths; the WebDAV GET path streams via Response.Body.
 /// </summary>
 public class WebDavObservabilityMiddleware(RequestDelegate next)
@@ -71,7 +71,7 @@ public class WebDavObservabilityMiddleware(RequestDelegate next)
 
         var originalBody = context.Response.Body;
 #pragma warning disable CA2000 // wrapper ownership transfers to the response for the duration of next(); it owns no resources and never disposes the wrapped body
-        var recordingStream = isGet ? new FirstByteRecordingStream(originalBody, stopwatch) : null;
+        var recordingStream = isGet ? new ResponseTimingStream(originalBody, stopwatch) : null;
 #pragma warning restore CA2000
         if (recordingStream is not null)
             context.Response.Body = recordingStream;
@@ -90,13 +90,15 @@ public class WebDavObservabilityMiddleware(RequestDelegate next)
             var elapsedMs = stopwatch.ElapsedMilliseconds;
             var path = context.Request.Path.Value ?? context.Request.Path.ToUriComponent();
             var firstByteMs = recordingStream?.FirstByteElapsedMilliseconds;
+            var maxIdleMs = recordingStream?.GetMaxIdleElapsedMilliseconds(elapsedMs);
+            var aborted = context.RequestAborted.IsCancellationRequested;
 
             Increment("total");
 
             var failed = status >= 500;
             if (failed) Increment("failed");
 
-            if (context.RequestAborted.IsCancellationRequested)
+            if (aborted)
             {
                 Increment("aborted");
                 // recordingStream exists exactly for GETs; a null first-byte mark
@@ -112,7 +114,7 @@ public class WebDavObservabilityMiddleware(RequestDelegate next)
                     method, path, status, elapsedMs);
             }
 
-            switch (ClassifySlow(method, firstByteMs, elapsedMs))
+            switch (ClassifySlow(method, firstByteMs, maxIdleMs, elapsedMs, aborted))
             {
                 case SlowKind.FirstByte:
                     Increment("slowFirstByte");
@@ -140,8 +142,8 @@ public class WebDavObservabilityMiddleware(RequestDelegate next)
                     if (!failed && StallThrottle.TryEmit(out var stallSuppressed))
                         Log.Warning(
                             "Stalled WebDAV stream. Method={Method} Path={Path} Status={Status} " +
-                            "FirstByteMs={FirstByteMs} DurationMs={DurationMs} Suppressed={Suppressed}",
-                            method, path, status, firstByteMs ?? 0, elapsedMs, stallSuppressed);
+                            "FirstByteMs={FirstByteMs} IdleMs={IdleMs} DurationMs={DurationMs} Suppressed={Suppressed}",
+                            method, path, status, firstByteMs ?? 0, maxIdleMs ?? 0, elapsedMs, stallSuppressed);
                     break;
 
                 case SlowKind.LongStream:
@@ -152,7 +154,8 @@ public class WebDavObservabilityMiddleware(RequestDelegate next)
     }
 
     // Pure classification so the timing tiers are testable without clock-dependent tests.
-    internal static SlowKind ClassifySlow(string method, long? firstByteMs, long elapsedMs)
+    internal static SlowKind ClassifySlow(
+        string method, long? firstByteMs, long? maxIdleMs, long elapsedMs, bool aborted = false)
     {
         var slowMs = (SlowThresholdOverride ?? SlowThreshold).TotalMilliseconds;
         var stallMs = (StallThresholdOverride ?? StallThreshold).TotalMilliseconds;
@@ -166,9 +169,7 @@ public class WebDavObservabilityMiddleware(RequestDelegate next)
         if (firstByte >= slowMs)
             return SlowKind.FirstByte;
 
-        // Stalled means strictly over the threshold; a stream ending exactly at
-        // the boundary is still a healthy long stream.
-        if (elapsedMs > stallMs)
+        if (!aborted && maxIdleMs > stallMs)
             return SlowKind.Stalled;
 
         return elapsedMs >= slowMs ? SlowKind.LongStream : SlowKind.None;
@@ -248,9 +249,12 @@ public class WebDavObservabilityMiddleware(RequestDelegate next)
     /// <summary>
     /// Records the elapsed time of the first body write; pass-through otherwise.
     /// </summary>
-    private sealed class FirstByteRecordingStream(Stream inner, Stopwatch stopwatch) : Stream
+    private sealed class ResponseTimingStream(Stream inner, Stopwatch stopwatch) : Stream
     {
+        private readonly object _timingLock = new();
         private long _firstByteMs;
+        private long _lastWriteCompletedMs;
+        private long _maxIdleMs;
         private int _firstByteRecorded;
 
         public long? FirstByteElapsedMilliseconds
@@ -263,38 +267,68 @@ public class WebDavObservabilityMiddleware(RequestDelegate next)
             }
         }
 
-        private void RecordFirstByte(int count)
+        public long? GetMaxIdleElapsedMilliseconds(long completedMs)
         {
-            // Zero-length writes carry no body byte; recording them would mark a
-            // first byte that never went out and misclassify the request.
+            lock (_timingLock)
+            {
+                if (_firstByteRecorded == 0)
+                    return null;
+
+                return Math.Max(_maxIdleMs, completedMs - _lastWriteCompletedMs);
+            }
+        }
+
+        private void RecordWriteStarted(int count)
+        {
             if (count <= 0) return;
-            if (Volatile.Read(ref _firstByteRecorded) != 0) return;
-            // Value before the flag so a reader that observes the flag also
-            // observes the timestamp (release/acquire pairing).
-            Interlocked.Exchange(ref _firstByteMs, stopwatch.ElapsedMilliseconds);
-            Volatile.Write(ref _firstByteRecorded, 1);
+
+            lock (_timingLock)
+            {
+                if (_firstByteRecorded == 0) return;
+                _maxIdleMs = Math.Max(_maxIdleMs, stopwatch.ElapsedMilliseconds - _lastWriteCompletedMs);
+            }
+        }
+
+        private void RecordWriteCompleted(int count)
+        {
+            if (count <= 0) return;
+
+            lock (_timingLock)
+            {
+                var completedMs = stopwatch.ElapsedMilliseconds;
+                if (_firstByteRecorded == 0)
+                {
+                    _firstByteMs = completedMs;
+                    Volatile.Write(ref _firstByteRecorded, 1);
+                }
+
+                _lastWriteCompletedMs = completedMs;
+            }
         }
 
         // Record only after the inner write succeeds: a failed write (client
         // disconnect, timeout) never put a byte on the wire.
         public override void Write(byte[] buffer, int offset, int count)
         {
+            RecordWriteStarted(count);
             inner.Write(buffer, offset, count);
-            RecordFirstByte(count);
+            RecordWriteCompleted(count);
         }
 
         public override async Task WriteAsync(
             byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
+            RecordWriteStarted(count);
             await inner.WriteAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
-            RecordFirstByte(count);
+            RecordWriteCompleted(count);
         }
 
         public override async ValueTask WriteAsync(
             ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
+            RecordWriteStarted(buffer.Length);
             await inner.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
-            RecordFirstByte(buffer.Length);
+            RecordWriteCompleted(buffer.Length);
         }
 
         public override void Flush() => inner.Flush();

--- a/backend/Middlewares/WebDavObservabilityMiddleware.cs
+++ b/backend/Middlewares/WebDavObservabilityMiddleware.cs
@@ -253,8 +253,9 @@ public class WebDavObservabilityMiddleware(RequestDelegate next)
     {
         private readonly object _timingLock = new();
         private long _firstByteMs;
-        private long _lastWriteCompletedMs;
+        private long _idleStartedMs;
         private long _maxIdleMs;
+        private int _activeWrites;
         private int _firstByteRecorded;
 
         public long? FirstByteElapsedMilliseconds
@@ -274,7 +275,9 @@ public class WebDavObservabilityMiddleware(RequestDelegate next)
                 if (_firstByteRecorded == 0)
                     return null;
 
-                return Math.Max(_maxIdleMs, completedMs - _lastWriteCompletedMs);
+                return _activeWrites == 0
+                    ? Math.Max(_maxIdleMs, completedMs - _idleStartedMs)
+                    : _maxIdleMs;
             }
         }
 
@@ -284,51 +287,78 @@ public class WebDavObservabilityMiddleware(RequestDelegate next)
 
             lock (_timingLock)
             {
-                if (_firstByteRecorded == 0) return;
-                _maxIdleMs = Math.Max(_maxIdleMs, stopwatch.ElapsedMilliseconds - _lastWriteCompletedMs);
+                var startedMs = stopwatch.ElapsedMilliseconds;
+                if (_firstByteRecorded != 0 && _activeWrites == 0)
+                    _maxIdleMs = Math.Max(_maxIdleMs, startedMs - _idleStartedMs);
+
+                _activeWrites++;
             }
         }
 
-        private void RecordWriteCompleted(int count)
+        private void RecordWriteFinished(int count, bool succeeded)
         {
             if (count <= 0) return;
 
             lock (_timingLock)
             {
-                var completedMs = stopwatch.ElapsedMilliseconds;
-                if (_firstByteRecorded == 0)
+                var finishedMs = stopwatch.ElapsedMilliseconds;
+                if (succeeded && _firstByteRecorded == 0)
                 {
-                    _firstByteMs = completedMs;
+                    _firstByteMs = finishedMs;
                     Volatile.Write(ref _firstByteRecorded, 1);
                 }
 
-                _lastWriteCompletedMs = completedMs;
+                _activeWrites--;
+                if (_activeWrites == 0)
+                    _idleStartedMs = finishedMs;
             }
         }
 
-        // Record only after the inner write succeeds: a failed write (client
-        // disconnect, timeout) never put a byte on the wire.
         public override void Write(byte[] buffer, int offset, int count)
         {
             RecordWriteStarted(count);
-            inner.Write(buffer, offset, count);
-            RecordWriteCompleted(count);
+            var succeeded = false;
+            try
+            {
+                inner.Write(buffer, offset, count);
+                succeeded = true;
+            }
+            finally
+            {
+                RecordWriteFinished(count, succeeded);
+            }
         }
 
         public override async Task WriteAsync(
             byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             RecordWriteStarted(count);
-            await inner.WriteAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
-            RecordWriteCompleted(count);
+            var succeeded = false;
+            try
+            {
+                await inner.WriteAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
+                succeeded = true;
+            }
+            finally
+            {
+                RecordWriteFinished(count, succeeded);
+            }
         }
 
         public override async ValueTask WriteAsync(
             ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
             RecordWriteStarted(buffer.Length);
-            await inner.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
-            RecordWriteCompleted(buffer.Length);
+            var succeeded = false;
+            try
+            {
+                await inner.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+                succeeded = true;
+            }
+            finally
+            {
+                RecordWriteFinished(buffer.Length, succeeded);
+            }
         }
 
         public override void Flush() => inner.Flush();

--- a/backend/Services/SupportPack/SupportPackService.cs
+++ b/backend/Services/SupportPack/SupportPackService.cs
@@ -279,8 +279,8 @@ public sealed class SupportPackService(
         startup: total, failed (5xx), aborted (client closed early, normal on seeks),
         slowFirstByte (GETs whose first byte took over five seconds - genuine
         server-side latency), slowMetadata (PROPFIND/HEAD over five seconds),
-        stalledStreams (streams still open after a minute), and longStreams (healthy
-        client-paced reads that simply outlived five seconds - not a server problem).
+        stalledStreams (streams with no body write attempted for over a minute), and
+        longStreams (healthy client-paced reads that simply outlived five seconds).
         slow is the sum of the three attention-worthy kinds.
         abortedBeforeFirstByte is the subset of aborted GETs that produced no body
         byte - those point at server-side latency, unlike an ordinary seek abort.

--- a/tests/NzbWebDAV.Tests/Middlewares/WebDavObservabilityMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/WebDavObservabilityMiddlewareTests.cs
@@ -322,6 +322,29 @@ public class WebDavObservabilityMiddlewareTests : IDisposable
     }
 
     [Fact]
+    public async Task Get_WhenWriteBlocksThenThrows_DoesNotCountWriteTimeAsIdle()
+    {
+        WebDavObservabilityMiddleware.SlowThresholdOverride = TimeSpan.FromHours(1);
+        WebDavObservabilityMiddleware.StallThresholdOverride = TimeSpan.FromMilliseconds(100);
+        var context = new DefaultHttpContext();
+        context.Request.Method = "GET";
+        context.Request.Path = "/content/tv/show.mkv";
+        context.Response.Body = new DelayedSecondWriteFailureStream();
+        var middleware = new WebDavObservabilityMiddleware(async ctx =>
+        {
+            await ctx.Response.Body.WriteAsync(new byte[] { 1 });
+            await ctx.Response.Body.WriteAsync(new byte[] { 2 });
+        });
+
+        await Assert.ThrowsAsync<IOException>(() => middleware.InvokeAsync(context));
+
+        var counters = WebDavObservabilityMiddleware.Snapshot();
+        Assert.False(context.RequestAborted.IsCancellationRequested);
+        Assert.False(counters.ContainsKey("stalledStreams"));
+        Assert.False(counters.ContainsKey("slow"));
+    }
+
+    [Fact]
     public async Task SlowWarnings_AreThrottledPerCategory()
     {
         WebDavObservabilityMiddleware.SlowThresholdOverride = TimeSpan.Zero;
@@ -384,6 +407,39 @@ public class WebDavObservabilityMiddlewareTests : IDisposable
         public override ValueTask WriteAsync(
             ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) =>
             throw new IOException("simulated client disconnect");
+
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+    }
+
+    private sealed class DelayedSecondWriteFailureStream : Stream
+    {
+        private int _writeCount;
+
+        public override bool CanWrite => true;
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+
+        public override async ValueTask WriteAsync(
+            ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (Interlocked.Increment(ref _writeCount) == 1)
+                return;
+
+            await Task.Delay(200, cancellationToken);
+            throw new IOException("simulated delayed write failure");
+        }
 
         public override void Flush() { }
         public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();

--- a/tests/NzbWebDAV.Tests/Middlewares/WebDavObservabilityMiddlewareTests.cs
+++ b/tests/NzbWebDAV.Tests/Middlewares/WebDavObservabilityMiddlewareTests.cs
@@ -188,17 +188,19 @@ public class WebDavObservabilityMiddlewareTests : IDisposable
     }
 
     [Fact]
-    public async Task Get_WithFirstByte_PastStallThreshold_CountsStalledStream()
+    public async Task Get_WithIdleGap_PastStallThreshold_CountsStalledStream()
     {
         WebDavObservabilityMiddleware.SlowThresholdOverride = TimeSpan.FromHours(1);
-        // Stalled means strictly over the threshold; a negative override keeps the
-        // test deterministic instead of racing a zero-millisecond request.
-        WebDavObservabilityMiddleware.StallThresholdOverride = TimeSpan.FromMilliseconds(-1);
+        WebDavObservabilityMiddleware.StallThresholdOverride = TimeSpan.FromMilliseconds(1);
         var context = new DefaultHttpContext();
         context.Request.Method = "GET";
         context.Request.Path = "/content/tv/show.mkv";
         var middleware = new WebDavObservabilityMiddleware(async ctx =>
-            await ctx.Response.Body.WriteAsync(new byte[] { 1 }));
+        {
+            await ctx.Response.Body.WriteAsync(new byte[] { 1 });
+            await Task.Delay(20);
+            await ctx.Response.Body.WriteAsync(new byte[] { 1 });
+        });
 
         await middleware.InvokeAsync(context);
 
@@ -263,6 +265,8 @@ public class WebDavObservabilityMiddlewareTests : IDisposable
     [Fact]
     public async Task AbortedGet_AfterFirstByte_IsNotAbortedBeforeFirstByte()
     {
+        WebDavObservabilityMiddleware.SlowThresholdOverride = TimeSpan.FromHours(1);
+        WebDavObservabilityMiddleware.StallThresholdOverride = TimeSpan.FromMilliseconds(-1);
         var context = new DefaultHttpContext();
         context.Request.Method = "GET";
         context.Request.Path = "/content/tv/show.mkv";
@@ -275,6 +279,7 @@ public class WebDavObservabilityMiddlewareTests : IDisposable
         var counters = WebDavObservabilityMiddleware.Snapshot();
         Assert.Equal(1, counters["aborted"]);
         Assert.False(counters.ContainsKey("abortedBeforeFirstByte"));
+        Assert.False(counters.ContainsKey("stalledStreams"));
     }
 
     [Fact]
@@ -386,26 +391,31 @@ public class WebDavObservabilityMiddlewareTests : IDisposable
         public override void SetLength(long value) => throw new NotSupportedException();
     }
 
-    // firstByteOrMinusOne stands in for long? because InlineData cannot convert int
+    // Sentinel values stand in for long? because InlineData cannot convert int
     // constants to Nullable<long> through reflection.
     [Theory]
-    [InlineData("PROPFIND", -1, 6_000, WebDavObservabilityMiddleware.SlowKind.Metadata)]
-    [InlineData("PROPFIND", -1, 100, WebDavObservabilityMiddleware.SlowKind.None)]
-    [InlineData("HEAD", -1, 6_000, WebDavObservabilityMiddleware.SlowKind.Metadata)]
-    [InlineData("DELETE", -1, 6_000, WebDavObservabilityMiddleware.SlowKind.None)]
-    [InlineData("GET", -1, 6_000, WebDavObservabilityMiddleware.SlowKind.FirstByte)]
-    [InlineData("GET", -1, 100, WebDavObservabilityMiddleware.SlowKind.None)]
-    [InlineData("GET", 6_000, 7_000, WebDavObservabilityMiddleware.SlowKind.FirstByte)]
-    [InlineData("GET", 10, 10_000, WebDavObservabilityMiddleware.SlowKind.LongStream)]
-    [InlineData("GET", 10, 60_000, WebDavObservabilityMiddleware.SlowKind.LongStream)]
-    [InlineData("GET", 10, 61_000, WebDavObservabilityMiddleware.SlowKind.Stalled)]
-    [InlineData("GET", 10, 100, WebDavObservabilityMiddleware.SlowKind.None)]
+    [InlineData("PROPFIND", -1, -1, 6_000, WebDavObservabilityMiddleware.SlowKind.Metadata)]
+    [InlineData("PROPFIND", -1, -1, 100, WebDavObservabilityMiddleware.SlowKind.None)]
+    [InlineData("HEAD", -1, -1, 6_000, WebDavObservabilityMiddleware.SlowKind.Metadata)]
+    [InlineData("DELETE", -1, -1, 6_000, WebDavObservabilityMiddleware.SlowKind.None)]
+    [InlineData("GET", -1, -1, 6_000, WebDavObservabilityMiddleware.SlowKind.FirstByte)]
+    [InlineData("GET", -1, -1, 100, WebDavObservabilityMiddleware.SlowKind.None)]
+    [InlineData("GET", 6_000, 10, 7_000, WebDavObservabilityMiddleware.SlowKind.FirstByte)]
+    [InlineData("GET", 10, 100, 10_000, WebDavObservabilityMiddleware.SlowKind.LongStream)]
+    [InlineData("GET", 10, 100, 600_000, WebDavObservabilityMiddleware.SlowKind.LongStream)]
+    [InlineData("GET", 10, 60_000, 600_000, WebDavObservabilityMiddleware.SlowKind.LongStream)]
+    [InlineData("GET", 10, 60_001, 61_000, WebDavObservabilityMiddleware.SlowKind.Stalled)]
+    [InlineData("GET", 10, 10, 100, WebDavObservabilityMiddleware.SlowKind.None)]
     public void ClassifySlow_AttributesByWhereTimeWent(
-        string method, long firstByteOrMinusOne, long elapsedMs, WebDavObservabilityMiddleware.SlowKind expected)
+        string method, long firstByteOrMinusOne, long maxIdleOrMinusOne, long elapsedMs,
+        WebDavObservabilityMiddleware.SlowKind expected)
     {
         long? firstByteMs = firstByteOrMinusOne >= 0 ? firstByteOrMinusOne : null;
+        long? maxIdleMs = maxIdleOrMinusOne >= 0 ? maxIdleOrMinusOne : null;
 
-        Assert.Equal(expected, WebDavObservabilityMiddleware.ClassifySlow(method, firstByteMs, elapsedMs));
+        Assert.Equal(
+            expected,
+            WebDavObservabilityMiddleware.ClassifySlow(method, firstByteMs, maxIdleMs, elapsedMs));
     }
 
     [Fact]
@@ -413,7 +423,8 @@ public class WebDavObservabilityMiddlewareTests : IDisposable
     {
         // Regression: a healthy stream that outlives the slow threshold and ends by
         // client close must not be attributed as server latency.
-        var kind = WebDavObservabilityMiddleware.ClassifySlow("GET", firstByteMs: 10, elapsedMs: 10_000);
+        var kind = WebDavObservabilityMiddleware.ClassifySlow(
+            "GET", firstByteMs: 10, maxIdleMs: 9_000, elapsedMs: 70_000, aborted: true);
 
         Assert.Equal(WebDavObservabilityMiddleware.SlowKind.LongStream, kind);
     }


### PR DESCRIPTION
## Summary
- classify stalled WebDAV GETs from response-body write inactivity rather than total request duration
- keep healthy long-running, client-paced streams in the `longStreams` counter
- exclude client-aborted GETs from stall warnings and include measured `IdleMs` in genuine warnings
- update support-pack guidance for the corrected metric

## Test plan
- `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter 'FullyQualifiedName~WebDavObservabilityMiddlewareTests' --logger 'console;verbosity=minimal'` (37 passed)

## Setup wizard impact
- None; no configuration options changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Monitoring**
  - Improved WebDAV request monitoring by measuring time to first response data and idle gaps between body writes.
  - Slow or stalled streams are classified more accurately, including clearer reporting of idle durations.
  - Aborted requests are excluded from stalled-stream classification when appropriate.

- **Documentation**
  - Updated support-pack documentation to clarify that stalled streams have no attempted body write for more than one minute.

- **Testing**
  - Expanded coverage for delayed, stalled, long-running, aborted, and metadata requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->