### PR TITLE
fix(sab): Sonarr/Radarr no longer loop on "Download doesn't contain intermediate path" after a job folder is removed

### DIFF
--- a/backend/Api/Controllers/DeleteWebdavItem/DeleteWebdavItemController.cs
+++ b/backend/Api/Controllers/DeleteWebdavItem/DeleteWebdavItemController.cs
@@ -81,8 +81,16 @@ public class DeleteWebdavItemController(
                 .Select(x => x.HistoryItemId!.Value)
                 .Distinct()
                 .ToList();
+            var deletedDirectoryIds = subtree
+                .Where(x => x.Type == DavItem.ItemType.Directory)
+                .Select(x => x.Id)
+                .ToList();
             var prunedHistoryIds = await dbClient
-                .PruneUnreferencedHistoryItemsAsync(historyIds, source: "explore-delete", ct: ct)
+                .PruneUnreferencedHistoryItemsAsync(
+                    historyIds,
+                    source: "explore-delete",
+                    ct: ct,
+                    deletedDirectoryIds: deletedDirectoryIds)
                 .ConfigureAwait(false);
 
             await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);

--- a/backend/Api/SabControllers/GetHistory/GetHistoryController.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryController.cs
@@ -29,7 +29,7 @@ public class GetHistoryController(
         if (request.HasUnsupportedStatus)
             query = query.Where(_ => false);
         else if (request.Status is { } status)
-            query = query.Where(q => q.DownloadStatus == status);
+            query = ApplyEffectiveStatusFilter(query, status);
 
         // Get total count before querying the page: DbContext does not support
         // concurrent operations.
@@ -79,7 +79,21 @@ public class GetHistoryController(
             }
         };
     }
-
+    // Completed rows whose download folder is gone are reported as Failed by
+    // HistoryItemAddedPayload, so status filtering has to use that same effective status.
+    private IQueryable<HistoryItem> ApplyEffectiveStatusFilter(
+        IQueryable<HistoryItem> query,
+        HistoryItem.DownloadStatusOption status)
+    {
+        var items = dbClient.Ctx.Items;
+        return status == HistoryItem.DownloadStatusOption.Completed
+            ? query.Where(q =>
+                q.DownloadStatus == HistoryItem.DownloadStatusOption.Completed
+                && items.Any(d => d.Id == q.DownloadDirId))
+            : query.Where(q =>
+                q.DownloadStatus != HistoryItem.DownloadStatusOption.Completed
+                || !items.Any(d => d.Id == q.DownloadDirId));
+    }
     protected override async Task<IActionResult> Handle()
     {
         var request = new GetHistoryRequest(Context, Config);

--- a/backend/Api/SabControllers/RetryHistory/RetryHistoryController.cs
+++ b/backend/Api/SabControllers/RetryHistory/RetryHistoryController.cs
@@ -65,7 +65,8 @@ public class RetryHistoryController(
         if (historyItem is null)
             throw new BadHttpRequestException("History item not found.");
 
-        if (historyItem.DownloadStatus != HistoryItem.DownloadStatusOption.Failed)
+        if (historyItem.DownloadStatus != HistoryItem.DownloadStatusOption.Failed
+            && await DownloadFolderExistsAsync(historyItem, ct).ConfigureAwait(false))
             throw new BadHttpRequestException("Only failed history items can be retried.");
 
         if (historyItem.NzbBlobId is null)
@@ -97,6 +98,16 @@ public class RetryHistoryController(
             throw new BadHttpRequestException("Failed to re-queue NZB.");
 
         return Guid.Parse(addResponse.NzoIds[0]);
+    }
+
+    // Completed rows whose download folder is gone are reported as Failed in mode=history, so the
+    // UI offers Retry for them; accept it here for the same rows.
+    private async Task<bool> DownloadFolderExistsAsync(HistoryItem historyItem, CancellationToken ct)
+    {
+        if (historyItem.DownloadDirId is null) return false;
+        return await dbClient.Ctx.Items.AsNoTracking()
+            .AnyAsync(d => d.Id == historyItem.DownloadDirId, ct)
+            .ConfigureAwait(false);
     }
 
     protected override async Task<IActionResult> Handle()

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -812,12 +812,33 @@ public sealed class DavDatabaseClient(
     public async Task<List<Guid>> PruneUnreferencedHistoryItemsAsync(
         IReadOnlyCollection<Guid> historyItemIds,
         string source = "webdav-unreferenced-prune",
+        IReadOnlyCollection<Guid>? deletedDirectoryIds = null,
         CancellationToken ct = default)
     {
-        if (historyItemIds.Count == 0) return [];
-
         const int batchSize = 500;
-        var distinctIds = historyItemIds.Distinct().ToList();
+        var candidateIds = historyItemIds.ToHashSet();
+
+        // Mount folders created before DavItems.HistoryItemId existed (2026-02) carry no
+        // back-reference, so their Completed history row is only reachable via DownloadDirId.
+        if (deletedDirectoryIds is { Count: > 0 })
+        {
+            foreach (var chunk in deletedDirectoryIds.Distinct().Chunk(batchSize))
+            {
+                var batch = chunk.ToList();
+                var legacyIds = await Ctx.HistoryItems
+                    .AsNoTracking()
+                    .Where(h => h.DownloadStatus == HistoryItem.DownloadStatusOption.Completed
+                                && h.DownloadDirId != null
+                                && batch.Contains(h.DownloadDirId.Value))
+                    .Select(h => h.Id)
+                    .ToListAsync(ct)
+                    .ConfigureAwait(false);
+                candidateIds.UnionWith(legacyIds);
+            }
+        }
+
+        if (candidateIds.Count == 0) return [];
+        var distinctIds = candidateIds.ToList();
 
         var stillReferenced = new HashSet<Guid>();
         foreach (var chunk in distinctIds.Chunk(batchSize))

--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -822,9 +822,8 @@ public sealed class DavDatabaseClient(
         // back-reference, so their Completed history row is only reachable via DownloadDirId.
         if (deletedDirectoryIds is { Count: > 0 })
         {
-            foreach (var chunk in deletedDirectoryIds.Distinct().Chunk(batchSize))
+            foreach (var batch in deletedDirectoryIds.Distinct().Chunk(batchSize).Select(chunk => chunk.ToList()))
             {
-                var batch = chunk.ToList();
                 var legacyIds = await Ctx.HistoryItems
                     .AsNoTracking()
                     .Where(h => h.DownloadStatus == HistoryItem.DownloadStatusOption.Completed

--- a/backend/Queue/HistoryItemAddedPayload.cs
+++ b/backend/Queue/HistoryItemAddedPayload.cs
@@ -9,6 +9,8 @@ namespace NzbWebDAV.Queue;
 /// </summary>
 public sealed class HistoryItemAddedPayload
 {
+    public const string DownloadFolderMissingFailMessage = "Download folder no longer exists.";
+
     [JsonPropertyName("nzo_id")] public string NzoId { get; init; } = null!;
     [JsonPropertyName("nzb_name")] public string NzbName { get; init; } = null!;
     [JsonPropertyName("name")] public string JobName { get; init; } = null!;
@@ -32,23 +34,33 @@ public sealed class HistoryItemAddedPayload
         IReadOnlyDictionary<string, long>? providerUsage = null,
         IReadOnlyDictionary<string, (string Host, string? Nickname)>? displayByMetricsKey = null)
     {
+        // A Completed slot with an empty `storage` is a state SABnzbd never produces; Sonarr/Radarr
+        // warn "Download doesn't contain intermediate path" forever instead of handling it.
+        var downloadFolderMissing = IsDownloadFolderMissing(historyItem, downloadFolder);
         return new HistoryItemAddedPayload
         {
             NzoId = historyItem.Id.ToString(),
             NzbName = historyItem.FileName,
             JobName = historyItem.JobName,
             Category = historyItem.Category,
-            Status = historyItem.DownloadStatus,
+            Status = downloadFolderMissing
+                ? HistoryItem.DownloadStatusOption.Failed
+                : historyItem.DownloadStatus,
             SizeInBytes = historyItem.TotalSegmentBytes,
             DownloadPath = GetDownloadPath(historyItem, downloadFolder, configManager),
             DownloadTimeSeconds = historyItem.DownloadTimeSeconds,
             Completed = new DateTimeOffset(historyItem.CreatedAt).ToUnixTimeSeconds(),
-            FailMessage = historyItem.FailMessage ?? "",
+            FailMessage = downloadFolderMissing
+                ? DownloadFolderMissingFailMessage
+                : historyItem.FailMessage ?? "",
             NzbBlobId = historyItem.NzbBlobId?.ToString(),
             Indexer = historyItem.IndexerName,
             Providers = QueueItemAddedPayload.MapProviders(providerUsage, displayByMetricsKey),
         };
     }
+
+    public static bool IsDownloadFolderMissing(HistoryItem historyItem, DavItem? downloadFolder) =>
+        historyItem.DownloadStatus == HistoryItem.DownloadStatusOption.Completed && downloadFolder == null;
 
     private static string? GetDownloadPath(
         HistoryItem historyItem,

--- a/backend/WebDav/DatabaseStoreCollection.cs
+++ b/backend/WebDav/DatabaseStoreCollection.cs
@@ -132,7 +132,7 @@ public class DatabaseStoreCollection(
             DeletionAuditLog.Record("webdav-delete", davItem, "client DELETE on directory");
             dbClient.Ctx.Items.Remove(davItem);
             await dbClient.Ctx.SaveChangesAsync().ConfigureAwait(false);
-            await PruneEmptyHistoryAsync(historyItemId, request.CancellationToken).ConfigureAwait(false);
+            await PruneEmptyHistoryAsync(historyItemId, request.CancellationToken, davItem.Id).ConfigureAwait(false);
             return DavStatusCode.Ok;
         }
 
@@ -144,15 +144,18 @@ public class DatabaseStoreCollection(
     // remove the HistoryItem too. Without this, external tools polling /api?mode=history
     // (third-party SAB-compatible clients, Sonarr, etc.) see the entry as Completed and hand the
     // player a URL pointing at the file we just deleted — re-clicking never re-enqueues.
-    private async Task PruneEmptyHistoryAsync(Guid? historyItemId, CancellationToken ct)
+    private async Task PruneEmptyHistoryAsync(Guid? historyItemId, CancellationToken ct, Guid? deletedDirectoryId = null)
     {
-        if (historyItemId is null) return;
+        if (historyItemId is null && deletedDirectoryId is null) return;
         var pruned = await dbClient.PruneUnreferencedHistoryItemsAsync(
-                [historyItemId.Value], source: "webdav-unreferenced-prune", ct: ct)
+                historyItemId is { } id ? [id] : [],
+                source: "webdav-unreferenced-prune",
+                ct: ct,
+                deletedDirectoryIds: deletedDirectoryId is { } dirId ? [dirId] : null)
             .ConfigureAwait(false);
         if (pruned.Count == 0) return;
 
         await dbClient.Ctx.SaveChangesAsync(ct).ConfigureAwait(false);
-        _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemRemoved, pruned[0].ToString());
+        _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemRemoved, string.Join(",", pruned));
     }
 }

--- a/tests/NzbWebDAV.Tests/Api/DeleteWebdavItemControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/DeleteWebdavItemControllerTests.cs
@@ -426,6 +426,75 @@ public sealed class DeleteWebdavItemControllerTests : IAsyncLifetime
             .SingleOrDefaultAsync(x => x.Id == nzbBlobId));
     }
 
+    [Fact]
+    public async Task DeleteAsync_LegacyJobFolderWithoutHistoryItemId_PrunesCompletedHistoryByDownloadDirId()
+    {
+        // Mount folders created before DavItems.HistoryItemId existed carry no back-reference;
+        // the only link is HistoryItems.DownloadDirId → job folder.
+        var (jobDir, completedHistoryId, _) = await SeedLegacyContentReleaseAsync("Legacy.Show.S01E01");
+
+        // A Failed row pointing at the same folder must survive (mark-failed reuses DownloadDirId).
+        var failedHistoryId = Guid.NewGuid();
+        var failedBlobId = Guid.NewGuid();
+        var failedHistory = CreateHistory(failedHistoryId, "Legacy.Show.S01E01.dup.nzb", "tv", failedBlobId);
+        failedHistory.DownloadStatus = HistoryItem.DownloadStatusOption.Failed;
+        failedHistory.DownloadDirId = jobDir.Id;
+        _context.HistoryItems.Add(failedHistory);
+        _context.NzbNames.Add(new NzbName { Id = failedBlobId, FileName = failedHistory.FileName });
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var result = await InvokeDeleteAsync(jobDir.Path);
+        Assert.Equal(200, GetStatusCode(result));
+
+        Assert.Null(await _context.Items.AsNoTracking().SingleOrDefaultAsync(x => x.Id == jobDir.Id));
+        Assert.Null(await _context.HistoryItems.AsNoTracking()
+            .SingleOrDefaultAsync(x => x.Id == completedHistoryId));
+        Assert.NotNull(await _context.HistoryItems.AsNoTracking()
+            .SingleOrDefaultAsync(x => x.Id == failedHistoryId));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_LegacyFileOnly_KeepsHistoryWhileJobFolderExists()
+    {
+        var (jobDir, completedHistoryId, file) = await SeedLegacyContentReleaseAsync("Legacy.Show.S01E02");
+
+        var result = await InvokeDeleteAsync(file.Path);
+        Assert.Equal(200, GetStatusCode(result));
+
+        Assert.NotNull(await _context.Items.AsNoTracking().SingleOrDefaultAsync(x => x.Id == jobDir.Id));
+        Assert.NotNull(await _context.HistoryItems.AsNoTracking()
+            .SingleOrDefaultAsync(x => x.Id == completedHistoryId));
+    }
+
+    private async Task<(DavItem JobDir, Guid HistoryId, DavItem File)> SeedLegacyContentReleaseAsync(string jobName)
+    {
+        var historyId = Guid.NewGuid();
+        var nzbBlobId = Guid.NewGuid();
+        var categoryDir = await EnsureCategoryAsync("tv");
+        var jobDir = NewDir(Guid.NewGuid(), categoryDir, jobName);
+        var file = DavItem.New(
+            Guid.NewGuid(),
+            jobDir,
+            "episode.mkv",
+            100,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.NzbFile,
+            null,
+            null,
+            historyItemId: null,
+            Guid.NewGuid(),
+            nzbBlobId);
+        var history = CreateHistory(historyId, $"{jobName}.nzb", "tv", nzbBlobId);
+        history.DownloadDirId = jobDir.Id;
+        _context.HistoryItems.Add(history);
+        _context.NzbNames.Add(new NzbName { Id = nzbBlobId, FileName = $"{jobName}.nzb" });
+        _context.Items.AddRange(jobDir, file);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+        return (jobDir, historyId, file);
+    }
+
     private DeleteWebdavItemController CreateDeleteController()
     {
         var controller = new DeleteWebdavItemController(

--- a/tests/NzbWebDAV.Tests/Api/GetHistoryMissingDownloadFolderTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/GetHistoryMissingDownloadFolderTests.cs
@@ -1,0 +1,170 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Api.SabControllers.GetHistory;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Interceptors;
+using NzbWebDAV.Database.MigrationHelpers;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Services;
+using NzbWebDAV.Tests.Database;
+
+namespace NzbWebDAV.Tests.Api;
+
+/// <summary>
+/// A Completed history row whose download folder no longer exists (deleted via
+/// WebDAV/Explore, or a legacy folder that predates <c>DavItems.HistoryItemId</c>)
+/// must be reported as Failed with a reason. SABnzbd never returns a Completed
+/// slot with an empty <c>storage</c>; Sonarr/Radarr respond to that shape with
+/// "Download doesn't contain intermediate path, Skipping." on every poll.
+/// </summary>
+[Collection(nameof(ConfigPathCollection))]
+public sealed class GetHistoryMissingDownloadFolderTests : IAsyncLifetime
+{
+    private readonly string _configRoot =
+        Path.Join(Path.GetTempPath(), $"nzbdav-history-missing-folder-cfg-{Guid.NewGuid():N}");
+    private string? _previousConfigPath;
+    private DavDatabaseContext _context = null!;
+    private DavDatabaseClient _dbClient = null!;
+    private ConfigManager _configManager = null!;
+
+    public async Task InitializeAsync()
+    {
+        _previousConfigPath = Environment.GetEnvironmentVariable("CONFIG_PATH");
+        Directory.CreateDirectory(_configRoot);
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configRoot);
+
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite($"Data Source={DavDatabaseContext.DatabaseFilePath}")
+            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .ReplaceService<
+                IMigrationsSqlGenerator,
+                SqliteMigrationsSqlGenerator<SqliteMigrationsSqlGenerator>>()
+            .Options;
+        _context = new DavDatabaseContext(options);
+        await _context.Database.MigrateAsync();
+        _dbClient = new DavDatabaseClient(_context);
+
+        _configManager = new ConfigManager();
+        _configManager.UpdateValues(
+        [
+            new ConfigItem
+            {
+                ConfigName = ConfigKeys.UsenetProviders,
+                ConfigValue = JsonSerializer.Serialize(new UsenetProviderConfig()),
+            },
+            new ConfigItem { ConfigName = ConfigKeys.RcloneMountDir, ConfigValue = "/mnt/nzbdav" },
+        ]);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _previousConfigPath);
+        try { Directory.Delete(_configRoot, recursive: true); } catch (IOException) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task CompletedWithMissingFolder_IsReportedAsFailedWithReason()
+    {
+        var orphanId = await SeedCompletedAsync("Orphan.Show.S01E01.nzb", downloadDirId: Guid.NewGuid());
+        var liveFolder = await SeedFolderAsync("Live.Show.S01E01");
+        var liveId = await SeedCompletedAsync("Live.Show.S01E01.nzb", downloadDirId: liveFolder.Id);
+
+        var response = await CreateController().GetHistoryAsync(BuildRequest(""));
+
+        var orphan = Assert.Single(response.History.Slots, s => s.NzoId == orphanId.ToString());
+        Assert.Equal(HistoryItem.DownloadStatusOption.Failed, orphan.Status);
+        Assert.Equal(HistoryItemAddedPayload.DownloadFolderMissingFailMessage, orphan.FailMessage);
+        Assert.True(string.IsNullOrEmpty(orphan.DownloadPath));
+
+        var live = Assert.Single(response.History.Slots, s => s.NzoId == liveId.ToString());
+        Assert.Equal(HistoryItem.DownloadStatusOption.Completed, live.Status);
+        Assert.False(string.IsNullOrEmpty(live.DownloadPath));
+    }
+
+    [Fact]
+    public async Task StatusFilters_UseTheReportedStatus()
+    {
+        var orphanId = await SeedCompletedAsync("Orphan.Show.S01E02.nzb", downloadDirId: Guid.NewGuid());
+        var liveFolder = await SeedFolderAsync("Live.Show.S01E02");
+        var liveId = await SeedCompletedAsync("Live.Show.S01E02.nzb", downloadDirId: liveFolder.Id);
+
+        // Sonarr/Radarr poll with failed_only=1 to find downloads to clean up.
+        var failedOnly = await CreateController().GetHistoryAsync(BuildRequest("?failed_only=1"));
+        var failedSlot = Assert.Single(failedOnly.History.Slots);
+        Assert.Equal(orphanId.ToString(), failedSlot.NzoId);
+        Assert.Equal(HistoryItem.DownloadStatusOption.Failed, failedSlot.Status);
+        Assert.Equal(1, failedOnly.History.TotalCount);
+
+        var completed = await CreateController().GetHistoryAsync(BuildRequest("?status=completed"));
+        var completedSlot = Assert.Single(completed.History.Slots);
+        Assert.Equal(liveId.ToString(), completedSlot.NzoId);
+        Assert.Equal(1, completed.History.TotalCount);
+    }
+
+    private async Task<Guid> SeedCompletedAsync(string fileName, Guid? downloadDirId)
+    {
+        var id = Guid.NewGuid();
+        _context.HistoryItems.Add(new HistoryItem
+        {
+            Id = id,
+            CreatedAt = DateTime.UtcNow,
+            FileName = fileName,
+            JobName = Path.GetFileNameWithoutExtension(fileName),
+            Category = "tv",
+            DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+            TotalSegmentBytes = 100,
+            DownloadTimeSeconds = 1,
+            NzbBlobId = id,
+            DownloadDirId = downloadDirId,
+        });
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+        return id;
+    }
+
+    private async Task<DavItem> SeedFolderAsync(string jobName)
+    {
+        var categoryDir = await _context.Items.AsNoTracking()
+            .SingleOrDefaultAsync(x => x.ParentId == DavItem.ContentFolder.Id && x.Name == "tv");
+        if (categoryDir is null)
+        {
+            categoryDir = NewDir(DavItem.ContentFolder, "tv");
+            _context.Items.Add(categoryDir);
+        }
+
+        var jobDir = NewDir(categoryDir, jobName);
+        _context.Items.Add(jobDir);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+        return jobDir;
+    }
+
+    private static DavItem NewDir(DavItem parent, string name) =>
+        DavItem.New(
+            Guid.NewGuid(),
+            parent,
+            name,
+            null,
+            DavItem.ItemType.Directory,
+            DavItem.ItemSubType.Directory,
+            null,
+            null,
+            null,
+            null);
+
+    private GetHistoryRequest BuildRequest(string queryString)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.QueryString = new QueryString(queryString);
+        return new GetHistoryRequest(httpContext, _configManager);
+    }
+
+    private GetHistoryController CreateController() =>
+        new(new DefaultHttpContext(), _dbClient, _configManager, new ProviderUsageTracker());
+}

--- a/tests/NzbWebDAV.Tests/Api/RetryHistoryControllerTests.cs
+++ b/tests/NzbWebDAV.Tests/Api/RetryHistoryControllerTests.cs
@@ -194,21 +194,44 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task RetryHistoryAsync_CompletedHistory_ThrowsBadRequest()
+    public async Task RetryHistoryAsync_CompletedHistoryWithDownloadFolder_ThrowsBadRequest()
     {
         var historyId = Guid.NewGuid();
+        var downloadDir = await SeedContentFolderAsync("tv", "Completed.Show");
         await SeedHistoryAsync(
             historyId,
             "Completed.Show.nzb",
             "tv",
             HistoryItem.DownloadStatusOption.Completed,
-            writeBlob: true);
+            writeBlob: true,
+            downloadDirId: downloadDir.Id);
 
         var request = await CreateRequest(historyId);
         var ex = await Assert.ThrowsAsync<BadHttpRequestException>(
             () => CreateController().RetryHistoryAsync(request));
         Assert.Equal("Only failed history items can be retried.", ex.Message);
         Assert.Empty(await _context.QueueItems.AsNoTracking().ToListAsync());
+    }
+
+    [Fact]
+    public async Task RetryHistoryAsync_CompletedHistoryWithMissingDownloadFolder_Requeues()
+    {
+        // mode=history reports these rows as Failed, so the Retry the UI offers must work.
+        var historyId = Guid.NewGuid();
+        await SeedHistoryAsync(
+            historyId,
+            "Orphaned.Show.nzb",
+            "tv",
+            HistoryItem.DownloadStatusOption.Completed,
+            writeBlob: true,
+            downloadDirId: Guid.NewGuid());
+
+        var response = await CreateController().RetryHistoryAsync(await CreateRequest(historyId));
+
+        Assert.True(response.Status);
+        var newId = Guid.Parse(response.NzoId!);
+        Assert.NotEqual(historyId, newId);
+        Assert.NotNull(await _context.QueueItems.AsNoTracking().SingleOrDefaultAsync(q => q.Id == newId));
     }
 
     [Fact]
@@ -338,7 +361,8 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
         string category,
         HistoryItem.DownloadStatusOption status,
         bool writeBlob,
-        Guid? arrDownloadId = null)
+        Guid? arrDownloadId = null,
+        Guid? downloadDirId = null)
     {
         if (writeBlob)
         {
@@ -372,6 +396,7 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
                 : null,
             NzbBlobId = id,
             ArrDownloadId = arrDownloadId,
+            DownloadDirId = downloadDirId,
             IndexerName = "test-indexer",
             ContentGroupKey = "group-key",
         });
@@ -379,4 +404,27 @@ public sealed class RetryHistoryControllerTests : IAsyncLifetime
         await _context.SaveChangesAsync();
         _context.ChangeTracker.Clear();
     }
+
+    private async Task<DavItem> SeedContentFolderAsync(string category, string jobName)
+    {
+        var categoryDir = NewDir(DavItem.ContentFolder, category);
+        var jobDir = NewDir(categoryDir, jobName);
+        _context.Items.AddRange(categoryDir, jobDir);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+        return jobDir;
+    }
+
+    private static DavItem NewDir(DavItem parent, string name) =>
+        DavItem.New(
+            Guid.NewGuid(),
+            parent,
+            name,
+            null,
+            DavItem.ItemType.Directory,
+            DavItem.ItemSubType.Directory,
+            null,
+            null,
+            null,
+            null);
 }

--- a/tests/NzbWebDAV.Tests/Queue/HistoryItemAddedPayloadTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/HistoryItemAddedPayloadTests.cs
@@ -16,7 +16,7 @@ public sealed class HistoryItemAddedPayloadTests
         ]);
 
         var payload = HistoryItemAddedPayload.FromHistoryItem(
-            HistoryItem("movies"),
+            NewHistoryItem("movies"),
             new DavItem { Name = "Movie" },
             config);
 
@@ -36,18 +36,58 @@ public sealed class HistoryItemAddedPayloadTests
         ]);
 
         var payload = HistoryItemAddedPayload.FromHistoryItem(
-            HistoryItem("tv"),
+            NewHistoryItem("tv"),
             new DavItem { Name = "Show" },
             config);
 
         Assert.Equal(Path.Join("/mnt/jellyfin", "tv", "Show"), payload.DownloadPath);
     }
 
-    private static HistoryItem HistoryItem(string category) => new()
+    [Fact]
+    public void CompletedWithoutDownloadFolder_ReportsFailedWithReason()
+    {
+        var payload = HistoryItemAddedPayload.FromHistoryItem(
+            NewHistoryItem("movies", HistoryItem.DownloadStatusOption.Completed),
+            downloadFolder: null,
+            new ConfigManager());
+
+        Assert.Equal(HistoryItem.DownloadStatusOption.Failed, payload.Status);
+        Assert.Equal(HistoryItemAddedPayload.DownloadFolderMissingFailMessage, payload.FailMessage);
+        Assert.Null(payload.DownloadPath);
+    }
+
+    [Fact]
+    public void CompletedWithDownloadFolder_StaysCompleted()
+    {
+        var payload = HistoryItemAddedPayload.FromHistoryItem(
+            NewHistoryItem("movies", HistoryItem.DownloadStatusOption.Completed),
+            new DavItem { Name = "Movie" },
+            new ConfigManager());
+
+        Assert.Equal(HistoryItem.DownloadStatusOption.Completed, payload.Status);
+        Assert.Equal("", payload.FailMessage);
+    }
+
+    [Fact]
+    public void FailedWithoutDownloadFolder_KeepsOriginalFailMessage()
+    {
+        var historyItem = NewHistoryItem("movies", HistoryItem.DownloadStatusOption.Failed);
+        historyItem.FailMessage = "Missing articles.";
+
+        var payload = HistoryItemAddedPayload.FromHistoryItem(historyItem, downloadFolder: null, new ConfigManager());
+
+        Assert.Equal(HistoryItem.DownloadStatusOption.Failed, payload.Status);
+        Assert.Equal("Missing articles.", payload.FailMessage);
+    }
+
+    private static HistoryItem NewHistoryItem(
+        string category,
+        HistoryItem.DownloadStatusOption status = HistoryItem.DownloadStatusOption.Completed) => new()
     {
         Id = Guid.NewGuid(),
         FileName = "release.nzb",
         JobName = "release",
         Category = category,
+        DownloadStatus = status,
     };
 }


### PR DESCRIPTION
## Summary

Users report Sonarr/Radarr logging `Download doesn't contain intermediate path, Skipping.` on every history poll. The cause is a **Completed** SAB history slot with an empty `storage` path — a shape SABnzbd never produces, so the Arrs never clean it up.

This happens when the job's mount folder under `/content` is gone but its history row remains:

- **Legacy folders** created before `DavItems.HistoryItemId` existed (migration `20260201023253`, no backfill) carry no back-reference, so WebDAV/Explore deletes never pruned their Completed history row.
- Any other path that removes the folder but keeps the row.

### Changes

- **`mode=history`**: a Completed row whose download folder no longer exists is reported as `Failed` with `fail_message: "Download folder no longer exists."`. The `status=`/`failed_only=1` filters use the same effective status, so Arr "Remove Failed" cleanup sees these rows. `mode=retry` accepts them, so the UI's Retry button (shown for Failed rows with an NZB blob) works.
- **Prune on delete**: `PruneUnreferencedHistoryItemsAsync` now also takes the deleted directory ids and prunes Completed rows whose `DownloadDirId` points at them (WebDAV `DELETE` and Explore delete). Restricted to Completed rows so Failed duplicates that share a `DownloadDirId` (mark-failed behaviour) are kept.

No data migration/backfill: `HealthCheckService` deliberately health-checks only files with `HistoryItemId == null`, so backfilling would remove legacy files from routine checks. Existing orphaned rows are handled non-destructively by the presentation fallback (retryable, blob preserved).

Related: "Failed to import movie, Destination already exists" is a Radarr-side condition (file already present at destination) and is not addressed here.

## Test plan

- [x] `HistoryItemAddedPayloadTests`: Completed+missing folder → Failed with reason; Completed+folder stays Completed; Failed keeps its own message.
- [x] `GetHistoryMissingDownloadFolderTests` (new): unfiltered listing, `failed_only=1` includes the orphan, `status=completed` excludes it, `TotalCount` matches.
- [x] `RetryHistoryControllerTests`: Completed with live folder still rejected; Completed with missing folder requeues.
- [x] `DeleteWebdavItemControllerTests`: deleting a legacy job folder (no `HistoryItemId`) prunes its Completed row and keeps a Failed row sharing the `DownloadDirId`; deleting only the file keeps the row while the folder exists.
- [x] 751 related backend tests (`History|Sab|Prune|DatabaseStore|RemoveMissingPayloads|Contract`) pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completed downloads whose download folder is missing are now reported as failed with a clear explanation.
  * History status filters now reflect the status shown to users.
  * Missing-folder downloads can be retried and requeued.
  * Deleting WebDAV folders now cleans up related unreferenced history, including legacy entries.
  * History removal notifications now include all affected entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->