### PR TITLE
fix(health): recover libraries downloaded before 1.3.0

### DIFF
--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -2404,7 +2404,8 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
         Guid? downloadId,
         CancellationToken ct,
         Func<ArrClient, IReadOnlyList<string>, bool>? shouldRequestSearch = null,
-        ArrInstanceBackoff? arrBackoff = null)
+        ArrInstanceBackoff? arrBackoff = null,
+        Guid? legacyDownloadId = null)
     {
         var anInstanceFailed = false;
         var sawConfiguredClient = false;
@@ -2526,12 +2527,22 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 else if (resolution.Kind == ArrDownloadIdResolutionKind.Ambiguous)
                 {
                     sawAmbiguousIdentity = true;
-                    continue;
+                    if (legacyDownloadId is null)
+                        continue;
+                    // Pre-provenance items retained the SAB nzo_id locally. Arr still has to
+                    // confirm grabbed history for it inside RemoveAndBlocklist before mutation.
+                    effectiveId = legacyDownloadId;
                 }
                 else
                 {
-                    sawMissingIdentity = true;
-                    continue;
+                    if (legacyDownloadId is null)
+                    {
+                        sawMissingIdentity = true;
+                        continue;
+                    }
+                    // This is only a candidate, not recovered provenance. Do not persist it as
+                    // ArrDownloadId unless exact import history independently proves the value.
+                    effectiveId = legacyDownloadId;
                 }
             }
 
@@ -2918,7 +2929,8 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                         .ToArray(),
                     arrConfig.EffectiveQueueReplacementSearchLimit(),
                     arrConfig.EffectiveQueueReplacementSearchWindow()),
-                _arrBackoff).ConfigureAwait(false);
+                _arrBackoff,
+                legacyDownloadId: davItem.NzbBlobId ?? davItem.HistoryItemId).ConfigureAwait(false);
 
             if (davItem.ArrDownloadId is null && arrResult.RecoveredDownloadId is { } recovered)
             {

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -2571,7 +2571,9 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 continue;
             }
 
-            var persistedRecovery = recoveredConflict ? null : recoveredDownloadId;
+            var persistedRecovery = recoveredConflict || sawAmbiguousIdentity
+                ? null
+                : recoveredDownloadId;
             if (repairOutcome == ArrRepairOutcome.RemoveAndBlocklistSucceeded)
             {
                 return new ArrLinkedRepairResult(

--- a/docs/configuration/repairs.md
+++ b/docs/configuration/repairs.md
@@ -76,6 +76,12 @@ that option to force-delete linked items at the threshold. With the default valu
 unlinked files are kept and surfaced as **Action needed**; set a value greater than `0` to
 auto-remove them after repeated failures.
 
+For linked files downloaded before Arr provenance tracking was available, InfiniDysk first tries
+to recover the original download from exact Arr import history, then falls back to the retained SAB
+`nzo_id`. Arr must still confirm grabbed history for that ID before InfiniDysk removes the media,
+marks the download failed, or requests a replacement. If that history has expired, the file remains
+untouched and is surfaced as **Action needed** instead of risking the wrong release.
+
 Successful full-file playback and a successful background health check reset the in-memory failure
 count. The count resets when InfiniDysk restarts, so it is intentionally not a durable replacement for
 health checks.

--- a/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
@@ -405,6 +405,7 @@ public class ArrLinkedRepairDecisionTests
     {
         var observed = new List<Guid>();
         var arrDownloadId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var legacyDownloadId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
         var clients = new ArrClient[]
         {
             new ScriptedArrClient(
@@ -421,7 +422,11 @@ public class ArrLinkedRepairDecisionTests
         };
 
         var result = await HealthCheckService.DecideArrLinkedRepairAsync(
-            clients, LibraryPath, arrDownloadId, CancellationToken.None);
+            clients,
+            LibraryPath,
+            arrDownloadId,
+            CancellationToken.None,
+            legacyDownloadId: legacyDownloadId);
 
         Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded, result.Decision);
         Assert.Equal([arrDownloadId], observed);
@@ -429,9 +434,8 @@ public class ArrLinkedRepairDecisionTests
     }
 
     [Fact]
-    public async Task NullProvenance_NeverFallsBackToLocalIds()
+    public async Task NullProvenance_WithoutLegacyIdentityDefers()
     {
-        var nzbBlobId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
         var clients = new ArrClient[]
         {
             new ScriptedArrClient(
@@ -449,13 +453,44 @@ public class ArrLinkedRepairDecisionTests
 
         Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferMissingDownloadIdentity, result.Decision);
         Assert.Null(result.RecoveredDownloadId);
-        _ = nzbBlobId;
+    }
+
+    [Fact]
+    public async Task MissingProvenance_UsesVerifiedLegacyDownloadId()
+    {
+        var legacyDownloadId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, downloadId) =>
+                {
+                    Assert.Equal(legacyDownloadId, downloadId);
+                    return Task.FromResult(ArrRepairOutcome.RemoveAndBlocklistSucceeded);
+                },
+                importHistory: (_, _, _) => Task.FromResult(new ArrHistory())),
+        };
+
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients,
+            LibraryPath,
+            null,
+            CancellationToken.None,
+            legacyDownloadId: legacyDownloadId);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded, result.Decision);
+        Assert.Null(result.RecoveredDownloadId);
     }
 
     [Fact]
     public async Task UniqueExactLegacyRecovery_IsUsedAndReturned()
     {
         var recovered = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        var legacyDownloadId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
         var clients = new ArrClient[]
         {
             new ScriptedArrClient(
@@ -489,11 +524,136 @@ public class ArrLinkedRepairDecisionTests
         };
 
         var result = await HealthCheckService.DecideArrLinkedRepairAsync(
-            clients, LibraryPath, null, CancellationToken.None);
+            clients,
+            LibraryPath,
+            null,
+            CancellationToken.None,
+            legacyDownloadId: legacyDownloadId);
 
         Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded, result.Decision);
         Assert.Equal(recovered, result.RecoveredDownloadId);
         Assert.Equal("http://radarr.test", result.RecoveryHost);
+    }
+
+    [Fact]
+    public async Task AmbiguousProvenance_UsesVerifiedLegacyDownloadId()
+    {
+        var first = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var second = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var legacyDownloadId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, downloadId) =>
+                {
+                    Assert.Equal(legacyDownloadId, downloadId);
+                    return Task.FromResult(ArrRepairOutcome.RemoveAndBlocklistSucceeded);
+                },
+                importHistory: (_, _, _) => Task.FromResult(new ArrHistory
+                {
+                    TotalRecords = 2,
+                    Records =
+                    [
+                        new ArrHistoryRecord
+                        {
+                            DownloadId = first.ToString(),
+                            EventType = 3,
+                            Data = new ArrHistoryData { FileId = "1", ImportedPath = LibraryPath },
+                        },
+                        new ArrHistoryRecord
+                        {
+                            DownloadId = second.ToString(),
+                            EventType = 3,
+                            Data = new ArrHistoryData { FileId = "1", ImportedPath = LibraryPath },
+                        },
+                    ],
+                })),
+        };
+
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients,
+            LibraryPath,
+            null,
+            CancellationToken.None,
+            legacyDownloadId: legacyDownloadId);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded, result.Decision);
+        Assert.Null(result.RecoveredDownloadId);
+    }
+
+    [Fact]
+    public async Task MissingProvenance_UnrecognizedLegacyIdDefersAsMissingHistory()
+    {
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, _) => Task.FromResult(ArrRepairOutcome.DownloadHistoryNotFound),
+                importHistory: (_, _, _) => Task.FromResult(new ArrHistory())),
+        };
+
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients,
+            LibraryPath,
+            null,
+            CancellationToken.None,
+            legacyDownloadId: Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"));
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferMissingDownloadHistory, result.Decision);
+    }
+
+    [Fact]
+    public async Task AmbiguousProvenance_UnrecognizedLegacyIdRemainsAmbiguous()
+    {
+        var first = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var second = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, _) => Task.FromResult(ArrRepairOutcome.DownloadHistoryNotFound),
+                importHistory: (_, _, _) => Task.FromResult(new ArrHistory
+                {
+                    TotalRecords = 2,
+                    Records =
+                    [
+                        new ArrHistoryRecord
+                        {
+                            DownloadId = first.ToString(),
+                            EventType = 3,
+                            Data = new ArrHistoryData { FileId = "1", ImportedPath = LibraryPath },
+                        },
+                        new ArrHistoryRecord
+                        {
+                            DownloadId = second.ToString(),
+                            EventType = 3,
+                            Data = new ArrHistoryData { FileId = "1", ImportedPath = LibraryPath },
+                        },
+                    ],
+                })),
+        };
+
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients,
+            LibraryPath,
+            null,
+            CancellationToken.None,
+            legacyDownloadId: Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"));
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferAmbiguousDownloadIdentity, result.Decision);
     }
 
     [Fact]
@@ -691,6 +851,35 @@ public class ArrLinkedRepairDecisionTests
 
         var result = await HealthCheckService.DecideArrLinkedRepairAsync(
             clients, LibraryPath, DownloadId, CancellationToken.None);
+
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, result.Decision);
+    }
+
+    [Fact]
+    public async Task UnreachableOwnerPlusLegacyHistoryMiss_ReturnsDeferUnreachable()
+    {
+        var clients = new ArrClient[]
+        {
+            new ScriptedArrClient(
+                host: "http://unreachable",
+                rootFolders: () => throw new HttpRequestException("down"),
+                removeAndBlocklist: (_, _) => throw new InvalidOperationException("should not be called")),
+            new ScriptedArrClient(
+                host: "http://radarr",
+                rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+                {
+                    new() { Path = "/media/movies" },
+                }),
+                removeAndBlocklist: (_, _) => Task.FromResult(ArrRepairOutcome.DownloadHistoryNotFound),
+                importHistory: (_, _, _) => Task.FromResult(new ArrHistory())),
+        };
+
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
+            clients,
+            LibraryPath,
+            null,
+            CancellationToken.None,
+            legacyDownloadId: Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"));
 
         Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferUnreachable, result.Decision);
     }

--- a/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
@@ -699,10 +699,11 @@ public class ArrLinkedRepairDecisionTests
     }
 
     [Fact]
-    public async Task UniqueRecoveryThenAmbiguousInstance_DoesNotReturnRecoveredId()
+    public async Task UniqueRecoveryThenAmbiguousLegacySuccess_DoesNotReturnRecoveredId()
     {
         var recovered = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
         var other = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+        var legacyDownloadId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
         var clients = new ArrClient[]
         {
             new ScriptedArrClient(
@@ -735,7 +736,11 @@ public class ArrLinkedRepairDecisionTests
                 {
                     new() { Path = "/media/movies" },
                 }),
-                removeAndBlocklist: (_, _) => throw new InvalidOperationException("must not mutate"),
+                removeAndBlocklist: (_, id) =>
+                {
+                    Assert.Equal(legacyDownloadId, id);
+                    return Task.FromResult(ArrRepairOutcome.RemoveAndBlocklistSucceeded);
+                },
                 importHistory: (_, _, _) => Task.FromResult(new ArrHistory
                 {
                     TotalRecords = 2,
@@ -758,9 +763,13 @@ public class ArrLinkedRepairDecisionTests
         };
 
         var result = await HealthCheckService.DecideArrLinkedRepairAsync(
-            clients, LibraryPath, null, CancellationToken.None);
+            clients,
+            LibraryPath,
+            null,
+            CancellationToken.None,
+            legacyDownloadId: legacyDownloadId);
 
-        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.DeferAmbiguousDownloadIdentity, result.Decision);
+        Assert.Equal(HealthCheckService.ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded, result.Decision);
         Assert.Null(result.RecoveredDownloadId);
     }
 


### PR DESCRIPTION
## Summary
- restore linked health repair for pre-1.3.0 downloads when modern Arr provenance is unavailable
- fall back to the retained SAB job ID only after exact import-history recovery fails or is ambiguous
- require Arr to confirm grabbed history before deleting media, blocklisting the release, or requesting a replacement

## Test plan
- `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~ArrLinkedRepairDecisionTests` (39 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repair handling for files with missing or ambiguous Arr download history.
  * Older download identifiers can now be verified before removal, blocklisting, failure marking, or replacement.
  * Files remain untouched and are flagged for **Action needed** when their download history cannot be confirmed.
  * Ambiguous cases without a verifiable legacy identifier remain deferred.

* **Documentation**
  * Added guidance for repairing linked files downloaded before provenance tracking was available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->