### PR TITLE
fix(queue): allow reviewed cleanup of large orphan backlogs

### DIFF
--- a/backend/Api/Controllers/RemoveUnlinkedFiles/RemoveUnlinkedFilesController.cs
+++ b/backend/Api/Controllers/RemoveUnlinkedFiles/RemoveUnlinkedFilesController.cs
@@ -15,10 +15,18 @@ public class RemoveUnlinkedFilesController(
 {
     protected override async Task<IActionResult> HandleRequest()
     {
-        var task = new RemoveUnlinkedFilesTask(configManager, websocketManager, isDryRun: false);
+        var task = new RemoveUnlinkedFilesTask(
+            configManager,
+            websocketManager,
+            isDryRun: false,
+            previewToken: Request.Headers["X-InfiniDysk-Cleanup-Preview"].FirstOrDefault());
         var executed = await task.Execute().ConfigureAwait(false);
         if (!executed)
-            return Conflict(new { error = "Remove Orphaned Files task is already running." });
-        return Ok(executed);
+            return Conflict(new RemoveUnlinkedFilesTaskResponse
+            {
+                Status = false,
+                Error = "Remove Orphaned Files task is already running.",
+            });
+        return Ok(new RemoveUnlinkedFilesTaskResponse());
     }
 }

--- a/backend/Api/Controllers/RemoveUnlinkedFiles/RemoveUnlinkedFilesDryRunController.cs
+++ b/backend/Api/Controllers/RemoveUnlinkedFiles/RemoveUnlinkedFilesDryRunController.cs
@@ -18,7 +18,14 @@ public class RemoveUnlinkedFilesDryRunController(
         var task = new RemoveUnlinkedFilesTask(configManager, websocketManager, isDryRun: true);
         var executed = await task.Execute().ConfigureAwait(false);
         if (!executed)
-            return Conflict(new { error = "Remove Orphaned Files task is already running." });
-        return Ok(executed);
+            return Conflict(new RemoveUnlinkedFilesTaskResponse
+            {
+                Status = false,
+                Error = "Remove Orphaned Files task is already running.",
+            });
+        return Ok(new RemoveUnlinkedFilesTaskResponse
+        {
+            PreviewToken = task.IssuedPreviewToken,
+        });
     }
 }

--- a/backend/Api/Controllers/RemoveUnlinkedFiles/RemoveUnlinkedFilesDryRunController.cs
+++ b/backend/Api/Controllers/RemoveUnlinkedFiles/RemoveUnlinkedFilesDryRunController.cs
@@ -17,6 +17,7 @@ public class RemoveUnlinkedFilesDryRunController(
     {
         var task = new RemoveUnlinkedFilesTask(configManager, websocketManager, isDryRun: true);
         var executed = await task.Execute().ConfigureAwait(false);
+        Response.Headers.CacheControl = "no-store";
         if (!executed)
             return Conflict(new RemoveUnlinkedFilesTaskResponse
             {

--- a/backend/Api/Controllers/RemoveUnlinkedFiles/RemoveUnlinkedFilesTaskResponse.cs
+++ b/backend/Api/Controllers/RemoveUnlinkedFiles/RemoveUnlinkedFilesTaskResponse.cs
@@ -1,0 +1,6 @@
+namespace NzbWebDAV.Api.Controllers.RemoveUnlinkedFiles;
+
+public sealed class RemoveUnlinkedFilesTaskResponse : BaseApiResponse
+{
+    public string? PreviewToken { get; init; }
+}

--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -227,7 +227,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
             var identified = await DryRunIdentifyUnlinkedFiles(startTime).ConfigureAwait(false);
             if (extremeUnlinkedRatio)
             {
-                previewFingerprint ??= await ComputePreviewFingerprint(startTime).ConfigureAwait(false);
+                previewFingerprint = await ComputePreviewFingerprint(startTime).ConfigureAwait(false);
                 IssuedPreviewToken = IssuePreviewApproval(previewFingerprint);
             }
             Complete($"Done. Identified {identified} unlinked files.");

--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -33,6 +33,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
     private readonly TimeSpan _previewLifetime;
     private readonly TimeSpan _progressHeartbeatInterval;
     private readonly Action<string>? _progressObserver;
+    private readonly Func<Task>? _beforePreviewApproval;
     private ProgressHeartbeat? _progressHeartbeat;
 
     internal record UnlinkedItemInfo(string Id, int Type, string Path);
@@ -79,7 +80,8 @@ public class RemoveUnlinkedFilesTask : BaseTask
         string? previewToken = null,
         TimeSpan? previewLifetime = null,
         TimeSpan? progressHeartbeatInterval = null,
-        Action<string>? progressObserver = null)
+        Action<string>? progressObserver = null,
+        Func<Task>? beforePreviewApproval = null)
     {
         _configManager = configManager;
         _websocketManager = websocketManager;
@@ -89,6 +91,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
         _previewLifetime = previewLifetime ?? DefaultPreviewLifetime;
         _progressHeartbeatInterval = progressHeartbeatInterval ?? DefaultProgressHeartbeatInterval;
         _progressObserver = progressObserver;
+        _beforePreviewApproval = beforePreviewApproval;
     }
 
     public string? IssuedPreviewToken { get; private set; }
@@ -172,6 +175,9 @@ public class RemoveUnlinkedFilesTask : BaseTask
             return;
         }
 
+        if (_isDryRun)
+            InvalidatePreviewApproval();
+
         // get linked file paths
         StartPhase("Scanning all linked files...");
         var startTime = DateTime.Now;
@@ -227,19 +233,29 @@ public class RemoveUnlinkedFilesTask : BaseTask
         if (_isDryRun)
         {
             StartPhase("Identifying unlinked files...");
-            var identified = await DryRunIdentifyUnlinkedFiles(startTime).ConfigureAwait(false);
+            int identified;
             if (extremeUnlinkedRatio)
             {
-                previewFingerprint = await ComputePreviewFingerprint(startTime).ConfigureAwait(false);
-                IssuedPreviewToken = IssuePreviewApproval(previewFingerprint);
+                await StagePreviewCandidates(startTime).ConfigureAwait(false);
+                var snapshot = await BuildStagedPreviewSnapshot().ConfigureAwait(false);
+                identified = snapshot.Count;
+                if (_beforePreviewApproval is not null)
+                    await _beforePreviewApproval().ConfigureAwait(false);
+                IssuedPreviewToken = IssuePreviewApproval(snapshot.Fingerprint, _previewLifetime);
             }
+            else
+                identified = await DryRunIdentifyUnlinkedFiles(startTime).ConfigureAwait(false);
             Complete($"Done. Identified {identified} unlinked files.");
         }
         else
         {
             if (extremeUnlinkedRatio)
                 ConsumePreviewApproval(_previewToken);
-            var removed = await RemoveUnlinkedItems(startTime, unlinkedItems).ConfigureAwait(false);
+            var removed = await RemoveUnlinkedItems(
+                    startTime,
+                    unlinkedItems,
+                    restrictToApprovedSnapshot: extremeUnlinkedRatio)
+                .ConfigureAwait(false);
             await RemoveEmptyDirectories(startTime).ConfigureAwait(false);
             Complete($"Done. Removed {removed} unlinked files.");
         }
@@ -515,14 +531,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
         await using var dbContext = CreateContext();
         var usenetFileType = (int)DavItem.ItemType.UsenetFile;
         using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
-        void Append(string? value)
-        {
-            hash.AppendData(Encoding.UTF8.GetBytes(value ?? "<null>"));
-            hash.AppendData([0]);
-        }
-
-        Append(_configManager.GetLibraryDir());
-        Append(_configManager.GetRcloneMountDir());
+        AppendPreviewFingerprintHeader(hash);
         var lastId = string.Empty;
         while (true)
         {
@@ -550,14 +559,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
                 break;
 
             foreach (var item in candidates)
-            {
-                Append(item.Id);
-                Append(item.Path);
-                Append(item.Name);
-                Append(item.GeneratedStrmOutputRoot);
-                Append(item.GeneratedStrmPath);
-                Append(item.GeneratedStrmTarget);
-            }
+                AppendPreviewFingerprintItem(hash, item);
 
             lastId = candidates[^1].Id;
         }
@@ -565,7 +567,108 @@ public class RemoveUnlinkedFilesTask : BaseTask
         return Convert.ToHexString(hash.GetHashAndReset());
     }
 
-    private string IssuePreviewApproval(string fingerprint)
+    private async Task StagePreviewCandidates(DateTime createdBefore)
+    {
+        await using var dbContext = CreateContext();
+        var usenetFileType = (int)DavItem.ItemType.UsenetFile;
+
+        await dbContext.Database.ExecuteSqlRawAsync(
+            """
+            DROP TABLE IF EXISTS TMP_APPROVED_UNLINKED_FILES;
+            CREATE TABLE TMP_APPROVED_UNLINKED_FILES (
+                Id TEXT NOT NULL PRIMARY KEY,
+                Type INTEGER NOT NULL,
+                Path TEXT NOT NULL,
+                Name TEXT NOT NULL,
+                GeneratedStrmOutputRoot TEXT NULL,
+                GeneratedStrmPath TEXT NULL,
+                GeneratedStrmTarget TEXT NULL
+            );
+            """).ConfigureAwait(false);
+
+        await dbContext.Database.ExecuteSqlInterpolatedAsync(
+            $"""
+             INSERT INTO TMP_APPROVED_UNLINKED_FILES
+                 (Id, Type, Path, Name, GeneratedStrmOutputRoot, GeneratedStrmPath, GeneratedStrmTarget)
+             SELECT CAST("Id" AS TEXT), "Type", "Path", "Name",
+                    "GeneratedStrmOutputRoot", "GeneratedStrmPath", "GeneratedStrmTarget"
+             FROM "DavItems"
+             WHERE "Type" = {usenetFileType}
+               AND "HistoryItemId" IS NULL
+               AND "CreatedAt" < {CreateWallClockParameter(dbContext, createdBefore)}
+               AND NOT EXISTS (
+                   SELECT 1 FROM TMP_LINKED_FILES t
+                   WHERE t.Id = "DavItems"."Id"
+               )
+             """).ConfigureAwait(false);
+    }
+
+    private async Task<PreviewSnapshot> BuildStagedPreviewSnapshot()
+    {
+        _allRemovedPaths.Clear();
+        await using var dbContext = CreateContext();
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        AppendPreviewFingerprintHeader(hash);
+
+        var lastId = string.Empty;
+        var identified = 0;
+        while (true)
+        {
+            var candidates = await dbContext.Database
+                .SqlQuery<UnlinkedFileInfo>(
+                    $"""
+                     SELECT Id, Type, Path, Name,
+                            GeneratedStrmOutputRoot, GeneratedStrmPath, GeneratedStrmTarget
+                     FROM TMP_APPROVED_UNLINKED_FILES
+                     WHERE Id > {lastId}
+                     ORDER BY Id
+                     LIMIT 100
+                     """)
+                .ToListAsync()
+                .ConfigureAwait(false);
+
+            if (candidates.Count == 0)
+                break;
+
+            foreach (var item in candidates)
+            {
+                AppendPreviewFingerprintItem(hash, item);
+                identified++;
+                _allRemovedPaths.Add(item.Path);
+                if (!string.IsNullOrWhiteSpace(item.GeneratedStrmPath))
+                    _allRemovedPaths.Add($"{item.GeneratedStrmPath} (strm sidecar of {item.Path})");
+            }
+
+            lastId = candidates[^1].Id;
+            UpdatePhase($"Identifying unlinked files...\nFound {identified}...");
+        }
+
+        return new PreviewSnapshot(Convert.ToHexString(hash.GetHashAndReset()), identified);
+    }
+
+    private void AppendPreviewFingerprintHeader(IncrementalHash hash)
+    {
+        AppendPreviewFingerprintValue(hash, _configManager.GetLibraryDir());
+        AppendPreviewFingerprintValue(hash, _configManager.GetRcloneMountDir());
+    }
+
+    private static void AppendPreviewFingerprintItem(IncrementalHash hash, UnlinkedFileInfo item)
+    {
+        AppendPreviewFingerprintValue(hash, item.Id);
+        AppendPreviewFingerprintValue(hash, item.Path);
+        AppendPreviewFingerprintValue(hash, item.Name);
+        AppendPreviewFingerprintValue(hash, item.GeneratedStrmOutputRoot);
+        AppendPreviewFingerprintValue(hash, item.GeneratedStrmPath);
+        AppendPreviewFingerprintValue(hash, item.GeneratedStrmTarget);
+    }
+
+    private static void AppendPreviewFingerprintValue(IncrementalHash hash, string? value)
+    {
+        hash.AppendData(Encoding.UTF8.GetBytes(value ?? "<null>"));
+        hash.AppendData([0]);
+    }
+
+    private static string IssuePreviewApproval(string fingerprint, TimeSpan previewLifetime)
     {
         var token = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
         lock (PreviewLock)
@@ -573,7 +676,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
             _previewApproval = new PreviewApproval(
                 token,
                 fingerprint,
-                DateTimeOffset.UtcNow + _previewLifetime);
+                DateTimeOffset.UtcNow + previewLifetime);
         }
 
         return token;
@@ -625,7 +728,16 @@ public class RemoveUnlinkedFilesTask : BaseTask
         }
     }
 
-    private async Task<int> RemoveUnlinkedItems(DateTime createdBefore, int totalCount)
+    private static void InvalidatePreviewApproval()
+    {
+        lock (PreviewLock)
+            _previewApproval = null;
+    }
+
+    private async Task<int> RemoveUnlinkedItems(
+        DateTime createdBefore,
+        int totalCount,
+        bool restrictToApprovedSnapshot = false)
     {
         StartPhase("Removing unlinked items...");
         _allRemovedPaths.Clear();
@@ -637,8 +749,35 @@ public class RemoveUnlinkedFilesTask : BaseTask
         {
             // Select items to delete (batch of 100). t.Id on the left inherits NOCASE from
             // the TMP_LINKED_FILES PK so lowercase DavItems.Id still match uppercase links.
-            var itemsToDelete = await dbContext.Database
-                .SqlQuery<UnlinkedFileInfo>(
+            var itemsToDelete = restrictToApprovedSnapshot
+                ? await dbContext.Database
+                    .SqlQuery<UnlinkedFileInfo>(
+                        $"""
+                         SELECT a.Id, a.Type, a.Path, a.Name,
+                                a.GeneratedStrmOutputRoot, a.GeneratedStrmPath, a.GeneratedStrmTarget
+                         FROM TMP_APPROVED_UNLINKED_FILES a
+                         INNER JOIN "DavItems" i ON CAST(i."Id" AS TEXT) = a.Id
+                         WHERE i."Type" = {usenetFileType}
+                           AND i."HistoryItemId" IS NULL
+                           AND i."CreatedAt" < {CreateWallClockParameter(dbContext, createdBefore)}
+                           AND i."Path" = a.Path
+                           AND i."Name" = a.Name
+                           AND (i."GeneratedStrmOutputRoot" = a.GeneratedStrmOutputRoot OR
+                                (i."GeneratedStrmOutputRoot" IS NULL AND a.GeneratedStrmOutputRoot IS NULL))
+                           AND (i."GeneratedStrmPath" = a.GeneratedStrmPath OR
+                                (i."GeneratedStrmPath" IS NULL AND a.GeneratedStrmPath IS NULL))
+                           AND (i."GeneratedStrmTarget" = a.GeneratedStrmTarget OR
+                                (i."GeneratedStrmTarget" IS NULL AND a.GeneratedStrmTarget IS NULL))
+                           AND NOT EXISTS (
+                               SELECT 1 FROM TMP_LINKED_FILES t
+                               WHERE t.Id = i."Id"
+                           )
+                         LIMIT 100
+                         """)
+                    .ToListAsync()
+                    .ConfigureAwait(false)
+                : await dbContext.Database
+                    .SqlQuery<UnlinkedFileInfo>(
                     $"""
                      SELECT CAST("Id" AS TEXT) AS "Id", "Type", "Path", "Name",
                             "GeneratedStrmOutputRoot", "GeneratedStrmPath", "GeneratedStrmTarget"
@@ -652,8 +791,8 @@ public class RemoveUnlinkedFilesTask : BaseTask
                        )
                      LIMIT 100
                      """)
-                .ToListAsync()
-                .ConfigureAwait(false);
+                    .ToListAsync()
+                    .ConfigureAwait(false);
 
             // If there are no more items to delete, we're done.
             if (itemsToDelete.Count == 0)
@@ -983,4 +1122,6 @@ public class RemoveUnlinkedFilesTask : BaseTask
         string Token,
         string Fingerprint,
         DateTimeOffset ExpiresAt);
+
+    private sealed record PreviewSnapshot(string Fingerprint, int Count);
 }

--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -617,8 +617,10 @@ public class RemoveUnlinkedFilesTask : BaseTask
             var candidates = await dbContext.Database
                 .SqlQuery<UnlinkedFileInfo>(
                     $"""
-                     SELECT Id, Type, Path, Name,
-                            GeneratedStrmOutputRoot, GeneratedStrmPath, GeneratedStrmTarget
+                     SELECT Id AS "Id", Type AS "Type", Path AS "Path", Name AS "Name",
+                            GeneratedStrmOutputRoot AS "GeneratedStrmOutputRoot",
+                            GeneratedStrmPath AS "GeneratedStrmPath",
+                            GeneratedStrmTarget AS "GeneratedStrmTarget"
                      FROM TMP_APPROVED_UNLINKED_FILES
                      WHERE Id > {lastId}
                      ORDER BY Id
@@ -753,8 +755,10 @@ public class RemoveUnlinkedFilesTask : BaseTask
                 ? await dbContext.Database
                     .SqlQuery<UnlinkedFileInfo>(
                         $"""
-                         SELECT a.Id, a.Type, a.Path, a.Name,
-                                a.GeneratedStrmOutputRoot, a.GeneratedStrmPath, a.GeneratedStrmTarget
+                         SELECT a.Id AS "Id", a.Type AS "Type", a.Path AS "Path", a.Name AS "Name",
+                                a.GeneratedStrmOutputRoot AS "GeneratedStrmOutputRoot",
+                                a.GeneratedStrmPath AS "GeneratedStrmPath",
+                                a.GeneratedStrmTarget AS "GeneratedStrmTarget"
                          FROM TMP_APPROVED_UNLINKED_FILES a
                          INNER JOIN "DavItems" i ON CAST(i."Id" AS TEXT) = a.Id
                          WHERE i."Type" = {usenetFileType}

--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -21,7 +21,7 @@ namespace NzbWebDAV.Tasks;
 public class RemoveUnlinkedFilesTask : BaseTask
 {
     private static readonly TimeSpan DefaultProgressHeartbeatInterval = TimeSpan.FromSeconds(2);
-    private static readonly TimeSpan PreviewLifetime = TimeSpan.FromMinutes(15);
+    private static readonly TimeSpan DefaultPreviewLifetime = TimeSpan.FromMinutes(15);
     private static readonly object PreviewLock = new();
     private static List<string> _allRemovedPaths = [];
     private static PreviewApproval? _previewApproval;
@@ -30,6 +30,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
     private readonly bool _isDryRun;
     private readonly Func<DavDatabaseContext>? _createContext;
     private readonly string? _previewToken;
+    private readonly TimeSpan _previewLifetime;
     private readonly TimeSpan _progressHeartbeatInterval;
     private readonly Action<string>? _progressObserver;
     private ProgressHeartbeat? _progressHeartbeat;
@@ -76,6 +77,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
         bool isDryRun,
         Func<DavDatabaseContext>? createContext,
         string? previewToken = null,
+        TimeSpan? previewLifetime = null,
         TimeSpan? progressHeartbeatInterval = null,
         Action<string>? progressObserver = null)
     {
@@ -84,6 +86,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
         _isDryRun = isDryRun;
         _createContext = createContext;
         _previewToken = previewToken;
+        _previewLifetime = previewLifetime ?? DefaultPreviewLifetime;
         _progressHeartbeatInterval = progressHeartbeatInterval ?? DefaultProgressHeartbeatInterval;
         _progressObserver = progressObserver;
     }
@@ -511,24 +514,6 @@ public class RemoveUnlinkedFilesTask : BaseTask
     {
         await using var dbContext = CreateContext();
         var usenetFileType = (int)DavItem.ItemType.UsenetFile;
-        var candidates = await dbContext.Database
-            .SqlQuery<UnlinkedFileInfo>(
-                $"""
-                 SELECT CAST("Id" AS TEXT) AS "Id", "Type", "Path", "Name",
-                        "GeneratedStrmOutputRoot", "GeneratedStrmPath", "GeneratedStrmTarget"
-                 FROM "DavItems"
-                 WHERE "Type" = {usenetFileType}
-                   AND "HistoryItemId" IS NULL
-                   AND "CreatedAt" < {CreateWallClockParameter(dbContext, createdBefore)}
-                   AND NOT EXISTS (
-                       SELECT 1 FROM TMP_LINKED_FILES t
-                       WHERE t.Id = "DavItems"."Id"
-                   )
-                 ORDER BY CAST("Id" AS TEXT)
-                 """)
-            .ToListAsync()
-            .ConfigureAwait(false);
-
         using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
         void Append(string? value)
         {
@@ -538,20 +523,49 @@ public class RemoveUnlinkedFilesTask : BaseTask
 
         Append(_configManager.GetLibraryDir());
         Append(_configManager.GetRcloneMountDir());
-        foreach (var item in candidates)
+        var lastId = string.Empty;
+        while (true)
         {
-            Append(item.Id);
-            Append(item.Path);
-            Append(item.Name);
-            Append(item.GeneratedStrmOutputRoot);
-            Append(item.GeneratedStrmPath);
-            Append(item.GeneratedStrmTarget);
+            var candidates = await dbContext.Database
+                .SqlQuery<UnlinkedFileInfo>(
+                    $"""
+                     SELECT CAST("Id" AS TEXT) AS "Id", "Type", "Path", "Name",
+                            "GeneratedStrmOutputRoot", "GeneratedStrmPath", "GeneratedStrmTarget"
+                     FROM "DavItems"
+                     WHERE "Type" = {usenetFileType}
+                       AND "HistoryItemId" IS NULL
+                       AND "CreatedAt" < {CreateWallClockParameter(dbContext, createdBefore)}
+                       AND CAST("Id" AS TEXT) > {lastId}
+                       AND NOT EXISTS (
+                           SELECT 1 FROM TMP_LINKED_FILES t
+                           WHERE t.Id = "DavItems"."Id"
+                       )
+                     ORDER BY CAST("Id" AS TEXT)
+                     LIMIT 100
+                     """)
+                .ToListAsync()
+                .ConfigureAwait(false);
+
+            if (candidates.Count == 0)
+                break;
+
+            foreach (var item in candidates)
+            {
+                Append(item.Id);
+                Append(item.Path);
+                Append(item.Name);
+                Append(item.GeneratedStrmOutputRoot);
+                Append(item.GeneratedStrmPath);
+                Append(item.GeneratedStrmTarget);
+            }
+
+            lastId = candidates[^1].Id;
         }
 
         return Convert.ToHexString(hash.GetHashAndReset());
     }
 
-    private static string IssuePreviewApproval(string fingerprint)
+    private string IssuePreviewApproval(string fingerprint)
     {
         var token = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
         lock (PreviewLock)
@@ -559,7 +573,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
             _previewApproval = new PreviewApproval(
                 token,
                 fingerprint,
-                DateTimeOffset.UtcNow + PreviewLifetime);
+                DateTimeOffset.UtcNow + _previewLifetime);
         }
 
         return token;
@@ -576,7 +590,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
         lock (PreviewLock)
         {
             if (_previewApproval is null
-                || !string.Equals(_previewApproval.Token, _previewToken, StringComparison.Ordinal))
+                || !_previewApproval.Token.FixedTimeEquals(_previewToken))
             {
                 reason = "The dry-run approval is missing or was replaced; run the dry run again.";
                 return false;
@@ -606,7 +620,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
 
         lock (PreviewLock)
         {
-            if (string.Equals(_previewApproval?.Token, previewToken, StringComparison.Ordinal))
+            if (_previewApproval?.Token.FixedTimeEquals(previewToken) == true)
                 _previewApproval = null;
         }
     }

--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -1,5 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Data.Common;
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Config;
@@ -19,11 +21,15 @@ namespace NzbWebDAV.Tasks;
 public class RemoveUnlinkedFilesTask : BaseTask
 {
     private static readonly TimeSpan DefaultProgressHeartbeatInterval = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan PreviewLifetime = TimeSpan.FromMinutes(15);
+    private static readonly object PreviewLock = new();
     private static List<string> _allRemovedPaths = [];
+    private static PreviewApproval? _previewApproval;
     private readonly ConfigManager _configManager;
     private readonly WebsocketManager _websocketManager;
     private readonly bool _isDryRun;
     private readonly Func<DavDatabaseContext>? _createContext;
+    private readonly string? _previewToken;
     private readonly TimeSpan _progressHeartbeatInterval;
     private readonly Action<string>? _progressObserver;
     private ProgressHeartbeat? _progressHeartbeat;
@@ -58,8 +64,9 @@ public class RemoveUnlinkedFilesTask : BaseTask
     public RemoveUnlinkedFilesTask(
         ConfigManager configManager,
         WebsocketManager websocketManager,
-        bool isDryRun)
-        : this(configManager, websocketManager, isDryRun, null)
+        bool isDryRun,
+        string? previewToken = null)
+        : this(configManager, websocketManager, isDryRun, null, previewToken)
     {
     }
 
@@ -68,6 +75,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
         WebsocketManager websocketManager,
         bool isDryRun,
         Func<DavDatabaseContext>? createContext,
+        string? previewToken = null,
         TimeSpan? progressHeartbeatInterval = null,
         Action<string>? progressObserver = null)
     {
@@ -75,9 +83,12 @@ public class RemoveUnlinkedFilesTask : BaseTask
         _websocketManager = websocketManager;
         _isDryRun = isDryRun;
         _createContext = createContext;
+        _previewToken = previewToken;
         _progressHeartbeatInterval = progressHeartbeatInterval ?? DefaultProgressHeartbeatInterval;
         _progressObserver = progressObserver;
     }
+
+    public string? IssuedPreviewToken { get; private set; }
 
     private DavDatabaseContext CreateContext() => DavDatabaseContexts.Create(_createContext);
 
@@ -187,6 +198,7 @@ public class RemoveUnlinkedFilesTask : BaseTask
         // so 90% leaves wide headroom while still catching a broken scan.
         var deletableItems = await CountDeletableItems(startTime).ConfigureAwait(false);
         var extremeUnlinkedRatio = deletableItems > 0 && unlinkedItems > deletableItems * 0.9;
+        string? previewFingerprint = null;
         if (extremeUnlinkedRatio)
         {
             var percent = 100.0 * unlinkedItems / deletableItems;
@@ -197,23 +209,33 @@ public class RemoveUnlinkedFilesTask : BaseTask
 
             if (!_isDryRun)
             {
-                _allRemovedPaths.Clear();
-                Complete($"Aborted: {detail} Cancelling to prevent accidental bulk deletion. " +
-                         "Run a dry-run to inspect if this is genuinely expected.");
-                return;
+                previewFingerprint = await ComputePreviewFingerprint(startTime).ConfigureAwait(false);
+                if (!TryValidatePreviewApproval(previewFingerprint, out var previewError))
+                {
+                    _allRemovedPaths.Clear();
+                    Complete($"Aborted: {detail} {previewError}");
+                    return;
+                }
             }
 
-            UpdatePhase($"Warning: {detail} A non-dry-run would abort.");
+            UpdatePhase($"Warning: {detail} Review the audit before cleanup.");
         }
 
         if (_isDryRun)
         {
             StartPhase("Identifying unlinked files...");
             var identified = await DryRunIdentifyUnlinkedFiles(startTime).ConfigureAwait(false);
+            if (extremeUnlinkedRatio)
+            {
+                previewFingerprint ??= await ComputePreviewFingerprint(startTime).ConfigureAwait(false);
+                IssuedPreviewToken = IssuePreviewApproval(previewFingerprint);
+            }
             Complete($"Done. Identified {identified} unlinked files.");
         }
         else
         {
+            if (extremeUnlinkedRatio)
+                ConsumePreviewApproval(_previewToken);
             var removed = await RemoveUnlinkedItems(startTime, unlinkedItems).ConfigureAwait(false);
             await RemoveEmptyDirectories(startTime).ConfigureAwait(false);
             Complete($"Done. Removed {removed} unlinked files.");
@@ -483,6 +505,110 @@ public class RemoveUnlinkedFilesTask : BaseTask
             .ConfigureAwait(false);
 
         return count;
+    }
+
+    private async Task<string> ComputePreviewFingerprint(DateTime createdBefore)
+    {
+        await using var dbContext = CreateContext();
+        var usenetFileType = (int)DavItem.ItemType.UsenetFile;
+        var candidates = await dbContext.Database
+            .SqlQuery<UnlinkedFileInfo>(
+                $"""
+                 SELECT CAST("Id" AS TEXT) AS "Id", "Type", "Path", "Name",
+                        "GeneratedStrmOutputRoot", "GeneratedStrmPath", "GeneratedStrmTarget"
+                 FROM "DavItems"
+                 WHERE "Type" = {usenetFileType}
+                   AND "HistoryItemId" IS NULL
+                   AND "CreatedAt" < {CreateWallClockParameter(dbContext, createdBefore)}
+                   AND NOT EXISTS (
+                       SELECT 1 FROM TMP_LINKED_FILES t
+                       WHERE t.Id = "DavItems"."Id"
+                   )
+                 ORDER BY CAST("Id" AS TEXT)
+                 """)
+            .ToListAsync()
+            .ConfigureAwait(false);
+
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        void Append(string? value)
+        {
+            hash.AppendData(Encoding.UTF8.GetBytes(value ?? "<null>"));
+            hash.AppendData([0]);
+        }
+
+        Append(_configManager.GetLibraryDir());
+        Append(_configManager.GetRcloneMountDir());
+        foreach (var item in candidates)
+        {
+            Append(item.Id);
+            Append(item.Path);
+            Append(item.Name);
+            Append(item.GeneratedStrmOutputRoot);
+            Append(item.GeneratedStrmPath);
+            Append(item.GeneratedStrmTarget);
+        }
+
+        return Convert.ToHexString(hash.GetHashAndReset());
+    }
+
+    private static string IssuePreviewApproval(string fingerprint)
+    {
+        var token = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
+        lock (PreviewLock)
+        {
+            _previewApproval = new PreviewApproval(
+                token,
+                fingerprint,
+                DateTimeOffset.UtcNow + PreviewLifetime);
+        }
+
+        return token;
+    }
+
+    private bool TryValidatePreviewApproval(string fingerprint, out string reason)
+    {
+        if (string.IsNullOrWhiteSpace(_previewToken))
+        {
+            reason = "Run and review a fresh dry run before cleanup.";
+            return false;
+        }
+
+        lock (PreviewLock)
+        {
+            if (_previewApproval is null
+                || !string.Equals(_previewApproval.Token, _previewToken, StringComparison.Ordinal))
+            {
+                reason = "The dry-run approval is missing or was replaced; run the dry run again.";
+                return false;
+            }
+
+            if (_previewApproval.ExpiresAt <= DateTimeOffset.UtcNow)
+            {
+                reason = "The dry-run approval expired; run the dry run again.";
+                return false;
+            }
+
+            if (!string.Equals(_previewApproval.Fingerprint, fingerprint, StringComparison.Ordinal))
+            {
+                reason = "The orphan or library-link state changed after the dry run; review a new dry run.";
+                return false;
+            }
+        }
+
+        reason = string.Empty;
+        return true;
+    }
+
+    private static void ConsumePreviewApproval(string? previewToken)
+    {
+        if (string.IsNullOrWhiteSpace(previewToken))
+            return;
+
+        lock (PreviewLock)
+        {
+            if (string.Equals(_previewApproval?.Token, previewToken, StringComparison.Ordinal))
+                _previewApproval = null;
+        }
     }
 
     private async Task<int> RemoveUnlinkedItems(DateTime createdBefore, int totalCount)
@@ -832,5 +958,15 @@ public class RemoveUnlinkedFilesTask : BaseTask
         }
     }
 
-    internal static void ClearAuditPathsForTests() => _allRemovedPaths = [];
+    internal static void ClearAuditPathsForTests()
+    {
+        _allRemovedPaths = [];
+        lock (PreviewLock)
+            _previewApproval = null;
+    }
+
+    private sealed record PreviewApproval(
+        string Token,
+        string Fingerprint,
+        DateTimeOffset ExpiresAt);
 }

--- a/docs/configuration/maintenance.md
+++ b/docs/configuration/maintenance.md
@@ -25,7 +25,7 @@ Database housekeeping, scheduled orphan cleanup, and one-off tools.
 | Task | Purpose | Caution |
 |------|---------|---------|
 | Clean Missing Payloads [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since } | Remove mounts whose payload blob **and** legacy metadata are both absent, and request Arr replacements | Permanent; dry run and `/config` backup required; never blocklists the release |
-| Remove Orphaned Files | Drop WebDAV files not linked from library | Permanent; dry run available. Library Directory must be the organized library, not the rclone mount |
+| Remove Orphaned Files | Drop WebDAV files not linked from library | Permanent; dry run available. If more than 90% appear unlinked, review the audit and use its 15-minute approval. Library Directory must be the organized library, not the rclone mount |
 | Prune Completed History | Remove completed SAB history rows | History-only; mounts stay; unlinked mounts become eligible for orphan cleanup |
 | Rename Windows-Invalid Paths | Sanitize existing names | Needs Windows-safe paths; backup + dry run |
 | Convert STRM → Symlinks | Strategy migration | Needs library dir + rclone mount |

--- a/docs/operations/retention-cleanup.md
+++ b/docs/operations/retention-cleanup.md
@@ -47,7 +47,7 @@ Back up `/config` and pause Arr imports before running cleanup. Restore the miss
 
 **Library Directory** must be the organized library root that contains your Arr-imported symlinks or STRMs (the parent of your Radarr/Sonarr root folders). It must be visible inside the InfiniDysk container. Do not point it at the rclone mount (`rclone.mount-dir`) or at `/completed-symlinks` — that folder is InfiniDysk's virtual view of current History rows, so scanning it cannot protect files after history is cleared. Remove Orphaned Files aborts (dry run included) when Library Directory is the mount or a path inside it.
 
-If more than 90% of eligible WebDAV files appear unlinked, a normal run is blocked until you run and review a fresh dry run. That approval lasts 15 minutes and is rejected if the orphan candidates, library links, or configured paths change.
+If more than 90% of eligible WebDAV files appear unlinked, a normal run is blocked until you run and review a fresh dry run. That approval lasts 15 minutes, is bound to the orphan candidates, library links, configured paths, and recorded generated-sidecar state, and is consumed after one cleanup attempt.
 
 History entries disappearing after an Arr import are client-initiated cleanup, not InfiniDysk deleting the mount: the Arr's **Remove Completed** setting, InfiniDysk **Automatic Queue Management** rules that call the Arr with `removeFromClient=true`, or a WebDAV DELETE of a release folder under `/completed-symlinks`. Mounted files stay streamable; only the History row is removed.
 

--- a/docs/operations/retention-cleanup.md
+++ b/docs/operations/retention-cleanup.md
@@ -47,6 +47,8 @@ Back up `/config` and pause Arr imports before running cleanup. Restore the miss
 
 **Library Directory** must be the organized library root that contains your Arr-imported symlinks or STRMs (the parent of your Radarr/Sonarr root folders). It must be visible inside the InfiniDysk container. Do not point it at the rclone mount (`rclone.mount-dir`) or at `/completed-symlinks` — that folder is InfiniDysk's virtual view of current History rows, so scanning it cannot protect files after history is cleared. Remove Orphaned Files aborts (dry run included) when Library Directory is the mount or a path inside it.
 
+If more than 90% of eligible WebDAV files appear unlinked, a normal run is blocked until you run and review a fresh dry run. That approval lasts 15 minutes and is rejected if the orphan candidates, library links, or configured paths change.
+
 History entries disappearing after an Arr import are client-initiated cleanup, not InfiniDysk deleting the mount: the Arr's **Remove Completed** setting, InfiniDysk **Automatic Queue Management** rules that call the Arr with `removeFromClient=true`, or a WebDAV DELETE of a release folder under `/completed-symlinks`. Mounted files stay streamable; only the History row is removed.
 
 ## NZB file backups

--- a/frontend/app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.test.tsx
+++ b/frontend/app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+/* global HTMLDialogElement */
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RemoveUnlinkedFiles } from "./remove-unlinked-files";
+
+const fetchMock = vi.fn<typeof fetch>();
+const websocketTopicMocks = vi.hoisted(() => ({
+  setProgress: null as ((message: string) => void) | null,
+  onOpen: null as (() => void) | null,
+}));
+
+vi.mock("~/utils/shared-websocket", () => ({
+  useWebsocketTopic: (
+    _topic: string,
+    _kind: string,
+    onMessage: (message: string) => void,
+    options: { onOpen?: () => void },
+  ) => {
+    websocketTopicMocks.setProgress = onMessage;
+    websocketTopicMocks.onOpen = options.onOpen ?? null;
+  },
+}));
+
+const savedConfig = { "media.library-dir": "/library" };
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  websocketTopicMocks.setProgress = null;
+  websocketTopicMocks.onOpen = null;
+  if (!HTMLDialogElement.prototype.showModal) {
+    HTMLDialogElement.prototype.showModal = function (this: HTMLDialogElement) {
+      this.open = true;
+    };
+    HTMLDialogElement.prototype.close = function (this: HTMLDialogElement) {
+      this.open = false;
+    };
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("RemoveUnlinkedFiles", () => {
+  it("sends the reviewed dry-run approval with an exceptional cleanup", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ status: true, previewToken: "approval-token" }))
+      .mockResolvedValueOnce(jsonResponse({ status: true }));
+    const user = userEvent.setup();
+    render(createElement(RemoveUnlinkedFiles, { savedConfig }));
+    websocketTopicMocks.onOpen?.();
+
+    await user.click(screen.getByRole("button", { name: "Dry Run" }));
+    await screen.findByText(/High-volume cleanup is unlocked/);
+    websocketTopicMocks.setProgress?.("Dry Run - Done. Identified 1730 unlinked files.");
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Run Task" })).toHaveProperty("disabled", false);
+    });
+    await user.click(screen.getByRole("button", { name: "Run Task" }));
+    await user.click(
+      screen.getByRole("checkbox", {
+        name: "I reviewed the dry-run audit and have a current /config backup",
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: "Remove orphaned files" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "/api/remove-unlinked-files", {
+      headers: { "X-InfiniDysk-Cleanup-Preview": "approval-token" },
+    });
+  });
+});

--- a/frontend/app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.test.tsx
+++ b/frontend/app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 /* global HTMLDialogElement */
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -60,11 +60,11 @@ describe("RemoveUnlinkedFiles", () => {
       .mockResolvedValueOnce(jsonResponse({ status: true }));
     const user = userEvent.setup();
     render(createElement(RemoveUnlinkedFiles, { savedConfig }));
-    websocketTopicMocks.onOpen?.();
+    act(() => websocketTopicMocks.onOpen?.());
 
     await user.click(screen.getByRole("button", { name: "Dry Run" }));
     await screen.findByText(/High-volume cleanup is unlocked/);
-    websocketTopicMocks.setProgress?.("Dry Run - Done. Identified 1730 unlinked files.");
+    act(() => websocketTopicMocks.setProgress?.("Dry Run - Done. Identified 1730 unlinked files."));
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Run Task" })).toHaveProperty("disabled", false);
     });

--- a/frontend/app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.tsx
+++ b/frontend/app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.tsx
@@ -1,6 +1,7 @@
 import { Button } from "~/components/ui/button";
 import { Alert } from "~/components/ui/feedback";
 import { Icon } from "~/components/ui/icon";
+import { ConfirmModal } from "~/components/confirm-modal/confirm-modal";
 import { useCallback, useEffect, useState } from "react";
 import { useWebsocketTopic } from "~/utils/shared-websocket";
 import { withUrlBase } from "~/utils/url-base";
@@ -17,6 +18,8 @@ export function RemoveUnlinkedFiles({ savedConfig }: RemoveUnlinkedFilesProps) {
   // Replayed non-terminal ctp state must not look like an active run until the user clicks.
   const [runStarted, setRunStarted] = useState<boolean>(false);
   const [statusError, setStatusError] = useState<string | null>(null);
+  const [previewToken, setPreviewToken] = useState<string | null>(null);
+  const [showConfirm, setShowConfirm] = useState(false);
   const progressMessage = progress?.replace("Dry Run - ", "");
 
   // derived variables
@@ -40,39 +43,54 @@ export function RemoveUnlinkedFiles({ savedConfig }: RemoveUnlinkedFilesProps) {
     if (isFinished) setRunStarted(false);
   }, [isFinished]);
 
-  const startTask = useCallback(async (url: string) => {
-    setStatusError(null);
-    // Clear any stale terminal message so isFinished doesn't mask the new run
-    // until its first progress message arrives.
-    setProgress(null);
-    setRunStarted(true);
-    setIsFetching(true);
-    try {
-      const response = await fetch(url);
-      if (response.status === 409) {
-        setStatusError("Task already running.");
+  const startTask = useCallback(
+    async (url: string, dryRun: boolean) => {
+      setShowConfirm(false);
+      setStatusError(null);
+      // Clear any stale terminal message so isFinished doesn't mask the new run
+      // until its first progress message arrives.
+      setProgress(null);
+      setRunStarted(true);
+      setIsFetching(true);
+      if (dryRun) setPreviewToken(null);
+      try {
+        const response = await fetch(url, {
+          ...(!dryRun && previewToken
+            ? { headers: { "X-InfiniDysk-Cleanup-Preview": previewToken } }
+            : {}),
+        });
+        const body = (await response.json().catch(() => null)) as {
+          error?: string;
+          previewToken?: string;
+        } | null;
+        if (!response.ok) {
+          setStatusError(body?.error || `Request failed (${response.status}).`);
+          setRunStarted(false);
+          return;
+        }
+        setPreviewToken(dryRun ? (body?.previewToken ?? null) : null);
+      } catch {
+        setPreviewToken(null);
+        setStatusError("Request failed.");
         setRunStarted(false);
-        return;
+      } finally {
+        setIsFetching(false);
       }
-      if (!response.ok) {
-        setStatusError(`Request failed (${response.status}).`);
-        setRunStarted(false);
-      }
-    } catch {
-      setStatusError("Request failed.");
-      setRunStarted(false);
-    } finally {
-      setIsFetching(false);
-    }
-  }, []);
+    },
+    [previewToken],
+  );
 
   // events
   const onRun = useCallback(async () => {
-    await startTask("/api/remove-unlinked-files");
-  }, [startTask]);
+    if (previewToken) {
+      setShowConfirm(true);
+      return;
+    }
+    await startTask("/api/remove-unlinked-files", false);
+  }, [previewToken, startTask]);
 
   const onDryRun = useCallback(async () => {
-    await startTask("/api/remove-unlinked-files/dry-run");
+    await startTask("/api/remove-unlinked-files/dry-run", true);
   }, [startTask]);
 
   return (
@@ -150,6 +168,12 @@ export function RemoveUnlinkedFiles({ savedConfig }: RemoveUnlinkedFilesProps) {
               )}
             </div>
           </div>
+          {previewToken && (
+            <p className="mt-3 border-t border-base-content/10 pt-2.5 text-xs text-base-content/50">
+              High-volume cleanup is unlocked for 15 minutes. The approval is invalidated if the
+              orphan or library-link snapshot changes.
+            </p>
+          )}
           <p className="mt-3 border-t border-base-content/10 pt-2.5 text-xs text-base-content/50">
             Dry Run previews the files that would be removed without changing anything. Library
             Directory must be the parent of your Radarr/Sonarr root folders containing imported
@@ -169,6 +193,19 @@ export function RemoveUnlinkedFiles({ savedConfig }: RemoveUnlinkedFilesProps) {
           </p>
         </div>
       </div>
+
+      <ConfirmModal
+        show={showConfirm}
+        title="Remove reviewed orphaned files?"
+        message="The files listed in the dry-run audit will be permanently removed from WebDAV."
+        checkboxMessage="I reviewed the dry-run audit and have a current /config backup"
+        requireCheckbox
+        errorMessage="Pause Arr imports while cleanup runs. Any candidate or library-link change will cancel this approval."
+        cancelText="Cancel"
+        confirmText="Remove orphaned files"
+        onCancel={() => setShowConfirm(false)}
+        onConfirm={() => void startTask("/api/remove-unlinked-files", false)}
+      />
     </>
   );
 }

--- a/frontend/app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.tsx
+++ b/frontend/app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.tsx
@@ -197,10 +197,17 @@ export function RemoveUnlinkedFiles({ savedConfig }: RemoveUnlinkedFilesProps) {
       <ConfirmModal
         show={showConfirm}
         title="Remove reviewed orphaned files?"
-        message="The files listed in the dry-run audit will be permanently removed from WebDAV."
+        message={
+          <>
+            <p>The files listed in the dry-run audit will be permanently removed from WebDAV.</p>
+            <p className="mt-2 text-warning">
+              Pause Arr imports while cleanup runs. Any candidate or library-link change will cancel
+              this approval.
+            </p>
+          </>
+        }
         checkboxMessage="I reviewed the dry-run audit and have a current /config backup"
         requireCheckbox
-        errorMessage="Pause Arr imports while cleanup runs. Any candidate or library-link change will cancel this approval."
         cancelText="Cancel"
         confirmText="Remove orphaned files"
         onCancel={() => setShowConfirm(false)}

--- a/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
@@ -705,7 +705,7 @@ public class RemoveUnlinkedFilesTaskTests
             await SeedRootsAsync(ctx);
             await SeedLinkedItemsAsync(ctx, libraryDir, 5);
 
-            await SeedOrphanItemsAsync(ctx, 46, "orphan");
+            await SeedOrphanItemsAsync(ctx, 106, "orphan");
 
             var config = new ConfigManager();
             config.UpdateValues(
@@ -721,7 +721,7 @@ public class RemoveUnlinkedFilesTaskTests
                 createContext: () => harness.CreateContext());
 
             Assert.True(await unapprovedCleanup.Execute());
-            Assert.Equal(51, await ctx.Items.CountAsync(x => x.Type == DavItem.ItemType.UsenetFile));
+            Assert.Equal(111, await ctx.Items.CountAsync(x => x.Type == DavItem.ItemType.UsenetFile));
             await BaseTask.ResetRunningTaskForTestsAsync();
 
             var dryRun = new RemoveUnlinkedFilesTask(
@@ -756,7 +756,7 @@ public class RemoveUnlinkedFilesTaskTests
                 previewToken: dryRun.IssuedPreviewToken);
 
             Assert.True(await staleCleanup.Execute());
-            Assert.Equal(52, await ctx.Items.CountAsync(x => x.Type == DavItem.ItemType.UsenetFile));
+            Assert.Equal(112, await ctx.Items.CountAsync(x => x.Type == DavItem.ItemType.UsenetFile));
             await BaseTask.ResetRunningTaskForTestsAsync();
 
             var refreshedDryRun = new RemoveUnlinkedFilesTask(
@@ -780,7 +780,7 @@ public class RemoveUnlinkedFilesTaskTests
             Assert.Equal(5, await ctx.Items.CountAsync(x => x.Type == DavItem.ItemType.UsenetFile));
             await BaseTask.ResetRunningTaskForTestsAsync();
 
-            await SeedOrphanItemsAsync(ctx, 46, "replay");
+            await SeedOrphanItemsAsync(ctx, 106, "replay");
             var replay = new RemoveUnlinkedFilesTask(
                 config,
                 websocket,
@@ -789,7 +789,7 @@ public class RemoveUnlinkedFilesTaskTests
                 previewToken: refreshedDryRun.IssuedPreviewToken);
 
             Assert.True(await replay.Execute());
-            Assert.Equal(51, await ctx.Items.CountAsync(x => x.Type == DavItem.ItemType.UsenetFile));
+            Assert.Equal(111, await ctx.Items.CountAsync(x => x.Type == DavItem.ItemType.UsenetFile));
             var replayProgress = websocket.PeekLastMessage(WebsocketTopic.CleanupTaskProgress);
             Assert.NotNull(replayProgress);
             Assert.Contains("missing or was replaced", replayProgress, StringComparison.Ordinal);
@@ -846,6 +846,76 @@ public class RemoveUnlinkedFilesTaskTests
             var progress = websocket.PeekLastMessage(WebsocketTopic.CleanupTaskProgress);
             Assert.NotNull(progress);
             Assert.Contains("approval expired", progress, StringComparison.Ordinal);
+        }
+        finally
+        {
+            await BaseTask.ResetRunningTaskForTestsAsync();
+            RemoveUnlinkedFilesTask.ClearAuditPathsForTests();
+            try { Directory.Delete(libraryDir, recursive: true); } catch (IOException) { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task Execute_RejectsCandidateAddedAfterDryRunSnapshot()
+    {
+        await BaseTask.ResetRunningTaskForTestsAsync();
+        var libraryDir = Path.Join(Path.GetTempPath(), $"nzbdav-lib-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(libraryDir);
+        await using var harness = await TempDb.CreateAsync();
+        try
+        {
+            var ctx = harness.Context;
+            await SeedRootsAsync(ctx);
+            await SeedLinkedItemsAsync(ctx, libraryDir, 5);
+            await SeedOrphanItemsAsync(ctx, 46, "reviewed");
+
+            var config = new ConfigManager();
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.MediaLibraryDir, ConfigValue = libraryDir },
+            ]);
+
+            const string latePath = "/content/late-after-audit.mkv";
+            var websocket = new WebsocketManager();
+            var dryRun = new RemoveUnlinkedFilesTask(
+                config,
+                websocket,
+                isDryRun: true,
+                createContext: () => harness.CreateContext(),
+                beforePreviewApproval: async () =>
+                {
+                    var lateId = Guid.NewGuid();
+                    ctx.Items.Add(DavItem.New(
+                        lateId,
+                        DavItem.ContentFolder,
+                        "late-after-audit.mkv",
+                        10,
+                        DavItem.ItemType.UsenetFile,
+                        DavItem.ItemSubType.NzbFile,
+                        null,
+                        null,
+                        null,
+                        null));
+                    await ctx.SaveChangesAsync();
+                });
+
+            Assert.True(await dryRun.Execute());
+            Assert.NotNull(dryRun.IssuedPreviewToken);
+            Assert.DoesNotContain(latePath, RemoveUnlinkedFilesTask.GetAuditReport(), StringComparison.Ordinal);
+            await BaseTask.ResetRunningTaskForTestsAsync();
+
+            var cleanup = new RemoveUnlinkedFilesTask(
+                config,
+                websocket,
+                isDryRun: false,
+                createContext: () => harness.CreateContext(),
+                previewToken: dryRun.IssuedPreviewToken);
+
+            Assert.True(await cleanup.Execute());
+            Assert.Equal(52, await ctx.Items.CountAsync(x => x.Type == DavItem.ItemType.UsenetFile));
+            var progress = websocket.PeekLastMessage(WebsocketTopic.CleanupTaskProgress);
+            Assert.NotNull(progress);
+            Assert.Contains("state changed", progress, StringComparison.Ordinal);
         }
         finally
         {

--- a/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
@@ -705,23 +705,7 @@ public class RemoveUnlinkedFilesTaskTests
             await SeedRootsAsync(ctx);
             await SeedLinkedItemsAsync(ctx, libraryDir, 5);
 
-            for (var i = 0; i < 46; i++)
-            {
-                var id = Guid.NewGuid();
-                ctx.Items.Add(DavItem.New(
-                    id,
-                    DavItem.ContentFolder,
-                    $"orphan-{i}.mkv",
-                    10,
-                    DavItem.ItemType.UsenetFile,
-                    DavItem.ItemSubType.NzbFile,
-                    null,
-                    null,
-                    null,
-                    null));
-            }
-
-            await ctx.SaveChangesAsync();
+            await SeedOrphanItemsAsync(ctx, 46, "orphan");
 
             var config = new ConfigManager();
             config.UpdateValues(
@@ -794,6 +778,74 @@ public class RemoveUnlinkedFilesTaskTests
 
             Assert.True(await cleanup.Execute());
             Assert.Equal(5, await ctx.Items.CountAsync(x => x.Type == DavItem.ItemType.UsenetFile));
+            await BaseTask.ResetRunningTaskForTestsAsync();
+
+            await SeedOrphanItemsAsync(ctx, 46, "replay");
+            var replay = new RemoveUnlinkedFilesTask(
+                config,
+                websocket,
+                isDryRun: false,
+                createContext: () => harness.CreateContext(),
+                previewToken: refreshedDryRun.IssuedPreviewToken);
+
+            Assert.True(await replay.Execute());
+            Assert.Equal(51, await ctx.Items.CountAsync(x => x.Type == DavItem.ItemType.UsenetFile));
+            var replayProgress = websocket.PeekLastMessage(WebsocketTopic.CleanupTaskProgress);
+            Assert.NotNull(replayProgress);
+            Assert.Contains("missing or was replaced", replayProgress, StringComparison.Ordinal);
+        }
+        finally
+        {
+            await BaseTask.ResetRunningTaskForTestsAsync();
+            RemoveUnlinkedFilesTask.ClearAuditPathsForTests();
+            try { Directory.Delete(libraryDir, recursive: true); } catch (IOException) { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task Execute_RejectsExpiredExtremeOrphanApproval()
+    {
+        await BaseTask.ResetRunningTaskForTestsAsync();
+        var libraryDir = Path.Join(Path.GetTempPath(), $"nzbdav-lib-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(libraryDir);
+        await using var harness = await TempDb.CreateAsync();
+        try
+        {
+            var ctx = harness.Context;
+            await SeedRootsAsync(ctx);
+            await SeedLinkedItemsAsync(ctx, libraryDir, 5);
+            await SeedOrphanItemsAsync(ctx, 46, "expired");
+
+            var config = new ConfigManager();
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.MediaLibraryDir, ConfigValue = libraryDir },
+            ]);
+
+            var websocket = new WebsocketManager();
+            var dryRun = new RemoveUnlinkedFilesTask(
+                config,
+                websocket,
+                isDryRun: true,
+                createContext: () => harness.CreateContext(),
+                previewLifetime: TimeSpan.Zero);
+
+            Assert.True(await dryRun.Execute());
+            Assert.NotNull(dryRun.IssuedPreviewToken);
+            await BaseTask.ResetRunningTaskForTestsAsync();
+
+            var cleanup = new RemoveUnlinkedFilesTask(
+                config,
+                websocket,
+                isDryRun: false,
+                createContext: () => harness.CreateContext(),
+                previewToken: dryRun.IssuedPreviewToken);
+
+            Assert.True(await cleanup.Execute());
+            Assert.Equal(51, await ctx.Items.CountAsync(x => x.Type == DavItem.ItemType.UsenetFile));
+            var progress = websocket.PeekLastMessage(WebsocketTopic.CleanupTaskProgress);
+            Assert.NotNull(progress);
+            Assert.Contains("approval expired", progress, StringComparison.Ordinal);
         }
         finally
         {
@@ -1273,6 +1325,30 @@ public class RemoveUnlinkedFilesTaskTests
             await File.WriteAllTextAsync(
                 Path.Join(libraryDir, $"{id:N}.strm"),
                 $"http://localhost/view/.ids/{id}.mkv");
+        }
+
+        await ctx.SaveChangesAsync();
+    }
+
+    private static async Task SeedOrphanItemsAsync(
+        DavDatabaseContext ctx,
+        int count,
+        string namePrefix)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            var id = Guid.NewGuid();
+            ctx.Items.Add(DavItem.New(
+                id,
+                DavItem.ContentFolder,
+                $"{namePrefix}-{i}.mkv",
+                10,
+                DavItem.ItemType.UsenetFile,
+                DavItem.ItemSubType.NzbFile,
+                null,
+                null,
+                null,
+                null));
         }
 
         await ctx.SaveChangesAsync();

--- a/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
+++ b/tests/NzbWebDAV.Tests/Tasks/RemoveUnlinkedFilesTaskTests.cs
@@ -693,6 +693,117 @@ public class RemoveUnlinkedFilesTaskTests
     }
 
     [Fact]
+    public async Task Execute_AllowsExtremeOrphanRatioAfterReviewedDryRun()
+    {
+        await BaseTask.ResetRunningTaskForTestsAsync();
+        var libraryDir = Path.Join(Path.GetTempPath(), $"nzbdav-lib-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(libraryDir);
+        await using var harness = await TempDb.CreateAsync();
+        try
+        {
+            var ctx = harness.Context;
+            await SeedRootsAsync(ctx);
+            await SeedLinkedItemsAsync(ctx, libraryDir, 5);
+
+            for (var i = 0; i < 46; i++)
+            {
+                var id = Guid.NewGuid();
+                ctx.Items.Add(DavItem.New(
+                    id,
+                    DavItem.ContentFolder,
+                    $"orphan-{i}.mkv",
+                    10,
+                    DavItem.ItemType.UsenetFile,
+                    DavItem.ItemSubType.NzbFile,
+                    null,
+                    null,
+                    null,
+                    null));
+            }
+
+            await ctx.SaveChangesAsync();
+
+            var config = new ConfigManager();
+            config.UpdateValues(
+            [
+                new ConfigItem { ConfigName = ConfigKeys.MediaLibraryDir, ConfigValue = libraryDir },
+            ]);
+
+            var websocket = new WebsocketManager();
+            var unapprovedCleanup = new RemoveUnlinkedFilesTask(
+                config,
+                websocket,
+                isDryRun: false,
+                createContext: () => harness.CreateContext());
+
+            Assert.True(await unapprovedCleanup.Execute());
+            Assert.Equal(51, await ctx.Items.CountAsync(x => x.Type == DavItem.ItemType.UsenetFile));
+            await BaseTask.ResetRunningTaskForTestsAsync();
+
+            var dryRun = new RemoveUnlinkedFilesTask(
+                config,
+                websocket,
+                isDryRun: true,
+                createContext: () => harness.CreateContext());
+
+            Assert.True(await dryRun.Execute());
+            Assert.NotNull(dryRun.IssuedPreviewToken);
+            await BaseTask.ResetRunningTaskForTestsAsync();
+
+            var changedId = Guid.NewGuid();
+            ctx.Items.Add(DavItem.New(
+                changedId,
+                DavItem.ContentFolder,
+                "changed-after-preview.mkv",
+                10,
+                DavItem.ItemType.UsenetFile,
+                DavItem.ItemSubType.NzbFile,
+                null,
+                null,
+                null,
+                null));
+            await ctx.SaveChangesAsync();
+
+            var staleCleanup = new RemoveUnlinkedFilesTask(
+                config,
+                websocket,
+                isDryRun: false,
+                createContext: () => harness.CreateContext(),
+                previewToken: dryRun.IssuedPreviewToken);
+
+            Assert.True(await staleCleanup.Execute());
+            Assert.Equal(52, await ctx.Items.CountAsync(x => x.Type == DavItem.ItemType.UsenetFile));
+            await BaseTask.ResetRunningTaskForTestsAsync();
+
+            var refreshedDryRun = new RemoveUnlinkedFilesTask(
+                config,
+                websocket,
+                isDryRun: true,
+                createContext: () => harness.CreateContext());
+
+            Assert.True(await refreshedDryRun.Execute());
+            Assert.NotNull(refreshedDryRun.IssuedPreviewToken);
+            await BaseTask.ResetRunningTaskForTestsAsync();
+
+            var cleanup = new RemoveUnlinkedFilesTask(
+                config,
+                websocket,
+                isDryRun: false,
+                createContext: () => harness.CreateContext(),
+                previewToken: refreshedDryRun.IssuedPreviewToken);
+
+            Assert.True(await cleanup.Execute());
+            Assert.Equal(5, await ctx.Items.CountAsync(x => x.Type == DavItem.ItemType.UsenetFile));
+        }
+        finally
+        {
+            await BaseTask.ResetRunningTaskForTestsAsync();
+            RemoveUnlinkedFilesTask.ClearAuditPathsForTests();
+            try { Directory.Delete(libraryDir, recursive: true); } catch (IOException) { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public async Task InsertLinkedIdBatchAsync_InsertsAllIds()
     {
         await using var harness = await TempDb.CreateAsync();


### PR DESCRIPTION
## Summary

- keep the existing 90% orphan-ratio safety stop for unreviewed cleanup runs
- issue a one-time, 15-minute approval after an exceptional dry run and bind it to the exact candidate, sidecar, configured-path, and library-link state
- require explicit UI confirmation before forwarding that approval
- document the high-volume cleanup workflow

## Support-pack diagnosis

The affected environment has 9,028 unique symlinks under `/mnt/debrid/nzbdav-symlinks`, and all 9,028 targets use the recognized `/mnt/debrid/nzbdav/.ids/...` format. The library mount is therefore healthy. Its dry run consistently identifies 1,730 genuine candidates, but the fixed 90% guard gives the operator no supported way to approve that reviewed backlog.

## Test plan

- `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter 'FullyQualifiedName~RemoveUnlinkedFilesTaskTests|FullyQualifiedName~AdminOpenApiIntegrationTests.CommittedContract_MatchesNormalizedRuntimeDocument'`
- `cd frontend && npx eslint app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.tsx app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.test.tsx`
- `cd frontend && npx prettier --check app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.tsx app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.test.tsx`
- `cd frontend && npm run typecheck`
- `cd frontend && npm test -- --run app/routes/settings/maintenance/remove-unlinked-files/remove-unlinked-files.test.tsx`
- Impeccable detector: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a safety approval flow for orphaned-file cleanup when more than 90% of files appear unlinked.
  - Dry runs now provide a time-limited approval token; cleanup requires a fresh, matching review.
  - Added confirmation prompts requiring users to review the audit and confirm a configuration backup.
  - Added clearer status, error, and approval-window messaging.
  - Prevented cleanup approvals from being reused or applied after relevant file state changes.

- **Documentation**
  - Updated maintenance and retention guidance to describe the 15-minute approval requirement and safety checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->