### PR TITLE
fix(metrics): rclone/Plex playback through shared streams no longer shows up as "App reads" on the Activity chart

### DIFF
--- a/backend/Clients/Usenet/Contexts/DownloadWorkloadClassifier.cs
+++ b/backend/Clients/Usenet/Contexts/DownloadWorkloadClassifier.cs
@@ -20,7 +20,7 @@ internal static class DownloadWorkloadClassifier
 
     internal static SegmentFetch.FetchWorkload ClassifyForMetrics(CancellationToken cancellationToken)
     {
-        if (MultiProviderNntpClient.CurrentReadSessionId is not null)
+        if (MultiProviderNntpClient.CurrentReadSessionId is not null || SharedStreamPumpContext.IsActive)
             return SegmentFetch.FetchWorkload.Streaming;
 
         return Classify(cancellationToken) switch

--- a/backend/Clients/Usenet/Contexts/SharedStreamPumpContext.cs
+++ b/backend/Clients/Usenet/Contexts/SharedStreamPumpContext.cs
@@ -1,0 +1,25 @@
+namespace NzbWebDAV.Clients.Usenet.Contexts;
+
+/// <summary>
+/// Marks the async flow of a shared-stream pump. The pump starts with execution-context
+/// flow suppressed so it never inherits one reader's request state, which also drops the
+/// read-session id; this marker keeps its fetches attributed to client playback.
+/// Attribution only — does not change admission priority at the provider gate.
+/// </summary>
+public sealed class SharedStreamPumpContext : IDisposable
+{
+    private static readonly AsyncLocal<bool> Active = new();
+    private readonly bool _previous;
+
+    private SharedStreamPumpContext()
+    {
+        _previous = Active.Value;
+        Active.Value = true;
+    }
+
+    public static bool IsActive => Active.Value;
+
+    public static IDisposable Begin() => new SharedStreamPumpContext();
+
+    public void Dispose() => Active.Value = _previous;
+}

--- a/backend/Streams/SharedStreamEntry.cs
+++ b/backend/Streams/SharedStreamEntry.cs
@@ -259,6 +259,7 @@ internal sealed class SharedStreamEntry : IAsyncDisposable
         {
             var upstream = _upstream
                 ?? throw new InvalidOperationException("Shared stream pump started without an upstream.");
+            using var pumpScope = SharedStreamPumpContext.Begin();
             using var fetchAttribution = FetchAttributionContext.Begin(System.IO.Path.GetFileName(Path));
             if (Anchor > 0 && upstream.CanSeek)
                 upstream.Seek(Anchor, SeekOrigin.Begin);

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadWorkloadClassifierTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/DownloadWorkloadClassifierTests.cs
@@ -44,6 +44,31 @@ public sealed class DownloadWorkloadClassifierTests
     }
 
     [Fact]
+    public void ClassifyForMetrics_SharedStreamPumpWithoutReadSession_IsStreaming()
+    {
+        using var source = new CancellationTokenSource();
+        using var scope = SharedStreamPumpContext.Begin();
+
+        var result = DownloadWorkloadClassifier.ClassifyForMetrics(source.Token);
+
+        Assert.Equal(SegmentFetch.FetchWorkload.Streaming, result);
+    }
+
+    [Fact]
+    public void SharedStreamPumpContext_DisposeRestoresPreviousState()
+    {
+        using var source = new CancellationTokenSource();
+
+        using (SharedStreamPumpContext.Begin())
+            Assert.True(SharedStreamPumpContext.IsActive);
+
+        Assert.False(SharedStreamPumpContext.IsActive);
+        Assert.Equal(
+            SegmentFetch.FetchWorkload.Background,
+            DownloadWorkloadClassifier.ClassifyForMetrics(source.Token));
+    }
+
+    [Fact]
     public void ClassifyForMetrics_QueueContext_IsQueue()
     {
         using var source = new CancellationTokenSource();

--- a/tests/NzbWebDAV.Tests/Streams/SharedStreamEntryTests.cs
+++ b/tests/NzbWebDAV.Tests/Streams/SharedStreamEntryTests.cs
@@ -1,4 +1,7 @@
 using System.Text;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Contexts;
+using NzbWebDAV.Database.Models.Metrics;
 using NzbWebDAV.Logging;
 using NzbWebDAV.Models;
 using NzbWebDAV.Streams;
@@ -16,6 +19,29 @@ public class SharedStreamEntryTests : IDisposable
 
     public void Dispose()
         => SynchronousObserverInvoker.ResetFailureLogThrottleForTests();
+
+    [Fact]
+    public async Task Pump_ClassifiesUpstreamReadsAsClientStreaming_WithoutInheritingReaderSession()
+    {
+        var payload = Encoding.ASCII.GetBytes("shared-pump-client-reads-payload");
+        var upstream = new WorkloadRecordingStream(payload);
+        var readerSession = Guid.NewGuid();
+
+        SharedStreamEntry entry;
+        using (MultiProviderNntpClient.BeginReadSessionScope(readerSession))
+            entry = StartEntry(upstream, payload.Length, ringSize: 64, chunkSize: 8, leadBytes: 64);
+        await using var entryLease = entry;
+        await using var reader = Attach(entry, 0);
+        Assert.Equal(payload, await ReadAllAsync(reader));
+
+        var observations = upstream.Snapshot();
+        Assert.NotEmpty(observations);
+        Assert.All(observations, o =>
+        {
+            Assert.Null(o.ReadSessionId);
+            Assert.Equal(SegmentFetch.FetchWorkload.Streaming, o.Workload);
+        });
+    }
 
     [Fact]
     public async Task TwoReaders_AreByteExact_AndFetchEachSegmentOnce()
@@ -550,6 +576,29 @@ public class SharedStreamEntryTests : IDisposable
             var read = await base.ReadAsync(buffer[..allowed], cancellationToken).ConfigureAwait(false);
             _consumed += read;
             return read;
+        }
+    }
+
+    private sealed class WorkloadRecordingStream(byte[] data) : MemoryStream(data)
+    {
+        private readonly List<(Guid? ReadSessionId, SegmentFetch.FetchWorkload Workload)> _observations = [];
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            lock (_observations)
+            {
+                _observations.Add((
+                    MultiProviderNntpClient.CurrentReadSessionId,
+                    DownloadWorkloadClassifier.ClassifyForMetrics(cancellationToken)));
+            }
+
+            return base.ReadAsync(buffer, cancellationToken);
+        }
+
+        public (Guid? ReadSessionId, SegmentFetch.FetchWorkload Workload)[] Snapshot()
+        {
+            lock (_observations)
+                return _observations.ToArray();
         }
     }
 


### PR DESCRIPTION
## Summary

With only rclone/Plex reading (no health checks or queue work running), the Overview **Activity** chart attributed most article fetches to **App reads** instead of **Client reads**.

Root cause: #1340 classifies a fetch as client/streaming only when the `AsyncLocal` read-session id is present. The shared-stream pump (`SharedStreamEntry.StartPump`) deliberately starts under `ExecutionContext.SuppressFlow()` so it never inherits a single reader's request state — which also drops the read-session id. Every article the pump fetched for attached clients was therefore recorded as `Background` and rendered as "App reads". Large open-ended rclone GETs go through the shared pump, while small ranges use a private stream (with a session) — hence the ~4k client / ~27k app split.

Fix: mark the pump's async flow with a new attribution-only `SharedStreamPumpContext`, and have `DownloadWorkloadClassifier.ClassifyForMetrics` treat it as `Streaming`. Admission priority and per-session diagnostics are unchanged.

## Test plan

- [x] `DownloadWorkloadClassifierTests`: pump marker → `Streaming`; disposing the marker restores `Background`.
- [x] `SharedStreamEntryTests.Pump_ClassifiesUpstreamReadsAsClientStreaming_WithoutInheritingReaderSession`: upstream reads issued by the pump see no read-session id (flow still suppressed) and classify as `Streaming`. Verified the test fails with the marker removed.
- [x] `dotnet test` filtered to classifier, shared-stream entry/registry, and terminal-miss logging suites: 52/52 pass.
- [x] `dotnet format --verify-no-changes` on touched files.
- [ ] Manual: with rclone/Plex scanning, Activity chart "Client reads" should now carry the bulk of the reads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workload metrics so shared-stream activity is correctly classified as streaming, even without an active read session.
  - Upstream reads from shared streams are now attributed to client streaming without inheriting the caller’s read-session identifier.

- **Tests**
  - Added coverage confirming streaming classification and proper restoration of workload context after shared-stream operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->