### PR TITLE
feat(usenet): benchmark configured provider limits above 50 connections

### DIFF
--- a/backend/Services/Benchmark/UsenetBenchmarkService.cs
+++ b/backend/Services/Benchmark/UsenetBenchmarkService.cs
@@ -773,14 +773,13 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
         if (sweep.Count < 3) return false;
 
         const double materialImprovement = 0.08;
-        var bestBeforeRecentLevels = sweep
-            .Take(sweep.Count - 2)
-            .Max(point => point.MegaBytesPerSec);
-        if (bestBeforeRecentLevels <= 0) return false;
+        var preceding = sweep[^3].MegaBytesPerSec;
+        var penultimate = sweep[^2].MegaBytesPerSec;
+        var latest = sweep[^1].MegaBytesPerSec;
+        if (preceding <= 0 || penultimate <= 0) return false;
 
-        return sweep
-            .Skip(sweep.Count - 2)
-            .All(point => point.MegaBytesPerSec <= bestBeforeRecentLevels * (1 + materialImprovement));
+        return penultimate <= preceding * (1 + materialImprovement)
+            && latest <= penultimate * (1 + materialImprovement);
     }
 
     internal static int? DetectKnee(

--- a/backend/Services/Benchmark/UsenetBenchmarkService.cs
+++ b/backend/Services/Benchmark/UsenetBenchmarkService.cs
@@ -26,9 +26,6 @@ namespace NzbWebDAV.Services.Benchmark;
 /// </summary>
 public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, BenchmarkCorpusProvider corpus)
 {
-    // Never open more than this many sockets at once, regardless of provider/config.
-    private const int HardConnectionCeiling = 50;
-
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -65,13 +62,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
         CancellationToken ct)
     {
         var profile = BenchmarkProfile.For(intensity);
-        var configuredProviderLimitForWarning = Math.Max(
-            1,
-            configuredProviderConnectionLimit);
-        var configuredProviderLimit = Math.Clamp(
-            configuredProviderConnectionLimit,
-            1,
-            HardConnectionCeiling);
+        var configuredProviderLimit = Math.Max(1, configuredProviderConnectionLimit);
         var transferTestConnections = BoundBenchmarkConnections(
             requestedTransferConnections,
             configuredProviderLimit);
@@ -249,6 +240,9 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
                         $"Your provider wouldn't allow more than {have} connections at once, so the test stopped there.");
                     break;
                 }
+
+                if (HasStableKnee(result.Sweep))
+                    break;
             }
 
             result.ProviderConnectionCap = providerCap;
@@ -258,7 +252,6 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
                     providerCap,
                     result.Warnings,
                     out var stillClimbing,
-                    configuredProviderLimitForWarning,
                     configuredProviderLimit),
                 configuredProviderLimit,
                 result.Warnings);
@@ -300,7 +293,6 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
                                 providerCap,
                                 [],
                                 out stillClimbing,
-                                configuredProviderLimitForWarning,
                                 configuredProviderLimit),
                             configuredProviderLimit,
                             result.Warnings);
@@ -750,20 +742,45 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
         Math.Clamp(
             requestedConnections,
             1,
-            Math.Clamp(configuredProviderLimit, 1, HardConnectionCeiling));
+            Math.Max(1, configuredProviderLimit));
 
     internal static List<int> BuildLevels(
         int configuredProviderLimit,
         BenchmarkProfile profile)
     {
-        var ceiling = Math.Clamp(configuredProviderLimit, 1, HardConnectionCeiling);
-
-        return profile.SweepLevels
+        var ceiling = Math.Max(1, configuredProviderLimit);
+        var levels = profile.SweepLevels
             .Where(l => l > 0 && l <= ceiling)
-            .Append(ceiling)
             .Distinct()
             .OrderBy(l => l)
             .ToList();
+
+        var current = levels.Count > 0 ? levels[^1] : 1;
+        while (current < ceiling)
+        {
+            var next = (int)Math.Min(ceiling, Math.Max((long)current + 1, (long)Math.Ceiling(current * 1.25)));
+            if (next >= ceiling * 0.9)
+                next = ceiling;
+            levels.Add(next);
+            current = next;
+        }
+
+        return levels;
+    }
+
+    internal static bool HasStableKnee(IReadOnlyList<BenchmarkSweepPoint> sweep)
+    {
+        if (sweep.Count < 3) return false;
+
+        const double materialImprovement = 0.08;
+        var bestBeforeRecentLevels = sweep
+            .Take(sweep.Count - 2)
+            .Max(point => point.MegaBytesPerSec);
+        if (bestBeforeRecentLevels <= 0) return false;
+
+        return sweep
+            .Skip(sweep.Count - 2)
+            .All(point => point.MegaBytesPerSec <= bestBeforeRecentLevels * (1 + materialImprovement));
     }
 
     internal static int? DetectKnee(
@@ -773,8 +790,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
     internal static int? DetectKnee(
         List<BenchmarkSweepPoint> sweep, int? providerCap, List<string> warnings,
         out bool stillClimbing,
-        int? configuredProviderLimit = null,
-        int? benchmarkConnectionCeiling = null)
+        int? configuredProviderLimit = null)
     {
         stillClimbing = false;
         if (sweep.Count == 0) return null;
@@ -811,24 +827,11 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
             if (prev.MegaBytesPerSec > 0 && (peak.MegaBytesPerSec - prev.MegaBytesPerSec) / prev.MegaBytesPerSec > 0.08)
             {
                 stillClimbing = true;
-                if (benchmarkConnectionCeiling is { } benchmarkCeiling
-                    && configuredProviderLimit is { } configuredLimit
-                    && configuredLimit > benchmarkCeiling
-                    && peak.Connections >= benchmarkCeiling)
-                {
-                    warnings.Add(
-                        $"Speed was still climbing at the benchmark ceiling ({benchmarkCeiling}), " +
-                        $"below your configured Provider Connection Limit ({configuredLimit}). " +
-                        "The benchmark does not probe higher in one run.");
-                }
-                else
-                {
-                    warnings.Add(
-                        configuredProviderLimit is { } limit && peak.Connections >= limit
-                            ? $"Speed was still climbing at your Provider Connection Limit ({limit}). " +
-                              "Raise that limit and re-run Auto-tune to test higher transfer counts."
-                            : "Speed was still climbing at the highest level tested — a faster line or even more connections may help.");
-                }
+                warnings.Add(
+                    configuredProviderLimit is { } limit && peak.Connections >= limit
+                        ? $"Speed was still climbing at your Provider Connection Limit ({limit}). " +
+                          "Raise that limit and re-run Auto-tune to test higher transfer counts."
+                        : "Speed was still climbing at the highest level tested — a faster line or even more connections may help.");
             }
         }
 

--- a/docs/configuration/usenet.md
+++ b/docs/configuration/usenet.md
@@ -78,7 +78,9 @@ admitted after at most eight consecutive transfer grants so health and control w
     the busy-pool keep-alive safeguards below apply in both scheduling modes.
 
 Auto-tune finds the transfer-throughput knee and applies its recommendation only to **Transfer
-Connections**. It never rewrites or probes above **Provider Connection Limit**. Releases before
+Connections**. It progressively adds connection levels, including above 50 when configured, and
+stops after throughput reaches a stable knee, the provider refuses more connections, or the data
+budget is exhausted. It never rewrites or probes above **Provider Connection Limit**. Releases before
 1.3.0 could sweep above the saved connection count; raise Provider Connection Limit first if you
 want Auto-tune to test a higher count. When the result says speed was still climbing at the ceiling,
 the provider may benefit from a higher limit if the account permits it. If the provider later

--- a/tests/NzbWebDAV.Tests/Services/Benchmark/DetectKneeTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Benchmark/DetectKneeTests.cs
@@ -121,27 +121,6 @@ public class DetectKneeTests
     }
 
     [Fact]
-    public void DetectKnee_StillClimbingAtHardCeilingDoesNotMisstateConfiguredLimit()
-    {
-        var sweep = Sweep((1, 10), (10, 20), (25, 40), (50, 80));
-        var warnings = new List<string>();
-
-        UsenetBenchmarkService.DetectKnee(
-            sweep,
-            providerCap: null,
-            warnings,
-            out var stillClimbing,
-            configuredProviderLimit: 51,
-            benchmarkConnectionCeiling: 50);
-
-        Assert.True(stillClimbing);
-        var warning = Assert.Single(warnings);
-        Assert.Contains("benchmark ceiling (50)", warning, StringComparison.Ordinal);
-        Assert.Contains("configured Provider Connection Limit (51)", warning, StringComparison.Ordinal);
-        Assert.DoesNotContain("Raise that limit", warning, StringComparison.Ordinal);
-    }
-
-    [Fact]
     public void DetectKnee_StillClimbingFalseOnPlateau()
     {
         var sweep = Sweep((1, 10), (2, 20), (4, 35), (8, 40), (16, 41));
@@ -231,6 +210,60 @@ public class DetectKneeTests
 
         Assert.Contains(7, levels);
         Assert.All(levels, level => Assert.InRange(level, 1, 7));
+    }
+
+    [Theory]
+    [InlineData(BenchmarkIntensity.Quick)]
+    [InlineData(BenchmarkIntensity.Thorough)]
+    public void BuildLevels_ProgressesBeyondFiftyToConfiguredProviderLimit(
+        BenchmarkIntensity intensity)
+    {
+        var levels = UsenetBenchmarkService.BuildLevels(
+            configuredProviderLimit: 100,
+            BenchmarkProfile.For(intensity));
+
+        Assert.Contains(levels, level => level > 50 && level < 100);
+        Assert.Equal(100, levels[^1]);
+        Assert.All(levels, level => Assert.InRange(level, 1, 100));
+    }
+
+    [Theory]
+    [InlineData(BenchmarkIntensity.Quick)]
+    [InlineData(BenchmarkIntensity.Thorough)]
+    public void BuildLevels_StopsAtConfiguredLimitBelowFifty(BenchmarkIntensity intensity)
+    {
+        var levels = UsenetBenchmarkService.BuildLevels(
+            configuredProviderLimit: 40,
+            BenchmarkProfile.For(intensity));
+
+        Assert.Equal(40, levels[^1]);
+        Assert.DoesNotContain(levels, level => level > 40);
+    }
+
+    [Fact]
+    public void BoundBenchmarkConnections_AllowsConfiguredLimitAboveFifty()
+    {
+        Assert.Equal(
+            100,
+            UsenetBenchmarkService.BoundBenchmarkConnections(
+                requestedConnections: 100,
+                configuredProviderLimit: 100));
+    }
+
+    [Fact]
+    public void HasStableKnee_StopsAfterTwoLevelsWithoutMaterialImprovement()
+    {
+        var sweep = Sweep((8, 100), (16, 105), (24, 107));
+
+        Assert.True(UsenetBenchmarkService.HasStableKnee(sweep));
+    }
+
+    [Fact]
+    public void HasStableKnee_ContinuesWhileThroughputIsMateriallyImproving()
+    {
+        var sweep = Sweep((8, 100), (16, 105), (24, 115));
+
+        Assert.False(UsenetBenchmarkService.HasStableKnee(sweep));
     }
 
     private static List<BenchmarkSweepPoint> Sweep(params (int Connections, double MegaBytesPerSec)[] points) =>

--- a/tests/NzbWebDAV.Tests/Services/Benchmark/DetectKneeTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Benchmark/DetectKneeTests.cs
@@ -266,6 +266,14 @@ public class DetectKneeTests
         Assert.False(UsenetBenchmarkService.HasStableKnee(sweep));
     }
 
+    [Fact]
+    public void HasStableKnee_ContinuesAfterMaterialRecovery()
+    {
+        var sweep = Sweep((8, 100), (16, 50), (24, 107));
+
+        Assert.False(UsenetBenchmarkService.HasStableKnee(sweep));
+    }
+
     private static List<BenchmarkSweepPoint> Sweep(params (int Connections, double MegaBytesPerSec)[] points) =>
         points.Select(point => new BenchmarkSweepPoint
         {


### PR DESCRIPTION
## Summary
- remove the fixed 50-connection ceiling from provider speed tests
- extend Quick and Thorough sweeps progressively to the configured provider limit
- stop after two consecutive levels without material throughput improvement
- retain provider-refusal, data-budget, and configured-limit safeguards
- document provider-bounded progressive Auto-tune behavior

Closes #1359

## Test plan
- `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter FullyQualifiedName~NzbWebDAV.Tests.Services.Benchmark` (59 passed)
- `dotnet build backend/NzbWebDAV.csproj -c Release --no-restore`
- `git diff --check`

## Notes
- Strict docs build was not run because `zensical` is not installed in the isolated worktree environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Auto-tune now supports configured provider connection limits above 50 connections.
  - Connection levels increase progressively toward the configured limit instead of jumping directly to it.
  - Benchmarking stops early when throughput reaches a stable plateau.

- **Bug Fixes**
  - Auto-tune now respects configured provider limits below or above 50 connections.

- **Documentation**
  - Updated configuration guidance to explain connection progression and stopping conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->