### PR TITLE
fix(nntp): keep playback working when a provider returns the wrong post

### DIFF
--- a/backend/Clients/Usenet/Contexts/YencFileValidationContext.cs
+++ b/backend/Clients/Usenet/Contexts/YencFileValidationContext.cs
@@ -1,0 +1,26 @@
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Clients.Usenet.Contexts;
+
+internal sealed class YencFileValidationContext : IDisposable
+{
+    private static readonly AsyncLocal<int?> ExpectedTotalParts = new();
+    private readonly int? _previous = ExpectedTotalParts.Value;
+
+    private YencFileValidationContext(int expectedTotalParts)
+    {
+        ExpectedTotalParts.Value = expectedTotalParts;
+    }
+
+    public static int? CurrentExpectedTotalParts => ExpectedTotalParts.Value;
+
+    public static bool MatchesExpectedFile(UsenetYencHeader header) =>
+        CurrentExpectedTotalParts is not { } expectedTotalParts
+        || header.TotalParts <= 0
+        || header.TotalParts == expectedTotalParts;
+
+    public static IDisposable Begin(int expectedTotalParts) =>
+        new YencFileValidationContext(expectedTotalParts);
+
+    public void Dispose() => ExpectedTotalParts.Value = _previous;
+}

--- a/backend/Clients/Usenet/Contexts/YencFileValidationContext.cs
+++ b/backend/Clients/Usenet/Contexts/YencFileValidationContext.cs
@@ -16,7 +16,7 @@ internal sealed class YencFileValidationContext : IDisposable
 
     public static bool MatchesExpectedFile(UsenetYencHeader header) =>
         CurrentExpectedTotalParts is not { } expectedTotalParts
-        || header.TotalParts <= 0
+        || (expectedTotalParts == 1 && header.TotalParts == 0)
         || header.TotalParts == expectedTotalParts;
 
     public static IDisposable Begin(int expectedTotalParts) =>

--- a/backend/Clients/Usenet/HeaderCachingNntpClient.cs
+++ b/backend/Clients/Usenet/HeaderCachingNntpClient.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using NzbWebDAV.Clients.Usenet.Contexts;
 using UsenetSharp.Models;
 
 namespace NzbWebDAV.Clients.Usenet;
@@ -30,7 +31,12 @@ public class HeaderCachingNntpClient(INntpClient usenetClient) : WrappingNntpCli
     public override async Task<UsenetYencHeader> GetYencHeadersAsync(string segmentId, CancellationToken ct)
     {
         if (_cache.TryGetValue(segmentId, out var cached))
-            return cached;
+        {
+            if (YencFileValidationContext.MatchesExpectedFile(cached))
+                return cached;
+
+            _cache.TryRemove(segmentId, out _);
+        }
 
         var header = await base.GetYencHeadersAsync(segmentId, ct).ConfigureAwait(false);
 
@@ -42,7 +48,8 @@ public class HeaderCachingNntpClient(INntpClient usenetClient) : WrappingNntpCli
             }
         }
 
-        _cache.TryAdd(segmentId, header);
+        if (YencFileValidationContext.MatchesExpectedFile(header))
+            _cache.TryAdd(segmentId, header);
         return header;
     }
 }

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -1274,7 +1274,17 @@ public class MultiProviderNntpClient(
         };
         if (bodyStream is null) return;
 
-        var header = await bodyStream.GetYencHeadersAsync(cancellationToken).ConfigureAwait(false);
+        UsenetYencHeader? header;
+        try
+        {
+            header = await bodyStream.GetYencHeadersAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            await bodyStream.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+
         if (header is null || YencFileValidationContext.MatchesExpectedFile(header))
             return;
 

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -1255,13 +1255,24 @@ public class MultiProviderNntpClient(
         CancellationToken cancellationToken)
     {
         if (requestedId is not { } segmentId
-            || YencFileValidationContext.CurrentExpectedTotalParts is not { } expectedTotalParts
-            || response is not UsenetDecodedBodyResponse
+            || YencFileValidationContext.CurrentExpectedTotalParts is not { } expectedTotalParts)
+            return;
+
+        var bodyStream = response switch
+        {
+            UsenetDecodedBodyResponse
             {
                 ResponseType: UsenetResponseType.ArticleRetrievedBodyFollows,
-                Stream: { } bodyStream,
-            })
-            return;
+                Stream: { } stream,
+            } => stream,
+            UsenetDecodedArticleResponse
+            {
+                ResponseType: UsenetResponseType.ArticleRetrievedHeadAndBodyFollow,
+                Stream: { } stream,
+            } => stream,
+            _ => null,
+        };
+        if (bodyStream is null) return;
 
         var header = await bodyStream.GetYencHeadersAsync(cancellationToken).ConfigureAwait(false);
         if (header is null || YencFileValidationContext.MatchesExpectedFile(header))

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -586,6 +586,8 @@ public class MultiProviderNntpClient(
             try
             {
                 response = await primaryResponse.ConfigureAwait(false);
+                await RejectMismatchedYencFileAsync(
+                    segmentId, response, cancellationToken).ConfigureAwait(false);
             }
             catch (NntpClientRetiredException)
             {
@@ -594,6 +596,7 @@ public class MultiProviderNntpClient(
             }
             catch (Exception e) when (!e.IsCancellationException(cancellationToken) && e is not OutOfMemoryException)
             {
+                response = null;
                 primaryStopwatch.Stop();
                 walk.Attempts++;
                 walk.NoteException(e);
@@ -714,6 +717,8 @@ public class MultiProviderNntpClient(
                         walk.Attempts++;
                         response = await provider.DecodedBodyAsync(
                             segmentId, deferredCallback.Invoke, cancellationToken).ConfigureAwait(false);
+                        await RejectMismatchedYencFileAsync(
+                            segmentId, response, cancellationToken).ConfigureAwait(false);
                         stopwatch.Stop();
                         var responseType = response.ResponseType;
                         if (responseType == UsenetResponseType.ArticleRetrievedBodyFollows)
@@ -1012,6 +1017,8 @@ public class MultiProviderNntpClient(
                 walk.Attempts++;
                 var result = await task(provider, deferredCallback.Invoke)
                     .ConfigureAwait(false);
+                await RejectMismatchedYencFileAsync(
+                    segmentId, result, cancellationToken).ConfigureAwait(false);
                 stopwatch.Stop();
                 if (result.ResponseType == successResponseType)
                 {
@@ -1155,6 +1162,8 @@ public class MultiProviderNntpClient(
             {
                 walk.Attempts++;
                 var result = await task.Invoke(provider).ConfigureAwait(false);
+                await RejectMismatchedYencFileAsync(
+                    articleId, result, cancellationToken).ConfigureAwait(false);
                 stopwatch.Stop();
 
                 // if no article with that message-id is found, try again with the next provider.
@@ -1240,6 +1249,33 @@ public class MultiProviderNntpClient(
         throw new InvalidOperationException("There are no usenet providers configured.");
     }
 
+    private static async Task RejectMismatchedYencFileAsync(
+        SegmentId? requestedId,
+        UsenetResponse response,
+        CancellationToken cancellationToken)
+    {
+        if (requestedId is not { } segmentId
+            || YencFileValidationContext.CurrentExpectedTotalParts is not { } expectedTotalParts
+            || response is not UsenetDecodedBodyResponse
+            {
+                ResponseType: UsenetResponseType.ArticleRetrievedBodyFollows,
+                Stream: { } bodyStream,
+            })
+            return;
+
+        var header = await bodyStream.GetYencHeadersAsync(cancellationToken).ConfigureAwait(false);
+        if (header is null || YencFileValidationContext.MatchesExpectedFile(header))
+            return;
+
+        await bodyStream.DisposeAsync().ConfigureAwait(false);
+
+        throw new UsenetMismatchedArticleException(
+            segmentId,
+            header.PartNumber,
+            header.TotalParts,
+            expectedTotalParts);
+    }
+
     private bool IsCachedMissing(SegmentId segmentId, MultiConnectionNntpClient provider)
     {
         if (articleMissCache == null) return false;
@@ -1266,6 +1302,8 @@ public class MultiProviderNntpClient(
     {
         if (segmentId is not { } id) return;
         if (ClassifyException(exception) != SegmentFetch.FetchStatus.Missing) return;
+        if (exception.TryGetCausingException<UsenetMismatchedArticleException>(out _))
+            return;
         var group = NormalizeStorageGroup(provider.StorageGroup);
         if (group.Length > 0) missingGroups.Add(group);
         MarkCachedMissing(id, provider);

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -143,6 +143,7 @@ public abstract class NntpClient : INntpClient
     public virtual async Task<long> GetFileSizeAsync(NzbFile file, CancellationToken ct)
     {
         if (file.Segments.Count == 0) return 0;
+        using var yencFileValidation = YencFileValidationContext.Begin(file.Segments.Count);
         var headers = await GetYencHeadersAsync(file.Segments[^1].MessageId, ct).ConfigureAwait(false);
         file.Segments[^1].ByteRange = LongRange.FromStartAndSize(headers.PartOffset, headers.PartSize);
         return headers.PartOffset + headers.PartSize;

--- a/backend/Clients/Usenet/SegmentCacheNntpClient.cs
+++ b/backend/Clients/Usenet/SegmentCacheNntpClient.cs
@@ -387,7 +387,10 @@ public sealed class SegmentCacheNntpClient : WrappingNntpClient
         {
             var header = JsonSerializer.Deserialize<UsenetYencHeader>(
                 File.ReadAllText(blobPath + ".h"), HeaderJsonOptions);
-            if (header == null || header.PartSize != entry.Size || !IsCoherentHeader(header))
+            if (header == null
+                || header.PartSize != entry.Size
+                || !IsCoherentHeader(header)
+                || !YencFileValidationContext.MatchesExpectedFile(header))
             {
                 RecordReadFailureAndDrop(hash);
                 return CacheLookupResult.ReadFailure;

--- a/backend/Exceptions/UsenetMismatchedArticleException.cs
+++ b/backend/Exceptions/UsenetMismatchedArticleException.cs
@@ -1,0 +1,11 @@
+namespace NzbWebDAV.Exceptions;
+
+internal sealed class UsenetMismatchedArticleException(
+    string segmentId,
+    int actualPartNumber,
+    int actualTotalParts,
+    int expectedTotalParts)
+    : UsenetArticleNotFoundException(
+        segmentId,
+        $"Provider returned yEnc part {actualPartNumber}/{actualTotalParts} " +
+        $"for a file with {expectedTotalParts} parts.");

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -105,6 +105,7 @@ public class NzbFileStream(
 
     public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
     {
+        using var yencFileValidation = YencFileValidationContext.Begin(fileSegmentIds.Length);
         if (buffer.IsEmpty) return 0;
         if (_position >= fileSize) return 0;
         // A prior Seek started the old inner stream's teardown non-blocking; join it

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/HeaderCachingNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/HeaderCachingNntpClientTests.cs
@@ -1,4 +1,5 @@
 using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
 using UsenetSharp.Models;
 
@@ -22,9 +23,26 @@ public class HeaderCachingNntpClientTests
         Assert.Equal(2, inner.HeaderRequestCount);
     }
 
+    [Fact]
+    public async Task GetYencHeadersAsync_CachedHeaderFromDifferentPost_IsRefetched()
+    {
+        var inner = new CountingHeaderClient { TotalParts = 931 };
+        var client = new HeaderCachingNntpClient(inner);
+
+        var stale = await client.GetYencHeadersAsync("segment-1", CancellationToken.None);
+        inner.TotalParts = 3;
+        using var validation = YencFileValidationContext.Begin(expectedTotalParts: 3);
+        var corrected = await client.GetYencHeadersAsync("segment-1", CancellationToken.None);
+
+        Assert.Equal(931, stale.TotalParts);
+        Assert.Equal(3, corrected.TotalParts);
+        Assert.Equal(2, inner.HeaderRequestCount);
+    }
+
     private sealed class CountingHeaderClient : NntpClient
     {
         public int HeaderRequestCount { get; private set; }
+        public int TotalParts { get; set; } = 10;
 
         public override Task ConnectAsync(
             string host, int port, bool useSsl, CancellationToken cancellationToken) =>
@@ -113,7 +131,7 @@ public class HeaderCachingNntpClientTests
                 PartNumber = 1,
                 PartOffset = segmentId == "segment-1" ? 100 : 200,
                 PartSize = 50,
-                TotalParts = 10,
+                TotalParts = TotalParts,
             });
         }
     }

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientYencValidationTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientYencValidationTests.cs
@@ -8,6 +8,7 @@ using NzbWebDAV.Streams;
 using NzbWebDAV.Tests.Fakes;
 using NzbWebDAV.Tests.TestUtils;
 using UsenetSharp.Models;
+using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Tests.Clients.Usenet;
 
@@ -130,6 +131,27 @@ public sealed class MultiProviderNntpClientYencValidationTests
         var header = await responseStream.GetYencHeadersAsync();
 
         Assert.Equal(3, header!.TotalParts);
+        Assert.Equal(1, wrongPost.ArticleRequestCount);
+        Assert.Equal(1, correctPost.ArticleRequestCount);
+    }
+
+    [Fact]
+    public async Task DecodedArticleAsync_HeaderInspectionFails_DisposesStreamAndUsesBackupProvider()
+    {
+        var innerSegments = new Dictionary<string, byte[]> { ["segment"] = [1, 2, 3] };
+        using var wrongInner = new FakeNntpClient(innerSegments, useCachedYencStreams: true);
+        using var correctInner = new FakeNntpClient(innerSegments, useCachedYencStreams: true);
+        var failingStream = new ThrowingHeaderYencStream();
+        using var wrongPost = new ArticleNntpClient(wrongInner, failingStream);
+        using var correctPost = new ArticleNntpClient(
+            correctInner, CreateHeader(partNumber: 1, totalParts: 3));
+        using var client = CreateProviderClient(wrongPost, correctPost);
+        using var validation = YencFileValidationContext.Begin(expectedTotalParts: 3);
+
+        var response = await client.DecodedArticleAsync("segment", CancellationToken.None);
+        await using var responseStream = response.Stream;
+
+        Assert.True(failingStream.IsDisposed);
         Assert.Equal(1, wrongPost.ArticleRequestCount);
         Assert.Equal(1, correctPost.ArticleRequestCount);
     }
@@ -326,8 +348,15 @@ public sealed class MultiProviderNntpClientYencValidationTests
 
     private sealed class ArticleNntpClient(
         INntpClient inner,
-        UsenetYencHeader header) : WrappingNntpClient(inner)
+        YencStream stream) : WrappingNntpClient(inner)
     {
+        public ArticleNntpClient(INntpClient inner, UsenetYencHeader header)
+            : this(inner, new CachedYencStream(
+                header,
+                new MemoryStream([1, 2, 3], writable: false)))
+        {
+        }
+
         public int ArticleRequestCount { get; private set; }
 
         public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
@@ -349,10 +378,23 @@ public sealed class MultiProviderNntpClientYencValidationTests
                 ResponseCode = (int)UsenetResponseType.ArticleRetrievedHeadAndBodyFollow,
                 ResponseMessage = "220 fake article",
                 ArticleHeaders = new UsenetArticleHeader { Headers = [] },
-                Stream = new CachedYencStream(
-                    header,
-                    new MemoryStream([1, 2, 3], writable: false)),
+                Stream = stream,
             });
+        }
+    }
+
+    private sealed class ThrowingHeaderYencStream() : YencStream(Stream.Null)
+    {
+        public bool IsDisposed { get; private set; }
+
+        public override ValueTask<UsenetYencHeader?> GetYencHeadersAsync(
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromException<UsenetYencHeader?>(new InvalidDataException("Malformed yEnc header"));
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = disposing;
+            base.Dispose(disposing);
         }
     }
 

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientYencValidationTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientYencValidationTests.cs
@@ -1,0 +1,228 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Contexts;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Models;
+using NzbWebDAV.Streams;
+using NzbWebDAV.Tests.Fakes;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public sealed class MultiProviderNntpClientYencValidationTests
+{
+    [Fact]
+    public async Task GetYencHeadersAsync_MismatchedTotalParts_UsesBackupProvider()
+    {
+        var segments = new Dictionary<string, byte[]> { ["segment"] = [1, 2, 3] };
+        var wrongPost = CreateClient(segments, partNumber: 557, totalParts: 931);
+        var correctPost = CreateClient(segments, partNumber: 1, totalParts: 3);
+        using var client = new MultiProviderNntpClient(
+            [
+                MultiProviderNntpClientTests.CreateProvider(wrongPost, host: "wrong.example"),
+                MultiProviderNntpClientTests.CreateProvider(
+                    correctPost,
+                    host: "correct.example",
+                    providerType: ProviderType.BackupOnly),
+            ],
+            cascadeEnabled: () => true);
+        using var validation = YencFileValidationContext.Begin(expectedTotalParts: 3);
+
+        var header = await client.GetYencHeadersAsync("segment", CancellationToken.None);
+
+        Assert.Equal(1, header.PartNumber);
+        Assert.Equal(3, header.TotalParts);
+        Assert.Equal(1, wrongPost.BodyRequestCount);
+        Assert.Equal(1, correctPost.BodyRequestCount);
+    }
+
+    [Fact]
+    public async Task GetYencHeadersAsync_MismatchedTotalParts_DoesNotSkipStorageGroupSibling()
+    {
+        var segments = new Dictionary<string, byte[]> { ["segment"] = [1, 2, 3] };
+        var wrongPost = CreateClient(segments, partNumber: 557, totalParts: 931);
+        var correctPost = CreateClient(segments, partNumber: 1, totalParts: 3);
+        using var client = new MultiProviderNntpClient(
+            [
+                MultiProviderNntpClientTests.CreateProvider(
+                    wrongPost, host: "wrong.example", storageGroup: "shared"),
+                MultiProviderNntpClientTests.CreateProvider(
+                    correctPost, host: "correct.example", storageGroup: "shared"),
+            ],
+            articleMissCache: new ArticleMissNegativeCache(new ConfigManager()));
+        using var validation = YencFileValidationContext.Begin(expectedTotalParts: 3);
+
+        var header = await client.GetYencHeadersAsync("segment", CancellationToken.None);
+
+        Assert.Equal(3, header.TotalParts);
+        Assert.Equal(1, wrongPost.BodyRequestCount);
+        Assert.Equal(1, correctPost.BodyRequestCount);
+    }
+
+    [Fact]
+    public async Task NzbFileStream_ByteZero_MismatchedTotalParts_UsesBackupProvider()
+    {
+        var segments = new Dictionary<string, byte[]>
+        {
+            ["first"] = [1, 2, 3],
+            ["second"] = [4, 5, 6],
+            ["third"] = [7, 8, 9],
+        };
+        var wrongPost = new FakeNntpClient(
+            segments,
+            useCachedYencStreams: true,
+            yencHeaders: new Dictionary<string, UsenetYencHeader>
+            {
+                ["first"] = new()
+                {
+                    FileName = "wrong.bin",
+                    FileSize = 318_803_968,
+                    LineLength = 128,
+                    PartNumber = 557,
+                    TotalParts = 931,
+                    PartOffset = 187_525_120,
+                    PartSize = 3,
+                },
+            });
+        var correctPost = new FakeNntpClient(segments, useCachedYencStreams: true);
+        using var client = new MultiProviderNntpClient(
+            [
+                MultiProviderNntpClientTests.CreateProvider(wrongPost, host: "wrong.example"),
+                MultiProviderNntpClientTests.CreateProvider(
+                    correctPost,
+                    host: "correct.example",
+                    providerType: ProviderType.BackupOnly),
+            ],
+            cascadeEnabled: () => true);
+        await using var stream = new NzbFileStream(
+            ["first", "second", "third"],
+            fileSize: 9,
+            client,
+            articleBufferSize: 4,
+            usePipelinedBodyRequests: true);
+
+        var buffer = new byte[1];
+        Assert.Equal(1, await stream.ReadAsync(buffer));
+
+        Assert.Equal(1, buffer[0]);
+        Assert.Equal(1, wrongPost.BodyRequestCounts["first"]);
+        Assert.Equal(1, correctPost.BodyRequestCounts["first"]);
+    }
+
+    [Fact]
+    public async Task NzbFileStream_SeekProbe_MismatchedTotalParts_UsesBackupProvider()
+    {
+        var segments = new Dictionary<string, byte[]>
+        {
+            ["first"] = [1, 2, 3],
+            ["second"] = [4, 5, 6],
+            ["third"] = [7, 8, 9],
+        };
+        var wrongPost = CreateClient(
+            segments, partNumber: 557, totalParts: 931, segmentId: "first");
+        var correctPost = new FakeNntpClient(segments, useCachedYencStreams: true);
+        using var client = CreateProviderClient(wrongPost, correctPost);
+        var previousBudget = NzbWebDAV.WebDav.Requests.RangeContext.GetReadBudget();
+        NzbWebDAV.WebDav.Requests.RangeContext.SetReadBudget(1);
+        try
+        {
+            await using var stream = new NzbFileStream(
+                ["first", "second", "third"],
+                fileSize: 9,
+                client,
+                articleBufferSize: 0,
+                usePipelinedBodyRequests: false);
+            stream.Seek(1, SeekOrigin.Begin);
+
+            var buffer = new byte[1];
+            Assert.Equal(1, await stream.ReadAsync(buffer));
+
+            Assert.Equal(2, buffer[0]);
+            Assert.True(wrongPost.BodyRequestCounts["first"] >= 1);
+            Assert.True(correctPost.BodyRequestCounts["first"] >= 1);
+        }
+        finally
+        {
+            NzbWebDAV.WebDav.Requests.RangeContext.SetReadBudget(previousBudget);
+        }
+    }
+
+    [Fact]
+    public async Task NzbFileStream_PipelinedMismatch_UsesBackupProvider()
+    {
+        var correctSegments = new Dictionary<string, byte[]>
+        {
+            ["first"] = [1, 2, 3],
+            ["second"] = [4, 5, 6],
+            ["third"] = [7, 8, 9],
+        };
+        var wrongSegments = correctSegments.ToDictionary(pair => pair.Key, pair => pair.Value.ToArray());
+        wrongSegments["second"] = [99, 99, 99];
+        var wrongPost = new FakeNntpClient(
+            wrongSegments,
+            useCachedYencStreams: true,
+            yencHeaders: new Dictionary<string, UsenetYencHeader>
+            {
+                ["second"] = new()
+                {
+                    FileName = "wrong.bin",
+                    FileSize = 318_803_968,
+                    LineLength = 128,
+                    PartNumber = 557,
+                    TotalParts = 931,
+                    PartOffset = 187_525_120,
+                    PartSize = 3,
+                },
+            });
+        var correctPost = new FakeNntpClient(correctSegments, useCachedYencStreams: true);
+        using var client = CreateProviderClient(wrongPost, correctPost);
+        await using var stream = new NzbFileStream(
+            ["first", "second", "third"],
+            fileSize: 9,
+            client,
+            articleBufferSize: 4,
+            usePipelinedBodyRequests: true);
+        using var output = new MemoryStream();
+
+        await stream.CopyToAsync(output);
+
+        Assert.Equal([1, 2, 3, 4, 5, 6, 7, 8, 9], output.ToArray());
+        Assert.True(wrongPost.BodyRequestCounts["second"] >= 1);
+        Assert.True(correctPost.BodyRequestCounts["second"] >= 1);
+    }
+
+    private static FakeNntpClient CreateClient(
+        IReadOnlyDictionary<string, byte[]> segments,
+        int partNumber,
+        int totalParts,
+        string segmentId = "segment") =>
+        new(
+            segments,
+            useCachedYencStreams: true,
+            yencHeaders: new Dictionary<string, UsenetYencHeader>
+            {
+                [segmentId] = new()
+                {
+                    FileName = "fake.bin",
+                    FileSize = 9,
+                    LineLength = 128,
+                    PartNumber = partNumber,
+                    TotalParts = totalParts,
+                    PartOffset = 0,
+                    PartSize = 3,
+                },
+            });
+
+    private static MultiProviderNntpClient CreateProviderClient(
+        INntpClient wrongPost,
+        INntpClient correctPost) =>
+        new(
+            [
+                MultiProviderNntpClientTests.CreateProvider(wrongPost, host: "wrong.example"),
+                MultiProviderNntpClientTests.CreateProvider(
+                    correctPost,
+                    host: "correct.example",
+                    providerType: ProviderType.BackupOnly),
+            ],
+            cascadeEnabled: () => true);
+}

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientYencValidationTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/MultiProviderNntpClientYencValidationTests.cs
@@ -3,14 +3,33 @@ using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Models;
+using NzbWebDAV.Models.Nzb;
 using NzbWebDAV.Streams;
 using NzbWebDAV.Tests.Fakes;
+using NzbWebDAV.Tests.TestUtils;
 using UsenetSharp.Models;
 
 namespace NzbWebDAV.Tests.Clients.Usenet;
 
+[Collection(nameof(GlobalLoggerCollection))]
 public sealed class MultiProviderNntpClientYencValidationTests
 {
+    [Theory]
+    [InlineData(1, 0, true)]
+    [InlineData(3, 0, false)]
+    [InlineData(3, 3, true)]
+    [InlineData(3, 931, false)]
+    public void MatchesExpectedFile_ValidatesTotalParts(
+        int expectedTotalParts,
+        int actualTotalParts,
+        bool expected)
+    {
+        using var validation = YencFileValidationContext.Begin(expectedTotalParts);
+        var header = CreateHeader(partNumber: 1, totalParts: actualTotalParts);
+
+        Assert.Equal(expected, YencFileValidationContext.MatchesExpectedFile(header));
+    }
+
     [Fact]
     public async Task GetYencHeadersAsync_MismatchedTotalParts_UsesBackupProvider()
     {
@@ -34,6 +53,85 @@ public sealed class MultiProviderNntpClientYencValidationTests
         Assert.Equal(3, header.TotalParts);
         Assert.Equal(1, wrongPost.BodyRequestCount);
         Assert.Equal(1, correctPost.BodyRequestCount);
+    }
+
+    [Fact]
+    public async Task GetYencHeadersAsync_MultipartHeaderWithoutTotal_UsesBackupProvider()
+    {
+        var segments = new Dictionary<string, byte[]> { ["segment"] = [1, 2, 3] };
+        var wrongPost = CreateClient(segments, partNumber: 1, totalParts: 0);
+        var correctPost = CreateClient(segments, partNumber: 1, totalParts: 3);
+        using var client = CreateProviderClient(wrongPost, correctPost);
+        using var validation = YencFileValidationContext.Begin(expectedTotalParts: 3);
+
+        var header = await client.GetYencHeadersAsync("segment", CancellationToken.None);
+
+        Assert.Equal(3, header.TotalParts);
+        Assert.Equal(1, wrongPost.BodyRequestCount);
+        Assert.Equal(1, correctPost.BodyRequestCount);
+    }
+
+    [Fact]
+    public async Task GetFileSizeAsync_MismatchedLastSegment_UsesBackupProvider()
+    {
+        var segments = new Dictionary<string, byte[]>
+        {
+            ["first"] = [1, 2, 3],
+            ["second"] = [4, 5, 6],
+            ["third"] = [7, 8, 9],
+        };
+        var wrongPost = CreateClient(
+            segments,
+            partNumber: 557,
+            totalParts: 931,
+            segmentId: "third",
+            partOffset: 187_525_120);
+        var correctPost = CreateClient(
+            segments,
+            partNumber: 3,
+            totalParts: 3,
+            segmentId: "third",
+            partOffset: 6);
+        using var client = CreateProviderClient(wrongPost, correctPost);
+        var file = new NzbFile { Subject = "fake.bin" };
+        foreach (var (segmentId, index) in segments.Keys.Select((id, index) => (id, index)))
+        {
+            file.Segments.Add(new NzbSegment
+            {
+                Bytes = 3,
+                MessageId = segmentId,
+                Number = index + 1,
+            });
+        }
+
+        var fileSize = await client.GetFileSizeAsync(file, CancellationToken.None);
+
+        Assert.Equal(9, fileSize);
+        Assert.Equal(new LongRange(6, 9), file.Segments[^1].ByteRange);
+        Assert.Equal(1, wrongPost.BodyRequestCounts["third"]);
+        Assert.Equal(1, correctPost.BodyRequestCounts["third"]);
+    }
+
+    [Fact]
+    public async Task DecodedArticleAsync_MismatchedTotalParts_UsesBackupProvider()
+    {
+        var innerSegments = new Dictionary<string, byte[]> { ["segment"] = [1, 2, 3] };
+        using var wrongInner = new FakeNntpClient(innerSegments, useCachedYencStreams: true);
+        using var correctInner = new FakeNntpClient(innerSegments, useCachedYencStreams: true);
+        using var wrongPost = new ArticleNntpClient(
+            wrongInner, CreateHeader(partNumber: 557, totalParts: 931));
+        using var correctPost = new ArticleNntpClient(
+            correctInner, CreateHeader(partNumber: 1, totalParts: 3));
+        using var client = CreateProviderClient(wrongPost, correctPost);
+        using var validation = YencFileValidationContext.Begin(expectedTotalParts: 3);
+
+        var response = await client.DecodedArticleAsync("segment", CancellationToken.None);
+        await using var responseStream = response.Stream;
+        var header = await responseStream.GetYencHeadersAsync();
+
+        Assert.Equal(3, header!.TotalParts);
+        Assert.Equal(1, wrongPost.ArticleRequestCount);
+        Assert.Equal(1, correctPost.ArticleRequestCount);
     }
 
     [Fact]
@@ -195,7 +293,8 @@ public sealed class MultiProviderNntpClientYencValidationTests
         IReadOnlyDictionary<string, byte[]> segments,
         int partNumber,
         int totalParts,
-        string segmentId = "segment") =>
+        string segmentId = "segment",
+        long partOffset = 0) =>
         new(
             segments,
             useCachedYencStreams: true,
@@ -208,10 +307,54 @@ public sealed class MultiProviderNntpClientYencValidationTests
                     LineLength = 128,
                     PartNumber = partNumber,
                     TotalParts = totalParts,
-                    PartOffset = 0,
+                    PartOffset = partOffset,
                     PartSize = 3,
                 },
             });
+
+    private static UsenetYencHeader CreateHeader(int partNumber, int totalParts) =>
+        new()
+        {
+            FileName = "fake.bin",
+            FileSize = 9,
+            LineLength = 128,
+            PartNumber = partNumber,
+            TotalParts = totalParts,
+            PartOffset = 0,
+            PartSize = 3,
+        };
+
+    private sealed class ArticleNntpClient(
+        INntpClient inner,
+        UsenetYencHeader header) : WrappingNntpClient(inner)
+    {
+        public int ArticleRequestCount { get; private set; }
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            CancellationToken cancellationToken) =>
+            DecodedArticleAsync(segmentId, null, cancellationToken);
+
+        public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+            SegmentId segmentId,
+            ArticleBodyCompletionHandler? onConnectionReadyAgain,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ArticleRequestCount++;
+            onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+            return Task.FromResult(new UsenetDecodedArticleResponse
+            {
+                SegmentId = segmentId.ToString(),
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedHeadAndBodyFollow,
+                ResponseMessage = "220 fake article",
+                ArticleHeaders = new UsenetArticleHeader { Headers = [] },
+                Stream = new CachedYencStream(
+                    header,
+                    new MemoryStream([1, 2, 3], writable: false)),
+            });
+        }
+    }
 
     private static MultiProviderNntpClient CreateProviderClient(
         INntpClient wrongPost,

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/SegmentCacheNntpClientTests.cs
@@ -15,6 +15,51 @@ namespace NzbWebDAV.Tests.Clients.Usenet;
 public sealed class SegmentCacheNntpClientTests
 {
     [Fact]
+    public async Task DecodedBodyAsync_CachedHeaderFromDifferentPost_RefetchesFromProvider()
+    {
+        var cacheDir = NewCacheDir();
+        const string segmentId = "segment-1";
+        byte[] staleContent = "old"u8.ToArray();
+        byte[] liveContent = "new"u8.ToArray();
+
+        try
+        {
+            WriteCacheEntry(cacheDir, segmentId, staleContent, totalParts: 931);
+            var inner = new FakeNntpClient(
+                new Dictionary<string, byte[]> { [segmentId] = liveContent },
+                useCachedYencStreams: true,
+                yencHeaders: new Dictionary<string, UsenetYencHeader>
+                {
+                    [segmentId] = new()
+                    {
+                        FileName = "fake.bin",
+                        FileSize = liveContent.Length,
+                        LineLength = 128,
+                        PartNumber = 1,
+                        PartOffset = 0,
+                        PartSize = liveContent.Length,
+                        TotalParts = 3,
+                    },
+                });
+            using var client = new SegmentCacheNntpClient(
+                inner, cacheDir, maxBytes: 1024 * 1024);
+            await client.CatalogLoadTask.WaitAsync(TimeSpan.FromSeconds(5));
+            using var validation = YencFileValidationContext.Begin(expectedTotalParts: 3);
+
+            var response = await client.DecodedBodyAsync(segmentId, CancellationToken.None);
+            await using var output = new MemoryStream();
+            await response.Stream!.CopyToAsync(output);
+
+            Assert.Equal(liveContent, output.ToArray());
+            Assert.Equal(1, inner.BodyRequestCount);
+        }
+        finally
+        {
+            DeleteCacheDir(cacheDir);
+        }
+    }
+
+    [Fact]
     public async Task CatalogHydration_DoesNotBlockConstruction_AndServesEntriesAfterLoad()
     {
         var cacheDir = Path.Join(
@@ -1572,7 +1617,11 @@ public sealed class SegmentCacheNntpClientTests
         return Path.Join(cacheDir, hash[..2], hash);
     }
 
-    private static void WriteCacheEntry(string cacheDir, string segmentId, byte[] content)
+    private static void WriteCacheEntry(
+        string cacheDir,
+        string segmentId,
+        byte[] content,
+        int totalParts = 1)
     {
         var hash = SegmentHash(segmentId);
         var directory = Path.Join(cacheDir, hash[..2]);
@@ -1587,7 +1636,7 @@ public sealed class SegmentCacheNntpClientTests
             PartNumber = 1,
             PartOffset = 0,
             PartSize = content.Length,
-            TotalParts = 1,
+            TotalParts = totalParts,
         };
         File.WriteAllText(
             Path.Join(directory, hash) + ".h",


### PR DESCRIPTION
## Summary

- validate successful BODY responses against the active NZB's yEnc `total` part count
- reject wrong-post responses as provider misses so the next eligible provider can serve the article
- evict stale in-memory header and on-disk segment cache entries whose yEnc geometry belongs to another post
- preserve missing-article classification so existing playback repair handling still applies when no provider has the correct copy

Closes #1356

## Test plan

- `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Debug --no-restore --filter 'FullyQualifiedName~MultiProviderNntpClientYencValidationTests|FullyQualifiedName~HeaderCachingNntpClientTests|FullyQualifiedName~SegmentCacheNntpClientTests'` (51 passed)
- `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Debug --no-restore --filter 'FullyQualifiedName~MultiProviderNntpClientTests|FullyQualifiedName~NzbFileStreamTests|FullyQualifiedName~NzbFileStreamExactIndex'` (179 passed)
- `dotnet build backend/NzbWebDAV.csproj -c Release --no-restore`
- `dotnet format NzbWebDAV.sln --verify-no-changes --no-restore`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of yEnc files when cached or provider-supplied headers reference a different file.
  * Automatically rejects mismatched parts and retries with another available provider.
  * Prevents invalid cached entries from being served and refreshes stale headers when needed.
  * Improves reliability for file-size checks, streaming reads, seek operations, and pipelined requests.

* **Tests**
  * Added coverage for provider fallback, cache refreshes, and mismatched yEnc metadata across supported request paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->