### PR TITLE
chore(license): declare MIT metadata for distributions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine
 # Label the image
 ARG REPO_URL
 LABEL org.opencontainers.image.source=${REPO_URL}
+LABEL org.opencontainers.image.licenses=MIT
 
 # Prepare environment
 WORKDIR /app

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 nzbdav-dev
+Copyright (c) 2026 hoivikaj
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "infinidysk",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "engines": {
     "node": ">=24"
@@ -53,7 +54,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@react-router/dev": "~8.3.0",
+    "@react-router/dev": "~8.3.1",
     "@stryker-mutator/core": "10.0.0",
     "@stryker-mutator/vitest-runner": "10.0.0",
     "@tailwindcss/vite": "^4.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@react-router/dev": "~8.3.1",
+    "@react-router/dev": "~8.3.0",
     "@stryker-mutator/core": "10.0.0",
     "@stryker-mutator/vitest-runner": "10.0.0",
     "@tailwindcss/vite": "^4.3.3",


### PR DESCRIPTION
## Summary
- declare the frontend package license as SPDX `MIT`
- publish `org.opencontainers.image.licenses=MIT` on container images

The repository root `LICENSE` is already recognized by GitHub as MIT on `main`; these declarations align distributed artifacts with that license.

## Validation
- `node -e 'const packageJson = require("./frontend/package.json"); if (packageJson.license !== "MIT") process.exit(1)'`
- verified the OCI label is present in `Dockerfile`
- `git diff --check`