### PR TITLE
fix(ui): render app activity reads as a solid line

### DIFF
--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.module.css
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.module.css
@@ -40,7 +40,6 @@
 .lineApp {
   stroke: var(--color-info);
   stroke-width: 1.5;
-  stroke-dasharray: 4 3;
   fill: none;
   vector-effect: non-scaling-stroke;
 }


### PR DESCRIPTION
## Summary
- Render the blue app-read series as a solid line in the activity dashboard for improved readability.

## Test plan
- `cd frontend && npm test -- app/routes/overview/components/throughput-chart/throughput-chart.test.tsx`