### PR TITLE
fix(usenet): speed tests use articles available from the selected provider

### DIFF
--- a/backend/Services/Benchmark/BenchmarkCorpusProvider.cs
+++ b/backend/Services/Benchmark/BenchmarkCorpusProvider.cs
@@ -24,10 +24,10 @@ public sealed class BenchmarkCorpusProvider(DavDatabaseClient db)
     private const int MaxQueueNzbsToScan = 10;
     private static readonly TimeSpan RecentHealthWindow = TimeSpan.FromDays(30);
 
-    public async Task<List<string>> GetSegmentPoolAsync(int maxSegments, CancellationToken ct)
+    internal async Task<List<BenchmarkSegment>> GetSegmentPoolAsync(int maxSegments, CancellationToken ct)
     {
-        var pool = new List<string>(Math.Min(maxSegments, 4096));
-        var seen = new HashSet<string>();
+        var pool = new List<BenchmarkSegment>(Math.Min(maxSegments, 4096));
+        var seen = new HashSet<string>(StringComparer.Ordinal);
 
         try
         {
@@ -50,7 +50,7 @@ public sealed class BenchmarkCorpusProvider(DavDatabaseClient db)
 
     // Primary source: segment ids persisted for previously-downloaded files.
     private async Task CollectFromCompletedFilesAsync(
-        List<string> pool, HashSet<string> seen, int maxSegments, CancellationToken ct)
+        List<BenchmarkSegment> pool, HashSet<string> seen, int maxSegments, CancellationToken ct)
     {
         var recentNzbItems = await db.Ctx.Items
             .Where(x => x.Type == DavItem.ItemType.UsenetFile && x.SubType == DavItem.ItemSubType.NzbFile)
@@ -58,13 +58,15 @@ public sealed class BenchmarkCorpusProvider(DavDatabaseClient db)
             .Take(MaxNzbFilesToConsider)
             .ToListAsync(ct).ConfigureAwait(false);
 
+        var sources = new List<IReadOnlyList<BenchmarkSegment>>();
         foreach (var item in RankCompletedCandidates(recentNzbItems, DateTimeOffset.UtcNow))
         {
-            if (pool.Count >= maxSegments) return;
             var nzbFile = await db.GetDavNzbFileAsync(item, ct).ConfigureAwait(false);
             if (nzbFile?.SegmentIds is { Length: > 0 } ids)
-                AddIds(pool, seen, ids, maxSegments);
+            sources.Add(BuildSegments(ids, nzbFile.SegmentFallbackIds));
         }
+
+        AddSegmentsRoundRobin(pool, seen, sources, maxSegments);
     }
 
     /// <summary>
@@ -85,46 +87,69 @@ public sealed class BenchmarkCorpusProvider(DavDatabaseClient db)
 
     // Fallback source: parse the raw nzb xml of items still sitting in the queue.
     private async Task CollectFromQueuedNzbsAsync(
-        List<string> pool, HashSet<string> seen, int maxSegments, CancellationToken ct)
+        List<BenchmarkSegment> pool, HashSet<string> seen, int maxSegments, CancellationToken ct)
     {
         var queuedNzbs = await db.Ctx.QueueNzbContents
             .Take(MaxQueueNzbsToScan)
             .ToListAsync(ct).ConfigureAwait(false);
 
+        var sources = new List<IReadOnlyList<BenchmarkSegment>>();
         foreach (var queued in queuedNzbs)
         {
-            if (pool.Count >= maxSegments) return;
             if (string.IsNullOrWhiteSpace(queued.NzbContents)) continue;
             try
             {
                 using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(queued.NzbContents));
                 var doc = await NzbDocument.LoadAsync(stream, ct).ConfigureAwait(false);
                 foreach (var file in doc.Files)
-                {
-                    AddIds(pool, seen, file.GetSegmentIds(), maxSegments);
-                    if (pool.Count >= maxSegments) return;
-                }
+                    sources.Add(BuildSegments(file.GetSegmentIds(), file.GetSegmentFallbackIds()));
             }
             catch (Exception e) when (e is not OperationCanceledException && e is not OutOfMemoryException)
             {
                 Log.Debug(e, "Skipping unparseable queued nzb during benchmark corpus build.");
             }
         }
+
+        AddSegmentsRoundRobin(pool, seen, sources, maxSegments);
     }
 
-    private static void AddIds(List<string> pool, HashSet<string> seen, IEnumerable<string> ids, int maxSegments)
+    internal static void AddSegmentsRoundRobin(
+        List<BenchmarkSegment> pool,
+        HashSet<string> seen,
+        IReadOnlyList<IReadOnlyList<BenchmarkSegment>> sources,
+        int maxSegments)
     {
-        foreach (var id in ids)
+        for (var index = 0; pool.Count < maxSegments; index++)
         {
-            if (pool.Count >= maxSegments) return;
-            if (string.IsNullOrWhiteSpace(id)) continue;
-            if (seen.Add(id)) pool.Add(id);
+            var anySourceHadSegment = false;
+            foreach (var source in sources)
+            {
+                if (index >= source.Count) continue;
+                anySourceHadSegment = true;
+
+                var segment = source[index];
+                if (string.IsNullOrWhiteSpace(segment.PrimaryId) || !seen.Add(segment.PrimaryId)) continue;
+
+                var fallbacks = segment.FallbackIds
+                    .Where(id => !string.IsNullOrWhiteSpace(id) && seen.Add(id))
+                    .ToArray();
+                pool.Add(new BenchmarkSegment(segment.PrimaryId, fallbacks));
+                if (pool.Count >= maxSegments) return;
+            }
+
+            if (!anySourceHadSegment) return;
         }
     }
 
+    private static List<BenchmarkSegment> BuildSegments(string[] ids, string[][]? fallbacks) =>
+        ids.Select((id, index) => new BenchmarkSegment(
+                id,
+                fallbacks is not null && index < fallbacks.Length ? fallbacks[index] : []))
+            .ToList();
+
     // Shuffle so sequential nzb ordering doesn't bias which segments land in the
     // smaller windows, and so retries don't keep hammering the same first article.
-    private static void Shuffle(List<string> list)
+    private static void Shuffle(List<BenchmarkSegment> list)
     {
         for (var i = list.Count - 1; i > 0; i--)
         {

--- a/backend/Services/Benchmark/BenchmarkCorpusProvider.cs
+++ b/backend/Services/Benchmark/BenchmarkCorpusProvider.cs
@@ -174,7 +174,7 @@ public sealed class BenchmarkCorpusProvider(DavDatabaseClient db)
     private static List<BenchmarkSegment> BuildSegments(string[] ids, string[][]? fallbacks) =>
         ids.Select((id, index) => new BenchmarkSegment(
                 id,
-                fallbacks is not null && index < fallbacks.Length ? fallbacks[index] : []))
+                fallbacks is not null && index < fallbacks.Length ? fallbacks[index] ?? [] : []))
             .ToList();
 
     // Shuffle so sequential nzb ordering doesn't bias which segments land in the

--- a/backend/Services/Benchmark/BenchmarkCorpusProvider.cs
+++ b/backend/Services/Benchmark/BenchmarkCorpusProvider.cs
@@ -27,15 +27,15 @@ public sealed class BenchmarkCorpusProvider(DavDatabaseClient db)
     internal async Task<List<BenchmarkSegment>> GetSegmentPoolAsync(int maxSegments, CancellationToken ct)
     {
         var pool = new List<BenchmarkSegment>(Math.Min(maxSegments, 4096));
-        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var ownersById = new Dictionary<string, int>(StringComparer.Ordinal);
 
         try
         {
-            await CollectFromCompletedFilesAsync(pool, seen, maxSegments, ct).ConfigureAwait(false);
+            await CollectFromCompletedFilesAsync(pool, ownersById, maxSegments, ct).ConfigureAwait(false);
 
             // Only crack open queued nzbs if completed downloads didn't give us much.
             if (pool.Count < maxSegments / 4)
-                await CollectFromQueuedNzbsAsync(pool, seen, maxSegments, ct).ConfigureAwait(false);
+                await CollectFromQueuedNzbsAsync(pool, ownersById, maxSegments, ct).ConfigureAwait(false);
         }
         catch (Exception e) when (e is not OperationCanceledException && e is not OutOfMemoryException)
         {
@@ -50,7 +50,7 @@ public sealed class BenchmarkCorpusProvider(DavDatabaseClient db)
 
     // Primary source: segment ids persisted for previously-downloaded files.
     private async Task CollectFromCompletedFilesAsync(
-        List<BenchmarkSegment> pool, HashSet<string> seen, int maxSegments, CancellationToken ct)
+        List<BenchmarkSegment> pool, Dictionary<string, int> ownersById, int maxSegments, CancellationToken ct)
     {
         var recentNzbItems = await db.Ctx.Items
             .Where(x => x.Type == DavItem.ItemType.UsenetFile && x.SubType == DavItem.ItemSubType.NzbFile)
@@ -66,7 +66,7 @@ public sealed class BenchmarkCorpusProvider(DavDatabaseClient db)
             sources.Add(BuildSegments(ids, nzbFile.SegmentFallbackIds));
         }
 
-        AddSegmentsRoundRobin(pool, seen, sources, maxSegments);
+        AddSegmentsRoundRobin(pool, ownersById, sources, maxSegments);
     }
 
     /// <summary>
@@ -87,7 +87,7 @@ public sealed class BenchmarkCorpusProvider(DavDatabaseClient db)
 
     // Fallback source: parse the raw nzb xml of items still sitting in the queue.
     private async Task CollectFromQueuedNzbsAsync(
-        List<BenchmarkSegment> pool, HashSet<string> seen, int maxSegments, CancellationToken ct)
+        List<BenchmarkSegment> pool, Dictionary<string, int> ownersById, int maxSegments, CancellationToken ct)
     {
         var queuedNzbs = await db.Ctx.QueueNzbContents
             .Take(MaxQueueNzbsToScan)
@@ -110,35 +110,65 @@ public sealed class BenchmarkCorpusProvider(DavDatabaseClient db)
             }
         }
 
-        AddSegmentsRoundRobin(pool, seen, sources, maxSegments);
+        AddSegmentsRoundRobin(pool, ownersById, sources, maxSegments);
     }
 
     internal static void AddSegmentsRoundRobin(
         List<BenchmarkSegment> pool,
-        HashSet<string> seen,
+        Dictionary<string, int> ownersById,
         IReadOnlyList<IReadOnlyList<BenchmarkSegment>> sources,
         int maxSegments)
     {
         for (var index = 0; pool.Count < maxSegments; index++)
         {
-            var anySourceHadSegment = false;
-            foreach (var source in sources)
-            {
-                if (index >= source.Count) continue;
-                anySourceHadSegment = true;
+            var eligibleSources = sources.Where(source => index < source.Count).ToList();
+            if (eligibleSources.Count == 0) return;
 
+            foreach (var source in eligibleSources)
+            {
                 var segment = source[index];
-                if (string.IsNullOrWhiteSpace(segment.PrimaryId) || !seen.Add(segment.PrimaryId)) continue;
+                if (string.IsNullOrWhiteSpace(segment.PrimaryId)) continue;
+
+                if (ownersById.TryGetValue(segment.PrimaryId, out var ownerIndex))
+                {
+                    MergeFallbacks(pool, ownersById, ownerIndex, segment.FallbackIds);
+                    continue;
+                }
 
                 var fallbacks = segment.FallbackIds
-                    .Where(id => !string.IsNullOrWhiteSpace(id) && seen.Add(id))
+                    .Where(id => !string.IsNullOrWhiteSpace(id)
+                                 && !StringComparer.Ordinal.Equals(id, segment.PrimaryId)
+                                 && !ownersById.ContainsKey(id))
+                    .Distinct(StringComparer.Ordinal)
                     .ToArray();
+                var newIndex = pool.Count;
                 pool.Add(new BenchmarkSegment(segment.PrimaryId, fallbacks));
+                ownersById.Add(segment.PrimaryId, newIndex);
+                foreach (var fallback in fallbacks)
+                    ownersById.Add(fallback, newIndex);
                 if (pool.Count >= maxSegments) return;
             }
-
-            if (!anySourceHadSegment) return;
         }
+    }
+
+    private static void MergeFallbacks(
+        List<BenchmarkSegment> pool,
+        Dictionary<string, int> ownersById,
+        int ownerIndex,
+        IEnumerable<string> fallbackIds)
+    {
+        var additions = fallbackIds
+            .Where(id => !string.IsNullOrWhiteSpace(id) && !ownersById.ContainsKey(id))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (additions.Length == 0) return;
+
+        var existing = pool[ownerIndex];
+        pool[ownerIndex] = new BenchmarkSegment(
+            existing.PrimaryId,
+            [.. existing.FallbackIds, .. additions]);
+        foreach (var fallback in additions)
+            ownersById.Add(fallback, ownerIndex);
     }
 
     private static List<BenchmarkSegment> BuildSegments(string[] ids, string[][]? fallbacks) =>

--- a/backend/Services/Benchmark/BenchmarkSegmentPool.cs
+++ b/backend/Services/Benchmark/BenchmarkSegmentPool.cs
@@ -16,9 +16,7 @@ internal sealed class BenchmarkSegmentPool(IReadOnlyList<BenchmarkSegment> segme
 {
     private readonly ConcurrentDictionary<string, byte> _dead = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, int> _retrievals = new(StringComparer.Ordinal);
-    private readonly IReadOnlyDictionary<string, string> _logicalSegmentIds = segments
-        .SelectMany(segment => segment.CandidateIds.Select(id => (id, segment.PrimaryId)))
-        .ToDictionary(pair => pair.id, pair => pair.PrimaryId, StringComparer.Ordinal);
+    private readonly IReadOnlyDictionary<string, string> _logicalSegmentIds = BuildLogicalSegmentIds(segments);
     private long _cursor = -1;
 
     public BenchmarkSegmentPool(IReadOnlyList<string> ids)
@@ -63,5 +61,15 @@ internal sealed class BenchmarkSegmentPool(IReadOnlyList<BenchmarkSegment> segme
         for (var i = 0; i < count && TryNext(out var id); i++)
             batch.Add(id);
         return batch;
+    }
+
+    private static Dictionary<string, string> BuildLogicalSegmentIds(
+        IReadOnlyList<BenchmarkSegment> source)
+    {
+        var logicalSegmentIds = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var segment in source)
+        foreach (var id in segment.CandidateIds)
+            logicalSegmentIds[id] = segment.PrimaryId;
+        return logicalSegmentIds;
     }
 }

--- a/backend/Services/Benchmark/BenchmarkSegmentPool.cs
+++ b/backend/Services/Benchmark/BenchmarkSegmentPool.cs
@@ -2,45 +2,66 @@ using System.Collections.Concurrent;
 
 namespace NzbWebDAV.Services.Benchmark;
 
-/// <summary>
-/// Thread-safe round-robin view over the benchmark corpus for one run. Skips
-/// message-ids observed to be dead (430) so wall-clock isn't wasted re-asking
-/// for them, and tracks whether the run wrapped around the pool (repeat
-/// fetches hit provider caches and inflate speeds).
-/// </summary>
-internal sealed class BenchmarkSegmentPool(IReadOnlyList<string> ids)
+internal sealed record BenchmarkSegment(string PrimaryId, IReadOnlyList<string> FallbackIds)
 {
-    private readonly ConcurrentDictionary<string, byte> _dead = new();
-    private long _cursor = -1;
-    private long _taken;
+    public IReadOnlyList<string> CandidateIds { get; } = [PrimaryId, .. FallbackIds];
+}
 
-    public int Count => ids.Count;
-    public int DeadCount => _dead.Count;
-    public bool WrappedAround => Interlocked.Read(ref _taken) > ids.Count;
+/// <summary>
+/// Thread-safe round-robin view over logical benchmark segments for one run.
+/// Definitive misses advance a segment to its next fallback Message-ID, and an
+/// exhausted pool stops producing work instead of recycling known-dead IDs.
+/// </summary>
+internal sealed class BenchmarkSegmentPool(IReadOnlyList<BenchmarkSegment> segments)
+{
+    private readonly ConcurrentDictionary<string, byte> _dead = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, int> _retrievals = new(StringComparer.Ordinal);
+    private readonly IReadOnlyDictionary<string, string> _logicalSegmentIds = segments
+        .SelectMany(segment => segment.CandidateIds.Select(id => (id, segment.PrimaryId)))
+        .ToDictionary(pair => pair.id, pair => pair.PrimaryId, StringComparer.Ordinal);
+    private long _cursor = -1;
+
+    public BenchmarkSegmentPool(IReadOnlyList<string> ids)
+        : this(ids.Select(id => new BenchmarkSegment(id, [])).ToArray())
+    {
+    }
+
+    public int Count => segments.Count;
+    public int DeadCount => segments.Count(segment => segment.CandidateIds.All(_dead.ContainsKey));
+    public bool Exhausted => DeadCount == Count;
+    public bool WrappedAround => _retrievals.Values.Any(count => count > 1);
 
     public void MarkDead(string id) => _dead.TryAdd(id, 0);
 
-    public string Next()
+    public void MarkRetrieved(string id)
     {
-        Interlocked.Increment(ref _taken);
-        var probes = Math.Min(ids.Count, 64);
-        for (var attempt = 0; attempt < probes; attempt++)
+        var logicalId = _logicalSegmentIds.GetValueOrDefault(id, id);
+        _retrievals.AddOrUpdate(logicalId, 1, (_, count) => count + 1);
+    }
+
+    public bool TryNext(out string id)
+    {
+        for (var attempt = 0; attempt < segments.Count; attempt++)
         {
-            var i = Interlocked.Increment(ref _cursor);
-            var id = ids[(int)((i % ids.Count + ids.Count) % ids.Count)];
-            if (!_dead.ContainsKey(id)) return id;
+            var index = Interlocked.Increment(ref _cursor);
+            var segment = segments[(int)((index % segments.Count + segments.Count) % segments.Count)];
+            var candidate = segment.CandidateIds.FirstOrDefault(candidateId => !_dead.ContainsKey(candidateId));
+            if (candidate is not null)
+            {
+                id = candidate;
+                return true;
+            }
         }
 
-        // Everything nearby looks dead — hand one back anyway; the worker just
-        // records another miss and the result carries a corpus warning.
-        var j = Interlocked.Increment(ref _cursor);
-        return ids[(int)((j % ids.Count + ids.Count) % ids.Count)];
+        id = string.Empty;
+        return false;
     }
 
     public List<string> NextBatch(int count)
     {
         var batch = new List<string>(count);
-        for (var i = 0; i < count; i++) batch.Add(Next());
+        for (var i = 0; i < count && TryNext(out var id); i++)
+            batch.Add(id);
         return batch;
     }
 }

--- a/backend/Services/Benchmark/UsenetBenchmarkService.cs
+++ b/backend/Services/Benchmark/UsenetBenchmarkService.cs
@@ -242,6 +242,9 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
                 Report("sweep", $"{have} conn → {sample.MegaBytesPerSec:0.0} MB/s",
                     ProgressPercent(15, 75, i + 1, levels.Count), result, have);
 
+                if (pool.Exhausted)
+                    break;
+
                 if (have < level)
                 {
                     providerCap = have;
@@ -310,7 +313,9 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
             }
 
             // 4) Pipelining — compare off vs. a few depths at a moderate concurrency.
-            if (result.Sweep.Count > 0 && Remaining() > MinUsefulBytes(lastMegaBytesPerSec, profile))
+            if (!pool.Exhausted
+                && result.Sweep.Count > 0
+                && Remaining() > MinUsefulBytes(lastMegaBytesPerSec, profile))
             {
                 var pipeConns = Math.Min(result.RecommendedConnections ?? 1, profile.PipelineTestConnections);
                 if (providerCap.HasValue) pipeConns = Math.Min(pipeConns, providerCap.Value);
@@ -343,6 +348,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
                 $"{pool.DeadCount} test articles were no longer available on the provider, which can bias speeds low. " +
                 "Downloading something recent refreshes the test pool.");
 
+        NormalizeUnavailableCorpusResult(result, pool);
         result.Confidence = ComputeConfidence(result);
         StampElapsed();
         Report("done", "Done.", 100, result, null, includeResult: true);
@@ -389,7 +395,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
         addData(baseline.Bytes);
         last = baseline.MegaBytesPerSec;
         result.BaselineMegaBytesPerSec = Math.Round(baseline.MegaBytesPerSec, 2);
-        if (baseline.OpenedConnections == 0) return result;
+        if (baseline.OpenedConnections == 0 || pool.Exhausted) return result;
 
         var bestMegaBytesPerSec = baseline.MegaBytesPerSec;
         var bestDepth = 0;
@@ -409,6 +415,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
             addData(sample.Bytes);
             last = Math.Max(last, sample.MegaBytesPerSec);
             result.Tested.Add(new BenchmarkPipeliningPoint { Depth = depth, MegaBytesPerSec = Math.Round(sample.MegaBytesPerSec, 2) });
+            if (pool.Exhausted) break;
             if (sample.MegaBytesPerSec > bestMegaBytesPerSec) { bestMegaBytesPerSec = sample.MegaBytesPerSec; bestDepth = depth; }
         }
 
@@ -536,12 +543,13 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
                        && !hardCt.IsCancellationRequested
                        && Interlocked.Read(ref counter.Value) < targetBytes)
                 {
-                    var id = pool.Next();
+                    if (!pool.TryNext(out var id)) break;
                     try
                     {
                         var response = await conn.DecodedBodyAsync(id, hardCt).ConfigureAwait(false);
                         // Drain with hardCt only — soft-stop never cancels mid-BODY.
                         await DrainAsync(response.Stream!, buffer, counter, hardCt).ConfigureAwait(false);
+                        pool.MarkRetrieved(id);
                     }
                     catch (UsenetArticleNotFoundException)
                     {
@@ -556,12 +564,20 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
                        && Interlocked.Read(ref counter.Value) < targetBytes)
                 {
                     var batch = pool.NextBatch(depth * 4);
+                    if (batch.Count == 0) break;
                     // Finish the whole batch once started so pipelined responses stay in sync.
                     await foreach (var r in conn.DecodedBodiesPipelinedAsync(batch, depth, hardCt)
                                        .WithCancellation(hardCt).ConfigureAwait(false))
                     {
                         if (r is { Found: true, Stream: not null })
+                        {
                             await DrainAsync(r.Stream, buffer, counter, hardCt).ConfigureAwait(false);
+                            pool.MarkRetrieved(r.SegmentId);
+                        }
+                        else if (r.DefinitivelyMissing)
+                        {
+                            pool.MarkDead(r.SegmentId);
+                        }
                         if (hardCt.IsCancellationRequested)
                             break;
                     }
@@ -699,6 +715,24 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
         }
 
         return providerLimit;
+    }
+
+    internal static void NormalizeUnavailableCorpusResult(
+        BenchmarkResult result,
+        BenchmarkSegmentPool pool)
+    {
+        if (result.DataUsedBytes > 0) return;
+
+        result.ThroughputTested = false;
+        result.RecommendedConnections = null;
+        result.Pipelining = null;
+        result.WrappedPool = false;
+        result.Warnings.RemoveAll(warning => warning.Contains("re-downloaded", StringComparison.Ordinal));
+        result.Warnings.Add(
+            pool.Exhausted
+                ? "The speed test could not find any provider-retrievable articles in the benchmark corpus. " +
+                  "Download something recent and try again."
+                : "The speed test did not receive any article data, so throughput could not be measured.");
     }
 
     internal static string ComputeConfidence(BenchmarkResult result)

--- a/backend/Services/Benchmark/UsenetBenchmarkService.cs
+++ b/backend/Services/Benchmark/UsenetBenchmarkService.cs
@@ -724,6 +724,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
         if (result.DataUsedBytes > 0) return;
 
         result.ThroughputTested = false;
+        result.Sweep.Clear();
         result.RecommendedConnections = null;
         result.Pipelining = null;
         result.WrappedPool = false;

--- a/backend/Services/Benchmark/UsenetBenchmarkService.cs
+++ b/backend/Services/Benchmark/UsenetBenchmarkService.cs
@@ -328,7 +328,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
                     ladder, pool, profile, profile.PipelineDepths, Remaining,
                     bytes => result.DataUsedBytes += bytes, result.Warnings, ct).ConfigureAwait(false);
             }
-            else if (result.Sweep.Count > 0)
+            else if (!pool.Exhausted && result.Sweep.Count > 0)
             {
                 result.Warnings.Add(
                     "Skipped the pipelining test — not enough data budget left after the connection sweep. " +
@@ -336,14 +336,14 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
             }
         }
 
-        if (pool.WrappedAround)
+        if (result.DataUsedBytes > 0 && pool.WrappedAround)
         {
             result.WrappedPool = true;
             result.Warnings.Add(
                 "The test re-downloaded some articles more than once, so provider caching may make speeds read high. " +
                 "A larger library of completed downloads gives the test more unique data.");
         }
-        if (pool.DeadCount > 0 && pool.DeadCount * 10 > pool.Count)
+        if (result.DataUsedBytes > 0 && pool.DeadCount > 0 && pool.DeadCount * 10 > pool.Count)
             result.Warnings.Add(
                 $"{pool.DeadCount} test articles were no longer available on the provider, which can bias speeds low. " +
                 "Downloading something recent refreshes the test pool.");
@@ -415,8 +415,8 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
             addData(sample.Bytes);
             last = Math.Max(last, sample.MegaBytesPerSec);
             result.Tested.Add(new BenchmarkPipeliningPoint { Depth = depth, MegaBytesPerSec = Math.Round(sample.MegaBytesPerSec, 2) });
-            if (pool.Exhausted) break;
             if (sample.MegaBytesPerSec > bestMegaBytesPerSec) { bestMegaBytesPerSec = sample.MegaBytesPerSec; bestDepth = depth; }
+            if (pool.Exhausted) break;
         }
 
         // Only recommend turning it on if it's a clear (>10%) win over the baseline.
@@ -728,7 +728,7 @@ public sealed class UsenetBenchmarkService(WebsocketManager websocketManager, Be
         result.RecommendedConnections = null;
         result.Pipelining = null;
         result.WrappedPool = false;
-        result.Warnings.RemoveAll(warning => warning.Contains("re-downloaded", StringComparison.Ordinal));
+        result.StillClimbing = false;
         result.Warnings.Add(
             pool.Exhausted
                 ? "The speed test could not find any provider-retrievable articles in the benchmark corpus. " +

--- a/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkCorpusProviderTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkCorpusProviderTests.cs
@@ -38,6 +38,41 @@ public class BenchmarkCorpusProviderTests
         Assert.Equal(20, ranked[^1].FileSize);
     }
 
+    [Fact]
+    public void AddSegmentsRoundRobin_DiversifiesSourcesAndPreservesFallbacks()
+    {
+        var pool = new List<BenchmarkSegment>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        IReadOnlyList<IReadOnlyList<BenchmarkSegment>> sources =
+        [
+            [new("a1", ["a1-fallback"]), new("a2", [])],
+            [new("b1", []), new("b2", [])],
+        ];
+
+        BenchmarkCorpusProvider.AddSegmentsRoundRobin(pool, seen, sources, 3);
+
+        Assert.Equal(["a1", "b1", "a2"], pool.Select(segment => segment.PrimaryId));
+        Assert.Equal(["a1-fallback"], pool[0].FallbackIds);
+    }
+
+    [Fact]
+    public void AddSegmentsRoundRobin_DeduplicatesPrimaryAndFallbackIds()
+    {
+        var pool = new List<BenchmarkSegment>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        IReadOnlyList<IReadOnlyList<BenchmarkSegment>> sources =
+        [
+            [new("shared", ["fallback", "shared"])],
+            [new("shared", []), new("unique", ["fallback"])],
+        ];
+
+        BenchmarkCorpusProvider.AddSegmentsRoundRobin(pool, seen, sources, 10);
+
+        Assert.Equal(["shared", "unique"], pool.Select(segment => segment.PrimaryId));
+        Assert.Equal(["fallback"], pool[0].FallbackIds);
+        Assert.Empty(pool[1].FallbackIds);
+    }
+
     private static DavItem Item(string name, long fileSize, DateTime createdAt, DateTimeOffset? lastHealth)
     {
         var id = Guid.NewGuid();

--- a/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkCorpusProviderTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkCorpusProviderTests.cs
@@ -42,14 +42,14 @@ public class BenchmarkCorpusProviderTests
     public void AddSegmentsRoundRobin_DiversifiesSourcesAndPreservesFallbacks()
     {
         var pool = new List<BenchmarkSegment>();
-        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var ownersById = new Dictionary<string, int>(StringComparer.Ordinal);
         IReadOnlyList<IReadOnlyList<BenchmarkSegment>> sources =
         [
             [new("a1", ["a1-fallback"]), new("a2", [])],
             [new("b1", []), new("b2", [])],
         ];
 
-        BenchmarkCorpusProvider.AddSegmentsRoundRobin(pool, seen, sources, 3);
+        BenchmarkCorpusProvider.AddSegmentsRoundRobin(pool, ownersById, sources, 3);
 
         Assert.Equal(["a1", "b1", "a2"], pool.Select(segment => segment.PrimaryId));
         Assert.Equal(["a1-fallback"], pool[0].FallbackIds);
@@ -59,18 +59,52 @@ public class BenchmarkCorpusProviderTests
     public void AddSegmentsRoundRobin_DeduplicatesPrimaryAndFallbackIds()
     {
         var pool = new List<BenchmarkSegment>();
-        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var ownersById = new Dictionary<string, int>(StringComparer.Ordinal);
         IReadOnlyList<IReadOnlyList<BenchmarkSegment>> sources =
         [
             [new("shared", ["fallback", "shared"])],
             [new("shared", []), new("unique", ["fallback"])],
         ];
 
-        BenchmarkCorpusProvider.AddSegmentsRoundRobin(pool, seen, sources, 10);
+        BenchmarkCorpusProvider.AddSegmentsRoundRobin(pool, ownersById, sources, 10);
 
         Assert.Equal(["shared", "unique"], pool.Select(segment => segment.PrimaryId));
         Assert.Equal(["fallback"], pool[0].FallbackIds);
         Assert.Empty(pool[1].FallbackIds);
+    }
+
+    [Fact]
+    public void AddSegmentsRoundRobin_MergesFallbacksFromDuplicatePrimary()
+    {
+        var pool = new List<BenchmarkSegment>();
+        var ownersById = new Dictionary<string, int>(StringComparer.Ordinal);
+        IReadOnlyList<IReadOnlyList<BenchmarkSegment>> sources =
+        [
+            [new("primary", ["fallback-a"])],
+            [new("primary", ["fallback-b"])],
+        ];
+
+        BenchmarkCorpusProvider.AddSegmentsRoundRobin(pool, ownersById, sources, 10);
+
+        var segment = Assert.Single(pool);
+        Assert.Equal(["fallback-a", "fallback-b"], segment.FallbackIds);
+    }
+
+    [Fact]
+    public void AddSegmentsRoundRobin_MergesWhenPrimaryWasPreviouslyFallback()
+    {
+        var pool = new List<BenchmarkSegment>();
+        var ownersById = new Dictionary<string, int>(StringComparer.Ordinal);
+        IReadOnlyList<IReadOnlyList<BenchmarkSegment>> sources =
+        [
+            [new("primary", ["shared"])],
+            [new("shared", ["additional"])],
+        ];
+
+        BenchmarkCorpusProvider.AddSegmentsRoundRobin(pool, ownersById, sources, 10);
+
+        var segment = Assert.Single(pool);
+        Assert.Equal(["shared", "additional"], segment.FallbackIds);
     }
 
     private static DavItem Item(string name, long fileSize, DateTime createdAt, DateTimeOffset? lastHealth)

--- a/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkMathTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkMathTests.cs
@@ -15,8 +15,8 @@ public class BenchmarkMathTests
             RecommendedConnections = 8,
             Pipelining = new BenchmarkPipelining(),
             WrappedPool = true,
+            StillClimbing = true,
             Sweep = [new BenchmarkSweepPoint { Connections = 1, MegaBytesPerSec = 0 }],
-            Warnings = ["The test re-downloaded some articles more than once."],
         };
 
         UsenetBenchmarkService.NormalizeUnavailableCorpusResult(result, pool);
@@ -26,10 +26,41 @@ public class BenchmarkMathTests
         Assert.Null(result.RecommendedConnections);
         Assert.Null(result.Pipelining);
         Assert.False(result.WrappedPool);
+        Assert.False(result.StillClimbing);
         Assert.Contains(result.Warnings, warning =>
             warning.Contains("provider-retrievable", StringComparison.Ordinal));
-        Assert.DoesNotContain(result.Warnings, warning =>
-            warning.Contains("re-downloaded", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void NormalizeUnavailableCorpusResult_KeepsResultsWhenDataMoved()
+    {
+        var pool = new BenchmarkSegmentPool(["retrieved"]);
+        var result = new BenchmarkResult
+        {
+            ThroughputTested = true,
+            DataUsedBytes = 1,
+            RecommendedConnections = 8,
+            Sweep = [new BenchmarkSweepPoint { Connections = 1, MegaBytesPerSec = 40 }],
+        };
+
+        UsenetBenchmarkService.NormalizeUnavailableCorpusResult(result, pool);
+
+        Assert.True(result.ThroughputTested);
+        Assert.Equal(8, result.RecommendedConnections);
+        Assert.Single(result.Sweep);
+    }
+
+    [Fact]
+    public void NormalizeUnavailableCorpusResult_ReportsNoDataWhenPoolIsNotExhausted()
+    {
+        var pool = new BenchmarkSegmentPool(["available"]);
+        var result = new BenchmarkResult { ThroughputTested = true };
+
+        UsenetBenchmarkService.NormalizeUnavailableCorpusResult(result, pool);
+
+        Assert.False(result.ThroughputTested);
+        Assert.Contains(result.Warnings, warning =>
+            warning.Contains("did not receive any article data", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkMathTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkMathTests.cs
@@ -5,6 +5,32 @@ namespace NzbWebDAV.Tests.Services.Benchmark;
 public class BenchmarkMathTests
 {
     [Fact]
+    public void NormalizeUnavailableCorpusResult_ClearsThroughputClaims()
+    {
+        var pool = new BenchmarkSegmentPool(["missing"]);
+        pool.MarkDead("missing");
+        var result = new BenchmarkResult
+        {
+            ThroughputTested = true,
+            RecommendedConnections = 8,
+            Pipelining = new BenchmarkPipelining(),
+            WrappedPool = true,
+            Warnings = ["The test re-downloaded some articles more than once."],
+        };
+
+        UsenetBenchmarkService.NormalizeUnavailableCorpusResult(result, pool);
+
+        Assert.False(result.ThroughputTested);
+        Assert.Null(result.RecommendedConnections);
+        Assert.Null(result.Pipelining);
+        Assert.False(result.WrappedPool);
+        Assert.Contains(result.Warnings, warning =>
+            warning.Contains("provider-retrievable", StringComparison.Ordinal));
+        Assert.DoesNotContain(result.Warnings, warning =>
+            warning.Contains("re-downloaded", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void ComputeSteadyRate_UsesMedianOfBuckets()
     {
         var buckets = new List<(long Bytes, double Seconds)>

--- a/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkMathTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkMathTests.cs
@@ -15,12 +15,14 @@ public class BenchmarkMathTests
             RecommendedConnections = 8,
             Pipelining = new BenchmarkPipelining(),
             WrappedPool = true,
+            Sweep = [new BenchmarkSweepPoint { Connections = 1, MegaBytesPerSec = 0 }],
             Warnings = ["The test re-downloaded some articles more than once."],
         };
 
         UsenetBenchmarkService.NormalizeUnavailableCorpusResult(result, pool);
 
         Assert.False(result.ThroughputTested);
+        Assert.Empty(result.Sweep);
         Assert.Null(result.RecommendedConnections);
         Assert.Null(result.Pipelining);
         Assert.False(result.WrappedPool);

--- a/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkSegmentPoolTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkSegmentPoolTests.cs
@@ -48,6 +48,50 @@ public class BenchmarkSegmentPoolTests
     }
 
     [Fact]
+    public void NextBatch_StopsAtExhaustionInsteadOfPaddingDeadIds()
+    {
+        var pool = new BenchmarkSegmentPool(
+        [
+            new BenchmarkSegment("a", ["a-fallback"]),
+            new BenchmarkSegment("b", []),
+        ]);
+        pool.MarkDead("b");
+
+        var batch = pool.NextBatch(8);
+
+        Assert.NotEmpty(batch);
+        Assert.DoesNotContain("b", batch);
+
+        pool.MarkDead("a");
+        pool.MarkDead("a-fallback");
+
+        Assert.Empty(pool.NextBatch(8));
+    }
+
+    [Fact]
+    public void Constructor_DuplicateCandidateIdsUseLastLogicalSegment()
+    {
+        var pool = new BenchmarkSegmentPool(
+        [
+            new BenchmarkSegment("first", ["shared"]),
+            new BenchmarkSegment("second", ["shared"]),
+        ]);
+
+        pool.MarkRetrieved("shared");
+        pool.MarkRetrieved("second");
+
+        Assert.True(pool.WrappedAround);
+    }
+
+    [Fact]
+    public void StringConstructor_DuplicateIdsDoNotThrow()
+    {
+        var pool = new BenchmarkSegmentPool(["duplicate", "duplicate"]);
+
+        Assert.Equal("duplicate", Next(pool));
+    }
+
+    [Fact]
     public void WrappedAround_TracksSuccessfulReuseRatherThanSelections()
     {
         var pool = new BenchmarkSegmentPool(["a"]);

--- a/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkSegmentPoolTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Benchmark/BenchmarkSegmentPoolTests.cs
@@ -5,50 +5,77 @@ namespace NzbWebDAV.Tests.Services.Benchmark;
 public class BenchmarkSegmentPoolTests
 {
     [Fact]
-    public void Next_ReturnsIdsInRoundRobinOrder()
+    public void TryNext_ReturnsIdsInRoundRobinOrder()
     {
         var pool = new BenchmarkSegmentPool(["a", "b", "c"]);
 
-        var actual = Enumerable.Range(0, 4).Select(_ => pool.Next()).ToList();
+        var actual = Enumerable.Range(0, 4).Select(_ => Next(pool)).ToList();
 
         Assert.Equal(["a", "b", "c", "a"], actual);
     }
 
     [Fact]
-    public void MarkDead_SkipsIdOnSubsequentCalls()
+    public void MarkDead_AdvancesLogicalSegmentToFallback()
     {
-        var pool = new BenchmarkSegmentPool(["a", "b", "c"]);
-        pool.MarkDead("b");
+        var pool = new BenchmarkSegmentPool(
+        [
+            new BenchmarkSegment("a", ["a-fallback"]),
+            new BenchmarkSegment("b", []),
+        ]);
 
-        var actual = Enumerable.Range(0, 4).Select(_ => pool.Next()).ToList();
+        pool.MarkDead("a");
 
-        Assert.DoesNotContain("b", actual);
-        Assert.Equal(["a", "c", "a", "c"], actual);
+        Assert.Equal("a-fallback", Next(pool));
+        Assert.Equal("b", Next(pool));
+        Assert.Equal(0, pool.DeadCount);
     }
 
     [Fact]
-    public void WrappedAround_BecomesTrueAfterCountIsExceeded()
+    public void TryNext_WhenAllCandidatesAreDead_ReturnsFalse()
     {
-        var pool = new BenchmarkSegmentPool(["a", "b", "c"]);
+        var pool = new BenchmarkSegmentPool(
+        [
+            new BenchmarkSegment("a", ["a-fallback"]),
+            new BenchmarkSegment("b", []),
+        ]);
+        pool.MarkDead("a");
+        pool.MarkDead("a-fallback");
+        pool.MarkDead("b");
 
-        pool.Next();
-        pool.Next();
-        pool.Next();
+        Assert.False(pool.TryNext(out _));
+        Assert.True(pool.Exhausted);
+        Assert.Equal(2, pool.DeadCount);
+    }
+
+    [Fact]
+    public void WrappedAround_TracksSuccessfulReuseRatherThanSelections()
+    {
+        var pool = new BenchmarkSegmentPool(["a"]);
+
+        Assert.Equal("a", Next(pool));
+        Assert.Equal("a", Next(pool));
         Assert.False(pool.WrappedAround);
 
-        pool.Next();
+        pool.MarkRetrieved("a");
+        Assert.False(pool.WrappedAround);
+        pool.MarkRetrieved("a");
         Assert.True(pool.WrappedAround);
     }
 
     [Fact]
-    public void Next_WhenAllIdsAreDead_StillReturnsAValue()
+    public void WrappedAround_TreatsFallbackAsSameLogicalSegment()
     {
-        var pool = new BenchmarkSegmentPool(["a", "b"]);
-        pool.MarkDead("a");
-        pool.MarkDead("b");
+        var pool = new BenchmarkSegmentPool([new BenchmarkSegment("a", ["a-fallback"])]);
 
-        var value = pool.Next();
+        pool.MarkRetrieved("a");
+        pool.MarkRetrieved("a-fallback");
 
-        Assert.Contains(value, new[] { "a", "b" });
+        Assert.True(pool.WrappedAround);
+    }
+
+    private static string Next(BenchmarkSegmentPool pool)
+    {
+        Assert.True(pool.TryNext(out var id));
+        return id;
     }
 }


### PR DESCRIPTION
## Summary
- diversify speed-test corpus selection across completed files
- preserve per-segment fallback Message-IDs and advance to them after definitive misses
- stop exhausted pools instead of retrying dead articles, including pipelined misses
- report zero-byte runs as an insufficient provider-retrievable corpus instead of a completed throughput test
- base cache-reuse warnings on successful logical-segment downloads

Closes #1358

## Test plan
- `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore --filter FullyQualifiedName~Services.Benchmark` (57 passed)
- `git diff --check`

## Setup wizard impact
Not applicable; no configuration options were added or changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Benchmark downloads now use fallback identifiers when a primary identifier is unavailable.
  * Benchmark corpus selection better balances sources and avoids duplicate content.
  * Benchmark runs stop gracefully when the available article pool is exhausted.
  * Pipelining tests are skipped when insufficient article data is available.
  * Unavailable corpus results no longer report misleading throughput data and now include a warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->