### PR TITLE
fix(health): prevent false repairs when stored segment alternatives are available

### DIFF
--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -791,10 +791,18 @@ public abstract class NntpClient : INntpClient
         CancellationToken cancellationToken)
     {
         var tasks = segmentIds
-            .Select(async (segmentId, index) => (
-                Index: index,
-                SegmentId: segmentId,
-                Result: await StatAsync(segmentId, cancellationToken).ConfigureAwait(false)))
+            .Select(async (segmentId, index) =>
+            {
+                try
+                {
+                    var response = await StatAsync(segmentId, cancellationToken).ConfigureAwait(false);
+                    return (Index: index, SegmentId: segmentId, Result: (UsenetStatResponse?)response);
+                }
+                catch (UsenetArticleNotFoundException)
+                {
+                    return (Index: index, SegmentId: segmentId, Result: (UsenetStatResponse?)null);
+                }
+            })
             .WithConcurrencyAsync(concurrency, cancellationToken);
 
         var processed = 0;
@@ -802,6 +810,11 @@ public abstract class NntpClient : INntpClient
         await foreach (var task in tasks.ConfigureAwait(false))
         {
             progress?.Report(++processed);
+            if (task.Result is null)
+            {
+                missing.Add((task.Index, task.SegmentId));
+                continue;
+            }
             if (task.Result.ResponseType == UsenetResponseType.ArticleExists) continue;
             if (UsenetArticleAvailability.IsDefinitiveMissing(task.Result))
             {

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -1612,7 +1612,12 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                     await childCts.CancelAsync().ConfigureAwait(false);
                     throw;
                 }
-                catch (Exception e)
+                catch (Exception e) when (e.IsCancellationException())
+                {
+                    await childCts.CancelAsync().ConfigureAwait(false);
+                    throw;
+                }
+                catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
                 {
                     return new HealthHoleCheckOutcome(index, false, ExceptionDispatchInfo.Capture(e));
                 }
@@ -1680,7 +1685,12 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                     await childCts.CancelAsync().ConfigureAwait(false);
                     throw;
                 }
-                catch (Exception e)
+                catch (Exception e) when (e.IsCancellationException())
+                {
+                    await childCts.CancelAsync().ConfigureAwait(false);
+                    throw;
+                }
+                catch (Exception e) when (!e.IsCancellationException() && e is not OutOfMemoryException)
                 {
                     return new HealthSegmentCheckOutcome(false, ExceptionDispatchInfo.Capture(e));
                 }
@@ -2223,8 +2233,13 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 if (!UsenetArticleAvailability.IsDefinitiveMissing(response))
                     return response;
             }
-            catch (UsenetArticleNotFoundException)
+            catch (UsenetArticleNotFoundException e)
             {
+                Log.Debug(
+                    e,
+                    "Health-check HEAD candidate {CandidateId} missing while probing primary {PrimaryId}",
+                    candidateId,
+                    primaryId);
             }
         }
 
@@ -2247,8 +2262,13 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 if (response.Stream is { } stream)
                     await stream.DisposeAsync().ConfigureAwait(false);
             }
-            catch (UsenetArticleNotFoundException)
+            catch (UsenetArticleNotFoundException e)
             {
+                Log.Debug(
+                    e,
+                    "Health-check BODY candidate {CandidateId} missing while probing primary {PrimaryId}",
+                    candidateId,
+                    primaryId);
             }
         }
 

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -1145,8 +1145,8 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 var progress = progressHook.ToPercentage(statSegments.Count);
                 if (!canClassify)
                 {
-                    await ArticleExistenceChecker.CheckAsync(
-                        _usenetClient, statSegments, concurrency, progress, statCts.Token).ConfigureAwait(false);
+                    await CheckLogicalSegmentsAsync(
+                        statSegments, payload.Segments, concurrency, progress, statCts).ConfigureAwait(false);
                 }
                 else
                 {
@@ -1158,7 +1158,7 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                             statSegments, depth: 0, concurrency, progress, statCts.Token)
                         .ConfigureAwait(false);
                     confirmedHoles = await ConfirmHolesThroughFallbacksAsync(
-                            missingIds, statSegments, nzbFile!, concurrency, statCts)
+                            missingIds, statSegments, payload.Segments, concurrency, statCts)
                         .ConfigureAwait(false);
                 }
             }
@@ -1400,7 +1400,7 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
         DavItem davItem,
         DavDatabaseClient dbClient,
         DavNzbFile nzbFile,
-        IReadOnlyList<string> segments,
+        ConcatenatedSegmentView segments,
         LongRange[] segmentRanges,
         List<int> missingIndices,
         List<int> corruptIndices,
@@ -1529,7 +1529,7 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
         ResolveContainerClassAsync(
             DavItem davItem,
             DavNzbFile nzbFile,
-            IReadOnlyList<string> segments,
+            ConcatenatedSegmentView segments,
             List<int> holeIndices,
             CancellationToken ct)
     {
@@ -1551,7 +1551,7 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             new HealthCheckAdmissionContext(
                 _healthCheckConnectionGate,
                 HealthCheckAdmissionPriority.Background));
-        var response = await _usenetClient.DecodedBodyAsync(segments[0], ct).ConfigureAwait(false);
+        var response = await GetDecodedBodyWithFallbackAsync(segments, 0, ct).ConfigureAwait(false);
         if (response.Stream is not { } headStream)
             throw new UsenetUnexpectedResponseException(segments[0], response.ResponseMessage);
         await using (headStream)
@@ -1580,7 +1580,7 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
     private async Task<List<int>> ConfirmHolesThroughFallbacksAsync(
         IReadOnlyList<string> primaryMissIds,
         SegmentIndexView statSegments,
-        DavNzbFile nzbFile,
+        ConcatenatedSegmentView segments,
         int concurrency,
         ContextualCancellationTokenSource statCts)
     {
@@ -1594,42 +1594,185 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 missingIndices.Add(statSegments.SourceIndexAt(index));
         }
 
+        using var childCts = ContextualCancellationTokenSource.CreateLinkedTokenSource(statCts.Token);
         var checks = missingIndices
-            .Select(async index => (
-                Index: index,
-                IsHole: await IsConfirmedHoleAsync(index, nzbFile, statCts.Token).ConfigureAwait(false)))
-            .WithConcurrencyAsync(concurrency, statCts.Token);
+            .Select(async index =>
+            {
+                try
+                {
+                    var isHole = await IsConfirmedHoleAsync(
+                        index,
+                        segments,
+                        () => RefreshHealthCheckWatchdog(statCts),
+                        childCts.Token).ConfigureAwait(false);
+                    return new HealthHoleCheckOutcome(index, isHole, null);
+                }
+                catch (OutOfMemoryException)
+                {
+                    await childCts.CancelAsync().ConfigureAwait(false);
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    return new HealthHoleCheckOutcome(index, false, ExceptionDispatchInfo.Capture(e));
+                }
+            })
+            .WithConcurrencyAsync(concurrency, childCts.Token);
 
         var holes = new List<int>();
-        await foreach (var (index, isHole) in checks.ConfigureAwait(false))
+        await foreach (var outcome in checks.ConfigureAwait(false))
         {
-            // keep the no-progress watchdog armed while fallback STATs are in flight
-            statCts.CancelAfter(HealthCheckProgressTimeout);
-            if (isHole) holes.Add(index);
+            try
+            {
+                statCts.Token.ThrowIfCancellationRequested();
+                if (outcome.Failure is { } failure)
+                {
+                    await childCts.CancelAsync().ConfigureAwait(false);
+                    failure.Throw();
+                }
+
+                RefreshHealthCheckWatchdog(statCts);
+                if (outcome.IsHole) holes.Add(outcome.Index);
+            }
+            catch
+            {
+                await childCts.CancelAsync().ConfigureAwait(false);
+                throw;
+            }
         }
 
         holes.Sort();
         return holes;
     }
 
-    private async Task<bool> IsConfirmedHoleAsync(int segmentIndex, DavNzbFile nzbFile, CancellationToken ct)
+    private async Task CheckLogicalSegmentsAsync(
+        SegmentIndexView statSegments,
+        ConcatenatedSegmentView segments,
+        int concurrency,
+        IProgress<int>? progress,
+        ContextualCancellationTokenSource statCts)
     {
-        if (nzbFile.SegmentFallbackIds is not { } fallbackIds ||
-            segmentIndex >= fallbackIds.Length ||
-            fallbackIds[segmentIndex] is not { Length: > 0 } alternates)
+        using var childCts = ContextualCancellationTokenSource.CreateLinkedTokenSource(statCts.Token);
+        var outcomes = Enumerable.Range(0, statSegments.Count)
+            .Select(async sampleIndex =>
+            {
+                var primaryId = statSegments[sampleIndex];
+                var sourceIndex = statSegments.SourceIndexAt(sampleIndex);
+                try
+                {
+                    if (await StatCandidateExistsAsync(
+                            primaryId,
+                            () => RefreshHealthCheckWatchdog(statCts),
+                            childCts.Token).ConfigureAwait(false) ||
+                        !await IsConfirmedHoleAsync(
+                            sourceIndex,
+                            segments,
+                            () => RefreshHealthCheckWatchdog(statCts),
+                            childCts.Token).ConfigureAwait(false))
+                        return new HealthSegmentCheckOutcome(true, null);
+
+                    return new HealthSegmentCheckOutcome(
+                        true,
+                        ExceptionDispatchInfo.Capture(new UsenetArticleNotFoundException(primaryId)));
+                }
+                catch (OutOfMemoryException)
+                {
+                    await childCts.CancelAsync().ConfigureAwait(false);
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    return new HealthSegmentCheckOutcome(false, ExceptionDispatchInfo.Capture(e));
+                }
+            })
+            .WithConcurrencyAsync(concurrency, childCts.Token);
+
+        var processed = 0;
+        await foreach (var outcome in outcomes.ConfigureAwait(false))
+        {
+            try
+            {
+                statCts.Token.ThrowIfCancellationRequested();
+                if (outcome.Conclusive)
+                    progress?.Report(++processed);
+                if (outcome.Failure is { } failure)
+                {
+                    await childCts.CancelAsync().ConfigureAwait(false);
+                    failure.Throw();
+                }
+            }
+            catch
+            {
+                await childCts.CancelAsync().ConfigureAwait(false);
+                throw;
+            }
+        }
+    }
+
+    private async Task<bool> StatCandidateExistsAsync(
+        string candidateId,
+        Action onProbeCompleted,
+        CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        UsenetStatResponse response;
+        try
+        {
+            response = await _usenetClient.StatAsync(candidateId, ct).ConfigureAwait(false);
+        }
+        catch (UsenetArticleNotFoundException)
+        {
+            return false;
+        }
+        finally
+        {
+            onProbeCompleted();
+        }
+
+        if (response.ResponseType == UsenetResponseType.ArticleExists)
             return true;
+        if (UsenetArticleAvailability.IsDefinitiveMissing(response))
+            return false;
+        throw new UsenetUnexpectedResponseException(candidateId, response.ResponseMessage);
+    }
+
+    private async Task<bool> IsConfirmedHoleAsync(
+        int segmentIndex,
+        ConcatenatedSegmentView segments,
+        Action onProbeCompleted,
+        CancellationToken ct)
+    {
+        var alternates = segments.FallbackIdsAt(segmentIndex);
 
         foreach (var fallbackId in alternates)
         {
-            var response = await _usenetClient.StatAsync(fallbackId, ct).ConfigureAwait(false);
-            if (response.ResponseType == UsenetResponseType.ArticleExists)
+            if (await StatCandidateExistsAsync(fallbackId, onProbeCompleted, ct).ConfigureAwait(false))
                 return false;
-            if (!UsenetArticleAvailability.IsDefinitiveMissing(response))
-                throw new UsenetUnexpectedResponseException(fallbackId, response.ResponseMessage);
         }
 
         return true;
     }
+
+    private static void RefreshHealthCheckWatchdog(ContextualCancellationTokenSource statCts)
+    {
+        try
+        {
+            statCts.CancelAfter(HealthCheckProgressTimeout);
+        }
+        catch (ObjectDisposedException)
+        {
+            // A completed probe can race health-check teardown.
+        }
+    }
+
+    private readonly record struct HealthSegmentCheckOutcome(
+        bool Conclusive,
+        ExceptionDispatchInfo? Failure);
+
+    private readonly record struct HealthHoleCheckOutcome(
+        int Index,
+        bool IsHole,
+        ExceptionDispatchInfo? Failure);
 
     /// <summary>
     /// Persists the degraded-damage record by writing a NEW blob and swapping
@@ -2055,15 +2198,70 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             : new SegmentIndexView(sampledSegments.Source, filteredIndexes.ToArray());
     }
 
-    private async Task UpdateReleaseDate(DavItem davItem, IReadOnlyList<string> segments, CancellationToken ct)
+    private async Task UpdateReleaseDate(DavItem davItem, ConcatenatedSegmentView segments, CancellationToken ct)
     {
         var firstSegmentId = segments.Count == 0 ? null : StringUtil.EmptyToNull(segments[0]);
         if (firstSegmentId == null) return;
-        var articleHeadersResponse = await _usenetClient.HeadAsync(firstSegmentId, ct).ConfigureAwait(false);
+        var articleHeadersResponse = await HeadWithFallbackAsync(segments, 0, ct).ConfigureAwait(false);
         if (articleHeadersResponse.ArticleHeaders is not { } articleHeaders)
             throw new UsenetUnexpectedResponseException(
                 firstSegmentId, articleHeadersResponse.ResponseMessage);
         davItem.ReleaseDate = articleHeaders.Date;
+    }
+
+    private async Task<UsenetHeadResponse> HeadWithFallbackAsync(
+        ConcatenatedSegmentView segments,
+        int sourceIndex,
+        CancellationToken ct)
+    {
+        var primaryId = segments[sourceIndex];
+        foreach (var candidateId in EnumerateSegmentCandidates(segments, sourceIndex))
+        {
+            try
+            {
+                var response = await _usenetClient.HeadAsync(candidateId, ct).ConfigureAwait(false);
+                if (!UsenetArticleAvailability.IsDefinitiveMissing(response))
+                    return response;
+            }
+            catch (UsenetArticleNotFoundException)
+            {
+            }
+        }
+
+        throw new UsenetArticleNotFoundException(primaryId);
+    }
+
+    private async Task<UsenetDecodedBodyResponse> GetDecodedBodyWithFallbackAsync(
+        ConcatenatedSegmentView segments,
+        int sourceIndex,
+        CancellationToken ct)
+    {
+        var primaryId = segments[sourceIndex];
+        foreach (var candidateId in EnumerateSegmentCandidates(segments, sourceIndex))
+        {
+            try
+            {
+                var response = await _usenetClient.DecodedBodyAsync(candidateId, ct).ConfigureAwait(false);
+                if (!UsenetArticleAvailability.IsDefinitiveMissing(response))
+                    return response;
+                if (response.Stream is { } stream)
+                    await stream.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (UsenetArticleNotFoundException)
+            {
+            }
+        }
+
+        throw new UsenetArticleNotFoundException(primaryId);
+    }
+
+    private static IEnumerable<string> EnumerateSegmentCandidates(
+        ConcatenatedSegmentView segments,
+        int sourceIndex)
+    {
+        yield return segments[sourceIndex];
+        foreach (var fallbackId in segments.FallbackIdsAt(sourceIndex))
+            yield return fallbackId;
     }
 
     private static async Task EnsurePayloadExistsAsync(
@@ -2094,7 +2292,12 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             var nzbFile = await dbClient.GetDavNzbFileAsync(davItem, ct).ConfigureAwait(false);
             return nzbFile is null
                 ? throw new MissingFilePayloadException(davItem, DavItem.ItemSubType.NzbFile)
-                : new HealthCheckPayload(nzbFile.SegmentIds, nzbFile);
+                : new HealthCheckPayload(
+                    new ConcatenatedSegmentView(
+                    [
+                        new HealthSegmentPart(nzbFile.SegmentIds, nzbFile.SegmentFallbackIds),
+                    ]),
+                    nzbFile);
         }
 
         if (davItem.SubType == DavItem.ItemSubType.RarFile)
@@ -2103,7 +2306,10 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             return rarFile is null
                 ? throw new MissingFilePayloadException(davItem, DavItem.ItemSubType.RarFile)
                 : new HealthCheckPayload(
-                    new ConcatenatedSegmentView(rarFile.RarParts.Select(part => part.SegmentIds).ToArray()),
+                    new ConcatenatedSegmentView(
+                        rarFile.RarParts
+                            .Select(part => new HealthSegmentPart(part.SegmentIds, part.SegmentFallbackIds))
+                            .ToArray()),
                     null);
         }
 
@@ -2113,15 +2319,18 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             return multipartFile is null
                 ? throw new MissingFilePayloadException(davItem, DavItem.ItemSubType.MultipartFile)
                 : new HealthCheckPayload(
-                    new ConcatenatedSegmentView(multipartFile.Metadata.FileParts.Select(part => part.SegmentIds).ToArray()),
+                    new ConcatenatedSegmentView(
+                        multipartFile.Metadata.FileParts
+                            .Select(part => new HealthSegmentPart(part.SegmentIds, part.SegmentFallbackIds))
+                            .ToArray()),
                     null);
         }
 
-        return new HealthCheckPayload(Array.Empty<string>(), null);
+        return new HealthCheckPayload(new ConcatenatedSegmentView(Array.Empty<HealthSegmentPart>()), null);
     }
 
     private readonly record struct HealthCheckPayload(
-        IReadOnlyList<string> Segments,
+        ConcatenatedSegmentView Segments,
         DavNzbFile? NzbFile);
 
     /// <summary>
@@ -2161,19 +2370,28 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
     /// Presents archive parts as one indexable sequence without copying every Message-ID
     /// into a temporary flattened list.
     /// </summary>
+    internal readonly record struct HealthSegmentPart(
+        string[] SegmentIds,
+        string[][]? SegmentFallbackIds);
+
     internal sealed class ConcatenatedSegmentView : IReadOnlyList<string>
     {
-        private readonly string[][] _parts;
+        private readonly HealthSegmentPart[] _parts;
         private readonly int[] _partEnds;
 
         public ConcatenatedSegmentView(string[][] parts)
+            : this(parts.Select(part => new HealthSegmentPart(part, null)).ToArray())
         {
-            _parts = parts.Where(part => part.Length > 0).ToArray();
+        }
+
+        public ConcatenatedSegmentView(HealthSegmentPart[] parts)
+        {
+            _parts = parts.Where(part => part.SegmentIds.Length > 0).ToArray();
             _partEnds = new int[_parts.Length];
             var count = 0;
             for (var index = 0; index < _parts.Length; index++)
             {
-                count = checked(count + _parts[index].Length);
+                count = checked(count + _parts[index].SegmentIds.Length);
                 _partEnds[index] = count;
             }
         }
@@ -2184,24 +2402,39 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
         {
             get
             {
-                if ((uint)index >= (uint)Count) throw new ArgumentOutOfRangeException(nameof(index));
-                var partIndex = Array.BinarySearch(_partEnds, index + 1);
-                if (partIndex < 0) partIndex = ~partIndex;
-                var partStart = partIndex == 0 ? 0 : _partEnds[partIndex - 1];
-                return _parts[partIndex][index - partStart];
+                var (part, localIndex) = Locate(index);
+                return part.SegmentIds[localIndex];
             }
+        }
+
+        public IReadOnlyList<string> FallbackIdsAt(int index)
+        {
+            var (part, localIndex) = Locate(index);
+            var rows = part.SegmentFallbackIds;
+            return rows is not null && localIndex < rows.Length
+                ? rows[localIndex] ?? Array.Empty<string>()
+                : Array.Empty<string>();
         }
 
         public IEnumerator<string> GetEnumerator()
         {
             foreach (var part in _parts)
             {
-                foreach (var segmentId in part)
+                foreach (var segmentId in part.SegmentIds)
                     yield return segmentId;
             }
         }
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+
+        private (HealthSegmentPart Part, int LocalIndex) Locate(int index)
+        {
+            if ((uint)index >= (uint)Count) throw new ArgumentOutOfRangeException(nameof(index));
+            var partIndex = Array.BinarySearch(_partEnds, index + 1);
+            if (partIndex < 0) partIndex = ~partIndex;
+            var partStart = partIndex == 0 ? 0 : _partEnds[partIndex - 1];
+            return (_parts[partIndex], index - partStart);
+        }
     }
 
     /// <summary>
@@ -3250,7 +3483,7 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             ? segments
             : segments.Take(RejectedReleaseSeedSegments).ToList();
 
-    private static IEnumerable<string> EnumerateRejectedReleaseSeedSegments(IReadOnlyList<string> segments)
+    private static IEnumerable<string> EnumerateRejectedReleaseSeedSegments(ConcatenatedSegmentView segments)
     {
         for (var index = 0; index < Math.Min(segments.Count, RejectedReleaseSeedSegments); index++)
             yield return segments[index];

--- a/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/Usenet/NntpClientCheckAllSegmentsTests.cs
@@ -231,6 +231,24 @@ public class NntpClientCheckAllSegmentsTests
     }
 
     [Fact]
+    public async Task CollectMissingSegmentsPipelinedAsync_ThrownNotFoundIsCollectedInInputOrder()
+    {
+        var client = new TrackingPipelinedStatClient(
+            pipelinedExists: [false, false, false],
+            recheckCodes: [430, 223],
+            throwNotFoundId: "b@example");
+
+        var missing = await client.CollectMissingSegmentsPipelinedAsync(
+            ["a@example", "b@example", "c@example"],
+            8,
+            2,
+            progress: null,
+            CancellationToken.None);
+
+        Assert.Equal(["a@example", "b@example"], missing);
+    }
+
+    [Fact]
     public async Task CollectMissingSegmentsPipelinedAsync_NonDefinitiveRecheckThrows()
     {
         var client = new TrackingPipelinedStatClient(
@@ -478,7 +496,8 @@ public class NntpClientCheckAllSegmentsTests
         bool[]? pipelinedExists,
         int[] recheckCodes,
         Exception? sweepException = null,
-        int throwAfterYieldCount = 0) : NntpClient
+        int throwAfterYieldCount = 0,
+        string? throwNotFoundId = null) : NntpClient
     {
         private int _recheckIndex;
 
@@ -547,6 +566,8 @@ public class NntpClientCheckAllSegmentsTests
             SegmentId segmentId, CancellationToken cancellationToken)
         {
             RecheckedSegmentIds.Add(segmentId);
+            if (string.Equals(segmentId, throwNotFoundId, StringComparison.Ordinal))
+                throw new UsenetArticleNotFoundException(segmentId);
             var code = recheckCodes[_recheckIndex++];
             return Task.FromResult(new UsenetStatResponse
             {

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
@@ -466,6 +466,34 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task PartialSample_NonDefinitiveFallback_DefersWithoutRepair()
+    {
+        var segments = NewSegmentIds(HealthCheckService.SampleFloor + 1000);
+        var sizes = Enumerable.Repeat(100L, segments.Length).ToArray();
+        var fallbackIds = Enumerable.Range(0, segments.Length)
+            .Select(_ => Array.Empty<string>())
+            .ToArray();
+        fallbackIds[50] = ["inconclusive-fallback@test"];
+        var (item, oldBlobId) = await AddVideoFileAsync(
+            "movie.mkv",
+            segments,
+            sizes,
+            fallbackIds: fallbackIds);
+        var fake = NewFakeClient(segments, missing: [50]);
+        var client = new NonDefinitiveStatNntpClient(fake, "inconclusive-fallback@test");
+        var (service, par2) = await NewServiceAsync(client, par2Outcome: false);
+
+        await service.PerformHealthCheck(item, _dbClient, concurrency: 4, CancellationToken.None);
+
+        var row = Assert.Single(GetHealthRows(item.Id));
+        Assert.Equal(HealthCheckResult.HealthResult.Unhealthy, row.Result);
+        Assert.Equal(HealthCheckResult.RepairAction.ActionNeeded, row.RepairStatus);
+        Assert.Empty(par2.Requests);
+        Assert.Equal(oldBlobId, ReloadItem(item.Id).FileBlobId);
+        HealthCheckService.CheckCachedMissingSegmentIds([segments[50]]);
+    }
+
+    [Fact]
     public async Task ToleranceDisabled_UsesLegacyPath()
     {
         _configManager.UpdateValues(
@@ -1204,6 +1232,26 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
                         ["Date"] = DateTimeOffset.UtcNow.AddDays(-1).ToString("R"),
                     },
                 },
+            });
+        }
+    }
+
+    private sealed class NonDefinitiveStatNntpClient(
+        INntpClient inner,
+        string inconclusiveId) : WrappingNntpClient(inner)
+    {
+        public override Task<UsenetStatResponse> StatAsync(
+            SegmentId segmentId,
+            CancellationToken cancellationToken)
+        {
+            if (!string.Equals(segmentId, inconclusiveId, StringComparison.Ordinal))
+                return base.StatAsync(segmentId, cancellationToken);
+
+            return Task.FromResult(new UsenetStatResponse
+            {
+                ResponseCode = 400,
+                ResponseMessage = "400 service temporarily unavailable",
+                ArticleExists = false,
             });
         }
     }

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
@@ -490,6 +490,7 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
         Assert.Equal(HealthCheckResult.RepairAction.ActionNeeded, row.RepairStatus);
         Assert.Empty(par2.Requests);
         Assert.Equal(oldBlobId, ReloadItem(item.Id).FileBlobId);
+        Assert.Equal(1, client.InconclusiveRequestCount);
         HealthCheckService.CheckCachedMissingSegmentIds([segments[50]]);
     }
 
@@ -1240,6 +1241,8 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
         INntpClient inner,
         string inconclusiveId) : WrappingNntpClient(inner)
     {
+        public int InconclusiveRequestCount { get; private set; }
+
         public override Task<UsenetStatResponse> StatAsync(
             SegmentId segmentId,
             CancellationToken cancellationToken)
@@ -1247,6 +1250,7 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
             if (!string.Equals(segmentId, inconclusiveId, StringComparison.Ordinal))
                 return base.StatAsync(segmentId, cancellationToken);
 
+            InconclusiveRequestCount++;
             return Task.FromResult(new UsenetStatResponse
             {
                 ResponseCode = 400,

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
@@ -127,6 +127,35 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
         Assert.Equal(HealthCheckAdmissionPriority.Background, admission.Priority);
     }
 
+    [Fact]
+    public async Task MissingReleaseDate_PrimaryHeadMissing_UsesLiveFallback()
+    {
+        var segments = NewSegmentIds(3);
+        var fallbackIds = new string[segments.Length][];
+        for (var index = 0; index < fallbackIds.Length; index++)
+            fallbackIds[index] = [];
+        fallbackIds[0] = ["alt-head@test"];
+        var (item, _) = await AddVideoFileAsync(
+            "movie.mkv",
+            segments,
+            [10_000, 10_000, 10_000],
+            fallbackIds: fallbackIds);
+        item.ReleaseDate = null;
+        await _context.SaveChangesAsync();
+        var headClient = new FallbackHeadNntpClient(
+            NewFakeClient(segments, missing: []),
+            segments[0],
+            "alt-head@test");
+        var (service, par2) = await NewServiceAsync(headClient, par2Outcome: false);
+
+        await service.PerformHealthCheck(item, _dbClient, concurrency: 4, CancellationToken.None);
+
+        Assert.Equal(HealthCheckResult.HealthResult.Healthy, Assert.Single(GetHealthRows(item.Id)).Result);
+        Assert.NotNull(ReloadItem(item.Id).ReleaseDate);
+        Assert.Equal([segments[0], "alt-head@test"], headClient.Requests);
+        Assert.Empty(par2.Requests);
+    }
+
     public async Task DisposeAsync()
     {
         _queueManager.Dispose();
@@ -403,6 +432,40 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task PartialSample_PrimaryMissingWithLiveFallback_IsHealthy()
+    {
+        var segments = NewSegmentIds(HealthCheckService.SampleFloor + 1000);
+        var sizes = Enumerable.Repeat(100L, segments.Length).ToArray();
+        var sampled = HealthCheckService.SampleSegments(segments.ToList());
+        var sampledId = sampled.First(id => Array.IndexOf(segments, id) != sampled.IndexOf(id));
+        var sourceIndex = Array.IndexOf(segments, sampledId);
+        var fallbackIds = Enumerable.Range(0, segments.Length)
+            .Select(_ => Array.Empty<string>())
+            .ToArray();
+        fallbackIds[sourceIndex] = ["alt-sampled@test"];
+        var (item, oldBlobId) = await AddVideoFileAsync(
+            "movie.mkv",
+            segments,
+            sizes,
+            fallbackIds: fallbackIds);
+        var fake = NewFakeClient(segments, missing: [sourceIndex]);
+        fake.Serve("alt-sampled@test", new byte[100]);
+        _failureTracker.RecordFailure(item.Id);
+        var (service, par2) = await NewServiceAsync(fake, par2Outcome: false);
+
+        await service.PerformHealthCheck(item, _dbClient, concurrency: 4, CancellationToken.None);
+
+        var row = Assert.Single(GetHealthRows(item.Id));
+        Assert.Equal(HealthCheckResult.HealthResult.Healthy, row.Result);
+        Assert.Equal(HealthCheckResult.RepairAction.None, row.RepairStatus);
+        Assert.Empty(par2.Requests);
+        Assert.Equal(oldBlobId, ReloadItem(item.Id).FileBlobId);
+        Assert.Equal(0, _failureTracker.GetFailureCount(item.Id));
+        Assert.True(fake.StatRequestCounts.ContainsKey("alt-sampled@test"));
+        HealthCheckService.CheckCachedMissingSegmentIds([sampledId]);
+    }
+
+    [Fact]
     public async Task ToleranceDisabled_UsesLegacyPath()
     {
         _configManager.UpdateValues(
@@ -484,6 +547,33 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
         Assert.Equal(0L, blob.CriticalHeadEndExclusive);
         Assert.Throws<UsenetArticleNotFoundException>(
             () => HealthCheckService.CheckCachedMissingSegmentIds([segments[5]]));
+    }
+
+    [Fact]
+    public async Task Mp4LayoutProbe_PrimaryHeadMissing_UsesLiveFallback()
+    {
+        var segments = NewSegmentIds(6);
+        var sizes = new long[] { 10_000, 10_000, 10_000, 10_000, 50, 10_000 };
+        var fallbackIds = new string[segments.Length][];
+        for (var index = 0; index < fallbackIds.Length; index++)
+            fallbackIds[index] = [];
+        fallbackIds[0] = ["alt-head@test"];
+        var (item, _) = await AddVideoFileAsync(
+            "movie.mp4",
+            segments,
+            sizes,
+            fallbackIds: fallbackIds);
+        var fake = NewFakeClient(segments, missing: [0, 4]);
+        fake.Serve("alt-head@test", Mp4Head(Box("ftyp", 16), Box("moov", 24)));
+        var (service, par2) = await NewServiceAsync(fake, par2Outcome: false);
+
+        await service.PerformHealthCheck(item, _dbClient, concurrency: 4, CancellationToken.None);
+
+        var row = Assert.Single(GetHealthRows(item.Id));
+        Assert.Equal(HealthCheckResult.HealthResult.Degraded, row.Result);
+        Assert.Equal(1, fake.BodyRequestCounts.GetValueOrDefault(segments[0]));
+        Assert.Equal(1, fake.BodyRequestCounts.GetValueOrDefault("alt-head@test"));
+        Assert.Equal([segments[4]], Assert.Single(par2.Requests));
     }
 
     [Fact]
@@ -833,6 +923,103 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
         Enumerable.Range(0, count).Select(i => $"seg{i}-{Guid.NewGuid():N}@test").ToArray();
 
     [Fact]
+    public async Task RarPayload_NonFirstPartPrimaryMissingWithLiveFallback_IsHealthy()
+    {
+        var ids = NewSegmentIds(4);
+        var fallbackId = $"rar-alt-{Guid.NewGuid():N}@test";
+        var blobId = Guid.NewGuid();
+        await BlobStore.WriteBlob(blobId, new DavRarFile
+        {
+            RarParts =
+            [
+                new DavRarFile.RarPart
+                {
+                    SegmentIds = ids[..2],
+                    SegmentFallbackIds = [["unused-alt@test"]],
+                },
+                new DavRarFile.RarPart
+                {
+                    SegmentIds = ids[2..],
+                    SegmentFallbackIds = [[], [fallbackId]],
+                },
+            ],
+        });
+        var item = DavItem.New(
+            Guid.NewGuid(),
+            DavItem.ContentFolder,
+            "archive-rar.mkv",
+            4096,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.RarFile,
+            DateTimeOffset.UtcNow.AddDays(-1),
+            null,
+            null,
+            blobId);
+        _context.Items.Add(item);
+        await _context.SaveChangesAsync();
+        var fake = NewFakeClient(ids, missing: [3]);
+        fake.Serve(fallbackId, new byte[128]);
+        var (service, par2) = await NewServiceAsync(fake, par2Outcome: false);
+
+        await service.PerformHealthCheck(item, _dbClient, 2, CancellationToken.None);
+
+        Assert.Equal(HealthCheckResult.HealthResult.Healthy, Assert.Single(GetHealthRows(item.Id)).Result);
+        Assert.Equal(1, fake.StatRequestCounts.GetValueOrDefault(fallbackId));
+        Assert.Empty(par2.Requests);
+        HealthCheckService.CheckCachedMissingSegmentIds([ids[3]]);
+    }
+
+    [Fact]
+    public async Task MultipartPayload_NonFirstPartPrimaryMissingWithLiveFallback_IsHealthy()
+    {
+        var ids = NewSegmentIds(4);
+        var fallbackId = $"multipart-alt-{Guid.NewGuid():N}@test";
+        var blobId = Guid.NewGuid();
+        await BlobStore.WriteBlob(blobId, new DavMultipartFile
+        {
+            Metadata = new DavMultipartFile.Meta
+            {
+                FileParts =
+                [
+                    new DavMultipartFile.FilePart
+                    {
+                        SegmentIds = ids[..2],
+                        SegmentFallbackIds = [["unused-alt@test"]],
+                    },
+                    new DavMultipartFile.FilePart
+                    {
+                        SegmentIds = ids[2..],
+                        SegmentFallbackIds = [[], [fallbackId]],
+                    },
+                ],
+            },
+        });
+        var item = DavItem.New(
+            Guid.NewGuid(),
+            DavItem.ContentFolder,
+            "archive-multipart.mkv",
+            4096,
+            DavItem.ItemType.UsenetFile,
+            DavItem.ItemSubType.MultipartFile,
+            DateTimeOffset.UtcNow.AddDays(-1),
+            null,
+            null,
+            blobId);
+        _context.Items.Add(item);
+        await _context.SaveChangesAsync();
+        var fake = NewFakeClient(ids, missing: [3]);
+        fake.Serve(fallbackId, new byte[128]);
+        var (service, par2) = await NewServiceAsync(fake, par2Outcome: false);
+
+        await service.PerformHealthCheck(item, _dbClient, 2, CancellationToken.None);
+
+        Assert.Equal(HealthCheckResult.HealthResult.Healthy, Assert.Single(GetHealthRows(item.Id)).Result);
+        Assert.Equal(1, fake.StatRequestCounts.GetValueOrDefault(fallbackId));
+        Assert.Empty(par2.Requests);
+        HealthCheckService.CheckCachedMissingSegmentIds([ids[3]]);
+    }
+
+    [Fact]
     public async Task RestartedMultipartPatch_PassesHealthStatSweepWithoutRepair()
     {
         var ids = NewSegmentIds(3);
@@ -974,6 +1161,40 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
             return Task.FromResult(new UsenetHeadResponse
             {
                 SegmentId = segmentId.ToString(),
+                ResponseCode = (int)UsenetResponseType.ArticleRetrievedHeadFollows,
+                ResponseMessage = "221 article headers follow",
+                ArticleHeaders = new UsenetArticleHeader
+                {
+                    Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["Date"] = DateTimeOffset.UtcNow.AddDays(-1).ToString("R"),
+                    },
+                },
+            });
+        }
+    }
+
+    private sealed class FallbackHeadNntpClient(
+        INntpClient inner,
+        string missingPrimaryId,
+        string fallbackId) : WrappingNntpClient(inner)
+    {
+        public List<string> Requests { get; } = [];
+
+        public override Task<UsenetHeadResponse> HeadAsync(
+            SegmentId segmentId,
+            CancellationToken cancellationToken)
+        {
+            var id = segmentId.ToString();
+            Requests.Add(id);
+            if (string.Equals(id, missingPrimaryId, StringComparison.Ordinal))
+                throw new UsenetArticleNotFoundException(id);
+            if (!string.Equals(id, fallbackId, StringComparison.Ordinal))
+                throw new InvalidOperationException($"Unexpected HEAD request for {id}");
+
+            return Task.FromResult(new UsenetHeadResponse
+            {
+                SegmentId = id,
                 ResponseCode = (int)UsenetResponseType.ArticleRetrievedHeadFollows,
                 ResponseMessage = "221 article headers follow",
                 ArticleHeaders = new UsenetArticleHeader

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckSampleSegmentsTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckSampleSegmentsTests.cs
@@ -88,6 +88,39 @@ public class HealthCheckSampleSegmentsTests
     }
 
     [Fact]
+    public void ConcatenatedSegmentView_PreservesFallbackRowsAcrossPartBoundaries()
+    {
+        var segments = new HealthCheckService.ConcatenatedSegmentView(
+        [
+            new HealthCheckService.HealthSegmentPart(
+                ["first", "second"],
+                [["first-alt"], null!]),
+            new HealthCheckService.HealthSegmentPart([], [["ignored-alt"]]),
+            new HealthCheckService.HealthSegmentPart(
+                ["third", "fourth"],
+                [["third-alt"], ["fourth-alt"], ["excess-alt"]]),
+        ]);
+
+        Assert.Equal(["first-alt"], segments.FallbackIdsAt(0));
+        Assert.Empty(segments.FallbackIdsAt(1));
+        Assert.Equal(["third-alt"], segments.FallbackIdsAt(2));
+        Assert.Equal(["fourth-alt"], segments.FallbackIdsAt(3));
+    }
+
+    [Fact]
+    public void ConcatenatedSegmentView_ShortFallbackRowsDoNotShiftLaterParts()
+    {
+        var segments = new HealthCheckService.ConcatenatedSegmentView(
+        [
+            new HealthCheckService.HealthSegmentPart(["first", "second"], [["first-alt"]]),
+            new HealthCheckService.HealthSegmentPart(["third"], [["third-alt"]]),
+        ]);
+
+        Assert.Empty(segments.FallbackIdsAt(1));
+        Assert.Equal(["third-alt"], segments.FallbackIdsAt(2));
+    }
+
+    [Fact]
     public void SampleSegments_CoverageTapersInsteadOfSteppingDown()
     {
         double Coverage(int count) =>


### PR DESCRIPTION
## Summary

- preserve source-indexed segment fallback metadata across NZB, RAR, and resolved multipart health payloads
- probe stored alternatives only after a definitive primary miss in routine and full-coverage health checks
- keep release-date HEAD and bounded MP4 layout probes fallback-aware without changing playback, queue validation, schemas, configuration, or provider policy
- normalize thrown definitive misses in the health-only pipelined miss collector while preserving non-definitive error handling

Fixes #1363.

## Test plan

- [x] Red/green: `PartialSample_PrimaryMissingWithLiveFallback_IsHealthy`
- [x] Red/green: `CollectMissingSegmentsPipelinedAsync_ThrownNotFoundIsCollectedInInputOrder`
- [x] Red/green: release-date HEAD and MP4 layout fallback regressions
- [x] Serialized RAR and resolved multipart fallback regressions
- [x] Non-definitive fallback response defers without PAR2 or blob mutation
- [x] `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter 'FullyQualifiedName~HealthCheckDegradedClassificationTests|FullyQualifiedName~HealthCheckSampleSegmentsTests|FullyQualifiedName~NntpClientCheckAllSegmentsTests'` (94 passed)
- [x] Unrelated CI timeout test rerun locally: `ConnectionPoolWarmConnectionTests.KeepAliveSkipsWhenHighPriorityBorrowerConsumesRestoredIdleConnection` (passed)
- [x] `git diff --check`

## Setup wizard impact

None. This fixes existing health-check behavior and adds no configuration option or persisted schema change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Health checks now use available fallback sources when primary content is missing.
  - Content successfully served through a fallback is classified as healthy rather than missing.
  - Missing segments are collected reliably without interrupting the overall process.
  - Fallback handling now works consistently across MP4, RAR, and multipart files.
  - Health checks better distinguish genuinely missing, degraded, and temporarily unverifiable content.
  - Fallback content is checked before repair actions are recommended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->