### PR TITLE
fix(arr): stop re-importing uploads rejected by queue rules

### DIFF
--- a/backend/Services/ArrMonitoringService.cs
+++ b/backend/Services/ArrMonitoringService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Diagnostics;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Clients.RadarrSonarr;
 using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
@@ -24,6 +25,7 @@ public class ArrMonitoringService : BackgroundService
     private const long RejectedReleaseMaxXmlCharacters = 8L * 1024 * 1024;
     private const int RejectedReleaseMaxSegments = 250_000;
     private static readonly TimeSpan RejectedReleaseCaptureTimeout = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan RejectedReleasePassCaptureBudget = TimeSpan.FromSeconds(2);
     private readonly ConfigManager _configManager;
     private readonly ArrReplacementSearchBudget _replacementSearchBudget;
     private readonly IDbContextFactory<DavDatabaseContext> _dbContextFactory;
@@ -81,6 +83,7 @@ public class ArrMonitoringService : BackgroundService
         // reports one Warning per release and action.
         var resolutions = new List<(string? Title, ArrConfig.QueueAction Action, string Reason, string IdentitySource)>();
         var rejectedReleaseCaptures = new Dictionary<Guid, string[]?>();
+        var captureBudget = new RejectedReleaseCaptureBudget(RejectedReleasePassCaptureBudget);
 
         // Skip a host that is timing out or refusing connections until its backoff elapses.
         if (_backoff.IsInBackoff(client.Host))
@@ -104,7 +107,7 @@ public class ArrMonitoringService : BackgroundService
             foreach (var record in stuckRecords)
             {
                 var resolution = await HandleStuckQueueItem(
-                    record, arrConfig, client, rejectedReleaseCaptures, timeout.Token)
+                        record, arrConfig, client, rejectedReleaseCaptures, timeout.Token, captureBudget)
                     .ConfigureAwait(false);
                 if (resolution is null) continue;
                 resolutions.Add(resolution.Value);
@@ -157,7 +160,8 @@ public class ArrMonitoringService : BackgroundService
         ArrConfig arrConfig,
         ArrClient client,
         IDictionary<Guid, string[]?>? rejectedReleaseCaptures,
-        CancellationToken ct)
+        CancellationToken ct,
+        RejectedReleaseCaptureBudget? captureBudget = null)
     {
         // since there may be multiple status messages, multiple actions may apply.
         // in such case, always perform the strongest action.
@@ -177,7 +181,8 @@ public class ArrMonitoringService : BackgroundService
         var shouldCapture = action is ArrConfig.QueueAction.RemoveAndBlocklist
             or ArrConfig.QueueAction.RemoveAndBlocklistAndSearch;
         var rejectedRelease = shouldCapture
-            ? await CaptureRejectedReleaseSegmentsAsync(item, client.Host, rejectedReleaseCaptures, ct)
+            ? await CaptureRejectedReleaseSegmentsAsync(
+                    item, client.Host, rejectedReleaseCaptures, captureBudget, ct)
                 .ConfigureAwait(false)
             : null;
         ct.ThrowIfCancellationRequested();
@@ -243,6 +248,7 @@ public class ArrMonitoringService : BackgroundService
         ArrQueueRecord item,
         string host,
         IDictionary<Guid, string[]?>? rejectedReleaseCaptures,
+        RejectedReleaseCaptureBudget? captureBudget,
         CancellationToken ct)
     {
         if (!Guid.TryParse(item.DownloadId, out var downloadId) || downloadId == Guid.Empty)
@@ -257,11 +263,42 @@ public class ArrMonitoringService : BackgroundService
         if (rejectedReleaseCaptures?.TryGetValue(downloadId, out var cachedSegments) is true)
             return cachedSegments is { Length: > 0 } ? (downloadId, cachedSegments) : null;
 
-        var segments = await CaptureRejectedReleaseSegmentsCoreAsync(item, host, downloadId, ct)
-            .ConfigureAwait(false);
+        if (captureBudget is not null && !captureBudget.TryStart())
+        {
+            rejectedReleaseCaptures?[downloadId] = null;
+            Log.Debug(
+                "Skipped fail-fast evidence capture for Arr download {DownloadId}; monitoring pass capture budget spent",
+                downloadId);
+            return null;
+        }
+
+        var started = Stopwatch.GetTimestamp();
+        string[]? segments;
+        try
+        {
+            segments = await CaptureRejectedReleaseSegmentsCoreAsync(item, host, downloadId, ct)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            captureBudget?.Consume(Stopwatch.GetElapsedTime(started));
+        }
         if (rejectedReleaseCaptures is not null)
             rejectedReleaseCaptures[downloadId] = segments;
         return segments is { Length: > 0 } ? (downloadId, segments) : null;
+    }
+
+    internal sealed class RejectedReleaseCaptureBudget(TimeSpan limit)
+    {
+        private readonly long _limitTicks = limit.Ticks;
+        private long _consumedTicks;
+
+        public bool TryStart() => Volatile.Read(ref _consumedTicks) < _limitTicks;
+
+        public void Consume(TimeSpan elapsed)
+        {
+            Interlocked.Add(ref _consumedTicks, Math.Max(0, elapsed.Ticks));
+        }
     }
     private async Task<string[]?> CaptureRejectedReleaseSegmentsCoreAsync(
         ArrQueueRecord item,

--- a/backend/Services/ArrMonitoringService.cs
+++ b/backend/Services/ArrMonitoringService.cs
@@ -1,8 +1,13 @@
-﻿using Microsoft.Extensions.Hosting;
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
 using NzbWebDAV.Clients.RadarrSonarr;
 using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
 using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Services.Diagnostics;
 using Serilog;
 
 namespace NzbWebDAV.Services;
@@ -16,17 +21,26 @@ namespace NzbWebDAV.Services;
 /// </summary>
 public class ArrMonitoringService : BackgroundService
 {
+    private const long RejectedReleaseMaxXmlCharacters = 8L * 1024 * 1024;
+    private const int RejectedReleaseMaxSegments = 250_000;
+    private static readonly TimeSpan RejectedReleaseCaptureTimeout = TimeSpan.FromSeconds(2);
     private readonly ConfigManager _configManager;
     private readonly ArrReplacementSearchBudget _replacementSearchBudget;
+    private readonly IDbContextFactory<DavDatabaseContext> _dbContextFactory;
+    private readonly IBlobStore _blobStore;
     private readonly ArrInstanceBackoff _backoff;
 
     public ArrMonitoringService(
         ConfigManager configManager,
         ArrReplacementSearchBudget replacementSearchBudget,
+        IDbContextFactory<DavDatabaseContext> dbContextFactory,
+        IBlobStore blobStore,
         ArrInstanceBackoff? backoff = null)
     {
         _configManager = configManager;
         _replacementSearchBudget = replacementSearchBudget;
+        _dbContextFactory = dbContextFactory;
+        _blobStore = blobStore;
         _backoff = backoff ?? new ArrInstanceBackoff();
     }
 
@@ -66,6 +80,7 @@ public class ArrMonitoringService : BackgroundService
         // the buffer support packs are built from, so detail goes to Debug and the pass
         // reports one Warning per release and action.
         var resolutions = new List<(string? Title, ArrConfig.QueueAction Action, string Reason, string IdentitySource)>();
+        var seededDownloadIds = new HashSet<Guid>();
 
         // Skip a host that is timing out or refusing connections until its backoff elapses.
         if (_backoff.IsInBackoff(client.Host))
@@ -88,7 +103,8 @@ public class ArrMonitoringService : BackgroundService
             var stuckRecords = GetActionableStuckRecords(queue, arrConfig.QueueRules);
             foreach (var record in stuckRecords)
             {
-                var resolution = await HandleStuckQueueItem(record, arrConfig, client, timeout.Token)
+                var resolution = await HandleStuckQueueItem(
+                    record, arrConfig, client, seededDownloadIds, timeout.Token)
                     .ConfigureAwait(false);
                 if (resolution is null) continue;
                 resolutions.Add(resolution.Value);
@@ -135,9 +151,13 @@ public class ArrMonitoringService : BackgroundService
             .ToList();
     }
 
-    private async Task<(string? Title, ArrConfig.QueueAction Action, string Reason, string IdentitySource)?>
+    internal async Task<(string? Title, ArrConfig.QueueAction Action, string Reason, string IdentitySource)?>
         HandleStuckQueueItem(
-        ArrQueueRecord item, ArrConfig arrConfig, ArrClient client, CancellationToken ct)
+        ArrQueueRecord item,
+        ArrConfig arrConfig,
+        ArrClient client,
+        ISet<Guid>? seededDownloadIds,
+        CancellationToken ct)
     {
         // since there may be multiple status messages, multiple actions may apply.
         // in such case, always perform the strongest action.
@@ -154,6 +174,13 @@ public class ArrMonitoringService : BackgroundService
             item.GetMatchingStatusMessages(matchingRules.Where(x => x.Action == action).Select(x => x.Message)),
             matchingRules.Where(x => x.Action == action).Select(x => x.Message));
         var (mediaKey, identitySource) = GetMediaKey(client, item);
+        var shouldCapture = action is ArrConfig.QueueAction.RemoveAndBlocklist
+            or ArrConfig.QueueAction.RemoveAndBlocklistAndSearch;
+        var rejectedRelease = shouldCapture
+            ? await CaptureRejectedReleaseSegmentsAsync(item, client.Host, seededDownloadIds, ct)
+                .ConfigureAwait(false)
+            : null;
+        ct.ThrowIfCancellationRequested();
 
         var requestedAction = action;
         action = ApplyReplacementSearchBudget(
@@ -188,6 +215,22 @@ public class ArrMonitoringService : BackgroundService
             return null;
         }
 
+        if (rejectedRelease is not null)
+        {
+            try
+            {
+                HealthCheckService.AddMissingSegmentIds(rejectedRelease.Value.SegmentIds);
+                seededDownloadIds?.Add(rejectedRelease.Value.DownloadId);
+                Log.Debug(
+                    "Recorded {SegmentCount} article IDs from blocklisted Arr download {DownloadId}",
+                    rejectedRelease.Value.SegmentIds.Length,
+                    rejectedRelease.Value.DownloadId);
+            }
+            catch (OutOfMemoryException exception)
+            {
+                OomDiagnostics.LogHeapStateOnOom(exception, "Arr queue rejected-release cache seeding");
+            }
+        }
         Log.Debug(
             "Resolved stuck queue record {QueueRecordId} ({QueueItemTitle}) from {Host} with action {Action}. " +
             "Reason: {Reason}. Media identity source: {IdentitySource}",
@@ -195,6 +238,152 @@ public class ArrMonitoringService : BackgroundService
         return (item.Title, action, reason, identitySource);
     }
 
+    private async Task<(Guid DownloadId, string[] SegmentIds)?> CaptureRejectedReleaseSegmentsAsync(
+        ArrQueueRecord item,
+        string host,
+        ISet<Guid>? seededDownloadIds,
+        CancellationToken ct)
+    {
+        if (!Guid.TryParse(item.DownloadId, out var downloadId) || downloadId == Guid.Empty)
+        {
+            Log.Warning(
+                "Could not record fail-fast evidence before blocklisting Arr queue record {QueueRecordId} from {Host}. " +
+                "Reason: download ID is missing or invalid",
+                item.Id,
+                host);
+            return null;
+        }
+        if (seededDownloadIds?.Contains(downloadId) is true)
+            return null;
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeout.CancelAfter(RejectedReleaseCaptureTimeout);
+        try
+        {
+            var blobId = await FindCompletedNzbBlobIdAsync(downloadId, timeout.Token).ConfigureAwait(false);
+            if (blobId is null)
+            {
+                Log.Warning(
+                    "Could not record fail-fast evidence before blocklisting Arr queue record {QueueRecordId} from {Host}. " +
+                    "Reason: no completed local history entry with an NZB blob matches download {DownloadId}",
+                    item.Id,
+                    host,
+                    downloadId);
+                return null;
+            }
+
+            await using var nzbStream = _blobStore.ReadBlob(blobId.Value);
+            if (nzbStream is null)
+            {
+                Log.Warning(
+                    "Could not record fail-fast evidence before blocklisting Arr queue record {QueueRecordId} from {Host}. " +
+                    "Reason: stored NZB blob {BlobId} is unavailable",
+                    item.Id,
+                    host,
+                    blobId);
+                return null;
+            }
+
+            var document = await LoadRejectedReleaseAsync(nzbStream, timeout.Token).ConfigureAwait(false);
+            var segments = SelectRejectedReleaseSeedSegments(
+                document, HealthCheckService.RejectedReleaseSeedSegments);
+            return segments.Length > 0 ? (downloadId, segments) : null;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+        {
+            Log.Warning(
+                "Could not record fail-fast evidence before blocklisting Arr queue record {QueueRecordId} from {Host}. " +
+                "Reason: local NZB capture exceeded {TimeoutSeconds} seconds",
+                item.Id,
+                host,
+                RejectedReleaseCaptureTimeout.TotalSeconds);
+            return null;
+        }
+        catch (OutOfMemoryException exception)
+        {
+            OomDiagnostics.LogHeapStateOnOom(exception, "Arr queue rejected-release capture");
+            return null;
+        }
+        catch (InvalidDataException exception)
+        {
+            Log.Warning(
+                "Could not record fail-fast evidence before blocklisting Arr queue record {QueueRecordId} from {Host}. " +
+                "Reason: stored NZB is unavailable for bounded parsing ({Reason})",
+                item.Id,
+                host,
+                exception.Message);
+            Log.Debug(exception, "Arr queue rejected-release NZB parsing failure stack");
+            return null;
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            exception.LogWarningKnownOrStack(
+                "Could not record fail-fast evidence before blocklisting Arr queue record {QueueRecordId} from {Host}.",
+                item.Id,
+                host);
+            return null;
+        }
+    }
+    private async Task<Guid?> FindCompletedNzbBlobIdAsync(Guid downloadId, CancellationToken ct)
+    {
+        await using var context = await _dbContextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+        return await context.HistoryItems
+            .AsNoTracking()
+            .Where(item => item.Id == downloadId
+                && item.DownloadStatus == HistoryItem.DownloadStatusOption.Completed
+                && item.NzbBlobId != null)
+            .Select(item => item.NzbBlobId)
+            .SingleOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+    }
+    private static Task<NzbDocument> LoadRejectedReleaseAsync(Stream nzbStream, CancellationToken ct)
+    {
+        var options = new NzbReadOptions(
+            RejectedReleaseMaxXmlCharacters,
+            charge: static _ => { },
+            reserve: static _ => NoReservation.Instance)
+        {
+            MaxSegments = RejectedReleaseMaxSegments,
+        };
+        return NzbDocument.LoadAsync(nzbStream, options, ct);
+    }
+    internal static string[] SelectRejectedReleaseSeedSegments(NzbDocument document, int maximum)
+    {
+        if (maximum <= 0) return [];
+        var files = document.Files.Where(file => file.Segments.Count > 0).ToList();
+        var result = new List<string>(Math.Min(maximum, files.Sum(file => file.Segments.Count)));
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        void TryAdd(string segmentId)
+        {
+            if (result.Count < maximum && seen.Add(segmentId))
+                result.Add(segmentId);
+        }
+
+        foreach (var file in files)
+        {
+            if (result.Count >= maximum) break;
+            TryAdd(file.Segments[0].MessageId);
+        }
+        foreach (var file in files)
+        {
+            foreach (var segment in file.Segments.Skip(1))
+            {
+                if (result.Count >= maximum) return result.ToArray();
+                TryAdd(segment.MessageId);
+            }
+        }
+        return result.ToArray();
+    }
+    private sealed class NoReservation : IDisposable
+    {
+        public static readonly NoReservation Instance = new();
+        public void Dispose() { }
+    }
     internal static ArrConfig.QueueAction ApplyReplacementSearchBudget(
         ArrConfig.QueueAction requestedAction,
         string mediaKey,

--- a/backend/Services/ArrMonitoringService.cs
+++ b/backend/Services/ArrMonitoringService.cs
@@ -80,7 +80,7 @@ public class ArrMonitoringService : BackgroundService
         // the buffer support packs are built from, so detail goes to Debug and the pass
         // reports one Warning per release and action.
         var resolutions = new List<(string? Title, ArrConfig.QueueAction Action, string Reason, string IdentitySource)>();
-        var seededDownloadIds = new HashSet<Guid>();
+        var rejectedReleaseCaptures = new Dictionary<Guid, string[]?>();
 
         // Skip a host that is timing out or refusing connections until its backoff elapses.
         if (_backoff.IsInBackoff(client.Host))
@@ -104,7 +104,7 @@ public class ArrMonitoringService : BackgroundService
             foreach (var record in stuckRecords)
             {
                 var resolution = await HandleStuckQueueItem(
-                    record, arrConfig, client, seededDownloadIds, timeout.Token)
+                    record, arrConfig, client, rejectedReleaseCaptures, timeout.Token)
                     .ConfigureAwait(false);
                 if (resolution is null) continue;
                 resolutions.Add(resolution.Value);
@@ -156,7 +156,7 @@ public class ArrMonitoringService : BackgroundService
         ArrQueueRecord item,
         ArrConfig arrConfig,
         ArrClient client,
-        ISet<Guid>? seededDownloadIds,
+        IDictionary<Guid, string[]?>? rejectedReleaseCaptures,
         CancellationToken ct)
     {
         // since there may be multiple status messages, multiple actions may apply.
@@ -177,7 +177,7 @@ public class ArrMonitoringService : BackgroundService
         var shouldCapture = action is ArrConfig.QueueAction.RemoveAndBlocklist
             or ArrConfig.QueueAction.RemoveAndBlocklistAndSearch;
         var rejectedRelease = shouldCapture
-            ? await CaptureRejectedReleaseSegmentsAsync(item, client.Host, seededDownloadIds, ct)
+            ? await CaptureRejectedReleaseSegmentsAsync(item, client.Host, rejectedReleaseCaptures, ct)
                 .ConfigureAwait(false)
             : null;
         ct.ThrowIfCancellationRequested();
@@ -220,7 +220,8 @@ public class ArrMonitoringService : BackgroundService
             try
             {
                 HealthCheckService.AddMissingSegmentIds(rejectedRelease.Value.SegmentIds);
-                seededDownloadIds?.Add(rejectedRelease.Value.DownloadId);
+                if (rejectedReleaseCaptures is not null)
+                    rejectedReleaseCaptures[rejectedRelease.Value.DownloadId] = [];
                 Log.Debug(
                     "Recorded {SegmentCount} article IDs from blocklisted Arr download {DownloadId}",
                     rejectedRelease.Value.SegmentIds.Length,
@@ -241,7 +242,7 @@ public class ArrMonitoringService : BackgroundService
     private async Task<(Guid DownloadId, string[] SegmentIds)?> CaptureRejectedReleaseSegmentsAsync(
         ArrQueueRecord item,
         string host,
-        ISet<Guid>? seededDownloadIds,
+        IDictionary<Guid, string[]?>? rejectedReleaseCaptures,
         CancellationToken ct)
     {
         if (!Guid.TryParse(item.DownloadId, out var downloadId) || downloadId == Guid.Empty)
@@ -253,8 +254,21 @@ public class ArrMonitoringService : BackgroundService
                 host);
             return null;
         }
-        if (seededDownloadIds?.Contains(downloadId) is true)
-            return null;
+        if (rejectedReleaseCaptures?.TryGetValue(downloadId, out var cachedSegments) is true)
+            return cachedSegments is { Length: > 0 } ? (downloadId, cachedSegments) : null;
+
+        var segments = await CaptureRejectedReleaseSegmentsCoreAsync(item, host, downloadId, ct)
+            .ConfigureAwait(false);
+        if (rejectedReleaseCaptures is not null)
+            rejectedReleaseCaptures[downloadId] = segments;
+        return segments is { Length: > 0 } ? (downloadId, segments) : null;
+    }
+    private async Task<string[]?> CaptureRejectedReleaseSegmentsCoreAsync(
+        ArrQueueRecord item,
+        string host,
+        Guid downloadId,
+        CancellationToken ct)
+    {
 
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
         timeout.CancelAfter(RejectedReleaseCaptureTimeout);
@@ -287,7 +301,7 @@ public class ArrMonitoringService : BackgroundService
             var document = await LoadRejectedReleaseAsync(nzbStream, timeout.Token).ConfigureAwait(false);
             var segments = SelectRejectedReleaseSeedSegments(
                 document, HealthCheckService.RejectedReleaseSeedSegments);
-            return segments.Length > 0 ? (downloadId, segments) : null;
+            return segments.Length > 0 ? segments : null;
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {

--- a/docs/configuration/arrs.md
+++ b/docs/configuration/arrs.md
@@ -83,7 +83,9 @@ containing any remembered article is failed in the download queue before import 
 requests, even when another indexer supplied it under a different release name. Plain **Remove**
 does not mark an upload as rejected.
 
-This memory is process-local and bounded. It is lost on restart, entries can be evicted, and
+This memory is process-local and bounded. Evidence capture is also limited to two seconds per
+monitoring pass so queue actions are not delayed by local evidence collection. It is lost on
+restart, entries can be evicted, and
 provider configuration changes can clear it. Protection also requires the completed download's
 local history and stored NZB to still exist. A replacement that starts importing before Arr's
 delete request returns can pass the check; later re-grabs are protected after Arr confirms the

--- a/docs/configuration/arrs.md
+++ b/docs/configuration/arrs.md
@@ -75,6 +75,20 @@ path problem) that led to the action.
 
 Disabling an instance opts it out of stuck-queue actions, Arr-linked repairs, and health polling. Use **Arr Health** off when you still want queue rules without Overview polling.
 
+## Blocklisted re-grab protection [since 1.4.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.4.0){ .nzbdav-since }
+
+When a queue rule successfully applies **Remove, Blocklist** or **Remove, Blocklist, Search**,
+InfiniDysk remembers a bounded sample of article IDs from the removed download. A later NZB
+containing any remembered article is failed in the download queue before import or Usenet article
+requests, even when another indexer supplied it under a different release name. Plain **Remove**
+does not mark an upload as rejected.
+
+This memory is process-local and bounded. It is lost on restart, entries can be evicted, and
+provider configuration changes can clear it. Protection also requires the completed download's
+local history and stored NZB to still exist. A replacement that starts importing before Arr's
+delete request returns can pass the check; later re-grabs are protected after Arr confirms the
+blocklist action succeeded.
+
 ## Arr Health on the Overview dashboard [since 1.2.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.2.0){ .nzbdav-since }
 
 When at least one Radarr or Sonarr instance is configured **and enabled**, Overview shows a compact **Arr Health** section: instance reachability, imports in the selected dashboard window, median/P95 handoff latency (InfiniDysk download completed → Arr `DownloadFolderImported`), queue depth, and items waiting unusually long for import.

--- a/docs/configuration/repairs.md
+++ b/docs/configuration/repairs.md
@@ -226,10 +226,12 @@ break that cycle:
 
 - **Fail re-grabs before import.** Releases rejected by repair are remembered: when repair removes
   a broken download and marks it failed, the release's article ids are recorded (as are articles
-  found definitively missing while downloading or streaming). A re-grabbed NZB containing any of
-  them fails within milliseconds while still in the download queue. *Arr sees a failed download
-  before import, blocklists the release, and moves on to a different one. The memory is in-process
-  and resets on restart; a loop that survives a restart is stopped again after one extra cycle.
+  found definitively missing while downloading or streaming). Successful **Remove, Blocklist** and
+  **Remove, Blocklist, Search** [queue-rule actions](arrs.md) record
+  the same in-process evidence. A re-grabbed NZB containing any remembered article fails while
+  still in the download queue, before import or Usenet article requests. The bounded memory resets
+  on restart and entries can be evicted; a loop that survives a restart is stopped again after one
+  extra cycle.
 - **Per-file repair rate limit.** After repair has removed 3 downloads for the same library file
   (the same episode or movie file path — not the whole series or folder) within 6 hours, further
   repairs for that file are deferred for a day and surfaced as **Action needed** in the health

--- a/tests/NzbWebDAV.Tests/Services/ArrMonitoringRejectedReleaseTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrMonitoringRejectedReleaseTests.cs
@@ -81,12 +81,12 @@ public sealed class ArrMonitoringRejectedReleaseTests
         };
 
         await service.HandleStuckQueueItem(
-            item, config, client, new HashSet<Guid>(), CancellationToken.None);
+            item, config, client, new Dictionary<Guid, string[]?>(), CancellationToken.None);
 
         Assert.Throws<UsenetArticleNotFoundException>(() =>
             HealthCheckService.CheckCachedMissingSegmentIds([segmentId]));
         HealthCheckService.CheckCachedMissingSegmentIds([$"{Guid.NewGuid():N}@test"]);
-                Assert.Equal([blobId], blobStore.ReadIds);
+        Assert.Equal([blobId], blobStore.ReadIds);
     }
 
     [Fact]
@@ -104,14 +104,15 @@ public sealed class ArrMonitoringRejectedReleaseTests
                 fixture.Item,
                 fixture.Config,
                 fixture.Client,
-                new HashSet<Guid>(),
+                new Dictionary<Guid, string[]?>(),
                 CancellationToken.None);
             await fixture.Handler.RequestReceived.Task;
 
             Assert.Equal([fixture.BlobId], fixture.BlobStore.ReadIds);
             HealthCheckService.CheckCachedMissingSegmentIds([fixture.SegmentId]);
 
-            response.SetResult(new HttpResponseMessage(HttpStatusCode.NoContent));
+            using var completionResponse = new HttpResponseMessage(HttpStatusCode.NoContent);
+            response.SetResult(completionResponse);
             await handling;
 
             Assert.Throws<UsenetArticleNotFoundException>(() =>
@@ -121,217 +122,305 @@ public sealed class ArrMonitoringRejectedReleaseTests
         }
     }
 
-            [Theory]
-            [InlineData(HttpStatusCode.BadRequest)]
-            [InlineData(HttpStatusCode.NotFound)]
-            [InlineData(HttpStatusCode.InternalServerError)]
-            public async Task UnsuccessfulBlocklist_DoesNotSeedRejectedReleaseSegments(HttpStatusCode statusCode)
-            {
-                var fixture = await Fixture.CreateAsync(statusCode, ArrConfig.QueueAction.RemoveAndBlocklist);
-                await using (fixture)
-                {
-                    await fixture.Service.HandleStuckQueueItem(
-                        fixture.Item,
-                        fixture.Config,
-                        fixture.Client,
-                        new HashSet<Guid>(),
-                        CancellationToken.None);
+    [Theory]
+    [InlineData(HttpStatusCode.BadRequest)]
+    [InlineData(HttpStatusCode.NotFound)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    public async Task UnsuccessfulBlocklist_DoesNotSeedRejectedReleaseSegments(HttpStatusCode statusCode)
+    {
+        var fixture = await Fixture.CreateAsync(statusCode, ArrConfig.QueueAction.RemoveAndBlocklist);
+        await using (fixture)
+        {
+            await fixture.Service.HandleStuckQueueItem(
+                fixture.Item,
+                fixture.Config,
+                fixture.Client,
+                new Dictionary<Guid, string[]?>(),
+                CancellationToken.None);
 
-                    HealthCheckService.CheckCachedMissingSegmentIds([fixture.SegmentId]);
-                    Assert.Equal([fixture.BlobId], fixture.BlobStore.ReadIds);
-                }
-            }
+            HealthCheckService.CheckCachedMissingSegmentIds([fixture.SegmentId]);
+            Assert.Equal([fixture.BlobId], fixture.BlobStore.ReadIds);
+        }
+    }
 
-            [Fact]
-            public async Task PlainRemoval_DoesNotReadBlobOrSeedSegments()
-            {
-                var fixture = await Fixture.CreateAsync(HttpStatusCode.OK, ArrConfig.QueueAction.Remove);
-                await using (fixture)
-                {
-                    await fixture.Service.HandleStuckQueueItem(
-                        fixture.Item,
-                        fixture.Config,
-                        fixture.Client,
-                        new HashSet<Guid>(),
-                        CancellationToken.None);
+    [Fact]
+    public async Task PlainRemoval_DoesNotReadBlobOrSeedSegments()
+    {
+        var fixture = await Fixture.CreateAsync(HttpStatusCode.OK, ArrConfig.QueueAction.Remove);
+        await using (fixture)
+        {
+            await fixture.Service.HandleStuckQueueItem(
+                fixture.Item,
+                fixture.Config,
+                fixture.Client,
+                new Dictionary<Guid, string[]?>(),
+                CancellationToken.None);
 
-                    HealthCheckService.CheckCachedMissingSegmentIds([fixture.SegmentId]);
-                    Assert.Empty(fixture.BlobStore.ReadIds);
-                    Assert.Contains("blocklist=false", fixture.Handler.RequestUri!.Query, StringComparison.Ordinal);
-                }
-            }
+            HealthCheckService.CheckCachedMissingSegmentIds([fixture.SegmentId]);
+            Assert.Empty(fixture.BlobStore.ReadIds);
+            Assert.Contains("blocklist=false", fixture.Handler.RequestUri!.Query, StringComparison.Ordinal);
+        }
+    }
 
-            [Fact]
-            public void SelectRejectedReleaseSeedSegments_CoversEachFileBeforeRemainingSegments()
-            {
-                var document = new NzbDocument();
-                var first = new NzbFile { Subject = "first.mkv" };
-                first.Segments.AddRange(
-                [
-                    new NzbSegment { Bytes = 1, MessageId = "first-1" },
+    [Fact]
+    public void SelectRejectedReleaseSeedSegments_CoversEachFileBeforeRemainingSegments()
+    {
+        var document = new NzbDocument();
+        var first = new NzbFile { Subject = "first.mkv" };
+        first.Segments.AddRange(
+        [
+            new NzbSegment { Bytes = 1, MessageId = "first-1" },
                     new NzbSegment { Bytes = 1, MessageId = "first-2" },
                 ]);
-                var second = new NzbFile { Subject = "second.par2" };
-                second.Segments.AddRange(
-                [
-                    new NzbSegment { Bytes = 1, MessageId = "second-1" },
+        var second = new NzbFile { Subject = "second.par2" };
+        second.Segments.AddRange(
+        [
+            new NzbSegment { Bytes = 1, MessageId = "second-1" },
                     new NzbSegment { Bytes = 1, MessageId = "second-2", FallbackMessageIds = ["fallback"] },
                 ]);
-                document.Files.AddRange([first, second]);
+        document.Files.AddRange([first, second]);
 
-                var selected = ArrMonitoringService.SelectRejectedReleaseSeedSegments(document, 3);
+        var selected = ArrMonitoringService.SelectRejectedReleaseSeedSegments(document, 3);
 
-                Assert.Equal(["first-1", "second-1", "first-2"], selected);
-                Assert.DoesNotContain("fallback", selected);
-            }
+        Assert.Equal(["first-1", "second-1", "first-2"], selected);
+        Assert.DoesNotContain("fallback", selected);
+    }
 
-            [Fact]
-            public void SelectRejectedReleaseSeedSegments_IsBoundedAndCoversEveryFile()
-            {
-                var document = new NzbDocument();
-                for (var fileIndex = 0; fileIndex < HealthCheckService.RejectedReleaseSeedSegments; fileIndex++)
-                {
-                    var file = new NzbFile { Subject = $"file-{fileIndex}.bin" };
-                    file.Segments.AddRange(
-                    [
-                        new NzbSegment { Bytes = 1, MessageId = $"file-{fileIndex}-first" },
+    [Fact]
+    public void SelectRejectedReleaseSeedSegments_IsBoundedAndCoversEveryFile()
+    {
+        var document = new NzbDocument();
+        for (var fileIndex = 0; fileIndex < HealthCheckService.RejectedReleaseSeedSegments; fileIndex++)
+        {
+            var file = new NzbFile { Subject = $"file-{fileIndex}.bin" };
+            file.Segments.AddRange(
+            [
+                new NzbSegment { Bytes = 1, MessageId = $"file-{fileIndex}-first" },
                         new NzbSegment { Bytes = 1, MessageId = $"file-{fileIndex}-second" },
                     ]);
-                    document.Files.Add(file);
-                }
+            document.Files.Add(file);
+        }
 
-                var selected = ArrMonitoringService.SelectRejectedReleaseSeedSegments(
-                    document,
-                    HealthCheckService.RejectedReleaseSeedSegments);
+        var selected = ArrMonitoringService.SelectRejectedReleaseSeedSegments(
+            document,
+            HealthCheckService.RejectedReleaseSeedSegments);
 
-                Assert.Equal(HealthCheckService.RejectedReleaseSeedSegments, selected.Length);
-                Assert.Equal(
-                    Enumerable.Range(0, HealthCheckService.RejectedReleaseSeedSegments)
-                        .Select(index => $"file-{index}-first"),
-                    selected);
-            }
+        Assert.Equal(HealthCheckService.RejectedReleaseSeedSegments, selected.Length);
+        Assert.Equal(
+            Enumerable.Range(0, HealthCheckService.RejectedReleaseSeedSegments)
+                .Select(index => $"file-{index}-first"),
+            selected);
+    }
 
-            [Theory]
-            [InlineData(EvidenceFailure.MissingBlob)]
-            [InlineData(EvidenceFailure.MalformedNzb)]
-            [InlineData(EvidenceFailure.FailedHistory)]
-            [InlineData(EvidenceFailure.InvalidDownloadId)]
-            public async Task UnavailableEvidence_DoesNotPreventConfiguredBlocklist(EvidenceFailure failure)
+    [Theory]
+    [InlineData(EvidenceFailure.MissingBlob)]
+    [InlineData(EvidenceFailure.MalformedNzb)]
+    [InlineData(EvidenceFailure.FailedHistory)]
+    [InlineData(EvidenceFailure.InvalidDownloadId)]
+    public async Task UnavailableEvidence_DoesNotPreventConfiguredBlocklist(EvidenceFailure failure)
+    {
+        var fixture = await Fixture.CreateAsync(
+            HttpStatusCode.NoContent,
+            ArrConfig.QueueAction.RemoveAndBlocklist,
+            failure: failure);
+        await using (fixture)
+        {
+            var resolution = await fixture.Service.HandleStuckQueueItem(
+                fixture.Item,
+                fixture.Config,
+                fixture.Client,
+                new Dictionary<Guid, string[]?>(),
+                CancellationToken.None);
+
+            Assert.NotNull(resolution);
+            Assert.NotNull(fixture.Handler.RequestUri);
+            HealthCheckService.CheckCachedMissingSegmentIds([fixture.SegmentId]);
+            if (failure == EvidenceFailure.InvalidDownloadId)
+                Assert.Empty(fixture.BlobStore.ReadIds);
+        }
+    }
+
+    [Fact]
+    public async Task RepeatedDownloadInOnePass_CapturesOnceButDeletesEveryRecord()
+    {
+        var fixture = await Fixture.CreateAsync(
+            HttpStatusCode.NoContent,
+            ArrConfig.QueueAction.RemoveAndBlocklist);
+        await using (fixture)
+        {
+            var rejectedReleaseCaptures = new Dictionary<Guid, string[]?>();
+            await fixture.Service.HandleStuckQueueItem(
+                fixture.Item,
+                fixture.Config,
+                fixture.Client,
+                rejectedReleaseCaptures,
+                CancellationToken.None);
+            await fixture.Service.HandleStuckQueueItem(
+                fixture.Item,
+                fixture.Config,
+                fixture.Client,
+                rejectedReleaseCaptures,
+                CancellationToken.None);
+
+            Assert.Equal([fixture.BlobId], fixture.BlobStore.ReadIds);
+            Assert.Equal(2, fixture.Handler.RequestCount);
+        }
+    }
+
+    [Fact]
+    public async Task RepeatedUnavailableEvidenceInOnePass_CapturesOnceButDeletesEveryRecord()
+    {
+        var fixture = await Fixture.CreateAsync(
+            HttpStatusCode.NoContent,
+            ArrConfig.QueueAction.RemoveAndBlocklist,
+            failure: EvidenceFailure.MalformedNzb);
+        await using (fixture)
+        {
+            var rejectedReleaseCaptures = new Dictionary<Guid, string[]?>();
+            await fixture.Service.HandleStuckQueueItem(
+                fixture.Item,
+                fixture.Config,
+                fixture.Client,
+                rejectedReleaseCaptures,
+                CancellationToken.None);
+            await fixture.Service.HandleStuckQueueItem(
+                fixture.Item,
+                fixture.Config,
+                fixture.Client,
+                rejectedReleaseCaptures,
+                CancellationToken.None);
+
+            Assert.Equal([fixture.BlobId], fixture.BlobStore.ReadIds);
+            Assert.Equal(2, fixture.Handler.RequestCount);
+            HealthCheckService.CheckCachedMissingSegmentIds([fixture.SegmentId]);
+        }
+    }
+
+    [Fact]
+    public async Task RepeatedCaptureTimeoutInOnePass_AttemptsCaptureOnceButDeletesEveryRecord()
+    {
+        var fixture = await Fixture.CreateAsync(
+            HttpStatusCode.NoContent,
+            ArrConfig.QueueAction.RemoveAndBlocklist,
+            failure: EvidenceFailure.CaptureTimeout);
+        await using (fixture)
+        {
+            var rejectedReleaseCaptures = new Dictionary<Guid, string[]?>();
+            await fixture.Service.HandleStuckQueueItem(
+                fixture.Item,
+                fixture.Config,
+                fixture.Client,
+                rejectedReleaseCaptures,
+                CancellationToken.None);
+            await fixture.Service.HandleStuckQueueItem(
+                fixture.Item,
+                fixture.Config,
+                fixture.Client,
+                rejectedReleaseCaptures,
+                CancellationToken.None);
+
+            Assert.Equal(1, fixture.DbContextFactory.AsyncCreateCount);
+            Assert.Equal(2, fixture.Handler.RequestCount);
+            HealthCheckService.CheckCachedMissingSegmentIds([fixture.SegmentId]);
+        }
+    }
+
+    [Fact]
+    public async Task FailedDelete_RetainsCapturedEvidenceForLaterSuccessfulRecord()
+    {
+        var fixture = await Fixture.CreateAsync(
+            HttpStatusCode.BadRequest,
+            ArrConfig.QueueAction.RemoveAndBlocklist);
+        await using (fixture)
+        {
+            var rejectedReleaseCaptures = new Dictionary<Guid, string[]?>();
+            await fixture.Service.HandleStuckQueueItem(
+                fixture.Item,
+                fixture.Config,
+                fixture.Client,
+                rejectedReleaseCaptures,
+                CancellationToken.None);
+            fixture.Handler.StatusCode = HttpStatusCode.NoContent;
+            await fixture.Service.HandleStuckQueueItem(
+                fixture.Item,
+                fixture.Config,
+                fixture.Client,
+                rejectedReleaseCaptures,
+                CancellationToken.None);
+
+            Assert.Equal([fixture.BlobId], fixture.BlobStore.ReadIds);
+            Assert.Equal(2, fixture.Handler.RequestCount);
+            Assert.Throws<UsenetArticleNotFoundException>(() =>
+                HealthCheckService.CheckCachedMissingSegmentIds([fixture.SegmentId]));
+        }
+    }
+
+    [Fact]
+    public async Task SuccessfulBlocklist_StopsRegrabBeforeAnyNntpRequest()
+    {
+        var fixture = await Fixture.CreateAsync(
+            HttpStatusCode.NoContent,
+            ArrConfig.QueueAction.RemoveAndBlocklistAndSearch);
+        await using (fixture)
+        {
+            await fixture.Service.HandleStuckQueueItem(
+                fixture.Item,
+                fixture.Config,
+                fixture.Client,
+                new Dictionary<Guid, string[]?>(),
+                CancellationToken.None);
+
+            var queueItem = new QueueItem
             {
-                var fixture = await Fixture.CreateAsync(
-                    HttpStatusCode.NoContent,
-                    ArrConfig.QueueAction.RemoveAndBlocklist,
-                    failure: failure);
-                await using (fixture)
-                {
-                    var resolution = await fixture.Service.HandleStuckQueueItem(
-                        fixture.Item,
-                        fixture.Config,
-                        fixture.Client,
-                        new HashSet<Guid>(),
-                        CancellationToken.None);
+                Id = Guid.NewGuid(),
+                CreatedAt = DateTime.UtcNow,
+                SortOrder = QueueItem.SortOrderStride,
+                FileName = "Synthetic.Regrab.nzb",
+                JobName = "Synthetic.Regrab",
+                NzbFileSize = 512,
+                TotalSegmentBytes = 128,
+                Category = "movies",
+                Priority = QueueItem.PriorityOption.Normal,
+                PostProcessing = QueueItem.PostProcessingOption.None,
+            };
+            await using var context = new DavDatabaseContext(fixture.Options);
+            context.QueueItems.Add(queueItem);
+            await context.SaveChangesAsync();
+            var dbClient = new DavDatabaseClient(context);
+            var nntpClient = new FakeNntpClient(new Dictionary<string, byte[]>());
+            var configManager = new ConfigManager();
+            using var healthCheckConnectionGate = new HealthCheckConnectionGate(configManager);
+            await using var nzbStream = new MemoryStream(
+                Encoding.UTF8.GetBytes(CreateNzb(fixture.SegmentId)),
+                writable: false);
+            var processor = new QueueItemProcessor(
+                queueItem,
+                nzbStream,
+                dbClient,
+                nntpClient,
+                configManager,
+                new WebsocketManager(),
+                new Progress<int>(),
+                healthCheckConnectionGate,
+                CancellationToken.None);
 
-                    Assert.NotNull(resolution);
-                    Assert.NotNull(fixture.Handler.RequestUri);
-                    HealthCheckService.CheckCachedMissingSegmentIds([fixture.SegmentId]);
-                    if (failure == EvidenceFailure.InvalidDownloadId)
-                        Assert.Empty(fixture.BlobStore.ReadIds);
-                }
-            }
+            await processor.ProcessAsync();
 
-            [Fact]
-            public async Task RepeatedDownloadInOnePass_CapturesOnceButDeletesEveryRecord()
-            {
-                var fixture = await Fixture.CreateAsync(
-                    HttpStatusCode.NoContent,
-                    ArrConfig.QueueAction.RemoveAndBlocklist);
-                await using (fixture)
-                {
-                    var seededDownloadIds = new HashSet<Guid>();
-                    await fixture.Service.HandleStuckQueueItem(
-                        fixture.Item,
-                        fixture.Config,
-                        fixture.Client,
-                        seededDownloadIds,
-                        CancellationToken.None);
-                    await fixture.Service.HandleStuckQueueItem(
-                        fixture.Item,
-                        fixture.Config,
-                        fixture.Client,
-                        seededDownloadIds,
-                        CancellationToken.None);
+            context.ChangeTracker.Clear();
+            Assert.DoesNotContain(await context.QueueItems.AsNoTracking().ToListAsync(), x => x.Id == queueItem.Id);
+            var failed = await context.HistoryItems.AsNoTracking().SingleAsync(x => x.Id == queueItem.Id);
+            Assert.Equal(HistoryItem.DownloadStatusOption.Failed, failed.DownloadStatus);
+            Assert.Contains(fixture.SegmentId, failed.FailMessage, StringComparison.Ordinal);
+            Assert.Equal(0, nntpClient.BodyRequestCount);
+            Assert.Equal(0, nntpClient.BatchRequestCount);
+            Assert.Equal(0, nntpClient.HeaderProbeCount);
+            Assert.Empty(nntpClient.StatRequestCounts);
+            Assert.Contains("blocklist=true", fixture.Handler.RequestUri!.Query, StringComparison.Ordinal);
+            Assert.Contains("skipRedownload=false", fixture.Handler.RequestUri.Query, StringComparison.Ordinal);
+        }
+    }
 
-                    Assert.Equal([fixture.BlobId], fixture.BlobStore.ReadIds);
-                    Assert.Equal(2, fixture.Handler.RequestCount);
-                }
-            }
-
-            [Fact]
-            public async Task SuccessfulBlocklist_StopsRegrabBeforeAnyNntpRequest()
-            {
-                var fixture = await Fixture.CreateAsync(
-                    HttpStatusCode.NoContent,
-                    ArrConfig.QueueAction.RemoveAndBlocklistAndSearch);
-                await using (fixture)
-                {
-                    await fixture.Service.HandleStuckQueueItem(
-                        fixture.Item,
-                        fixture.Config,
-                        fixture.Client,
-                        new HashSet<Guid>(),
-                        CancellationToken.None);
-
-                    var queueItem = new QueueItem
-                    {
-                        Id = Guid.NewGuid(),
-                        CreatedAt = DateTime.UtcNow,
-                        SortOrder = QueueItem.SortOrderStride,
-                        FileName = "Synthetic.Regrab.nzb",
-                        JobName = "Synthetic.Regrab",
-                        NzbFileSize = 512,
-                        TotalSegmentBytes = 128,
-                        Category = "movies",
-                        Priority = QueueItem.PriorityOption.Normal,
-                        PostProcessing = QueueItem.PostProcessingOption.None,
-                    };
-                    await using var context = new DavDatabaseContext(fixture.Options);
-                    context.QueueItems.Add(queueItem);
-                    await context.SaveChangesAsync();
-                    var dbClient = new DavDatabaseClient(context);
-                    var nntpClient = new FakeNntpClient(new Dictionary<string, byte[]>());
-                    var configManager = new ConfigManager();
-                    using var healthCheckConnectionGate = new HealthCheckConnectionGate(configManager);
-                    await using var nzbStream = new MemoryStream(
-                        Encoding.UTF8.GetBytes(CreateNzb(fixture.SegmentId)),
-                        writable: false);
-                    var processor = new QueueItemProcessor(
-                        queueItem,
-                        nzbStream,
-                        dbClient,
-                        nntpClient,
-                        configManager,
-                        new WebsocketManager(),
-                        new Progress<int>(),
-                        healthCheckConnectionGate,
-                        CancellationToken.None);
-
-                    await processor.ProcessAsync();
-
-                    context.ChangeTracker.Clear();
-                    Assert.DoesNotContain(await context.QueueItems.AsNoTracking().ToListAsync(), x => x.Id == queueItem.Id);
-                    var failed = await context.HistoryItems.AsNoTracking().SingleAsync(x => x.Id == queueItem.Id);
-                    Assert.Equal(HistoryItem.DownloadStatusOption.Failed, failed.DownloadStatus);
-                    Assert.Contains(fixture.SegmentId, failed.FailMessage, StringComparison.Ordinal);
-                    Assert.Equal(0, nntpClient.BodyRequestCount);
-                    Assert.Equal(0, nntpClient.BatchRequestCount);
-                    Assert.Equal(0, nntpClient.HeaderProbeCount);
-                    Assert.Empty(nntpClient.StatRequestCounts);
-                    Assert.Contains("blocklist=true", fixture.Handler.RequestUri!.Query, StringComparison.Ordinal);
-                    Assert.Contains("skipRedownload=false", fixture.Handler.RequestUri.Query, StringComparison.Ordinal);
-                }
-            }
-
-        private static string CreateNzb(string segmentId) => $$"""
+    private static string CreateNzb(string segmentId) => $$"""
                 <?xml version="1.0" encoding="utf-8"?>
                 <nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
                     <file subject="Synthetic.Release.mkv">
@@ -350,6 +439,7 @@ public sealed class ArrMonitoringRejectedReleaseTests
         HttpStatusCode statusCode,
         TaskCompletionSource<HttpResponseMessage>? response = null) : HttpMessageHandler
     {
+        public HttpStatusCode StatusCode { get; set; } = statusCode;
         public Uri? RequestUri { get; private set; }
         public int RequestCount { get; private set; }
         public TaskCompletionSource RequestReceived { get; } =
@@ -364,15 +454,28 @@ public sealed class ArrMonitoringRejectedReleaseTests
             RequestCount++;
             RequestReceived.TrySetResult();
             return response is null
-                ? new HttpResponseMessage(statusCode)
+                ? new HttpResponseMessage(StatusCode)
                 : await response.Task.WaitAsync(cancellationToken);
         }
     }
 
-    private sealed class TestDbContextFactory(DbContextOptions<DavDatabaseContext> options)
+    private sealed class TestDbContextFactory(
+        DbContextOptions<DavDatabaseContext> options,
+        bool timeOut = false)
         : IDbContextFactory<DavDatabaseContext>
     {
+        public int AsyncCreateCount { get; private set; }
+
         public DavDatabaseContext CreateDbContext() => new(options);
+
+        public async Task<DavDatabaseContext> CreateDbContextAsync(
+            CancellationToken cancellationToken = default)
+        {
+            AsyncCreateCount++;
+            if (timeOut)
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return new DavDatabaseContext(options);
+        }
     }
 
     private sealed class MemoryBlobStore(Dictionary<Guid, byte[]> blobs) : IBlobStore
@@ -408,6 +511,7 @@ public sealed class ArrMonitoringRejectedReleaseTests
             Guid blobId,
             string segmentId,
             MemoryBlobStore blobStore,
+            TestDbContextFactory dbContextFactory,
             DeleteHandler handler,
             TestArrClient client,
             ArrMonitoringService service,
@@ -420,6 +524,7 @@ public sealed class ArrMonitoringRejectedReleaseTests
             BlobId = blobId;
             SegmentId = segmentId;
             BlobStore = blobStore;
+            DbContextFactory = dbContextFactory;
             Handler = handler;
             Client = client;
             Service = service;
@@ -431,6 +536,7 @@ public sealed class ArrMonitoringRejectedReleaseTests
         public DbContextOptions<DavDatabaseContext> Options { get; }
         public string SegmentId { get; }
         public MemoryBlobStore BlobStore { get; }
+        public TestDbContextFactory DbContextFactory { get; }
         public DeleteHandler Handler { get; }
         public TestArrClient Client { get; }
         public ArrMonitoringService Service { get; }
@@ -480,10 +586,13 @@ public sealed class ArrMonitoringRejectedReleaseTests
             var handler = new DeleteHandler(statusCode, response);
             var httpClient = new HttpClient(handler);
             var client = new TestArrClient(httpClient);
+            var dbContextFactory = new TestDbContextFactory(
+                options,
+                timeOut: failure == EvidenceFailure.CaptureTimeout);
             var service = new ArrMonitoringService(
                 new ConfigManager(),
                 new ArrReplacementSearchBudget(),
-                new TestDbContextFactory(options),
+                dbContextFactory,
                 blobStore);
             var item = new ArrQueueRecord
             {
@@ -512,6 +621,7 @@ public sealed class ArrMonitoringRejectedReleaseTests
                 blobId,
                 segmentId,
                 blobStore,
+                dbContextFactory,
                 handler,
                 client,
                 service,
@@ -533,5 +643,6 @@ public sealed class ArrMonitoringRejectedReleaseTests
         MalformedNzb,
         FailedHistory,
         InvalidDownloadId,
+        CaptureTimeout,
     }
 }

--- a/tests/NzbWebDAV.Tests/Services/ArrMonitoringRejectedReleaseTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrMonitoringRejectedReleaseTests.cs
@@ -1,0 +1,537 @@
+using System.Net;
+using System.Text;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Clients.RadarrSonarr;
+using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Services;
+using NzbWebDAV.Tests.Database;
+using NzbWebDAV.Tests.Fakes;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Tests.Services;
+
+[Collection(nameof(ConfigPathCollection))]
+public sealed class ArrMonitoringRejectedReleaseTests
+{
+    [Fact]
+    public async Task SuccessfulBlocklist_SeedsRejectedReleaseSegments()
+    {
+        var segmentId = $"{Guid.NewGuid():N}@test";
+        var downloadId = Guid.NewGuid();
+        var blobId = Guid.NewGuid();
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+            .UseSqlite(connection)
+            .Options;
+        await using (var context = new DavDatabaseContext(options))
+        {
+            await context.Database.EnsureCreatedAsync();
+            context.HistoryItems.Add(new HistoryItem
+            {
+                Id = downloadId,
+                CreatedAt = DateTime.UtcNow,
+                FileName = "synthetic.nzb",
+                JobName = "Synthetic.Release",
+                Category = "movies",
+                DownloadStatus = HistoryItem.DownloadStatusOption.Completed,
+                NzbBlobId = blobId,
+            });
+            await context.SaveChangesAsync();
+        }
+        var blobStore = new MemoryBlobStore(new Dictionary<Guid, byte[]>
+        {
+            [blobId] = Encoding.UTF8.GetBytes(CreateNzb(segmentId)),
+        });
+        var config = new ArrConfig
+        {
+            QueueRules =
+            [
+                new ArrConfig.QueueRule
+                {
+                    Message = "not wanted",
+                    Action = ArrConfig.QueueAction.RemoveAndBlocklist,
+                },
+            ],
+        };
+        using var httpClient = new HttpClient(new DeleteHandler(HttpStatusCode.NoContent));
+        var client = new TestArrClient(httpClient);
+        var service = new ArrMonitoringService(
+            new ConfigManager(),
+            new ArrReplacementSearchBudget(),
+            new TestDbContextFactory(options),
+            blobStore);
+        var item = new ArrQueueRecord
+        {
+            Id = 42,
+            Title = "Synthetic.Release",
+            Status = "completed",
+            DownloadId = downloadId.ToString("D"),
+            StatusMessages =
+            [
+                new ArrQueueStatusMessage { Messages = ["not wanted"] },
+            ],
+        };
+
+        await service.HandleStuckQueueItem(
+            item, config, client, new HashSet<Guid>(), CancellationToken.None);
+
+        Assert.Throws<UsenetArticleNotFoundException>(() =>
+            HealthCheckService.CheckCachedMissingSegmentIds([segmentId]));
+        HealthCheckService.CheckCachedMissingSegmentIds([$"{Guid.NewGuid():N}@test"]);
+                Assert.Equal([blobId], blobStore.ReadIds);
+    }
+
+    [Fact]
+    public async Task Blocklist_PublishesCapturedSegmentsOnlyAfterSuccessfulResponse()
+    {
+        var response = new TaskCompletionSource<HttpResponseMessage>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var fixture = await Fixture.CreateAsync(
+            HttpStatusCode.OK,
+            ArrConfig.QueueAction.RemoveAndBlocklist,
+            response);
+        await using (fixture)
+        {
+            var handling = fixture.Service.HandleStuckQueueItem(
+                fixture.Item,
+                fixture.Config,
+                fixture.Client,
+                new HashSet<Guid>(),
+                CancellationToken.None);
+            await fixture.Handler.RequestReceived.Task;
+
+            Assert.Equal([fixture.BlobId], fixture.BlobStore.ReadIds);
+            HealthCheckService.CheckCachedMissingSegmentIds([fixture.SegmentId]);
+
+            response.SetResult(new HttpResponseMessage(HttpStatusCode.NoContent));
+            await handling;
+
+            Assert.Throws<UsenetArticleNotFoundException>(() =>
+                HealthCheckService.CheckCachedMissingSegmentIds([fixture.SegmentId]));
+            Assert.Contains("blocklist=true", fixture.Handler.RequestUri!.Query, StringComparison.Ordinal);
+            Assert.Contains("skipRedownload=true", fixture.Handler.RequestUri.Query, StringComparison.Ordinal);
+        }
+    }
+
+            [Theory]
+            [InlineData(HttpStatusCode.BadRequest)]
+            [InlineData(HttpStatusCode.NotFound)]
+            [InlineData(HttpStatusCode.InternalServerError)]
+            public async Task UnsuccessfulBlocklist_DoesNotSeedRejectedReleaseSegments(HttpStatusCode statusCode)
+            {
+                var fixture = await Fixture.CreateAsync(statusCode, ArrConfig.QueueAction.RemoveAndBlocklist);
+                await using (fixture)
+                {
+                    await fixture.Service.HandleStuckQueueItem(
+                        fixture.Item,
+                        fixture.Config,
+                        fixture.Client,
+                        new HashSet<Guid>(),
+                        CancellationToken.None);
+
+                    HealthCheckService.CheckCachedMissingSegmentIds([fixture.SegmentId]);
+                    Assert.Equal([fixture.BlobId], fixture.BlobStore.ReadIds);
+                }
+            }
+
+            [Fact]
+            public async Task PlainRemoval_DoesNotReadBlobOrSeedSegments()
+            {
+                var fixture = await Fixture.CreateAsync(HttpStatusCode.OK, ArrConfig.QueueAction.Remove);
+                await using (fixture)
+                {
+                    await fixture.Service.HandleStuckQueueItem(
+                        fixture.Item,
+                        fixture.Config,
+                        fixture.Client,
+                        new HashSet<Guid>(),
+                        CancellationToken.None);
+
+                    HealthCheckService.CheckCachedMissingSegmentIds([fixture.SegmentId]);
+                    Assert.Empty(fixture.BlobStore.ReadIds);
+                    Assert.Contains("blocklist=false", fixture.Handler.RequestUri!.Query, StringComparison.Ordinal);
+                }
+            }
+
+            [Fact]
+            public void SelectRejectedReleaseSeedSegments_CoversEachFileBeforeRemainingSegments()
+            {
+                var document = new NzbDocument();
+                var first = new NzbFile { Subject = "first.mkv" };
+                first.Segments.AddRange(
+                [
+                    new NzbSegment { Bytes = 1, MessageId = "first-1" },
+                    new NzbSegment { Bytes = 1, MessageId = "first-2" },
+                ]);
+                var second = new NzbFile { Subject = "second.par2" };
+                second.Segments.AddRange(
+                [
+                    new NzbSegment { Bytes = 1, MessageId = "second-1" },
+                    new NzbSegment { Bytes = 1, MessageId = "second-2", FallbackMessageIds = ["fallback"] },
+                ]);
+                document.Files.AddRange([first, second]);
+
+                var selected = ArrMonitoringService.SelectRejectedReleaseSeedSegments(document, 3);
+
+                Assert.Equal(["first-1", "second-1", "first-2"], selected);
+                Assert.DoesNotContain("fallback", selected);
+            }
+
+            [Fact]
+            public void SelectRejectedReleaseSeedSegments_IsBoundedAndCoversEveryFile()
+            {
+                var document = new NzbDocument();
+                for (var fileIndex = 0; fileIndex < HealthCheckService.RejectedReleaseSeedSegments; fileIndex++)
+                {
+                    var file = new NzbFile { Subject = $"file-{fileIndex}.bin" };
+                    file.Segments.AddRange(
+                    [
+                        new NzbSegment { Bytes = 1, MessageId = $"file-{fileIndex}-first" },
+                        new NzbSegment { Bytes = 1, MessageId = $"file-{fileIndex}-second" },
+                    ]);
+                    document.Files.Add(file);
+                }
+
+                var selected = ArrMonitoringService.SelectRejectedReleaseSeedSegments(
+                    document,
+                    HealthCheckService.RejectedReleaseSeedSegments);
+
+                Assert.Equal(HealthCheckService.RejectedReleaseSeedSegments, selected.Length);
+                Assert.Equal(
+                    Enumerable.Range(0, HealthCheckService.RejectedReleaseSeedSegments)
+                        .Select(index => $"file-{index}-first"),
+                    selected);
+            }
+
+            [Theory]
+            [InlineData(EvidenceFailure.MissingBlob)]
+            [InlineData(EvidenceFailure.MalformedNzb)]
+            [InlineData(EvidenceFailure.FailedHistory)]
+            [InlineData(EvidenceFailure.InvalidDownloadId)]
+            public async Task UnavailableEvidence_DoesNotPreventConfiguredBlocklist(EvidenceFailure failure)
+            {
+                var fixture = await Fixture.CreateAsync(
+                    HttpStatusCode.NoContent,
+                    ArrConfig.QueueAction.RemoveAndBlocklist,
+                    failure: failure);
+                await using (fixture)
+                {
+                    var resolution = await fixture.Service.HandleStuckQueueItem(
+                        fixture.Item,
+                        fixture.Config,
+                        fixture.Client,
+                        new HashSet<Guid>(),
+                        CancellationToken.None);
+
+                    Assert.NotNull(resolution);
+                    Assert.NotNull(fixture.Handler.RequestUri);
+                    HealthCheckService.CheckCachedMissingSegmentIds([fixture.SegmentId]);
+                    if (failure == EvidenceFailure.InvalidDownloadId)
+                        Assert.Empty(fixture.BlobStore.ReadIds);
+                }
+            }
+
+            [Fact]
+            public async Task RepeatedDownloadInOnePass_CapturesOnceButDeletesEveryRecord()
+            {
+                var fixture = await Fixture.CreateAsync(
+                    HttpStatusCode.NoContent,
+                    ArrConfig.QueueAction.RemoveAndBlocklist);
+                await using (fixture)
+                {
+                    var seededDownloadIds = new HashSet<Guid>();
+                    await fixture.Service.HandleStuckQueueItem(
+                        fixture.Item,
+                        fixture.Config,
+                        fixture.Client,
+                        seededDownloadIds,
+                        CancellationToken.None);
+                    await fixture.Service.HandleStuckQueueItem(
+                        fixture.Item,
+                        fixture.Config,
+                        fixture.Client,
+                        seededDownloadIds,
+                        CancellationToken.None);
+
+                    Assert.Equal([fixture.BlobId], fixture.BlobStore.ReadIds);
+                    Assert.Equal(2, fixture.Handler.RequestCount);
+                }
+            }
+
+            [Fact]
+            public async Task SuccessfulBlocklist_StopsRegrabBeforeAnyNntpRequest()
+            {
+                var fixture = await Fixture.CreateAsync(
+                    HttpStatusCode.NoContent,
+                    ArrConfig.QueueAction.RemoveAndBlocklistAndSearch);
+                await using (fixture)
+                {
+                    await fixture.Service.HandleStuckQueueItem(
+                        fixture.Item,
+                        fixture.Config,
+                        fixture.Client,
+                        new HashSet<Guid>(),
+                        CancellationToken.None);
+
+                    var queueItem = new QueueItem
+                    {
+                        Id = Guid.NewGuid(),
+                        CreatedAt = DateTime.UtcNow,
+                        SortOrder = QueueItem.SortOrderStride,
+                        FileName = "Synthetic.Regrab.nzb",
+                        JobName = "Synthetic.Regrab",
+                        NzbFileSize = 512,
+                        TotalSegmentBytes = 128,
+                        Category = "movies",
+                        Priority = QueueItem.PriorityOption.Normal,
+                        PostProcessing = QueueItem.PostProcessingOption.None,
+                    };
+                    await using var context = new DavDatabaseContext(fixture.Options);
+                    context.QueueItems.Add(queueItem);
+                    await context.SaveChangesAsync();
+                    var dbClient = new DavDatabaseClient(context);
+                    var nntpClient = new FakeNntpClient(new Dictionary<string, byte[]>());
+                    var configManager = new ConfigManager();
+                    using var healthCheckConnectionGate = new HealthCheckConnectionGate(configManager);
+                    await using var nzbStream = new MemoryStream(
+                        Encoding.UTF8.GetBytes(CreateNzb(fixture.SegmentId)),
+                        writable: false);
+                    var processor = new QueueItemProcessor(
+                        queueItem,
+                        nzbStream,
+                        dbClient,
+                        nntpClient,
+                        configManager,
+                        new WebsocketManager(),
+                        new Progress<int>(),
+                        healthCheckConnectionGate,
+                        CancellationToken.None);
+
+                    await processor.ProcessAsync();
+
+                    context.ChangeTracker.Clear();
+                    Assert.DoesNotContain(await context.QueueItems.AsNoTracking().ToListAsync(), x => x.Id == queueItem.Id);
+                    var failed = await context.HistoryItems.AsNoTracking().SingleAsync(x => x.Id == queueItem.Id);
+                    Assert.Equal(HistoryItem.DownloadStatusOption.Failed, failed.DownloadStatus);
+                    Assert.Contains(fixture.SegmentId, failed.FailMessage, StringComparison.Ordinal);
+                    Assert.Equal(0, nntpClient.BodyRequestCount);
+                    Assert.Equal(0, nntpClient.BatchRequestCount);
+                    Assert.Equal(0, nntpClient.HeaderProbeCount);
+                    Assert.Empty(nntpClient.StatRequestCounts);
+                    Assert.Contains("blocklist=true", fixture.Handler.RequestUri!.Query, StringComparison.Ordinal);
+                    Assert.Contains("skipRedownload=false", fixture.Handler.RequestUri.Query, StringComparison.Ordinal);
+                }
+            }
+
+        private static string CreateNzb(string segmentId) => $$"""
+                <?xml version="1.0" encoding="utf-8"?>
+                <nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
+                    <file subject="Synthetic.Release.mkv">
+                        <groups><group>alt.binaries.test</group></groups>
+                        <segments><segment bytes="128" number="1">{{segmentId}}</segment></segments>
+                    </file>
+                </nzb>
+                """;
+
+    private sealed class TestArrClient(HttpClient client) : ArrClient("http://arr.test", "test-key")
+    {
+        protected override HttpClient Client => client;
+    }
+
+    private sealed class DeleteHandler(
+        HttpStatusCode statusCode,
+        TaskCompletionSource<HttpResponseMessage>? response = null) : HttpMessageHandler
+    {
+        public Uri? RequestUri { get; private set; }
+        public int RequestCount { get; private set; }
+        public TaskCompletionSource RequestReceived { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Assert.Equal(HttpMethod.Delete, request.Method);
+            RequestUri = request.RequestUri;
+            RequestCount++;
+            RequestReceived.TrySetResult();
+            return response is null
+                ? new HttpResponseMessage(statusCode)
+                : await response.Task.WaitAsync(cancellationToken);
+        }
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<DavDatabaseContext> options)
+        : IDbContextFactory<DavDatabaseContext>
+    {
+        public DavDatabaseContext CreateDbContext() => new(options);
+    }
+
+    private sealed class MemoryBlobStore(Dictionary<Guid, byte[]> blobs) : IBlobStore
+    {
+        public List<Guid> ReadIds { get; } = [];
+
+        public Task WriteBlob(Guid id, Stream stream, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task WriteBlob<T>(Guid id, T blob, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Stream? ReadBlob(Guid id)
+        {
+            ReadIds.Add(id);
+            return blobs.TryGetValue(id, out var value) ? new MemoryStream(value, writable: false) : null;
+        }
+
+        public Task<T?> ReadBlob<T>(Guid id) => throw new NotSupportedException();
+        public bool Exists(Guid id) => blobs.ContainsKey(id);
+        public bool Delete(Guid id) => blobs.Remove(id);
+    }
+
+    private sealed class Fixture : IAsyncDisposable
+    {
+        private readonly SqliteConnection _connection;
+        private readonly HttpClient _httpClient;
+
+        private Fixture(
+            SqliteConnection connection,
+            HttpClient httpClient,
+            DbContextOptions<DavDatabaseContext> options,
+            Guid blobId,
+            string segmentId,
+            MemoryBlobStore blobStore,
+            DeleteHandler handler,
+            TestArrClient client,
+            ArrMonitoringService service,
+            ArrQueueRecord item,
+            ArrConfig config)
+        {
+            _connection = connection;
+            _httpClient = httpClient;
+            Options = options;
+            BlobId = blobId;
+            SegmentId = segmentId;
+            BlobStore = blobStore;
+            Handler = handler;
+            Client = client;
+            Service = service;
+            Item = item;
+            Config = config;
+        }
+
+        public Guid BlobId { get; }
+        public DbContextOptions<DavDatabaseContext> Options { get; }
+        public string SegmentId { get; }
+        public MemoryBlobStore BlobStore { get; }
+        public DeleteHandler Handler { get; }
+        public TestArrClient Client { get; }
+        public ArrMonitoringService Service { get; }
+        public ArrQueueRecord Item { get; }
+        public ArrConfig Config { get; }
+
+        public static async Task<Fixture> CreateAsync(
+            HttpStatusCode statusCode,
+            ArrConfig.QueueAction action,
+            TaskCompletionSource<HttpResponseMessage>? response = null,
+            EvidenceFailure failure = EvidenceFailure.None)
+        {
+            var segmentId = $"{Guid.NewGuid():N}@test";
+            var downloadId = Guid.NewGuid();
+            var blobId = Guid.NewGuid();
+            var connection = new SqliteConnection("Data Source=:memory:");
+            await connection.OpenAsync();
+            var options = new DbContextOptionsBuilder<DavDatabaseContext>()
+                .UseSqlite(connection)
+                .Options;
+            await using (var context = new DavDatabaseContext(options))
+            {
+                await context.Database.EnsureCreatedAsync();
+                context.HistoryItems.Add(new HistoryItem
+                {
+                    Id = downloadId,
+                    CreatedAt = DateTime.UtcNow,
+                    FileName = "synthetic.nzb",
+                    JobName = "Synthetic.Release",
+                    Category = "movies",
+                    DownloadStatus = failure == EvidenceFailure.FailedHistory
+                        ? HistoryItem.DownloadStatusOption.Failed
+                        : HistoryItem.DownloadStatusOption.Completed,
+                    NzbBlobId = blobId,
+                });
+                await context.SaveChangesAsync();
+            }
+
+            var blobs = new Dictionary<Guid, byte[]>();
+            if (failure != EvidenceFailure.MissingBlob)
+            {
+                blobs[blobId] = failure == EvidenceFailure.MalformedNzb
+                    ? "<not-an-nzb"u8.ToArray()
+                    : Encoding.UTF8.GetBytes(CreateNzb(segmentId));
+            }
+            var blobStore = new MemoryBlobStore(blobs);
+            var handler = new DeleteHandler(statusCode, response);
+            var httpClient = new HttpClient(handler);
+            var client = new TestArrClient(httpClient);
+            var service = new ArrMonitoringService(
+                new ConfigManager(),
+                new ArrReplacementSearchBudget(),
+                new TestDbContextFactory(options),
+                blobStore);
+            var item = new ArrQueueRecord
+            {
+                Id = 42,
+                Title = "Synthetic.Release",
+                Status = "completed",
+                DownloadId = failure == EvidenceFailure.InvalidDownloadId
+                    ? "not-a-guid"
+                    : downloadId.ToString("D"),
+                StatusMessages =
+                [
+                    new ArrQueueStatusMessage { Messages = ["not wanted"] },
+                ],
+            };
+            var config = new ArrConfig
+            {
+                QueueRules =
+                [
+                    new ArrConfig.QueueRule { Message = "not wanted", Action = action },
+                ],
+            };
+            return new Fixture(
+                connection,
+                httpClient,
+                options,
+                blobId,
+                segmentId,
+                blobStore,
+                handler,
+                client,
+                service,
+                item,
+                config);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            _httpClient.Dispose();
+            await _connection.DisposeAsync();
+        }
+    }
+
+    public enum EvidenceFailure
+    {
+        None,
+        MissingBlob,
+        MalformedNzb,
+        FailedHistory,
+        InvalidDownloadId,
+    }
+}

--- a/tests/NzbWebDAV.Tests/Services/ArrMonitoringRejectedReleaseTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrMonitoringRejectedReleaseTests.cs
@@ -356,6 +356,17 @@ public sealed class ArrMonitoringRejectedReleaseTests
     }
 
     [Fact]
+    public void CaptureBudget_StopsNewWorkAfterCumulativeLimit()
+    {
+        var budget = new ArrMonitoringService.RejectedReleaseCaptureBudget(TimeSpan.FromMilliseconds(1));
+
+        Assert.True(budget.TryStart());
+        budget.Consume(TimeSpan.FromMilliseconds(2));
+
+        Assert.False(budget.TryStart());
+    }
+
+    [Fact]
     public async Task SuccessfulBlocklist_StopsRegrabBeforeAnyNntpRequest()
     {
         var fixture = await Fixture.CreateAsync(


### PR DESCRIPTION
Closes #1365

## Summary

- capture a bounded set of canonical article IDs from the exact completed InfiniDysk history entry before an Arr queue-rule blocklist request
- publish those IDs to the existing in-process fail-fast cache only after Arr confirms a successful 2xx deletion
- cache successful and unavailable capture outcomes per monitoring pass so season-pack records perform one bounded capture attempt while preserving every configured Arr action
- preserve plain removal, replacement-search budgets/refunds, cancellation behavior, and season-pack action aggregation
- stop overlapping re-grabs in `QueueItemProcessor` before any BODY, batch, header, or STAT request
- document the process-local cache, eviction/restart/provider-change limits, missing-history/blob fallback, and the in-flight DELETE race

The capture is best effort and bounded to two seconds, 8 MiB of XML characters, 250,000 parsed segments, and the existing 200-ID rejection seed. If exact local evidence is unavailable or malformed, the configured Arr action still runs. A replacement already past the queue precheck while Arr's DELETE is in flight cannot be retroactively stopped.

## Test plan

- `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter 'FullyQualifiedName~ArrMonitoringRejectedReleaseTests|FullyQualifiedName~ArrReplacementSearchBudgetTests|FullyQualifiedName~ArrMonitoringAggregationTests|FullyQualifiedName~HealthCheckRejectedReleaseSeedTests|FullyQualifiedName~RejectedReleaseFailFastTests|FullyQualifiedName~RadarrSonarrClientTests|FullyQualifiedName~SabFailedDownloadIdentityTests|FullyQualifiedName~NzbDocumentTests'` (94 passed)
- `zensical build --clean --strict`
- touched-file `dotnet format --verify-no-changes` checks for the backend service and regression test
- `git diff --check`

The first CI run had one unrelated timeout in `ConnectionPoolWarmConnectionTests.KeepAliveSkipsWhenHighPriorityBorrowerConsumesRestoredIdleConnection`; the other 5,136 backend tests passed. The exact timeout test does not reproduce locally.

A solution-wide `dotnet format NzbWebDAV.sln --verify-no-changes --no-restore` remains red on pre-existing vendored SharpCompress whitespace and unrelated missing-final-newline diagnostics; those files are outside this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added protection against re-grabbing previously rejected releases by remembering a bounded sample of article IDs.
  - Re-grabs containing remembered articles are rejected before import or Usenet requests, including releases renamed by another indexer.
  - Protection applies to **Remove, Blocklist** and **Remove, Blocklist, Search** actions; plain **Remove** is unchanged.

- **Documentation**
  - Updated Arr queue-rule and repair guidance with protection limits, persistence behavior, and evidence requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->