### PR TITLE
fix(ui): match app read legend to the activity chart

### DIFF
--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.test.tsx
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.test.tsx
@@ -55,6 +55,14 @@ describe("ThroughputChart", () => {
     expect(markup).toContain('data-series="client-articles"');
   });
 
+  it("uses a solid blue swatch for app reads in the legend", () => {
+    const markup = renderMarkup([point(3, 1)]);
+
+    expect(markup).toContain("App reads · 2");
+    expect(markup).toContain("border-t-2 border-info");
+    expect(markup).not.toContain("border-dashed");
+  });
+
   it("labels the y-axis with the error-dominant coordinate scale", () => {
     const markup = renderMarkup([point(2, 2, 10)], 10);
 

--- a/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
+++ b/frontend/app/routes/overview/components/throughput-chart/throughput-chart.tsx
@@ -345,7 +345,7 @@ export function ThroughputChart({
                 Client reads · {formatNumber(safeTotalClientArticles)}
               </span>
               <span className="inline-flex items-center gap-1.5">
-                <span className="inline-block w-2.5 border-t-2 border-dashed border-info" />
+                <span className="inline-block w-2.5 border-t-2 border-info" />
                 App reads · {formatNumber(totalAppArticles)}
               </span>
               {maxNetworkRate > 0 && (


### PR DESCRIPTION
## Summary
- Render the blue app-read legend swatch as a solid line, matching the activity chart.
- Cover the legend styling contract in the throughput-chart component test.

## Test plan
- `cd frontend && npm test -- app/routes/overview/components/throughput-chart/throughput-chart.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the App reads legend marker in the throughput chart to display as a solid blue swatch instead of a dashed line.
  - Added coverage to verify the legend label and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->