### PR TITLE
fix(repair): stop a busy PAR2 repair from freezing every health-check worker

### DIFF
--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -45,6 +45,12 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
     private static readonly TimeSpan MissingPayloadConfirmedRecheck = TimeSpan.FromDays(7);
     private static readonly TimeSpan HealthCheckProgressTimeout = TimeSpan.FromMinutes(5);
 
+    /// <summary>
+    /// How long an item waits before another repair attempt after PAR2 reported that a
+    /// different repair owned the single-repair slot.
+    /// </summary>
+    internal static readonly TimeSpan Par2AdmissionDeferral = TimeSpan.FromMinutes(15);
+
     // Repeated remove-and-blocklist repairs for the same library path in a short window indicate
     // a replacement loop (Arr keeps re-grabbing a release repair keeps rejecting, issue #732).
     // After the limit is hit, further repairs at that path are deferred instead of deleting again.
@@ -1279,6 +1285,13 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 await HandleUnreadablePayloadAsync(davItem, dbClient, exception, ct).ConfigureAwait(false);
                 return;
             }
+
+            if (par2Outcome is Par2RepairOutcome.Deferred)
+            {
+                await DeferRepairUntilOwnerAvailable(davItem, dbClient, ct).ConfigureAwait(false);
+                return;
+            }
+
             if (par2Outcome is not Par2RepairOutcome.NotRepaired)
             {
                 var utcNow = DateTimeOffset.UtcNow;
@@ -1427,6 +1440,12 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             ? await _par2RepairService.TryPar2RepairAsync(
                 davItem, holeSegmentIds, ct).ConfigureAwait(false)
             : Par2RepairOutcome.NotRepaired;
+        if (par2Outcome is Par2RepairOutcome.Deferred)
+        {
+            await DeferRepairUntilOwnerAvailable(davItem, dbClient, ct).ConfigureAwait(false);
+            return;
+        }
+
         if (par2Outcome is not Par2RepairOutcome.NotRepaired)
         {
             var utcNow = DateTimeOffset.UtcNow;
@@ -2961,6 +2980,12 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 failureSnapshot.HasTargetableSegmentIds ? failureSnapshot.SegmentIds : null,
                 ct).ConfigureAwait(false)
             : Par2RepairOutcome.NotRepaired;
+        if (par2Outcome is Par2RepairOutcome.Deferred)
+        {
+            await DeferRepairUntilOwnerAvailable(davItem, dbClient, ct).ConfigureAwait(false);
+            return;
+        }
+
         if (par2Outcome is not Par2RepairOutcome.NotRepaired)
         {
             var utcNow = DateTimeOffset.UtcNow;
@@ -3431,6 +3456,37 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
         }
     }
 
+
+    /// <summary>
+    /// Holds an item for a later repair attempt when PAR2 reported
+    /// <see cref="Par2RepairOutcome.Deferred"/>: another repair owned the single-repair slot,
+    /// so nothing was learned about this file. Falling through to *Arr replacement here would
+    /// remove and re-grab a download that parity may still be able to fix.
+    /// </summary>
+    private async Task DeferRepairUntilOwnerAvailable(
+        DavItem davItem,
+        DavDatabaseClient dbClient,
+        CancellationToken ct)
+    {
+        var now = _timeProvider.GetUtcNow();
+        davItem.HealthRepairPending = true;
+        davItem.LastHealthCheck = now;
+        // Keep the UnixEpoch urgent sentinel, exactly as the schedule deferral does.
+        davItem.NextHealthCheck = NextHealthCheckAfterScheduleDeferral(
+            davItem.NextHealthCheck, now + Par2AdmissionDeferral);
+        Log.Information(
+            "Repair deferred for {Path}: another repair is already running. Retrying after {Delay}.",
+            davItem.Path,
+            Par2AdmissionDeferral);
+        await RecordHealthResult(
+            dbClient,
+            davItem,
+            HealthCheckResult.HealthResult.Unhealthy,
+            HealthCheckResult.RepairAction.ActionNeeded,
+            "Repair deferred because another repair is already running. "
+            + $"This file is queued for another attempt in {Par2AdmissionDeferral.TotalMinutes:0} minutes.",
+            ct).ConfigureAwait(false);
+    }
 
     private async Task DeferRepairUntilWindow(
         DavItem davItem,

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -30,12 +30,33 @@ public enum Par2RepairOutcome
     NotRepaired = 0,
     Repaired = 1,
     VerifiedClean = 2,
+
+    /// <summary>
+    /// Another repair held the single-owner slot for longer than
+    /// <see cref="Par2RepairService.AdmissionWaitTimeout"/>. Nothing was learned about the
+    /// file, so callers must retry later instead of treating it as unrepairable.
+    /// </summary>
+    Deferred = 3,
 }
 
 public partial class Par2RepairService : BackgroundService
 {
     private const int MaxQueueLength = 50;
     private const int MaxAttempts = 3;
+
+    /// <summary>
+    /// How long an inline caller (a health-check worker or a playback report) waits for the
+    /// single repair owner before giving up with <see cref="Par2RepairOutcome.Deferred"/>.
+    /// Waiting longer would hold a health-check worker slot hostage to an unrelated repair,
+    /// which makes <c>repair.healthcheck-workers</c> stop meaning "files checked at once"
+    /// (issue: one dead release froze the whole library scan). Background queue items are
+    /// not inline callers and still wait indefinitely.
+    /// <para>
+    /// Settable for tests so coverage does not wait on the real timeout. Tests that override
+    /// it must restore the original value in a finally block.
+    /// </para>
+    /// </summary>
+    internal static TimeSpan AdmissionWaitTimeout { get; set; } = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan CatalogWarningInterval = TimeSpan.FromMinutes(1);
     private static readonly TimeSpan CatalogMaxRetryDelay = TimeSpan.FromMinutes(1);
 
@@ -119,6 +140,31 @@ public partial class Par2RepairService : BackgroundService
 
     internal Action? OnWorkersStarting { get; set; }
     internal Func<CancellationToken, Task>? BeforePatchPublicationForTests { get; set; }
+
+    /// <summary>
+    /// Takes the single-repair slot the way a running repair does, so tests can observe how
+    /// inline callers behave while a repair is already in flight. Dispose to release it.
+    /// </summary>
+    internal async Task<IDisposable> HoldAdmissionForTestsAsync(CancellationToken ct)
+    {
+        await _repairAdmission.WaitAsync(ct).ConfigureAwait(false);
+        Interlocked.Exchange(ref _admissionActive, 1);
+        PublishAdmissionMetrics();
+        return new AdmissionHold(this);
+    }
+
+    private sealed class AdmissionHold(Par2RepairService owner) : IDisposable
+    {
+        private int _disposed;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 1) return;
+            Interlocked.Exchange(ref owner._admissionActive, 0);
+            owner._repairAdmission.Release();
+            owner.PublishAdmissionMetrics();
+        }
+    }
 
     internal int PendingZeroFillCount => _pendingZeroFillPaths.Count;
 
@@ -246,10 +292,16 @@ public partial class Par2RepairService : BackgroundService
             var mine = new RepairFlight(missingSegmentIds);
             var flight = _repairFlights.GetOrAdd(davItem.Id, mine);
             if (ReferenceEquals(flight, mine))
-                return await RunFlightAsync(flight, davItem, missingSegmentIds, queueGuard: false, ct).ConfigureAwait(false);
+                return await RunFlightAsync(
+                        flight, davItem, missingSegmentIds,
+                        queueGuard: false, AdmissionWaitTimeout, ct)
+                    .ConfigureAwait(false);
             try
             {
                 var result = await flight.Task.WaitAsync(ct).ConfigureAwait(false);
+                // The in-flight repair never started, so retrying here would only queue behind
+                // the same owner. Hand the deferral straight back to the caller.
+                if (result == Par2RepairOutcome.Deferred) return result;
                 if (result == Par2RepairOutcome.NotRepaired || flight.Covers(missingSegmentIds)
                     || missingSegmentIds is { Count: > 0 } && missingSegmentIds.All(_patchStore.HasUsablePatch))
                     return result;
@@ -673,15 +725,24 @@ public partial class Par2RepairService : BackgroundService
             return;
         }
 
-        await RunFlightAsync(item.Flight, davItem, item.MissingSegmentIds, queueGuard: true, ct)
+        await RunFlightAsync(
+                item.Flight, davItem, item.MissingSegmentIds,
+                queueGuard: true, admissionTimeout: null, ct)
             .ConfigureAwait(false);
     }
 
+    /// <param name="admissionTimeout">
+    /// How long to wait for the single repair owner, or <c>null</c> to wait indefinitely.
+    /// Inline callers pass a bounded timeout so they never hold a health-check worker slot
+    /// behind an unrelated repair; the background queue passes <c>null</c> so queued jobs
+    /// are never silently dropped.
+    /// </param>
     private async Task<Par2RepairOutcome> RunFlightAsync(
         RepairFlight flight,
         DavItem davItem,
         IReadOnlyList<string>? missingSegmentIds,
         bool queueGuard,
+        TimeSpan? admissionTimeout,
         CancellationToken ct)
     {
         var admitted = false;
@@ -699,9 +760,17 @@ public partial class Par2RepairService : BackgroundService
             PublishAdmissionMetrics();
             try
             {
-                await _repairAdmission.WaitAsync(ct).ConfigureAwait(false);
-                admitted = true;
-                Interlocked.Exchange(ref _admissionActive, 1);
+                if (admissionTimeout is { } timeout)
+                {
+                    admitted = await _repairAdmission.WaitAsync(timeout, ct).ConfigureAwait(false);
+                }
+                else
+                {
+                    await _repairAdmission.WaitAsync(ct).ConfigureAwait(false);
+                    admitted = true;
+                }
+
+                if (admitted) Interlocked.Exchange(ref _admissionActive, 1);
             }
             finally
             {
@@ -712,6 +781,15 @@ public partial class Par2RepairService : BackgroundService
                 PrometheusMetrics.Current?.ObservePar2AdmissionWait(wait.Elapsed);
                 PublishAdmissionMetrics();
             }
+            if (!admitted)
+            {
+                Log.Debug(
+                    "PAR2 repair deferred for {Path}: another repair held the single-owner slot for {Timeout}.",
+                    davItem.Path, admissionTimeout);
+                flight.Completion.TrySetResult(Par2RepairOutcome.Deferred);
+                return Par2RepairOutcome.Deferred;
+            }
+
             var result = await RunRepairAsync(davItem, missingSegmentIds, flight, ct).ConfigureAwait(false);
             flight.Completion.TrySetResult(result);
             return result;

--- a/docs/configuration/repairs.md
+++ b/docs/configuration/repairs.md
@@ -53,7 +53,14 @@ Repair checks PAR2 packet hashes and source-slice checksums, reconstructs unavai
 and verifies every affected volume's whole-file MD5 before publishing any segment patches.
 Only validated posted bytes are stored. Sources and parity are read through Usenet without
 downloading or extracting a whole release to disk. One repair owner runs at a time across
-health and playback requests; additional jobs wait without multiplying the memory budget.
+health and playback requests; queued jobs wait without multiplying the memory budget.
+
+A health check or playback report that finds damage while another repair already owns that
+slot waits only briefly, then defers the file for another attempt in 15 minutes and releases
+its health-check worker. Deferred files keep their place in the repair queue and are never
+sent to *Arr replacement on that basis, because a busy repair slot says nothing about whether
+parity can fix the file. Without this, a single unrepairable release could hold every
+health-check worker and stop the library scan entirely.
 
 The budget includes NZB/PAR2 metadata, source windows, reconstruction buffers, and staged
 patches. Discovery also limits metadata candidates to 128, metadata scanning to 512 MiB,

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
@@ -543,6 +543,31 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task DeferredPar2_HoldsItemForRetryInsteadOfReplacement()
+    {
+        var segments = NewSegmentIds(HealthCheckService.SampleFloor + 1000);
+        var sizes = Enumerable.Repeat(100L, segments.Length).ToArray();
+        var (item, oldBlobId) = await AddVideoFileAsync("movie.mkv", segments, sizes);
+        var fake = NewFakeClient(segments, missing: [50]);
+        var (service, par2) = await NewServiceAsync(fake, Par2RepairOutcome.Deferred);
+
+        await service.PerformHealthCheck(item, _dbClient, concurrency: 4, CancellationToken.None);
+
+        // A busy repair owner is not evidence that the file is unrepairable, so the item
+        // is held for another repair attempt rather than handed to the replacement path.
+        var reloaded = ReloadItem(item.Id);
+        Assert.True(reloaded.HealthRepairPending);
+        Assert.NotNull(reloaded.NextHealthCheck);
+        Assert.True(reloaded.NextHealthCheck > DateTimeOffset.UtcNow);
+        Assert.Equal(oldBlobId, reloaded.FileBlobId);
+        Assert.Equal([segments[50]], Assert.Single(par2.Requests));
+        var row = Assert.Single(GetHealthRows(item.Id));
+        Assert.Equal(HealthCheckResult.HealthResult.Unhealthy, row.Result);
+        Assert.Equal(HealthCheckResult.RepairAction.ActionNeeded, row.RepairStatus);
+        Assert.Contains("another repair", row.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task ToleranceDisabled_UsesLegacyPath()
     {
         _configManager.UpdateValues(

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairAdmissionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairAdmissionTests.cs
@@ -1,0 +1,105 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services.Repair;
+
+namespace NzbWebDAV.Tests.Services.Repair;
+
+/// <summary>
+/// Only one PAR2 repair runs at a time. Inline callers (health-check workers and playback
+/// reports) must not park on that slot indefinitely: a health-check worker that waits is a
+/// worker that is not checking any other file, so one unrepairable release used to freeze
+/// the whole library scan.
+/// </summary>
+public sealed class Par2RepairAdmissionTests
+{
+    [Fact]
+    public async Task InlineCaller_DefersWhenAnotherRepairHoldsTheSlot()
+    {
+        var directory = NewTempDirectory();
+        var previousTimeout = Par2RepairService.AdmissionWaitTimeout;
+        Par2RepairService.AdmissionWaitTimeout = TimeSpan.FromMilliseconds(50);
+        try
+        {
+            var store = new RepairPatchStore(directory, 1024 * 1024);
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
+            var service = new Par2RepairService(NewConfig(), null!, store);
+
+            using var heldByAnotherRepair =
+                await service.HoldAdmissionForTestsAsync(CancellationToken.None);
+
+            var outcome = await service
+                .TryPar2RepairAsync(NewItem(), ["segment@test"], CancellationToken.None)
+                .WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(Par2RepairOutcome.Deferred, outcome);
+        }
+        finally
+        {
+            Par2RepairService.AdmissionWaitTimeout = previousTimeout;
+            DeleteTempDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public async Task InlineCaller_StopsWaitingOnceTheSlotIsFree()
+    {
+        var directory = NewTempDirectory();
+        var previousTimeout = Par2RepairService.AdmissionWaitTimeout;
+        Par2RepairService.AdmissionWaitTimeout = TimeSpan.FromMilliseconds(50);
+        try
+        {
+            var store = new RepairPatchStore(directory, 1024 * 1024);
+            await store.EnsureCatalogLoadedAsync(CancellationToken.None);
+            var service = new Par2RepairService(NewConfig(), null!, store);
+
+            using (await service.HoldAdmissionForTestsAsync(CancellationToken.None))
+            {
+                Assert.Equal(
+                    Par2RepairOutcome.Deferred,
+                    await service
+                        .TryPar2RepairAsync(NewItem(), ["segment@test"], CancellationToken.None)
+                        .WaitAsync(TimeSpan.FromSeconds(5)));
+            }
+
+            // Releasing the slot must leave the semaphore usable: a deferral is a give-up,
+            // never a leaked permit.
+            using var reacquired = await service.HoldAdmissionForTestsAsync(CancellationToken.None)
+                .WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.NotNull(reacquired);
+        }
+        finally
+        {
+            Par2RepairService.AdmissionWaitTimeout = previousTimeout;
+            DeleteTempDirectory(directory);
+        }
+    }
+
+    private static ConfigManager NewConfig()
+    {
+        var config = new ConfigManager();
+        config.UpdateValues(
+        [
+            new ConfigItem { ConfigName = ConfigKeys.RepairEnable, ConfigValue = "true" },
+            new ConfigItem { ConfigName = ConfigKeys.RepairPar2Enabled, ConfigValue = "true" },
+        ]);
+        return config;
+    }
+
+    private static DavItem NewItem() => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = "movie.mkv",
+        Path = "/content/movie/movie.mkv",
+        Type = DavItem.ItemType.UsenetFile,
+        SubType = DavItem.ItemSubType.NzbFile,
+    };
+
+    private static string NewTempDirectory() =>
+        Path.Join(Path.GetTempPath(), $"nzbdav-par2-admission-{Guid.NewGuid():N}");
+
+    private static void DeleteTempDirectory(string directory)
+    {
+        try { Directory.Delete(directory, recursive: true); }
+        catch (IOException) { /* best effort */ }
+    }
+}


### PR DESCRIPTION
## Problem

Only one PAR2 repair runs at a time (`Par2RepairService._repairAdmission`, a `SemaphoreSlim(1, 1)`). A health-check worker that found damage awaited that semaphore with no timeout, and it kept its `_inProgress` slot for the whole wait.

One release whose articles are all gone could therefore park every worker. Observed on a live instance: a repair started at 21:34:50 UTC and was still running 15 minutes later with `BytesRead` 0, grinding through ~97 failed BODY fetches per minute, while metrics showed

```
nzbdav_par2_repair_active 1
nzbdav_par2_repair_admission_waiters 2
nzbdav_health_check_gate_operations{state="active"} 0
```

Three of four workers were sitting in PAR2, no STAT work was in flight, and the last completed health check was three seconds after that repair began. With `repair.healthcheck-workers` set to 4, no library file was checked for the whole window — the setting had stopped meaning "files checked at once", which is what the docs promise.

## Change

Inline callers (health-check workers and playback reports) now wait a bounded `Par2RepairService.AdmissionWaitTimeout` (5s) and get the new `Par2RepairOutcome.Deferred` if the slot does not free up. The background repair queue keeps waiting indefinitely, so queued jobs are never silently dropped.

`Deferred` is deliberately not folded into `NotRepaired`. A busy repair slot says nothing about whether parity can fix the file, and `NotRepaired` falls through to the *Arr replacement path — which would remove and re-grab a download that parity might still recover. All three health-check call sites now defer the item instead: `HealthRepairPending` is set, the next attempt is scheduled 15 minutes out (preserving the `UnixEpoch` urgent sentinel), and an `ActionNeeded` result explains why.

## Tests

- `Par2RepairAdmissionTests.InlineCaller_DefersWhenAnotherRepairHoldsTheSlot` — an inline caller returns `Deferred` instead of blocking. Fails with `TimeoutException` without the bounded wait.
- `Par2RepairAdmissionTests.InlineCaller_StopsWaitingOnceTheSlotIsFree` — a deferral gives up cleanly and never leaks a permit.
- `HealthCheckDegradedClassificationTests.DeferredPar2_HoldsItemForRetryInsteadOfReplacement` — a deferred repair marks the item pending and leaves the blob alone rather than entering the replacement path. Fails without the call-site guards.

Full suite on this branch: 5189 passed, 0 failed, 9 skipped (`dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release`). `dotnet format whitespace --verify-no-changes` reports nothing in the five changed files.

## Not in scope

Two related findings from the same investigation, left for separate PRs:

1. The PAR2 phase of a health check has no wall-clock deadline of its own — only the STAT sweep has one (`HealthCheckProgressTimeout`). The repair *owner* can still grind for a long time on a dead release; this PR only stops it from taking the other workers with it.
2. Discovery has no early-out for a release whose articles are all missing. It walks the recovery set until a byte or request budget trips, at roughly 600 ms per dead article.

Also present on a clean `main` checkout, unrelated to this change: `ArchitectureBoundaryTests.NonApiCodeDoesNotDependOnControllers` fails.

https://claude.ai/code/session_017B8WaHYfyRiuLJvBLYA9s3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Health checks now defer PAR2 repairs when another repair is active, rather than incorrectly sending files to replacement.
  * Deferred files remain queued, retain their original data, and are automatically retried after 15 minutes.
  * Health-check workers are released promptly when repair capacity is unavailable.

* **Documentation**
  * Updated repair guidance to explain deferred repairs and queue behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->