### PR TITLE
feat(ui): activity chart separates client playback reads from app-triggered reads

### DIFF
--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsController.cs
@@ -82,7 +82,7 @@ public class GetOverviewStatsController(
         var indexerApiUsage = new List<GetOverviewStatsResponse.IndexerApiUsageRow>();
         var lifetime = new GetOverviewStatsResponse.LifetimeBlock();
         var records = new GetOverviewStatsResponse.RecordsBlock();
-        long totalArticles = 0, totalMisses = 0, totalErrors = 0, totalBytesFetched = 0;
+        long totalArticles = 0, totalClientArticles = 0, totalMisses = 0, totalErrors = 0, totalBytesFetched = 0;
 
         Task<WindowSectionResult>? windowTask = null;
         Task<DetailSectionResult>? detailTask = null;
@@ -118,6 +118,7 @@ public class GetOverviewStatsController(
             heatmap = w.Heatmap;
             failover = w.Failover;
             totalArticles = w.TotalArticles;
+            totalClientArticles = w.TotalClientArticles;
             totalMisses = w.TotalMisses;
             totalErrors = w.TotalErrors;
             totalBytesFetched = w.TotalBytesFetched;
@@ -155,6 +156,7 @@ public class GetOverviewStatsController(
             Throughput = throughput,
             ThroughputBucketSizeMs = throughputBucketSizeMs,
             TotalArticles = totalArticles,
+            TotalClientArticles = totalClientArticles,
             TotalMisses = totalMisses,
             TotalErrors = totalErrors,
             TotalBytesFetched = totalBytesFetched,
@@ -186,6 +188,7 @@ public class GetOverviewStatsController(
         GetOverviewStatsResponse.HeatmapBlock Heatmap,
         GetOverviewStatsResponse.FailoverBlock Failover,
         long TotalArticles,
+        long TotalClientArticles,
         long TotalMisses,
         long TotalErrors,
         long TotalBytesFetched,
@@ -268,14 +271,14 @@ public class GetOverviewStatsController(
         List<(string From, SegmentFetch.FetchStatus Reason, long Count)> misses;
         List<GetOverviewStatsResponse.ThroughputPoint> throughput;
         List<GetOverviewStatsResponse.ProviderRow> providers;
-        long totalArticles, totalMisses, totalErrors, totalBytesFetched;
+        long totalArticles, totalClientArticles, totalMisses, totalErrors, totalBytesFetched;
         List<ProviderLifetimeTotal> lifetimeTotals = [];
 
         if (useRollups)
         {
             var hoursTask = metricsA.ProviderHourly
                 .Where(h => h.Hour >= windowStart)
-                .Select(h => new { h.Hour, h.Provider, h.Articles, h.BytesFetched, h.Misses, h.Errors, h.Retries, h.FailoverSaves, h.SumDurationMs })
+                .Select(h => new { h.Hour, h.Provider, h.Articles, h.ClientArticles, h.BytesFetched, h.Misses, h.Errors, h.Retries, h.FailoverSaves, h.SumDurationMs })
                 .ToListAsync();
             var failoverEdgesTask = metricsB.FailoverHourly
                 .Where(f => f.Hour >= windowStart)
@@ -301,7 +304,7 @@ public class GetOverviewStatsController(
                 : [];
 
             throughput = BuildThroughputFromHourly(
-                hours.Select(h => (h.Hour, h.Articles, h.Misses, h.Errors, h.BytesFetched)),
+                hours.Select(h => (h.Hour, h.Articles, h.ClientArticles, h.Misses, h.Errors, h.BytesFetched)),
                 sessions.Select(s => (s.EndedAt, s.BytesServed)),
                 bucketSize);
             providers = BuildProvidersFromHourly(
@@ -313,12 +316,14 @@ public class GetOverviewStatsController(
                 window,
                 window == GetOverviewStatsRequest.OverviewWindow.AllTime ? lifetimeTotals : null);
             totalArticles = hours.Sum(h => h.Articles);
+            totalClientArticles = hours.Sum(h => h.ClientArticles);
             totalMisses = hours.Sum(h => h.Misses);
             totalErrors = hours.Sum(h => h.Errors);
             totalBytesFetched = hours.Sum(h => h.BytesFetched);
             if (window == GetOverviewStatsRequest.OverviewWindow.AllTime)
             {
                 totalArticles += lifetimeTotals.Sum(x => x.Articles);
+                totalClientArticles += lifetimeTotals.Sum(x => x.ClientArticles);
                 totalMisses += lifetimeTotals.Sum(x => x.Misses);
                 totalErrors += lifetimeTotals.Sum(x => x.Errors);
                 totalBytesFetched += lifetimeTotals.Sum(x => x.BytesFetched);
@@ -339,6 +344,7 @@ public class GetOverviewStatsController(
                     p.Minute,
                     p.Provider,
                     p.Articles,
+                    p.ClientArticles,
                     p.BytesFetched,
                     p.Misses,
                     p.Errors,
@@ -349,7 +355,7 @@ public class GetOverviewStatsController(
                 .ToListAsync();
             var throughputMinutesTask = metricsB.ThroughputMinutes
                 .Where(t => t.Minute >= windowStart)
-                .Select(t => new { t.Minute, t.Articles, t.Misses, t.Errors, t.BytesServed, t.BytesFetched })
+                .Select(t => new { t.Minute, t.Articles, t.ClientArticles, t.Misses, t.Errors, t.BytesServed, t.BytesFetched })
                 .ToListAsync();
             var failoverMissesTask = metricsC.FailoverMisses
                 .Where(f => f.At >= windowStart)
@@ -366,12 +372,13 @@ public class GetOverviewStatsController(
             var failoverMisses = await failoverMissesTask.ConfigureAwait(false);
 
             throughput = BuildThroughputFromMinutes(
-                throughputMinutes.Select(t => (t.Minute, t.Articles, t.Misses, t.Errors, t.BytesServed, t.BytesFetched)),
+                throughputMinutes.Select(t => (t.Minute, t.Articles, t.ClientArticles, t.Misses, t.Errors, t.BytesServed, t.BytesFetched)),
                 bucketSize);
             providers = BuildProvidersFromMinutes(
                 minutes.Select(m => (m.Minute, m.Provider, m.Articles, m.BytesFetched, m.Misses, m.Errors, m.Retries, m.SumDurationMs)),
                 windowStart, window, labelsByMetricsKey, nowMs);
             totalArticles = minutes.Sum(m => m.Articles);
+            totalClientArticles = minutes.Sum(m => m.ClientArticles);
             totalMisses = minutes.Sum(m => m.Misses);
             totalErrors = minutes.Sum(m => m.Errors);
             totalBytesFetched = minutes.Sum(m => m.BytesFetched);
@@ -429,7 +436,7 @@ public class GetOverviewStatsController(
                             && lifetimeTotals.Count > 0);
         return new WindowSectionResult(
             tiles, throughput, bucketSize, providers, sessionsBlock, heatmap, failover,
-            totalArticles, totalMisses, totalErrors, totalBytesFetched,
+            totalArticles, totalClientArticles, totalMisses, totalErrors, totalBytesFetched,
             series.BucketSize, series.Start, series.End, truncated);
     }
 
@@ -771,16 +778,17 @@ public class GetOverviewStatsController(
     }
 
     internal static List<GetOverviewStatsResponse.ThroughputPoint> BuildThroughputFromMinutes(
-        IEnumerable<(long Minute, long Articles, long Misses, long Errors, long BytesServed, long BytesFetched)> minutes,
+        IEnumerable<(long Minute, long Articles, long ClientArticles, long Misses, long Errors, long BytesServed, long BytesFetched)> minutes,
         long bucketSize)
     {
-        var byBucket = new Dictionary<long, (long Articles, long Misses, long Errors, long BytesServed, long BytesFetched)>();
+        var byBucket = new Dictionary<long, (long Articles, long ClientArticles, long Misses, long Errors, long BytesServed, long BytesFetched)>();
         foreach (var m in minutes)
         {
             var b = m.Minute - (m.Minute % bucketSize);
             byBucket.TryGetValue(b, out var cur);
             byBucket[b] = (
                 cur.Articles + m.Articles,
+                cur.ClientArticles + m.ClientArticles,
                 cur.Misses + m.Misses,
                 cur.Errors + m.Errors,
                 cur.BytesServed + m.BytesServed,
@@ -793,6 +801,7 @@ public class GetOverviewStatsController(
             {
                 Bucket = kv.Key,
                 Articles = kv.Value.Articles,
+                ClientArticles = kv.Value.ClientArticles,
                 Misses = kv.Value.Misses,
                 Errors = kv.Value.Errors,
                 BytesServed = kv.Value.BytesServed,
@@ -802,17 +811,18 @@ public class GetOverviewStatsController(
     }
 
     internal static List<GetOverviewStatsResponse.ThroughputPoint> BuildThroughputFromHourly(
-        IEnumerable<(long Hour, long Articles, long Misses, long Errors, long BytesFetched)> hours,
+        IEnumerable<(long Hour, long Articles, long ClientArticles, long Misses, long Errors, long BytesFetched)> hours,
         IEnumerable<(long EndedAt, long BytesServed)> sessions,
         long bucketSize)
     {
-        var byBucket = new Dictionary<long, (long Articles, long Misses, long Errors, long BytesServed, long BytesFetched)>();
+        var byBucket = new Dictionary<long, (long Articles, long ClientArticles, long Misses, long Errors, long BytesServed, long BytesFetched)>();
         foreach (var h in hours)
         {
             var b = h.Hour - (h.Hour % bucketSize);
             byBucket.TryGetValue(b, out var cur);
             byBucket[b] = (
                 cur.Articles + h.Articles,
+                cur.ClientArticles + h.ClientArticles,
                 cur.Misses + h.Misses,
                 cur.Errors + h.Errors,
                 cur.BytesServed,
@@ -822,7 +832,7 @@ public class GetOverviewStatsController(
         {
             var b = endedAt - (endedAt % bucketSize);
             byBucket.TryGetValue(b, out var cur);
-            byBucket[b] = (cur.Articles, cur.Misses, cur.Errors, cur.BytesServed + bytes, cur.BytesFetched);
+            byBucket[b] = (cur.Articles, cur.ClientArticles, cur.Misses, cur.Errors, cur.BytesServed + bytes, cur.BytesFetched);
         }
 
         return byBucket
@@ -831,6 +841,7 @@ public class GetOverviewStatsController(
             {
                 Bucket = kv.Key,
                 Articles = kv.Value.Articles,
+                ClientArticles = kv.Value.ClientArticles,
                 Misses = kv.Value.Misses,
                 Errors = kv.Value.Errors,
                 BytesServed = kv.Value.BytesServed,

--- a/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsResponse.cs
+++ b/backend/Api/Controllers/GetOverviewStats/GetOverviewStatsResponse.cs
@@ -12,6 +12,7 @@ public class GetOverviewStatsResponse
     /// <summary>Chart bucket width in ms for normalizing throughput totals into rates.</summary>
     public long ThroughputBucketSizeMs { get; init; }
     public long TotalArticles { get; init; }
+    public long TotalClientArticles { get; init; }
     public long TotalMisses { get; init; }
     public long TotalErrors { get; init; }
     public long TotalBytesFetched { get; init; }
@@ -62,6 +63,7 @@ public class GetOverviewStatsResponse
     {
         public long Bucket { get; init; }
         public long Articles { get; init; }
+        public long ClientArticles { get; init; }
         public long Misses { get; init; }
         public long Errors { get; init; }
         public long BytesServed { get; init; }

--- a/backend/Clients/Usenet/Contexts/DownloadWorkloadClassifier.cs
+++ b/backend/Clients/Usenet/Contexts/DownloadWorkloadClassifier.cs
@@ -1,4 +1,5 @@
 using NzbWebDAV.Clients.Usenet.Concurrency;
+using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Services.Metrics;
 
@@ -15,5 +16,17 @@ internal static class DownloadWorkloadClassifier
         if (cancellationToken.GetContext<DownloadPriorityContext>()?.Priority == SemaphorePriority.High)
             return DownloadWorkload.Streaming;
         return DownloadWorkload.Background;
+    }
+
+    internal static SegmentFetch.FetchWorkload ClassifyForMetrics(CancellationToken cancellationToken)
+    {
+        return Classify(cancellationToken) switch
+        {
+            DownloadWorkload.Streaming => SegmentFetch.FetchWorkload.Streaming,
+            DownloadWorkload.Queue => SegmentFetch.FetchWorkload.Queue,
+            DownloadWorkload.Maintenance => SegmentFetch.FetchWorkload.Maintenance,
+            DownloadWorkload.Background => SegmentFetch.FetchWorkload.Background,
+            _ => SegmentFetch.FetchWorkload.Unknown,
+        };
     }
 }

--- a/backend/Clients/Usenet/Contexts/DownloadWorkloadClassifier.cs
+++ b/backend/Clients/Usenet/Contexts/DownloadWorkloadClassifier.cs
@@ -20,13 +20,15 @@ internal static class DownloadWorkloadClassifier
 
     internal static SegmentFetch.FetchWorkload ClassifyForMetrics(CancellationToken cancellationToken)
     {
+        if (MultiProviderNntpClient.CurrentReadSessionId is not null)
+            return SegmentFetch.FetchWorkload.Streaming;
+
         return Classify(cancellationToken) switch
         {
-            DownloadWorkload.Streaming => SegmentFetch.FetchWorkload.Streaming,
             DownloadWorkload.Queue => SegmentFetch.FetchWorkload.Queue,
             DownloadWorkload.Maintenance => SegmentFetch.FetchWorkload.Maintenance,
             DownloadWorkload.Background => SegmentFetch.FetchWorkload.Background,
-            _ => SegmentFetch.FetchWorkload.Unknown,
+            _ => SegmentFetch.FetchWorkload.Background,
         };
     }
 }

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -561,6 +561,7 @@ public class MultiProviderNntpClient(
         BatchCallbackCoordinator coordinator,
         CancellationToken cancellationToken)
     {
+        var fetchWorkload = DownloadWorkloadClassifier.ClassifyForMetrics(cancellationToken);
         var admissionSignaled = false;
         void SignalAdmission()
         {
@@ -598,7 +599,7 @@ public class MultiProviderNntpClient(
                 walk.NoteException(e);
                 var reason = ClassifyAndRecordFailure(
                     primaryProvider.MetricsKey, e, primaryStopwatch.ElapsedMilliseconds, 0,
-                    primaryTraceRange, NntpOperation.PipelinedBody, segmentId);
+                    fetchWorkload, primaryTraceRange, NntpOperation.PipelinedBody, segmentId);
                 (priorMisses ??= []).Add((primaryProvider.MetricsKey, reason));
                 lastException = ExceptionDispatchInfo.Capture(e);
             }
@@ -608,7 +609,7 @@ public class MultiProviderNntpClient(
                 primaryStopwatch.Stop();
                 _usageTracker.RecordSuccess(primaryProvider.MetricsKey);
                 RecordFetch(primaryProvider.MetricsKey, SegmentFetch.FetchStatus.Ok,
-                    primaryStopwatch.ElapsedMilliseconds, 0, primaryTraceRange);
+                    primaryStopwatch.ElapsedMilliseconds, 0, fetchWorkload, primaryTraceRange);
                 return WrapProviderResponse(response, primaryProvider.MetricsKey);
             }
 
@@ -620,7 +621,7 @@ public class MultiProviderNntpClient(
                 walk.CurrentDefinitiveMisses++;
                 primaryStopwatch.Stop();
                 RecordFetch(primaryProvider.MetricsKey, SegmentFetch.FetchStatus.Missing,
-                    primaryStopwatch.ElapsedMilliseconds, 0, primaryTraceRange);
+                    primaryStopwatch.ElapsedMilliseconds, 0, fetchWorkload, primaryTraceRange);
                 (priorMisses ??= []).Add((primaryProvider.MetricsKey, SegmentFetch.FetchStatus.Missing));
             }
             else if (response != null)
@@ -721,7 +722,7 @@ public class MultiProviderNntpClient(
                             RecordSuccessfulFetch(
                                 provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
                                 stopwatch.ElapsedMilliseconds, priorMisses?.Count ?? 0,
-                                traceRange, priorMisses);
+                                fetchWorkload, traceRange, priorMisses);
                             response = WrapProviderResponse(response, provider.MetricsKey);
                             gateOwnedByTransfer = true;
                             deferredCallback.Activate((result, failureReason) =>
@@ -739,7 +740,8 @@ public class MultiProviderNntpClient(
                         else
                         {
                             RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing,
-                                stopwatch.ElapsedMilliseconds, priorMisses?.Count ?? 0, traceRange);
+                                stopwatch.ElapsedMilliseconds, priorMisses?.Count ?? 0,
+                                fetchWorkload, traceRange);
                             (priorMisses ??= []).Add((provider.MetricsKey, SegmentFetch.FetchStatus.Missing));
                             if (UsenetArticleAvailability.IsDefinitiveMissing(response))
                             {
@@ -768,7 +770,7 @@ public class MultiProviderNntpClient(
                         MarkCachedMissingOnThrownMiss(e, segmentId, provider, missingGroups);
                         var reason = ClassifyAndRecordFailure(
                             provider.MetricsKey, e, stopwatch.ElapsedMilliseconds,
-                            priorMisses?.Count ?? 0, traceRange,
+                            priorMisses?.Count ?? 0, fetchWorkload, traceRange,
                             NntpOperation.PipelinedBody, segmentId);
                         (priorMisses ??= []).Add((provider.MetricsKey, reason));
                         deferredCallback.Discard();
@@ -964,6 +966,7 @@ public class MultiProviderNntpClient(
         CancellationToken cancellationToken)
         where T : UsenetResponse
     {
+        var fetchWorkload = DownloadWorkloadClassifier.ClassifyForMetrics(cancellationToken);
         var attribution = AttributionContext.Value;
         if (attribution != null) attribution.Host = null;
         ExceptionDispatchInfo? lastException = null;
@@ -1016,7 +1019,7 @@ public class MultiProviderNntpClient(
                     _usageTracker.RecordSuccess(provider.MetricsKey);
                     RecordSuccessfulFetch(
                         provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
-                        stopwatch.ElapsedMilliseconds, attemptIndex, traceRange, priorMisses);
+                        stopwatch.ElapsedMilliseconds, attemptIndex, fetchWorkload, traceRange, priorMisses);
                     result = WrapProviderResponse(result, provider.MetricsKey);
                     deferredCallback.Activate(onConnectionReadyAgain ?? ((_, _) => { }));
                     return result;
@@ -1027,7 +1030,7 @@ public class MultiProviderNntpClient(
                 {
                     walk.CurrentDefinitiveMisses++;
                     RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing,
-                        stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
+                        stopwatch.ElapsedMilliseconds, attemptIndex, fetchWorkload, traceRange);
                     (priorMisses ??= []).Add((provider.MetricsKey, SegmentFetch.FetchStatus.Missing));
                     lastNoArticleResult = result;
                     lastOutcomeWasException = false;
@@ -1039,7 +1042,7 @@ public class MultiProviderNntpClient(
 
                 walk.UnexpectedResponses++;
                 RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing,
-                    stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
+                    stopwatch.ElapsedMilliseconds, attemptIndex, fetchWorkload, traceRange);
                 ArticleBodyCompletion.InvokeContained(
                     onConnectionReadyAgain, ArticleBodyResult.NotRetrieved);
                 return result;
@@ -1059,7 +1062,7 @@ public class MultiProviderNntpClient(
                 MarkCachedMissingOnThrownMiss(e, segmentId, provider, missingGroups);
                 var reason = ClassifyAndRecordFailure(
                     provider.MetricsKey, e, stopwatch.ElapsedMilliseconds, attemptIndex,
-                    traceRange, operation, segmentId);
+                    fetchWorkload, traceRange, operation, segmentId);
                 (priorMisses ??= []).Add((provider.MetricsKey, reason));
                 deferredCallback.Discard();
                 lastException = ExceptionDispatchInfo.Capture(e);
@@ -1098,6 +1101,7 @@ public class MultiProviderNntpClient(
         CancellationToken cancellationToken
     ) where T : UsenetResponse
     {
+        var fetchWorkload = DownloadWorkloadClassifier.ClassifyForMetrics(cancellationToken);
         var attribution = AttributionContext.Value;
         if (attribution != null) attribution.Host = null;
         ExceptionDispatchInfo? lastException = null;
@@ -1160,7 +1164,7 @@ public class MultiProviderNntpClient(
                 {
                     walk.CurrentDefinitiveMisses++;
                     RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing,
-                        stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
+                        stopwatch.ElapsedMilliseconds, attemptIndex, fetchWorkload, traceRange);
                     (priorMisses ??= new()).Add((provider.MetricsKey, SegmentFetch.FetchStatus.Missing));
                     lastNoArticleResult = result;
                     lastOutcomeWasException = false;
@@ -1183,7 +1187,7 @@ public class MultiProviderNntpClient(
                     _usageTracker.RecordSuccess(provider.MetricsKey);
                     RecordSuccessfulFetch(
                         provider.MetricsKey, SegmentFetch.FetchStatus.Ok,
-                        stopwatch.ElapsedMilliseconds, attemptIndex, traceRange, priorMisses);
+                        stopwatch.ElapsedMilliseconds, attemptIndex, fetchWorkload, traceRange, priorMisses);
                     result = WrapProviderResponse(result, provider.MetricsKey);
                 }
                 else if (result is UsenetDecodedBodyResponse or UsenetDecodedArticleResponse)
@@ -1191,7 +1195,7 @@ public class MultiProviderNntpClient(
                     // BODY/ARTICLE response with an unexpected (non-success, non-430) response type.
                     walk.UnexpectedResponses++;
                     RecordFetch(provider.MetricsKey, SegmentFetch.FetchStatus.Missing,
-                        stopwatch.ElapsedMilliseconds, attemptIndex, traceRange);
+                        stopwatch.ElapsedMilliseconds, attemptIndex, fetchWorkload, traceRange);
                 }
                 // STAT/HEAD/DATE successes: intentionally no SegmentFetch row (not a segment transfer;
                 // matches StatsPipelinedAsync which records nothing).
@@ -1210,7 +1214,7 @@ public class MultiProviderNntpClient(
                 MarkCachedMissingOnThrownMiss(e, articleId, provider, missingGroups);
                 var reason = ClassifyAndRecordFailure(
                     provider.MetricsKey, e, stopwatch.ElapsedMilliseconds, attemptIndex,
-                    traceRange, operation, articleId);
+                    fetchWorkload, traceRange, operation, articleId);
                 (priorMisses ??= new()).Add((provider.MetricsKey, reason));
                 lastException = ExceptionDispatchInfo.Capture(e);
                 lastOutcomeWasException = ClassifyException(e) != SegmentFetch.FetchStatus.Missing;
@@ -1362,6 +1366,7 @@ public class MultiProviderNntpClient(
         SegmentFetch.FetchStatus status,
         long durationMs,
         int retries,
+        SegmentFetch.FetchWorkload workload,
         StreamTraceRangeContext? traceRange,
         bool enqueue = true)
     {
@@ -1379,6 +1384,7 @@ public class MultiProviderNntpClient(
             At = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
             Provider = metricsKey,
             ReadSessionId = ReadSessionScope.Value,
+            Workload = workload,
             Bytes = 0, // bytes flow lazily through CountingYencStream → ProviderBytesTracker
             DurationMs = (int)Math.Min(int.MaxValue, durationMs),
             Status = status,
@@ -1398,11 +1404,12 @@ public class MultiProviderNntpClient(
         SegmentFetch.FetchStatus status,
         long durationMs,
         int retries,
+        SegmentFetch.FetchWorkload workload,
         StreamTraceRangeContext? traceRange,
         List<(string Host, SegmentFetch.FetchStatus Reason)>? priorMisses)
     {
         var fetch = RecordFetch(
-            metricsKey, status, durationMs, retries, traceRange, enqueue: false);
+            metricsKey, status, durationMs, retries, workload, traceRange, enqueue: false);
         if (priorMisses is not { Count: > 0 })
         {
             metricsWriter?.RecordFetch(fetch);
@@ -1422,10 +1429,11 @@ public class MultiProviderNntpClient(
     /// </summary>
     private SegmentFetch.FetchStatus ClassifyAndRecordFailure(
         string metricsKey, Exception exception, long durationMs, int retries,
-        StreamTraceRangeContext? traceRange, NntpOperation operation, SegmentId? segmentId)
+        SegmentFetch.FetchWorkload workload, StreamTraceRangeContext? traceRange,
+        NntpOperation operation, SegmentId? segmentId)
     {
         var status = ClassifyException(exception);
-        RecordFetch(metricsKey, status, durationMs, retries, traceRange);
+        RecordFetch(metricsKey, status, durationMs, retries, workload, traceRange);
         if (status == SegmentFetch.FetchStatus.Other)
         {
             exception.TryGetCausingException<ArgumentException>(out var argumentException);

--- a/backend/Clients/Usenet/SegmentCacheNntpClient.cs
+++ b/backend/Clients/Usenet/SegmentCacheNntpClient.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Services;
@@ -108,7 +109,7 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         if (MultiProviderNntpClient.AttributionContext.Value != null)
             return await base.DecodedBodyAsync(segmentId, onConnectionReadyAgain, ct).ConfigureAwait(false);
 
-        var local = TryOpenCacheResponse(segmentId);
+        var local = TryOpenCacheResponse(segmentId, ct);
         if (local.Found)
         {
             ArticleBodyCompletion.InvokeContained(onConnectionReadyAgain, ArticleBodyResult.Retrieved);
@@ -124,7 +125,7 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
     {
         if (MultiProviderNntpClient.AttributionContext.Value == null)
         {
-            var local = TryOpenCacheResponse(segmentId);
+            var local = TryOpenCacheResponse(segmentId, ct);
             if (local.Found)
                 return local.Response;
         }
@@ -148,7 +149,7 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         if (MultiProviderNntpClient.AttributionContext.Value != null)
             return await base.DecodedBodyAsync(segmentId, exclusiveConnection, ct).ConfigureAwait(false);
 
-        var local = TryOpenCacheResponse(segmentId);
+        var local = TryOpenCacheResponse(segmentId, ct);
         if (local.Found)
         {
             ArticleBodyCompletion.InvokeContained(
@@ -174,7 +175,7 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         return LocalDataBatchOverlay.ExecuteAsync(
             segmentIds,
             onConnectionReadyAgain,
-            TryOpenCacheResponse,
+            segmentId => TryOpenCacheResponse(segmentId, cancellationToken),
             (misses, callback, token) => base.DecodedBodiesAsync(misses, callback, token),
             TransformRemoteForCachingAsync,
             cancellationToken);
@@ -194,21 +195,21 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         return LocalDataBatchOverlay.ExecuteAsync(
             segmentIds,
             exclusiveConnection.OnConnectionReadyAgain,
-            TryOpenCacheResponse,
+            segmentId => TryOpenCacheResponse(segmentId, cancellationToken),
             (misses, callback, token) =>
                 base.DecodedBodiesAsync(misses, new UsenetExclusiveConnection(callback), token),
             TransformRemoteForCachingAsync,
             cancellationToken);
     }
 
-    private LocalLookupResult TryOpenCacheResponse(SegmentId segmentId)
+    private LocalLookupResult TryOpenCacheResponse(SegmentId segmentId, CancellationToken cancellationToken)
     {
         string id = segmentId;
         var lookup = TryServeFromCache(id, out var cached, out var servedBytes);
         if (lookup == CacheLookupResult.Hit)
         {
             _statistics.RecordHit(servedBytes);
-            RecordCacheHit();
+            RecordCacheHit(DownloadWorkloadClassifier.ClassifyForMetrics(cancellationToken));
             return LocalLookupResult.Hit(cached!);
         }
 
@@ -453,7 +454,7 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         PublishIndexGauges();
     }
 
-    private void RecordCacheHit()
+    private void RecordCacheHit(SegmentFetch.FetchWorkload workload)
     {
         _usageTracker?.RecordSuccess(CacheProviderName);
         PrometheusMetrics.Current?.RecordSegmentFetch(CacheProviderName, "ok", TimeSpan.Zero);
@@ -462,6 +463,7 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
             At = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
             Provider = CacheProviderName,
             ReadSessionId = MultiProviderNntpClient.CurrentReadSessionId,
+            Workload = workload,
             Bytes = 0,
             DurationMs = 0,
             Status = SegmentFetch.FetchStatus.Ok,

--- a/backend/Config/UsenetProviderIdentity.cs
+++ b/backend/Config/UsenetProviderIdentity.cs
@@ -294,11 +294,12 @@ public static class UsenetProviderIdentity
         {
             await db.Database.ExecuteSqlRawAsync(
                 """
-                INSERT INTO ProviderMinutes (Minute, Provider, Articles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, Hist)
-                SELECT Minute, {0}, Articles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, Hist
+                INSERT INTO ProviderMinutes (Minute, Provider, Articles, ClientArticles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, Hist)
+                SELECT Minute, {0}, Articles, ClientArticles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, Hist
                 FROM ProviderMinutes WHERE Provider = {1}
                 ON CONFLICT(Minute, Provider) DO UPDATE SET
                     Articles = ProviderMinutes.Articles + excluded.Articles,
+                    ClientArticles = ProviderMinutes.ClientArticles + excluded.ClientArticles,
                     BytesFetched = ProviderMinutes.BytesFetched + excluded.BytesFetched,
                     Misses = ProviderMinutes.Misses + excluded.Misses,
                     Errors = ProviderMinutes.Errors + excluded.Errors,
@@ -320,11 +321,12 @@ public static class UsenetProviderIdentity
         {
             await db.Database.ExecuteSqlRawAsync(
                 """
-                INSERT INTO ProviderHourly (Hour, Provider, Articles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, P95DurationMs)
-                SELECT Hour, {0}, Articles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, P95DurationMs
+                INSERT INTO ProviderHourly (Hour, Provider, Articles, ClientArticles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, P95DurationMs)
+                SELECT Hour, {0}, Articles, ClientArticles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, P95DurationMs
                 FROM ProviderHourly WHERE Provider = {1}
                 ON CONFLICT(Hour, Provider) DO UPDATE SET
                     Articles = ProviderHourly.Articles + excluded.Articles,
+                    ClientArticles = ProviderHourly.ClientArticles + excluded.ClientArticles,
                     BytesFetched = ProviderHourly.BytesFetched + excluded.BytesFetched,
                     Misses = ProviderHourly.Misses + excluded.Misses,
                     Errors = ProviderHourly.Errors + excluded.Errors,

--- a/backend/Config/UsenetProviderIdentity.cs
+++ b/backend/Config/UsenetProviderIdentity.cs
@@ -294,12 +294,13 @@ public static class UsenetProviderIdentity
         {
             await db.Database.ExecuteSqlRawAsync(
                 """
-                INSERT INTO ProviderMinutes (Minute, Provider, Articles, ClientArticles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, Hist)
-                SELECT Minute, {0}, Articles, ClientArticles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, Hist
+                INSERT INTO ProviderMinutes (Minute, Provider, Articles, ClientArticles, ClientArticlesFinalized, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, Hist)
+                SELECT Minute, {0}, Articles, ClientArticles, ClientArticlesFinalized, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, Hist
                 FROM ProviderMinutes WHERE Provider = {1}
                 ON CONFLICT(Minute, Provider) DO UPDATE SET
                     Articles = ProviderMinutes.Articles + excluded.Articles,
                     ClientArticles = ProviderMinutes.ClientArticles + excluded.ClientArticles,
+                    ClientArticlesFinalized = ProviderMinutes.ClientArticlesFinalized OR excluded.ClientArticlesFinalized,
                     BytesFetched = ProviderMinutes.BytesFetched + excluded.BytesFetched,
                     Misses = ProviderMinutes.Misses + excluded.Misses,
                     Errors = ProviderMinutes.Errors + excluded.Errors,

--- a/backend/Database/MetricsDbContext.cs
+++ b/backend/Database/MetricsDbContext.cs
@@ -61,6 +61,7 @@ public sealed class MetricsDbContext : DbContext
 
             e.Property(x => x.At).IsRequired();
             e.Property(x => x.Provider).IsRequired().HasMaxLength(255);
+            e.Property(x => x.Workload).HasConversion<int>().IsRequired();
             e.Property(x => x.Status).HasConversion<int>().IsRequired();
             e.Property(x => x.Bytes).IsRequired();
             e.Property(x => x.DurationMs).IsRequired();
@@ -109,6 +110,7 @@ public sealed class MetricsDbContext : DbContext
             e.Property(x => x.BytesServed).IsRequired();
             e.Property(x => x.BytesFetched).IsRequired();
             e.Property(x => x.Articles).IsRequired();
+            e.Property(x => x.ClientArticles).IsRequired();
             e.Property(x => x.Misses).IsRequired();
             e.Property(x => x.Errors).IsRequired();
             e.Property(x => x.ActiveReadsMax).IsRequired();
@@ -121,6 +123,7 @@ public sealed class MetricsDbContext : DbContext
 
             e.Property(x => x.Provider).IsRequired().HasMaxLength(255);
             e.Property(x => x.Articles).IsRequired();
+            e.Property(x => x.ClientArticles).IsRequired();
             e.Property(x => x.BytesFetched).IsRequired();
             e.Property(x => x.Misses).IsRequired();
             e.Property(x => x.Errors).IsRequired();
@@ -136,6 +139,7 @@ public sealed class MetricsDbContext : DbContext
 
             e.Property(x => x.Provider).IsRequired().HasMaxLength(255);
             e.Property(x => x.Articles).IsRequired();
+            e.Property(x => x.ClientArticles).IsRequired();
             e.Property(x => x.BytesFetched).IsRequired();
             e.Property(x => x.Misses).IsRequired();
             e.Property(x => x.Errors).IsRequired();
@@ -187,6 +191,7 @@ public sealed class MetricsDbContext : DbContext
             e.Property(x => x.Provider).IsRequired().HasMaxLength(255);
             e.Property(x => x.BytesFetched).IsRequired();
             e.Property(x => x.Articles).IsRequired();
+            e.Property(x => x.ClientArticles).IsRequired();
             e.Property(x => x.Misses).IsRequired();
             e.Property(x => x.Errors).IsRequired();
             e.Property(x => x.Retries).IsRequired();

--- a/backend/Database/MetricsDbContext.cs
+++ b/backend/Database/MetricsDbContext.cs
@@ -111,6 +111,7 @@ public sealed class MetricsDbContext : DbContext
             e.Property(x => x.BytesFetched).IsRequired();
             e.Property(x => x.Articles).IsRequired();
             e.Property(x => x.ClientArticles).IsRequired();
+            e.Property(x => x.ClientArticlesFinalized).IsRequired();
             e.Property(x => x.Misses).IsRequired();
             e.Property(x => x.Errors).IsRequired();
             e.Property(x => x.ActiveReadsMax).IsRequired();
@@ -124,6 +125,7 @@ public sealed class MetricsDbContext : DbContext
             e.Property(x => x.Provider).IsRequired().HasMaxLength(255);
             e.Property(x => x.Articles).IsRequired();
             e.Property(x => x.ClientArticles).IsRequired();
+            e.Property(x => x.ClientArticlesFinalized).IsRequired();
             e.Property(x => x.BytesFetched).IsRequired();
             e.Property(x => x.Misses).IsRequired();
             e.Property(x => x.Errors).IsRequired();

--- a/backend/Database/MetricsMigrations/20260904233100_AddClientArticleCounters.Designer.cs
+++ b/backend/Database/MetricsMigrations/20260904233100_AddClientArticleCounters.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NzbWebDAV.Database;
 
@@ -10,9 +11,11 @@ using NzbWebDAV.Database;
 namespace NzbWebDAV.Database.MetricsMigrations
 {
     [DbContext(typeof(MetricsDbContext))]
-    partial class MetricsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260904233100_AddClientArticleCounters")]
+    partial class AddClientArticleCounters
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.11");

--- a/backend/Database/MetricsMigrations/20260904233100_AddClientArticleCounters.cs
+++ b/backend/Database/MetricsMigrations/20260904233100_AddClientArticleCounters.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.MetricsMigrations
+{
+    /// <inheritdoc />
+    public partial class AddClientArticleCounters : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "ClientArticles",
+                table: "ThroughputMinutes",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0L);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Workload",
+                table: "SegmentFetches",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<long>(
+                name: "ClientArticles",
+                table: "ProviderMinutes",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0L);
+
+            migrationBuilder.AddColumn<long>(
+                name: "ClientArticles",
+                table: "ProviderLifetimeTotals",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0L);
+
+            migrationBuilder.AddColumn<long>(
+                name: "ClientArticles",
+                table: "ProviderHourly",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0L);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ClientArticles",
+                table: "ThroughputMinutes");
+
+            migrationBuilder.DropColumn(
+                name: "Workload",
+                table: "SegmentFetches");
+
+            migrationBuilder.DropColumn(
+                name: "ClientArticles",
+                table: "ProviderMinutes");
+
+            migrationBuilder.DropColumn(
+                name: "ClientArticles",
+                table: "ProviderLifetimeTotals");
+
+            migrationBuilder.DropColumn(
+                name: "ClientArticles",
+                table: "ProviderHourly");
+        }
+    }
+}

--- a/backend/Database/MetricsMigrations/20260906191846_PreserveFinalizedClientArticles.Designer.cs
+++ b/backend/Database/MetricsMigrations/20260906191846_PreserveFinalizedClientArticles.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NzbWebDAV.Database;
 
@@ -10,9 +11,11 @@ using NzbWebDAV.Database;
 namespace NzbWebDAV.Database.MetricsMigrations
 {
     [DbContext(typeof(MetricsDbContext))]
-    partial class MetricsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260906191846_PreserveFinalizedClientArticles")]
+    partial class PreserveFinalizedClientArticles
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.11");

--- a/backend/Database/MetricsMigrations/20260906191846_PreserveFinalizedClientArticles.cs
+++ b/backend/Database/MetricsMigrations/20260906191846_PreserveFinalizedClientArticles.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NzbWebDAV.Database.MetricsMigrations
+{
+    /// <inheritdoc />
+    public partial class PreserveFinalizedClientArticles : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "ClientArticlesFinalized",
+                table: "ThroughputMinutes",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ClientArticlesFinalized",
+                table: "ProviderMinutes",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ClientArticlesFinalized",
+                table: "ThroughputMinutes");
+
+            migrationBuilder.DropColumn(
+                name: "ClientArticlesFinalized",
+                table: "ProviderMinutes");
+        }
+    }
+}

--- a/backend/Database/Models/Metrics/ProviderHourly.cs
+++ b/backend/Database/Models/Metrics/ProviderHourly.cs
@@ -5,6 +5,7 @@ public class ProviderHourly
     public long Hour { get; set; }
     public string Provider { get; set; } = null!;
     public long Articles { get; set; }
+    public long ClientArticles { get; set; }
     public long BytesFetched { get; set; }
     public long Misses { get; set; }
     public long Errors { get; set; }

--- a/backend/Database/Models/Metrics/ProviderLifetimeTotal.cs
+++ b/backend/Database/Models/Metrics/ProviderLifetimeTotal.cs
@@ -9,6 +9,7 @@ public class ProviderLifetimeTotal
     public string Provider { get; set; } = null!;
     public long BytesFetched { get; set; }
     public long Articles { get; set; }
+    public long ClientArticles { get; set; }
     public long Misses { get; set; }
     public long Errors { get; set; }
     public long Retries { get; set; }

--- a/backend/Database/Models/Metrics/ProviderMinute.cs
+++ b/backend/Database/Models/Metrics/ProviderMinute.cs
@@ -5,6 +5,7 @@ public class ProviderMinute
     public long Minute { get; set; }
     public string Provider { get; set; } = null!;
     public long Articles { get; set; }
+    public long ClientArticles { get; set; }
     public long BytesFetched { get; set; }
     public long Misses { get; set; }
     public long Errors { get; set; }

--- a/backend/Database/Models/Metrics/ProviderMinute.cs
+++ b/backend/Database/Models/Metrics/ProviderMinute.cs
@@ -6,6 +6,7 @@ public class ProviderMinute
     public string Provider { get; set; } = null!;
     public long Articles { get; set; }
     public long ClientArticles { get; set; }
+    public bool ClientArticlesFinalized { get; set; }
     public long BytesFetched { get; set; }
     public long Misses { get; set; }
     public long Errors { get; set; }

--- a/backend/Database/Models/Metrics/SegmentFetch.cs
+++ b/backend/Database/Models/Metrics/SegmentFetch.cs
@@ -7,10 +7,21 @@ public class SegmentFetch
     public string Provider { get; set; } = null!;
     public Guid? ReadSessionId { get; set; }
     public Guid? QueueItemId { get; set; }
+    public FetchWorkload Workload { get; set; }
     public long Bytes { get; set; }
     public int DurationMs { get; set; }
     public FetchStatus Status { get; set; }
     public int Retries { get; set; }
+
+    // Values are persisted; append new members without renumbering existing ones.
+    public enum FetchWorkload
+    {
+        Unknown = 0,
+        Streaming = 1,
+        Queue = 2,
+        Maintenance = 3,
+        Background = 4,
+    }
 
     public enum FetchStatus
     {

--- a/backend/Database/Models/Metrics/ThroughputMinute.cs
+++ b/backend/Database/Models/Metrics/ThroughputMinute.cs
@@ -6,6 +6,7 @@ public class ThroughputMinute
     public long BytesServed { get; set; }
     public long BytesFetched { get; set; }
     public long Articles { get; set; }
+    public long ClientArticles { get; set; }
     public long Misses { get; set; }
     public long Errors { get; set; }
     public int ActiveReadsMax { get; set; }

--- a/backend/Database/Models/Metrics/ThroughputMinute.cs
+++ b/backend/Database/Models/Metrics/ThroughputMinute.cs
@@ -7,6 +7,7 @@ public class ThroughputMinute
     public long BytesFetched { get; set; }
     public long Articles { get; set; }
     public long ClientArticles { get; set; }
+    public bool ClientArticlesFinalized { get; set; }
     public long Misses { get; set; }
     public long Errors { get; set; }
     public int ActiveReadsMax { get; set; }

--- a/backend/Services/Metrics/MetricsRetentionService.cs
+++ b/backend/Services/Metrics/MetricsRetentionService.cs
@@ -123,6 +123,7 @@ public class MetricsRetentionService(ConfigManager configManager) : BackgroundSe
                     Provider = g.Key,
                     BytesFetched = g.Sum(x => x.BytesFetched),
                     Articles = g.Sum(x => x.Articles),
+                    ClientArticles = g.Sum(x => x.ClientArticles),
                     Misses = g.Sum(x => x.Misses),
                     Errors = g.Sum(x => x.Errors),
                     Retries = g.Sum(x => x.Retries),
@@ -151,6 +152,7 @@ public class MetricsRetentionService(ConfigManager configManager) : BackgroundSe
 
                     total.BytesFetched += fold.BytesFetched;
                     total.Articles += fold.Articles;
+                    total.ClientArticles += fold.ClientArticles;
                     total.Misses += fold.Misses;
                     total.Errors += fold.Errors;
                     total.Retries += fold.Retries;

--- a/backend/Services/Metrics/MetricsRollupService.cs
+++ b/backend/Services/Metrics/MetricsRollupService.cs
@@ -136,8 +136,8 @@ public class MetricsRollupService(
             await db.Database.ExecuteSqlRawAsync(
                 """
                 INSERT INTO ProviderHourly
-                    (Hour, Provider, Articles, BytesFetched, Misses, Errors, Retries, SumDurationMs, P95DurationMs)
-                VALUES ({0}, {1}, 0, {2}, 0, 0, 0, 0, NULL)
+                    (Hour, Provider, Articles, ClientArticles, BytesFetched, Misses, Errors, Retries, SumDurationMs, P95DurationMs)
+                VALUES ({0}, {1}, 0, 0, {2}, 0, 0, 0, 0, NULL)
                 ON CONFLICT(Hour, Provider) DO UPDATE SET
                     BytesFetched = ProviderHourly.BytesFetched + excluded.BytesFetched;
                 """,
@@ -146,8 +146,8 @@ public class MetricsRollupService(
             await db.Database.ExecuteSqlRawAsync(
                 """
                 INSERT INTO ThroughputMinutes
-                    (Minute, BytesServed, BytesFetched, Articles, Misses, Errors, ActiveReadsMax)
-                VALUES ({0}, 0, {1}, 0, 0, 0, 0)
+                    (Minute, BytesServed, BytesFetched, Articles, ClientArticles, Misses, Errors, ActiveReadsMax)
+                VALUES ({0}, 0, {1}, 0, 0, 0, 0, 0)
                 ON CONFLICT(Minute) DO UPDATE SET
                     BytesFetched = ThroughputMinutes.BytesFetched + excluded.BytesFetched;
                 """,
@@ -158,6 +158,7 @@ public class MetricsRollupService(
     internal static async Task RollupMinuteAsync(MetricsDbContext db, long minute)
     {
         var next = minute + OneMinute;
+        var streamingWorkload = (int)SegmentFetch.FetchWorkload.Streaming;
 
         // ThroughputMinute: read-session bytes (downstream) + fetch bytes (upstream).
         // BytesFetched intentionally omitted from ON CONFLICT — owned by ProviderBytesTracker.
@@ -165,22 +166,24 @@ public class MetricsRollupService(
         // tracker already deposited via ApplyByteCountersAsync.
         await db.Database.ExecuteSqlRawAsync(
             """
-            INSERT INTO ThroughputMinutes (Minute, BytesServed, BytesFetched, Articles, Misses, Errors, ActiveReadsMax)
+            INSERT INTO ThroughputMinutes (Minute, BytesServed, BytesFetched, Articles, ClientArticles, Misses, Errors, ActiveReadsMax)
             SELECT
                 {0} AS Minute,
                 COALESCE((SELECT SUM(BytesServed) FROM ReadSessions WHERE EndedAt >= {0} AND EndedAt < {1}), 0) AS BytesServed,
                 0 AS BytesFetched,
                 COALESCE((SELECT COUNT(*) FROM SegmentFetches WHERE At >= {0} AND At < {1}), 0) AS Articles,
+                COALESCE((SELECT COUNT(*) FROM SegmentFetches WHERE At >= {0} AND At < {1} AND Workload = {2}), 0) AS ClientArticles,
                 COALESCE((SELECT COUNT(*) FROM SegmentFetches WHERE At >= {0} AND At < {1} AND Status = 1), 0) AS Misses,
                 COALESCE((SELECT COUNT(*) FROM SegmentFetches WHERE At >= {0} AND At < {1} AND Status NOT IN (0, 1)), 0) AS Errors,
                 0 AS ActiveReadsMax
             ON CONFLICT(Minute) DO UPDATE SET
                 BytesServed  = excluded.BytesServed,
                 Articles     = excluded.Articles,
+                ClientArticles = excluded.ClientArticles,
                 Misses       = excluded.Misses,
                 Errors       = excluded.Errors;
             """,
-            minute, next).ConfigureAwait(false);
+            minute, next, streamingWorkload).ConfigureAwait(false);
 
         // ProviderMinute: per-provider counters. BytesFetched intentionally omitted from
         // ON CONFLICT — the tracker is the sole writer of that column.
@@ -189,15 +192,16 @@ public class MetricsRollupService(
         // scoreboard. FailoverMisses can contain multiple edges for one rescue.
         await db.Database.ExecuteSqlRawAsync(
             """
-            INSERT INTO ProviderMinutes (Minute, Provider, Articles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, Hist)
+            INSERT INTO ProviderMinutes (Minute, Provider, Articles, ClientArticles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, Hist)
             SELECT {0}, Provider,
                 COUNT(*),
+                SUM(CASE WHEN Workload = {2} THEN 1 ELSE 0 END),
                 0,
                 SUM(CASE WHEN Status = 1 THEN 1 ELSE 0 END),
                 SUM(CASE WHEN Status NOT IN (0, 1) THEN 1 ELSE 0 END),
                 SUM(Retries),
                 (SELECT COUNT(*) FROM MetricEvents e
-                    WHERE e.Kind = {2} AND e.Tag1 = SegmentFetches.Provider
+                    WHERE e.Kind = {3} AND e.Tag1 = SegmentFetches.Provider
                         AND e.At >= {0} AND e.At < {1}),
                 -- Ok-only durations so Overview "Avg ok ms" is not inflated by misses/errors.
                 SUM(CASE WHEN Status = 0 THEN DurationMs ELSE 0 END),
@@ -207,23 +211,25 @@ public class MetricsRollupService(
             GROUP BY Provider
             ON CONFLICT(Minute, Provider) DO UPDATE SET
                 Articles      = excluded.Articles,
+                ClientArticles = excluded.ClientArticles,
                 Misses        = excluded.Misses,
                 Errors        = excluded.Errors,
                 Retries       = excluded.Retries,
                 FailoverSaves = excluded.FailoverSaves,
                 SumDurationMs = excluded.SumDurationMs;
             """,
-            minute, next, MetricsWriter.FailoverSaveEventKind).ConfigureAwait(false);
+                minute, next, streamingWorkload, MetricsWriter.FailoverSaveEventKind).ConfigureAwait(false);
     }
 
-    private static async Task RollupHourAsync(MetricsDbContext db, long hour)
+            internal static async Task RollupHourAsync(MetricsDbContext db, long hour)
     {
         var next = hour + OneHour;
         await db.Database.ExecuteSqlRawAsync(
             """
-            INSERT INTO ProviderHourly (Hour, Provider, Articles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, P95DurationMs)
+            INSERT INTO ProviderHourly (Hour, Provider, Articles, ClientArticles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, P95DurationMs)
             SELECT {0}, Provider,
                 SUM(Articles),
+                SUM(ClientArticles),
                 SUM(BytesFetched),
                 SUM(Misses),
                 SUM(Errors),
@@ -236,6 +242,7 @@ public class MetricsRollupService(
             GROUP BY Provider
             ON CONFLICT(Hour, Provider) DO UPDATE SET
                 Articles      = excluded.Articles,
+                ClientArticles = excluded.ClientArticles,
                 BytesFetched  = excluded.BytesFetched,
                 Misses        = excluded.Misses,
                 Errors        = excluded.Errors,

--- a/backend/Services/Metrics/MetricsRollupService.cs
+++ b/backend/Services/Metrics/MetricsRollupService.cs
@@ -166,20 +166,23 @@ public class MetricsRollupService(
         // tracker already deposited via ApplyByteCountersAsync.
         await db.Database.ExecuteSqlRawAsync(
             """
-            INSERT INTO ThroughputMinutes (Minute, BytesServed, BytesFetched, Articles, ClientArticles, Misses, Errors, ActiveReadsMax)
+            INSERT INTO ThroughputMinutes (Minute, BytesServed, BytesFetched, Articles, ClientArticles, ClientArticlesFinalized, Misses, Errors, ActiveReadsMax)
             SELECT
                 {0} AS Minute,
                 COALESCE((SELECT SUM(BytesServed) FROM ReadSessions WHERE EndedAt >= {0} AND EndedAt < {1}), 0) AS BytesServed,
                 0 AS BytesFetched,
                 COALESCE((SELECT COUNT(*) FROM SegmentFetches WHERE At >= {0} AND At < {1}), 0) AS Articles,
                 COALESCE((SELECT COUNT(*) FROM SegmentFetches WHERE At >= {0} AND At < {1} AND Workload = {2}), 0) AS ClientArticles,
+                1 AS ClientArticlesFinalized,
                 COALESCE((SELECT COUNT(*) FROM SegmentFetches WHERE At >= {0} AND At < {1} AND Status = 1), 0) AS Misses,
                 COALESCE((SELECT COUNT(*) FROM SegmentFetches WHERE At >= {0} AND At < {1} AND Status NOT IN (0, 1)), 0) AS Errors,
                 0 AS ActiveReadsMax
             ON CONFLICT(Minute) DO UPDATE SET
                 BytesServed  = excluded.BytesServed,
                 Articles     = excluded.Articles,
-                ClientArticles = excluded.ClientArticles,
+                ClientArticles = CASE WHEN ThroughputMinutes.ClientArticlesFinalized
+                    THEN ThroughputMinutes.ClientArticles ELSE excluded.ClientArticles END,
+                ClientArticlesFinalized = excluded.ClientArticlesFinalized,
                 Misses       = excluded.Misses,
                 Errors       = excluded.Errors;
             """,
@@ -192,10 +195,11 @@ public class MetricsRollupService(
         // scoreboard. FailoverMisses can contain multiple edges for one rescue.
         await db.Database.ExecuteSqlRawAsync(
             """
-            INSERT INTO ProviderMinutes (Minute, Provider, Articles, ClientArticles, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, Hist)
+            INSERT INTO ProviderMinutes (Minute, Provider, Articles, ClientArticles, ClientArticlesFinalized, BytesFetched, Misses, Errors, Retries, FailoverSaves, SumDurationMs, Hist)
             SELECT {0}, Provider,
                 COUNT(*),
                 SUM(CASE WHEN Workload = {2} THEN 1 ELSE 0 END),
+                1,
                 0,
                 SUM(CASE WHEN Status = 1 THEN 1 ELSE 0 END),
                 SUM(CASE WHEN Status NOT IN (0, 1) THEN 1 ELSE 0 END),
@@ -211,7 +215,9 @@ public class MetricsRollupService(
             GROUP BY Provider
             ON CONFLICT(Minute, Provider) DO UPDATE SET
                 Articles      = excluded.Articles,
-                ClientArticles = excluded.ClientArticles,
+                ClientArticles = CASE WHEN ProviderMinutes.ClientArticlesFinalized
+                    THEN ProviderMinutes.ClientArticles ELSE excluded.ClientArticles END,
+                ClientArticlesFinalized = excluded.ClientArticlesFinalized,
                 Misses        = excluded.Misses,
                 Errors        = excluded.Errors,
                 Retries       = excluded.Retries,

--- a/backend/Services/Metrics/MetricsRollupService.cs
+++ b/backend/Services/Metrics/MetricsRollupService.cs
@@ -180,8 +180,7 @@ public class MetricsRollupService(
             ON CONFLICT(Minute) DO UPDATE SET
                 BytesServed  = excluded.BytesServed,
                 Articles     = excluded.Articles,
-                ClientArticles = CASE WHEN ThroughputMinutes.ClientArticlesFinalized
-                    THEN ThroughputMinutes.ClientArticles ELSE excluded.ClientArticles END,
+                ClientArticles = MAX(ThroughputMinutes.ClientArticles, excluded.ClientArticles),
                 ClientArticlesFinalized = excluded.ClientArticlesFinalized,
                 Misses       = excluded.Misses,
                 Errors       = excluded.Errors;
@@ -215,8 +214,7 @@ public class MetricsRollupService(
             GROUP BY Provider
             ON CONFLICT(Minute, Provider) DO UPDATE SET
                 Articles      = excluded.Articles,
-                ClientArticles = CASE WHEN ProviderMinutes.ClientArticlesFinalized
-                    THEN ProviderMinutes.ClientArticles ELSE excluded.ClientArticles END,
+                ClientArticles = MAX(ProviderMinutes.ClientArticles, excluded.ClientArticles),
                 ClientArticlesFinalized = excluded.ClientArticlesFinalized,
                 Misses        = excluded.Misses,
                 Errors        = excluded.Errors,
@@ -227,7 +225,7 @@ public class MetricsRollupService(
                 minute, next, streamingWorkload, MetricsWriter.FailoverSaveEventKind).ConfigureAwait(false);
     }
 
-            internal static async Task RollupHourAsync(MetricsDbContext db, long hour)
+    internal static async Task RollupHourAsync(MetricsDbContext db, long hour)
     {
         var next = hour + OneHour;
         await db.Database.ExecuteSqlRawAsync(

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -1029,6 +1029,7 @@ export type OverviewStatsResponse = {
   throughput: ThroughputPoint[];
   throughputBucketSizeMs: number;
   totalArticles: number;
+  totalClientArticles: number;
   totalMisses: number;
   totalErrors: number;
   totalBytesFetched: number;
@@ -1178,6 +1179,7 @@ export type FailoverBucket = {
 export type ThroughputPoint = {
   bucket: number;
   articles: number;
+  clientArticles: number;
   misses: number;
   errors: number;
   bytesServed: number;

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.module.css
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.module.css
@@ -30,9 +30,17 @@
   vector-effect: non-scaling-stroke;
 }
 
-.lineArticles {
+.lineClient {
   stroke: var(--color-success);
   stroke-width: 1.5;
+  fill: none;
+  vector-effect: non-scaling-stroke;
+}
+
+.lineApp {
+  stroke: var(--color-info);
+  stroke-width: 1.5;
+  stroke-dasharray: 4 3;
   fill: none;
   vector-effect: non-scaling-stroke;
 }

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.module.css.d.ts
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.module.css.d.ts
@@ -3,7 +3,8 @@ declare const styles: {
   readonly chartArea: string;
   readonly svg: string;
   readonly gridline: string;
-  readonly lineArticles: string;
+  readonly lineApp: string;
+  readonly lineClient: string;
   readonly lineErrors: string;
   readonly crosshair: string;
   readonly hoverTooltip: string;

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.test.tsx
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.test.tsx
@@ -5,9 +5,10 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { ThroughputPoint } from "~/clients/backend-client.server";
 import { ThroughputChart } from "./throughput-chart";
 
-const point = (articles: number, errors = 0): ThroughputPoint => ({
+const point = (articles: number, clientArticles = 0, errors = 0): ThroughputPoint => ({
   bucket: 0,
   articles,
+  clientArticles,
   misses: 0,
   errors,
   bytesServed: 0,
@@ -19,6 +20,7 @@ function renderMarkup(points: ThroughputPoint[], totalErrors = 0) {
     <ThroughputChart
       points={points}
       totalArticles={points.reduce((sum, item) => sum + item.articles, 0)}
+      totalClientArticles={points.reduce((sum, item) => sum + item.clientArticles, 0)}
       totalMisses={0}
       totalErrors={totalErrors}
       totalBytesServed={0}
@@ -30,7 +32,7 @@ function renderMarkup(points: ThroughputPoint[], totalErrors = 0) {
 
 function articlesPathD(markup: string): string {
   const match = markup.match(
-    /d="([^"]*)"[^>]*data-series="articles"|data-series="articles"[^>]*d="([^"]*)"/,
+    /d="([^"]*)"[^>]*data-series="client-articles"|data-series="client-articles"[^>]*d="([^"]*)"/,
   );
   return match?.[1] ?? match?.[2] ?? "";
 }
@@ -40,20 +42,21 @@ describe("ThroughputChart", () => {
     cleanup();
   });
   it("does not draw the green series when every article bucket is zero", () => {
-    const markup = renderMarkup([point(0, 1), point(0)], 1);
+    const markup = renderMarkup([point(0, 0, 1), point(0)], 1);
 
-    expect(markup).not.toContain('data-series="articles"');
+    expect(markup).not.toContain('data-series="client-articles"');
+    expect(markup).not.toContain('data-series="app-articles"');
     expect(markup).toContain('data-series="errors"');
   });
 
   it("draws the green series when an article bucket has activity", () => {
-    const markup = renderMarkup([point(0), point(2)]);
+    const markup = renderMarkup([point(0), point(2, 2)]);
 
-    expect(markup).toContain('data-series="articles"');
+    expect(markup).toContain('data-series="client-articles"');
   });
 
   it("skips idle stretches but anchors each run to leading and trailing zeros", () => {
-    const markup = renderMarkup([point(0), point(5), point(0), point(0), point(3), point(0)]);
+    const markup = renderMarkup([point(0), point(5, 5), point(0), point(0), point(3, 3), point(0)]);
     const d = articlesPathD(markup);
 
     expect(d).not.toBe("");
@@ -83,6 +86,7 @@ describe("ThroughputChart", () => {
       <ThroughputChart
         points={points}
         totalArticles={11}
+        totalClientArticles={0}
         totalMisses={1}
         totalErrors={2}
         totalBytesServed={100}
@@ -108,6 +112,7 @@ describe("ThroughputChart", () => {
       <ThroughputChart
         points={updated}
         totalArticles={15}
+        totalClientArticles={0}
         totalMisses={1}
         totalErrors={4}
         totalBytesServed={100}
@@ -128,6 +133,7 @@ describe("ThroughputChart", () => {
       <ThroughputChart
         points={points}
         totalArticles={11}
+        totalClientArticles={0}
         totalMisses={0}
         totalErrors={2}
         totalBytesServed={0}
@@ -150,6 +156,7 @@ describe("ThroughputChart", () => {
       <ThroughputChart
         points={shifted}
         totalArticles={12}
+        totalClientArticles={0}
         totalMisses={0}
         totalErrors={2}
         totalBytesServed={0}

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.test.tsx
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.test.tsx
@@ -55,6 +55,32 @@ describe("ThroughputChart", () => {
     expect(markup).toContain('data-series="client-articles"');
   });
 
+  it("keeps aggregate download throughput neutral instead of labeling it as app reads", () => {
+    const markup = renderToStaticMarkup(
+      <ThroughputChart
+        points={[
+          {
+            ...point(10, 10, 0),
+            bucket: 0,
+            bytesFetched: 60 * 1024 * 1024,
+            bytesServed: 0,
+          },
+        ]}
+        totalArticles={10}
+        totalClientArticles={10}
+        totalMisses={0}
+        totalErrors={0}
+        totalBytesServed={0}
+        bucketSizeMs={60_000}
+        window="24h"
+      />,
+    );
+
+    expect(markup).toContain("Client reads · 10");
+    expect(markup).toContain("Peak download");
+    expect(markup).not.toContain("App reads · 0 · peak");
+  });
+
   it("skips idle stretches but anchors each run to leading and trailing zeros", () => {
     const markup = renderMarkup([point(0), point(5, 5), point(0), point(0), point(3, 3), point(0)]);
     const d = articlesPathD(markup);

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.test.tsx
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.test.tsx
@@ -55,6 +55,13 @@ describe("ThroughputChart", () => {
     expect(markup).toContain('data-series="client-articles"');
   });
 
+  it("labels the y-axis with the error-dominant coordinate scale", () => {
+    const markup = renderMarkup([point(2, 2, 10)], 10);
+
+    expect(markup).toContain(">10</span>");
+    expect(markup).toContain(">5</span>");
+  });
+
   it("keeps aggregate download throughput neutral instead of labeling it as app reads", () => {
     const markup = renderToStaticMarkup(
       <ThroughputChart

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
@@ -42,46 +42,55 @@ export function ThroughputChart({
     setKeyboardBucket(null);
   }, [window]);
 
-  const { clientArticlesPath, appArticlesPath, errorsPath, maxArticles, maxClientArticles, maxAppArticles, maxNetworkRate, xPercent, yPercent } =
-    useMemo(() => {
-      if (points.length === 0) {
-        return {
-          clientArticlesPath: "",
-          appArticlesPath: "",
-          errorsPath: "",
-          maxArticles: 0,
-          maxClientArticles: 0,
-          maxAppArticles: 0,
-          maxNetworkRate: 0,
-          xPercent: (_: number) => 0,
-          yPercent: (_: number) => 0,
-        };
-      }
-      const peakClientArticles = Math.max(0, ...points.map(clientArticles));
-      const peakAppArticles = Math.max(0, ...points.map(appArticles));
-      const peakArticles = Math.max(peakClientArticles, peakAppArticles);
-      const scaleMax = Math.max(1, peakArticles, ...points.map((p) => p.errors));
-      const maxRate = Math.max(0, ...points.map((p) => (p.bytesFetched ?? 0) / bucketSeconds));
-      const xStep = points.length > 1 ? VB_W / (points.length - 1) : 0;
-      const innerH = VB_H - TOP_PAD - BOT_PAD;
-      const y = (v: number) => VB_H - BOT_PAD - (v / scaleMax) * innerH;
-
-      const xPct = (i: number) => (points.length > 1 ? (i / (points.length - 1)) * 100 : 50);
-      const yPct = (v: number) =>
-        100 - ((v / scaleMax) * (1 - (TOP_PAD + BOT_PAD) / VB_H) * 100 + (BOT_PAD / VB_H) * 100);
-
+  const {
+    clientArticlesPath,
+    appArticlesPath,
+    errorsPath,
+    maxArticles,
+    maxClientArticles,
+    maxAppArticles,
+    maxNetworkRate,
+    xPercent,
+    yPercent,
+  } = useMemo(() => {
+    if (points.length === 0) {
       return {
-        clientArticlesPath: buildArticlesSeriesPath(points, clientArticles, xStep, y),
-        appArticlesPath: buildArticlesSeriesPath(points, appArticles, xStep, y),
-        errorsPath: buildSparseSeriesPath(points, (p) => p.errors, xStep, y),
-        maxArticles: peakArticles,
-        maxClientArticles: peakClientArticles,
-        maxAppArticles: peakAppArticles,
-        maxNetworkRate: maxRate,
-        xPercent: xPct,
-        yPercent: yPct,
+        clientArticlesPath: "",
+        appArticlesPath: "",
+        errorsPath: "",
+        maxArticles: 0,
+        maxClientArticles: 0,
+        maxAppArticles: 0,
+        maxNetworkRate: 0,
+        xPercent: (_: number) => 0,
+        yPercent: (_: number) => 0,
       };
-    }, [points, bucketSeconds]);
+    }
+    const peakClientArticles = Math.max(0, ...points.map(clientArticles));
+    const peakAppArticles = Math.max(0, ...points.map(appArticles));
+    const peakArticles = Math.max(peakClientArticles, peakAppArticles);
+    const scaleMax = Math.max(1, peakArticles, ...points.map((p) => p.errors));
+    const maxRate = Math.max(0, ...points.map((p) => (p.bytesFetched ?? 0) / bucketSeconds));
+    const xStep = points.length > 1 ? VB_W / (points.length - 1) : 0;
+    const innerH = VB_H - TOP_PAD - BOT_PAD;
+    const y = (v: number) => VB_H - BOT_PAD - (v / scaleMax) * innerH;
+
+    const xPct = (i: number) => (points.length > 1 ? (i / (points.length - 1)) * 100 : 50);
+    const yPct = (v: number) =>
+      100 - ((v / scaleMax) * (1 - (TOP_PAD + BOT_PAD) / VB_H) * 100 + (BOT_PAD / VB_H) * 100);
+
+    return {
+      clientArticlesPath: buildArticlesSeriesPath(points, clientArticles, xStep, y),
+      appArticlesPath: buildArticlesSeriesPath(points, appArticles, xStep, y),
+      errorsPath: buildSparseSeriesPath(points, (p) => p.errors, xStep, y),
+      maxArticles: peakArticles,
+      maxClientArticles: peakClientArticles,
+      maxAppArticles: peakAppArticles,
+      maxNetworkRate: maxRate,
+      xPercent: xPct,
+      yPercent: yPct,
+    };
+  }, [points, bucketSeconds]);
 
   const xTicks = useMemo(() => {
     if (points.length === 0) return [];
@@ -240,10 +249,18 @@ export function ThroughputChart({
                     className={styles.gridline}
                   />
                   {maxClientArticles > 0 && (
-                    <path d={clientArticlesPath} className={styles.lineClient} data-series="client-articles" />
+                    <path
+                      d={clientArticlesPath}
+                      className={styles.lineClient}
+                      data-series="client-articles"
+                    />
                   )}
                   {maxAppArticles > 0 && (
-                    <path d={appArticlesPath} className={styles.lineApp} data-series="app-articles" />
+                    <path
+                      d={appArticlesPath}
+                      className={styles.lineApp}
+                      data-series="app-articles"
+                    />
                   )}
                   {totalErrors > 0 && errorsPath && (
                     <path d={errorsPath} className={styles.lineErrors} data-series="errors" />

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
@@ -344,8 +344,13 @@ export function ThroughputChart({
               <span className="inline-flex items-center gap-1.5">
                 <span className="inline-block w-2.5 border-t-2 border-dashed border-info" />
                 App reads · {formatNumber(totalAppArticles)}
-                {maxNetworkRate > 0 && <> · peak {formatBytes(maxNetworkRate)}/s</>}
               </span>
+              {maxNetworkRate > 0 && (
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="inline-block h-0.5 w-2.5 bg-base-content/40" />
+                  Peak download · {formatBytes(maxNetworkRate)}/s
+                </span>
+              )}
               {totalErrors > 0 && (
                 <span className="inline-flex items-center gap-1.5">
                   <span className="inline-block h-0.5 w-2.5 bg-error" />

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
@@ -6,6 +6,7 @@ import { formatBytes, formatNumber } from "../../utils/format";
 export type ThroughputChartProps = {
   points: ThroughputPoint[];
   totalArticles: number;
+  totalClientArticles: number;
   totalMisses: number;
   totalErrors: number;
   totalBytesServed: number;
@@ -21,6 +22,7 @@ const BOT_PAD = 4;
 export function ThroughputChart({
   points,
   totalArticles,
+  totalClientArticles,
   totalMisses,
   totalErrors,
   totalBytesServed,
@@ -40,20 +42,25 @@ export function ThroughputChart({
     setKeyboardBucket(null);
   }, [window]);
 
-  const { articlesPath, errorsPath, maxArticles, maxNetworkRate, xPercent, yPercent } =
+  const { clientArticlesPath, appArticlesPath, errorsPath, maxArticles, maxClientArticles, maxAppArticles, maxNetworkRate, xPercent, yPercent } =
     useMemo(() => {
       if (points.length === 0) {
         return {
-          articlesPath: "",
+          clientArticlesPath: "",
+          appArticlesPath: "",
           errorsPath: "",
           maxArticles: 0,
+          maxClientArticles: 0,
+          maxAppArticles: 0,
           maxNetworkRate: 0,
           xPercent: (_: number) => 0,
           yPercent: (_: number) => 0,
         };
       }
-      const peakArticles = Math.max(0, ...points.map((p) => p.articles));
-      const scaleMax = Math.max(1, peakArticles);
+      const peakClientArticles = Math.max(0, ...points.map(clientArticles));
+      const peakAppArticles = Math.max(0, ...points.map(appArticles));
+      const peakArticles = Math.max(peakClientArticles, peakAppArticles);
+      const scaleMax = Math.max(1, peakArticles, ...points.map((p) => p.errors));
       const maxRate = Math.max(0, ...points.map((p) => (p.bytesFetched ?? 0) / bucketSeconds));
       const xStep = points.length > 1 ? VB_W / (points.length - 1) : 0;
       const innerH = VB_H - TOP_PAD - BOT_PAD;
@@ -64,9 +71,12 @@ export function ThroughputChart({
         100 - ((v / scaleMax) * (1 - (TOP_PAD + BOT_PAD) / VB_H) * 100 + (BOT_PAD / VB_H) * 100);
 
       return {
-        articlesPath: buildArticlesSeriesPath(points, xStep, y),
+        clientArticlesPath: buildArticlesSeriesPath(points, clientArticles, xStep, y),
+        appArticlesPath: buildArticlesSeriesPath(points, appArticles, xStep, y),
         errorsPath: buildSparseSeriesPath(points, (p) => p.errors, xStep, y),
         maxArticles: peakArticles,
+        maxClientArticles: peakClientArticles,
+        maxAppArticles: peakAppArticles,
         maxNetworkRate: maxRate,
         xPercent: xPct,
         yPercent: yPct,
@@ -138,7 +148,8 @@ export function ThroughputChart({
   };
 
   const hasData = points.length > 0;
-  const hasArticleActivity = maxArticles > 0;
+  const safeTotalClientArticles = Math.min(totalArticles, Math.max(0, totalClientArticles ?? 0));
+  const totalAppArticles = totalArticles - safeTotalClientArticles;
   const bucketLabel =
     window === "1h" || window === "24h" ? "min" : window === "all" ? "day" : "hour";
   const hover = cursorIdx !== null ? (points[cursorIdx] ?? null) : null;
@@ -147,6 +158,8 @@ export function ThroughputChart({
     ? describeThroughputBucket(keyboardPoint, window, bucketSeconds)
     : "";
   const hoverNetworkRate = hover ? (hover.bytesFetched ?? 0) / bucketSeconds : 0;
+  const hoverClientArticles = hover ? clientArticles(hover) : 0;
+  const hoverAppArticles = hover ? appArticles(hover) : 0;
   const tooltipPlacement =
     cursorIdx === null || points.length < 2
       ? "tooltip-top"
@@ -164,7 +177,7 @@ export function ThroughputChart({
           <div>
             <h3 className="card-title text-base">Activity</h3>
             <p className="text-xs text-base-content/50">
-              Articles fetched per {bucketLabel}, last {window}
+              Article reads per {bucketLabel}, last {window}
             </p>
           </div>
           <div className="flex gap-[18px]">
@@ -191,7 +204,7 @@ export function ThroughputChart({
                 className={styles.chartArea}
                 tabIndex={0}
                 role="img"
-                aria-label={`${formatNumber(totalArticles)} articles, ${formatNumber(totalErrors)} errors, ${formatBytes(totalBytesServed)} served. Use arrow keys for bucket details.`}
+                aria-label={`${formatNumber(safeTotalClientArticles)} client reads, ${formatNumber(totalAppArticles)} app reads, ${formatNumber(totalArticles)} articles total, ${formatNumber(totalErrors)} errors, ${formatBytes(totalBytesServed)} served. Use arrow keys for bucket details.`}
                 aria-describedby="overview-throughput-keyboard-status"
                 onMouseMove={handleMouseMove}
                 onMouseLeave={handleMouseLeave}
@@ -226,8 +239,11 @@ export function ThroughputChart({
                     y2={TOP_PAD.toFixed(1)}
                     className={styles.gridline}
                   />
-                  {hasArticleActivity && (
-                    <path d={articlesPath} className={styles.lineArticles} data-series="articles" />
+                  {maxClientArticles > 0 && (
+                    <path d={clientArticlesPath} className={styles.lineClient} data-series="client-articles" />
+                  )}
+                  {maxAppArticles > 0 && (
+                    <path d={appArticlesPath} className={styles.lineApp} data-series="app-articles" />
                   )}
                   {totalErrors > 0 && errorsPath && (
                     <path d={errorsPath} className={styles.lineErrors} data-series="errors" />
@@ -241,7 +257,7 @@ export function ThroughputChart({
                       className={`tooltip tooltip-open ${tooltipPlacement} ${styles.hoverTooltip}`}
                       style={{
                         left: `${xPercent(cursorIdx)}%`,
-                        top: `${yPercent(hover.articles)}%`,
+                        top: `${yPercent(Math.max(hoverClientArticles, hoverAppArticles))}%`,
                       }}
                     >
                       <div className="tooltip-content">
@@ -249,7 +265,9 @@ export function ThroughputChart({
                           <div className="font-semibold">
                             {formatBucketTime(hover.bucket, window)}
                           </div>
-                          <div>{formatNumber(hover.articles)} articles</div>
+                          <div>{formatNumber(hoverClientArticles)} client reads</div>
+                          <div>{formatNumber(hoverAppArticles)} app reads</div>
+                          <div>{formatNumber(hover.articles)} articles total</div>
                           {hoverNetworkRate > 0 && (
                             <div>{formatBytes(hoverNetworkRate)}/s downloaded</div>
                           )}
@@ -304,7 +322,11 @@ export function ThroughputChart({
             <div className="mt-2 flex flex-wrap items-center gap-3.5 text-[11px] text-base-content/50">
               <span className="inline-flex items-center gap-1.5">
                 <span className="inline-block h-0.5 w-2.5 bg-success" />
-                Articles
+                Client reads · {formatNumber(safeTotalClientArticles)}
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <span className="inline-block w-2.5 border-t-2 border-dashed border-info" />
+                App reads · {formatNumber(totalAppArticles)}
                 {maxNetworkRate > 0 && <> · peak {formatBytes(maxNetworkRate)}/s</>}
               </span>
               {totalErrors > 0 && (
@@ -338,6 +360,7 @@ export function ThroughputChart({
  */
 function buildArticlesSeriesPath(
   points: ThroughputPoint[],
+  getValue: (p: ThroughputPoint) => number,
   xStep: number,
   y: (v: number) => number,
 ): string {
@@ -345,14 +368,14 @@ function buildArticlesSeriesPath(
   let i = 0;
   while (i < points.length) {
     const current = points[i];
-    if (!current || current.articles <= 0) {
+    if (!current || getValue(current) <= 0) {
       i++;
       continue;
     }
     const runStart = i;
     while (i < points.length) {
       const p = points[i];
-      if (!p || p.articles <= 0) break;
+      if (!p || getValue(p) <= 0) break;
       i++;
     }
     const runEnd = i - 1;
@@ -363,7 +386,7 @@ function buildArticlesSeriesPath(
       const p = points[j];
       if (!p) continue;
       const x = (j * xStep).toFixed(1);
-      const yy = y(p.articles).toFixed(1);
+      const yy = y(getValue(p)).toFixed(1);
       parts.push(`${j === from ? "M" : "L"}${x},${yy}`);
     }
     // Edge-of-window isolated spike with no adjacent zero needs a tiny stroke.
@@ -371,7 +394,7 @@ function buildArticlesSeriesPath(
       const p = points[from];
       if (p) {
         const x2 = (from * xStep + Math.max(xStep * 0.15, 1)).toFixed(1);
-        const yy = y(p.articles).toFixed(1);
+        const yy = y(getValue(p)).toFixed(1);
         parts.push(`L${x2},${yy}`);
       }
     }
@@ -451,7 +474,9 @@ function describeThroughputBucket(
 ): string {
   const parts = [
     formatBucketTime(point.bucket, window),
-    `${formatNumber(point.articles)} articles`,
+    `${formatNumber(clientArticles(point))} client reads`,
+    `${formatNumber(appArticles(point))} app reads`,
+    `${formatNumber(point.articles)} articles total`,
   ];
   const rate = (point.bytesFetched ?? 0) / bucketSeconds;
   if (rate > 0) parts.push(`${formatBytes(rate)}/s downloaded`);
@@ -459,6 +484,14 @@ function describeThroughputBucket(
   if (point.errors > 0) parts.push(`${formatNumber(point.errors)} errors`);
   if (point.bytesServed > 0) parts.push(`${formatBytes(point.bytesServed)} served`);
   return parts.join(", ");
+}
+
+function clientArticles(point: ThroughputPoint): number {
+  return Math.min(point.articles, Math.max(0, point.clientArticles ?? 0));
+}
+
+function appArticles(point: ThroughputPoint): number {
+  return Math.max(0, point.articles - clientArticles(point));
 }
 
 function formatBucketTime(ms: number, window: OverviewWindow): string {

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
@@ -47,6 +47,7 @@ export function ThroughputChart({
     appArticlesPath,
     errorsPath,
     maxArticles,
+    scaleMax,
     maxClientArticles,
     maxAppArticles,
     maxNetworkRate,
@@ -59,6 +60,7 @@ export function ThroughputChart({
         appArticlesPath: "",
         errorsPath: "",
         maxArticles: 0,
+        scaleMax: 0,
         maxClientArticles: 0,
         maxAppArticles: 0,
         maxNetworkRate: 0,
@@ -84,6 +86,7 @@ export function ThroughputChart({
       appArticlesPath: buildArticlesSeriesPath(points, appArticles, xStep, y),
       errorsPath: buildSparseSeriesPath(points, (p) => p.errors, xStep, y),
       maxArticles: peakArticles,
+      scaleMax,
       maxClientArticles: peakClientArticles,
       maxAppArticles: peakAppArticles,
       maxNetworkRate: maxRate,
@@ -205,8 +208,8 @@ export function ThroughputChart({
           <>
             <div className={styles.plot}>
               <div className="flex h-40 w-9 shrink-0 flex-col items-end justify-between text-[10px] text-base-content/50 tabular-nums select-none">
-                <span>{formatNumber(maxArticles)}</span>
-                <span>{formatNumber(Math.round(maxArticles / 2))}</span>
+                <span>{formatNumber(scaleMax)}</span>
+                <span>{formatNumber(Math.round(scaleMax / 2))}</span>
                 <span>0</span>
               </div>
               <div

--- a/frontend/app/routes/overview/route.tsx
+++ b/frontend/app/routes/overview/route.tsx
@@ -398,6 +398,7 @@ export default function Overview({ loaderData }: Route.ComponentProps) {
           <ThroughputChart
             points={stats.throughput}
             totalArticles={stats.totalArticles}
+            totalClientArticles={stats.totalClientArticles}
             totalMisses={stats.totalMisses}
             totalErrors={stats.totalErrors}
             totalBytesServed={stats.sessions.totalBytesServed}

--- a/frontend/app/routes/overview/utils/merge-overview-stats.test.ts
+++ b/frontend/app/routes/overview/utils/merge-overview-stats.test.ts
@@ -40,7 +40,7 @@ describe("mergeOverviewStats", () => {
         totalMisses: 40,
         totalErrors: 2,
         throughput: [
-          { bucket: 1, articles: 5, misses: 2, errors: 0, bytesServed: 10, bytesFetched: 20 },
+          { bucket: 1, articles: 5, clientArticles: 0, misses: 2, errors: 0, bytesServed: 10, bytesFetched: 20 },
         ],
         tiles: {
           activeReads: 2,
@@ -66,7 +66,7 @@ describe("mergeOverviewStats", () => {
       partial({
         includedSections: ["window"],
         throughput: [
-          { bucket: 1, articles: 5, misses: 1, errors: 0, bytesServed: 10, bytesFetched: 20 },
+          { bucket: 1, articles: 5, clientArticles: 0, misses: 1, errors: 0, bytesServed: 10, bytesFetched: 20 },
         ],
       }),
     );

--- a/frontend/app/routes/overview/utils/merge-overview-stats.test.ts
+++ b/frontend/app/routes/overview/utils/merge-overview-stats.test.ts
@@ -40,7 +40,15 @@ describe("mergeOverviewStats", () => {
         totalMisses: 40,
         totalErrors: 2,
         throughput: [
-          { bucket: 1, articles: 5, clientArticles: 0, misses: 2, errors: 0, bytesServed: 10, bytesFetched: 20 },
+          {
+            bucket: 1,
+            articles: 5,
+            clientArticles: 0,
+            misses: 2,
+            errors: 0,
+            bytesServed: 10,
+            bytesFetched: 20,
+          },
         ],
         tiles: {
           activeReads: 2,
@@ -66,7 +74,15 @@ describe("mergeOverviewStats", () => {
       partial({
         includedSections: ["window"],
         throughput: [
-          { bucket: 1, articles: 5, clientArticles: 0, misses: 1, errors: 0, bytesServed: 10, bytesFetched: 20 },
+          {
+            bucket: 1,
+            articles: 5,
+            clientArticles: 0,
+            misses: 1,
+            errors: 0,
+            bytesServed: 10,
+            bytesFetched: 20,
+          },
         ],
       }),
     );

--- a/frontend/app/routes/overview/utils/merge-overview-stats.test.ts
+++ b/frontend/app/routes/overview/utils/merge-overview-stats.test.ts
@@ -61,11 +61,11 @@ describe("mergeOverviewStats", () => {
     );
 
     expect(withWindow.totalArticles).toBe(99);
-  expect(withWindow.totalClientArticles).toBe(30);
+    expect(withWindow.totalClientArticles).toBe(30);
     expect(withWindow.totalMisses).toBe(40);
     expect(withWindow.totalErrors).toBe(2);
     expect(withWindow.throughput).toHaveLength(1);
-  expect(withWindow.throughput[0]?.clientArticles).toBe(3);
+    expect(withWindow.throughput[0]?.clientArticles).toBe(3);
     expect(withWindow.catalogue.fileCount).toBe(42);
     expect(withWindow.indexers).toHaveLength(1);
     expect(withWindow.includedSections).toEqual(expect.arrayContaining(["static", "window"]));
@@ -100,7 +100,7 @@ describe("mergeOverviewStats", () => {
     );
 
     expect(withDetail.throughput).toHaveLength(1);
-  expect(withDetail.throughput[0]?.clientArticles).toBe(4);
+    expect(withDetail.throughput[0]?.clientArticles).toBe(4);
     expect(withDetail.latency.p50Ms).toBe(12);
     expect(withDetail.errors).toEqual([{ status: "Missing", count: 3 }]);
   });

--- a/frontend/app/routes/overview/utils/merge-overview-stats.test.ts
+++ b/frontend/app/routes/overview/utils/merge-overview-stats.test.ts
@@ -37,13 +37,14 @@ describe("mergeOverviewStats", () => {
       partial({
         includedSections: ["window"],
         totalArticles: 99,
+        totalClientArticles: 30,
         totalMisses: 40,
         totalErrors: 2,
         throughput: [
           {
             bucket: 1,
             articles: 5,
-            clientArticles: 0,
+            clientArticles: 3,
             misses: 2,
             errors: 0,
             bytesServed: 10,
@@ -60,9 +61,11 @@ describe("mergeOverviewStats", () => {
     );
 
     expect(withWindow.totalArticles).toBe(99);
+  expect(withWindow.totalClientArticles).toBe(30);
     expect(withWindow.totalMisses).toBe(40);
     expect(withWindow.totalErrors).toBe(2);
     expect(withWindow.throughput).toHaveLength(1);
+  expect(withWindow.throughput[0]?.clientArticles).toBe(3);
     expect(withWindow.catalogue.fileCount).toBe(42);
     expect(withWindow.indexers).toHaveLength(1);
     expect(withWindow.includedSections).toEqual(expect.arrayContaining(["static", "window"]));
@@ -77,7 +80,7 @@ describe("mergeOverviewStats", () => {
           {
             bucket: 1,
             articles: 5,
-            clientArticles: 0,
+            clientArticles: 4,
             misses: 1,
             errors: 0,
             bytesServed: 10,
@@ -97,6 +100,7 @@ describe("mergeOverviewStats", () => {
     );
 
     expect(withDetail.throughput).toHaveLength(1);
+  expect(withDetail.throughput[0]?.clientArticles).toBe(4);
     expect(withDetail.latency.p50Ms).toBe(12);
     expect(withDetail.errors).toEqual([{ status: "Missing", count: 3 }]);
   });

--- a/frontend/app/routes/overview/utils/merge-overview-stats.ts
+++ b/frontend/app/routes/overview/utils/merge-overview-stats.ts
@@ -23,6 +23,7 @@ export const EMPTY_OVERVIEW_STATS: OverviewStatsResponse = {
   throughput: [],
   throughputBucketSizeMs: 60_000,
   totalArticles: 0,
+  totalClientArticles: 0,
   totalMisses: 0,
   totalErrors: 0,
   totalBytesFetched: 0,
@@ -100,6 +101,7 @@ export function mergeOverviewStats(
     next.throughput = partial.throughput;
     next.throughputBucketSizeMs = partial.throughputBucketSizeMs;
     next.totalArticles = partial.totalArticles;
+    next.totalClientArticles = partial.totalClientArticles ?? 0;
     next.totalMisses = partial.totalMisses;
     next.totalErrors = partial.totalErrors;
     next.totalBytesFetched = partial.totalBytesFetched;

--- a/tests/NzbWebDAV.Tests/Api/GetOverviewStatsThroughputTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetOverviewStatsThroughputTests.cs
@@ -14,18 +14,20 @@ public class GetOverviewStatsThroughputTests
         var m1 = m0 + OneMinute;
         var minutes = new[]
         {
-            (m0, 10L, 1L, 0L, 100L, 1_000L),
-            (m1, 5L, 0L, 2L, 50L, 500L),
-            (m1, 1L, 0L, 0L, 10L, 250L), // same minute bucket as m1 when bucketSize=minute
+            (m0, 10L, 4L, 1L, 0L, 100L, 1_000L),
+            (m1, 5L, 2L, 0L, 2L, 50L, 500L),
+            (m1, 1L, 1L, 0L, 0L, 10L, 250L), // same minute bucket as m1 when bucketSize=minute
         };
 
         var points = GetOverviewStatsController.BuildThroughputFromMinutes(minutes, OneMinute);
 
         Assert.Equal(2, points.Count);
         Assert.Equal(m0, points[0].Bucket);
+        Assert.Equal(4, points[0].ClientArticles);
         Assert.Equal(1_000, points[0].BytesFetched);
         Assert.Equal(100, points[0].BytesServed);
         Assert.Equal(m1, points[1].Bucket);
+        Assert.Equal(3, points[1].ClientArticles);
         Assert.Equal(750, points[1].BytesFetched);
         Assert.Equal(60, points[1].BytesServed);
     }
@@ -37,8 +39,8 @@ public class GetOverviewStatsThroughputTests
         var h1 = h0 + OneHour;
         var hours = new[]
         {
-            (h0, 20L, 2L, 1L, 4_000L),
-            (h1, 8L, 0L, 0L, 1_500L),
+            (h0, 20L, 8L, 2L, 1L, 4_000L),
+            (h1, 8L, 0L, 0L, 0L, 1_500L),
         };
         var sessions = new[]
         {
@@ -50,6 +52,7 @@ public class GetOverviewStatsThroughputTests
 
         Assert.Equal(2, points.Count);
         Assert.Equal(4_000, points[0].BytesFetched);
+        Assert.Equal(8, points[0].ClientArticles);
         Assert.Equal(200, points[0].BytesServed);
         Assert.Equal(1_500, points[1].BytesFetched);
         Assert.Equal(50, points[1].BytesServed);
@@ -61,15 +64,17 @@ public class GetOverviewStatsThroughputTests
         var start = 1_700_000_000_000L - (1_700_000_000_000L % OneHour);
         var minutes = new[]
         {
-            (start, 1L, 0L, 0L, 0L, 100L),
-            (start + OneMinute, 1L, 0L, 0L, 0L, 250L),
-            (start + OneHour, 1L, 0L, 0L, 0L, 400L),
+            (start, 1L, 1L, 0L, 0L, 0L, 100L),
+            (start + OneMinute, 1L, 0L, 0L, 0L, 0L, 250L),
+            (start + OneHour, 1L, 1L, 0L, 0L, 0L, 400L),
         };
 
         var points = GetOverviewStatsController.BuildThroughputFromMinutes(minutes, OneHour);
 
         Assert.Equal(2, points.Count);
         Assert.Equal(350, points[0].BytesFetched);
+        Assert.Equal(1, points[0].ClientArticles);
         Assert.Equal(400, points[1].BytesFetched);
+        Assert.Equal(1, points[1].ClientArticles);
     }
 }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadWorkloadClassifierTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadWorkloadClassifierTests.cs
@@ -1,0 +1,91 @@
+using NzbWebDAV.Clients.Usenet.Concurrency;
+using NzbWebDAV.Clients.Usenet.Contexts;
+using NzbWebDAV.Database.Models.Metrics;
+using NzbWebDAV.Extensions;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public sealed class DownloadWorkloadClassifierTests
+{
+    [Fact]
+    public void ClassifyForMetrics_WithoutContext_IsBackground()
+    {
+        using var source = new CancellationTokenSource();
+
+        var result = DownloadWorkloadClassifier.ClassifyForMetrics(source.Token);
+
+        Assert.Equal(SegmentFetch.FetchWorkload.Background, result);
+    }
+
+    [Fact]
+    public void ClassifyForMetrics_HighPriority_IsStreaming()
+    {
+        using var source = new CancellationTokenSource();
+        using var scope = source.Token.SetContext(new DownloadPriorityContext
+        {
+            Priority = SemaphorePriority.High,
+        });
+
+        var result = DownloadWorkloadClassifier.ClassifyForMetrics(source.Token);
+
+        Assert.Equal(SegmentFetch.FetchWorkload.Streaming, result);
+    }
+
+    [Fact]
+    public void ClassifyForMetrics_QueueContext_IsQueue()
+    {
+        using var source = new CancellationTokenSource();
+        using var scope = source.Token.SetContext(CreateQueueContext());
+
+        var result = DownloadWorkloadClassifier.ClassifyForMetrics(source.Token);
+
+        Assert.Equal(SegmentFetch.FetchWorkload.Queue, result);
+    }
+
+    [Fact]
+    public void ClassifyForMetrics_MaintenanceContext_IsMaintenance()
+    {
+        using var source = new CancellationTokenSource();
+        using var scope = source.Token.SetContext(MaintenanceDownloadContext.Instance);
+
+        var result = DownloadWorkloadClassifier.ClassifyForMetrics(source.Token);
+
+        Assert.Equal(SegmentFetch.FetchWorkload.Maintenance, result);
+    }
+
+    [Fact]
+    public void ClassifyForMetrics_QueueContextWinsOverHighPriority()
+    {
+        using var source = new CancellationTokenSource();
+        using var priorityScope = source.Token.SetContext(new DownloadPriorityContext
+        {
+            Priority = SemaphorePriority.High,
+        });
+        using var queueScope = source.Token.SetContext(CreateQueueContext());
+
+        var result = DownloadWorkloadClassifier.ClassifyForMetrics(source.Token);
+
+        Assert.Equal(SegmentFetch.FetchWorkload.Queue, result);
+    }
+
+    [Fact]
+    public void ClassifyForMetrics_MaintenanceContextWinsOverHighPriority()
+    {
+        using var source = new CancellationTokenSource();
+        using var priorityScope = source.Token.SetContext(new DownloadPriorityContext
+        {
+            Priority = SemaphorePriority.High,
+        });
+        using var maintenanceScope = source.Token.SetContext(MaintenanceDownloadContext.Instance);
+
+        var result = DownloadWorkloadClassifier.ClassifyForMetrics(source.Token);
+
+        Assert.Equal(SegmentFetch.FetchWorkload.Maintenance, result);
+    }
+
+    private static QueueDownloadContext CreateQueueContext() => new()
+    {
+        IsPrimary = true,
+        GetFanOutConcurrency = () => 1,
+    };
+}

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadWorkloadClassifierTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadWorkloadClassifierTests.cs
@@ -1,5 +1,6 @@
 using NzbWebDAV.Clients.Usenet.Concurrency;
 using NzbWebDAV.Clients.Usenet.Contexts;
+using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Extensions;
 
@@ -18,13 +19,24 @@ public sealed class DownloadWorkloadClassifierTests
     }
 
     [Fact]
-    public void ClassifyForMetrics_HighPriority_IsStreaming()
+    public void ClassifyForMetrics_HighPriorityWithoutReadSession_IsBackground()
     {
         using var source = new CancellationTokenSource();
         using var scope = source.Token.SetContext(new DownloadPriorityContext
         {
             Priority = SemaphorePriority.High,
         });
+
+        var result = DownloadWorkloadClassifier.ClassifyForMetrics(source.Token);
+
+        Assert.Equal(SegmentFetch.FetchWorkload.Background, result);
+    }
+
+    [Fact]
+    public void ClassifyForMetrics_ReadSession_IsStreaming()
+    {
+        using var source = new CancellationTokenSource();
+        using var scope = MultiProviderNntpClient.BeginReadSessionScope(Guid.NewGuid());
 
         var result = DownloadWorkloadClassifier.ClassifyForMetrics(source.Token);
 

--- a/tests/NzbWebDAV.Tests/Services/Metrics/MetricsRollupFailoverSavesTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/MetricsRollupFailoverSavesTests.cs
@@ -146,6 +146,36 @@ public sealed class MetricsRollupFailoverSavesTests
         });
     }
 
+    [Fact]
+    public async Task RollupMinute_LateClientFetch_IncreasesFinalizedClientArticles()
+    {
+        await withMetricsDb(async context =>
+        {
+            await context.Database.ExecuteSqlRawAsync(
+                """
+                INSERT INTO SegmentFetches
+                    (At, Provider, ReadSessionId, QueueItemId, Workload, Bytes, DurationMs, Status, Retries)
+                VALUES ({0}, 'streaming', NULL, NULL, 1, 0, 20, 0, 0);
+                """,
+                Minute + 1);
+
+            await MetricsRollupService.RollupMinuteAsync(context, Minute);
+            await context.Database.ExecuteSqlRawAsync(
+                """
+                INSERT INTO SegmentFetches
+                    (At, Provider, ReadSessionId, QueueItemId, Workload, Bytes, DurationMs, Status, Retries)
+                VALUES ({0}, 'streaming', NULL, NULL, 1, 0, 30, 0, 0);
+                """,
+                Minute + 2);
+            await MetricsRollupService.RollupMinuteAsync(context, Minute);
+
+            var throughput = await context.ThroughputMinutes.AsNoTracking().SingleAsync();
+            var provider = await context.ProviderMinutes.AsNoTracking().SingleAsync();
+            Assert.Equal(2, throughput.ClientArticles);
+            Assert.Equal(2, provider.ClientArticles);
+        });
+    }
+
     private static async Task withMetricsDb(Func<MetricsDbContext, Task> body)
     {
         var databasePath = Path.Join(

--- a/tests/NzbWebDAV.Tests/Services/Metrics/MetricsRollupFailoverSavesTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/MetricsRollupFailoverSavesTests.cs
@@ -116,6 +116,36 @@ public sealed class MetricsRollupFailoverSavesTests
         });
     }
 
+    [Fact]
+    public async Task RollupMinute_RetainedSourceRows_PreservesFinalizedClientArticles()
+    {
+        await withMetricsDb(async context =>
+        {
+            await context.Database.ExecuteSqlRawAsync(
+                """
+                INSERT INTO SegmentFetches
+                    (At, Provider, ReadSessionId, QueueItemId, Workload, Bytes, DurationMs, Status, Retries)
+                VALUES
+                    ({0}, 'streaming', NULL, NULL, 1, 0, 20, 0, 0),
+                    ({1}, 'streaming', NULL, NULL, 1, 0, 30, 0, 0);
+                """,
+                Minute + 1, Minute + 2);
+
+            await MetricsRollupService.RollupMinuteAsync(context, Minute);
+            await context.Database.ExecuteSqlRawAsync(
+                "DELETE FROM SegmentFetches WHERE At = {0}", Minute + 1);
+
+            await MetricsRollupService.RollupMinuteAsync(context, Minute);
+
+            var throughput = await context.ThroughputMinutes.AsNoTracking().SingleAsync();
+            var provider = await context.ProviderMinutes.AsNoTracking().SingleAsync();
+            Assert.Equal(2, throughput.ClientArticles);
+            Assert.Equal(2, provider.ClientArticles);
+            Assert.True(throughput.ClientArticlesFinalized);
+            Assert.True(provider.ClientArticlesFinalized);
+        });
+    }
+
     private static async Task withMetricsDb(Func<MetricsDbContext, Task> body)
     {
         var databasePath = Path.Join(

--- a/tests/NzbWebDAV.Tests/Services/Metrics/ProviderMetricsKeyTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Metrics/ProviderMetricsKeyTests.cs
@@ -140,6 +140,20 @@ public class ProviderMetricsKeyTests
             BytesFetched = 100,
             Articles = 1,
         });
+        harness.Context.ProviderMinutes.AddRange(
+            new ProviderMinute
+            {
+                Minute = hour,
+                Provider = "news.example.com",
+                ClientArticles = 4,
+                ClientArticlesFinalized = true,
+            },
+            new ProviderMinute
+            {
+                Minute = hour,
+                Provider = firstKey,
+                ClientArticles = 1,
+            });
         await harness.Context.SaveChangesAsync();
 
         await UsenetProviderIdentity.RemapHostKeyedMetricsAsync(
@@ -152,6 +166,9 @@ public class ProviderMetricsKeyTests
         Assert.Equal(11, firstRow.Articles);
         Assert.False(await verify.ProviderHourly.AnyAsync(x => x.Provider == "news.example.com"));
         Assert.False(await verify.ProviderHourly.AnyAsync(x => x.Provider == secondKey));
+        var minuteRow = await verify.ProviderMinutes.SingleAsync(x => x.Provider == firstKey && x.Minute == hour);
+        Assert.Equal(5, minuteRow.ClientArticles);
+        Assert.True(minuteRow.ClientArticlesFinalized);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Split Overview Activity article reads into solid client playback and dashed app-triggered series.
- Persist token-context workload attribution through raw fetches, rollups, retention, provider remapping, and Overview API totals.
- Historical pre-upgrade rows default to Unknown and display as app activity; no historical backfill is performed.

## Validation
- `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~Metrics|FullyQualifiedName~GetOverviewStats|FullyQualifiedName~MultiProviderNntpClient|FullyQualifiedName~SegmentCacheNntpClient|FullyQualifiedName~StartupDatabaseMigration"`
- `dotnet test tests/NzbWebDAV.ArchitectureTests/NzbWebDAV.ArchitectureTests.csproj -c Release`
- `cd frontend && npx vitest run app/routes/overview && npm run typecheck && npm run lint`
- `./scripts/export-admin-openapi.sh`

## Upgrade notes
- Back up `/config` before upgrading: the additive metrics SQLite migration runs automatically at startup.
- No setup-wizard change is required; this feature adds no configuration.
- Manual private/shared-stream and queue/maintenance attribution checks require non-production Usenet credentials and were not run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Overview statistics now distinguish client article reads from application article reads.
  * Throughput charts display separate client and application article series with updated legends, tooltips, and accessibility descriptions.
  * Client article totals are tracked across minute, hourly, and lifetime metrics.
  * Fetch activity is categorized by workload for more detailed reporting.
* **Bug Fixes**
  * Improved consistency of article-read aggregation across reporting windows and providers, including rerun and late-arriving data.
* **Tests**
  * Added coverage for chart rendering, aggregation, workload classification, and metric persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->