### PR TITLE
fix(arr): retain WebDAV items when Arr repair only partially completes

### DIFF
--- a/backend/Clients/RadarrSonarr/ArrClient.cs
+++ b/backend/Clients/RadarrSonarr/ArrClient.cs
@@ -148,6 +148,93 @@ public class ArrClient(string host, string apiKey)
         _ = await Post<object>($"/history/failed/{historyId}", new { }, ct).ConfigureAwait(false);
     }
 
+    protected async Task<ArrRepairOutcome> CompleteRepairAfterMediaRemovalAsync(
+        ArrMediaFileMatch mediaFile,
+        int historyId,
+        Func<CancellationToken, Task<ArrRepairOutcome>> finishSearch,
+        CancellationToken ct)
+    {
+        try
+        {
+            await MarkHistoryFailed(historyId, ct).ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            LogPostDeleteRepairFailure(
+                exception,
+                mediaFile,
+                ArrRepairOutcome.MediaRemovedBlocklistUnconfirmed,
+                ct);
+            return ArrRepairOutcome.MediaRemovedBlocklistUnconfirmed;
+        }
+
+        try
+        {
+            return await finishSearch(ct).ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            LogPostDeleteRepairFailure(
+                exception,
+                mediaFile,
+                ArrRepairOutcome.MediaRemovedBlocklistConfirmedSearchUnconfirmed,
+                ct);
+            return ArrRepairOutcome.MediaRemovedBlocklistConfirmedSearchUnconfirmed;
+        }
+    }
+
+    private void LogPostDeleteRepairFailure(
+        Exception exception,
+        ArrMediaFileMatch mediaFile,
+        ArrRepairOutcome outcome,
+        CancellationToken ct)
+    {
+        var reason = GetPostDeleteFailureReason(exception, ct);
+        var instance = Uri.TryCreate(Host, UriKind.Absolute, out var uri)
+            ? uri.GetComponents(UriComponents.SchemeAndServer, UriFormat.SafeUnescaped)
+            : "configured Arr instance";
+        var clientKind = GetType().Name;
+
+        if (reason == "unexpected post-delete failure")
+        {
+            Log.Error(
+                exception,
+                "Unexpected {ClientKind} repair failure after accepted media deletion on {Instance} for {MediaKind} file {MediaFileId}; outcome {Outcome}",
+                clientKind,
+                instance,
+                mediaFile.Kind,
+                mediaFile.FileId,
+                outcome);
+            return;
+        }
+
+        Log.Warning(
+            "{ClientKind} repair incomplete after accepted media deletion on {Instance} for {MediaKind} file {MediaFileId}; outcome {Outcome}. Reason: {Reason}",
+            clientKind,
+            instance,
+            mediaFile.Kind,
+            mediaFile.FileId,
+            outcome,
+            reason);
+        Log.Debug(exception, "Known Arr post-delete repair failure stack");
+    }
+
+    private static string GetPostDeleteFailureReason(
+        Exception exception,
+        CancellationToken ct) => exception switch
+    {
+        OperationCanceledException when ct.IsCancellationRequested =>
+            "repair cancellation requested",
+        OperationCanceledException => "request timed out or was cancelled",
+        HttpRequestException { StatusCode: { } statusCode } =>
+            $"HTTP {(int)statusCode}",
+        HttpRequestException => "HTTP transport failure",
+        JsonException => "unusable JSON response",
+        InvalidDataException => "unusable response data",
+        IOException => "response I/O failure",
+        _ => "unexpected post-delete failure",
+    };
+
     /// <summary>
     /// Retries transient Arr API failures for repair search notifications.
     /// Delete/blocklist steps rely on <see cref="NzbWebDAV.Services.HealthCheckService.DecideArrLinkedRepairAsync"/> fail-safe instead.

--- a/backend/Clients/RadarrSonarr/ArrClient.cs
+++ b/backend/Clients/RadarrSonarr/ArrClient.cs
@@ -170,6 +170,7 @@ public class ArrClient(string host, string apiKey)
 
         try
         {
+            ct.ThrowIfCancellationRequested();
             return await finishSearch(ct).ConfigureAwait(false);
         }
         catch (Exception exception) when (exception is not OutOfMemoryException)

--- a/backend/Clients/RadarrSonarr/BaseModels/ArrRepairOutcome.cs
+++ b/backend/Clients/RadarrSonarr/BaseModels/ArrRepairOutcome.cs
@@ -2,8 +2,10 @@ namespace NzbWebDAV.Clients.RadarrSonarr.BaseModels;
 
 public enum ArrRepairOutcome
 {
-    RemoveAndBlocklistSucceeded,
-    RemoveAndBlocklistSucceededSearchWithheld,
-    MediaItemNotFound,
-    DownloadHistoryNotFound,
+    RemoveAndBlocklistSucceeded = 0,
+    RemoveAndBlocklistSucceededSearchWithheld = 1,
+    MediaItemNotFound = 2,
+    DownloadHistoryNotFound = 3,
+    MediaRemovedBlocklistUnconfirmed = 4,
+    MediaRemovedBlocklistConfirmedSearchUnconfirmed = 5,
 }

--- a/backend/Clients/RadarrSonarr/RadarrClient.cs
+++ b/backend/Clients/RadarrSonarr/RadarrClient.cs
@@ -131,37 +131,42 @@ public class RadarrClient(string host, string apiKey) : ArrClient(host, apiKey)
             throw new InvalidOperationException(
                 $"Failed to delete movie file {mediaFile.FileId} from radarr instance `{Host}`.");
 
-        await MarkHistoryFailed(historyId.Value, ct).ConfigureAwait(false);
+        return await CompleteRepairAfterMediaRemovalAsync(
+            mediaFile,
+            historyId.Value,
+            async token =>
+            {
+                if (shouldRequestSearch is not null && !shouldRequestSearch([$"movie:{movieId}"]))
+                {
+                    Log.Warning(
+                        "Radarr repair on {Host}: automatic replacement-search limit reached for movie {MovieId}; " +
+                        "the file was removed and its download blocklisted without starting another search.",
+                        Host,
+                        movieId);
+                    return ArrRepairOutcome.RemoveAndBlocklistSucceededSearchWithheld;
+                }
 
-        if (shouldRequestSearch is not null && !shouldRequestSearch([$"movie:{movieId}"]))
-        {
-            Log.Warning(
-                "Radarr repair on {Host}: automatic replacement-search limit reached for movie {MovieId}; " +
-                "the file was removed and its download blocklisted without starting another search.",
-                Host,
-                movieId);
-            return ArrRepairOutcome.RemoveAndBlocklistSucceededSearchWithheld;
-        }
+                try
+                {
+                    await ExecuteWithTransientRetryAsync(
+                        commandToken => CommandAsync(
+                            new { name = "MoviesSearch", movieIds = new[] { movieId } },
+                            commandToken),
+                        token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) { throw; }
+                catch (Exception ex)
+                {
+                    Log.Warning(
+                        ex,
+                        "Radarr repair on {Host}: failed to request MoviesSearch for movie {MovieId}",
+                        Host,
+                        movieId);
+                }
 
-        try
-        {
-            await ExecuteWithTransientRetryAsync(
-                token => CommandAsync(
-                    new { name = "MoviesSearch", movieIds = new[] { movieId } },
-                    token),
-                ct).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException) { throw; }
-        catch (Exception ex)
-        {
-            Log.Warning(
-                ex,
-                "Radarr repair on {Host}: failed to request MoviesSearch for movie {MovieId}",
-                Host,
-                movieId);
-        }
-
-        return ArrRepairOutcome.RemoveAndBlocklistSucceeded;
+                return ArrRepairOutcome.RemoveAndBlocklistSucceeded;
+            },
+            ct).ConfigureAwait(false);
     }
 
     public override Task<ArrHistory> GetMediaImportHistoryAsync(

--- a/backend/Clients/RadarrSonarr/SonarrClient.cs
+++ b/backend/Clients/RadarrSonarr/SonarrClient.cs
@@ -154,45 +154,52 @@ public class SonarrClient(string host, string apiKey) : ArrClient(host, apiKey)
             throw new InvalidOperationException(
                 $"Failed to delete episode file {mediaFile.FileId} from sonarr instance `{Host}`.");
 
-        await MarkHistoryFailed(historyId.Value, ct).ConfigureAwait(false);
+        return await CompleteRepairAfterMediaRemovalAsync(
+            mediaFile,
+            historyId.Value,
+            async token =>
+            {
+                try
+                {
+                    if (episodeIds.Count == 0)
+                    {
+                        Log.Warning(
+                            "Sonarr repair on {Host}: no episodes linked to episode file {EpisodeFileId}; skipping EpisodeSearch",
+                            Host,
+                            mediaFile.FileId);
+                    }
+                    else if (shouldRequestSearch is not null &&
+                             !shouldRequestSearch(episodeIds.Select(id => $"episode:{id}").ToArray()))
+                    {
+                        Log.Warning(
+                            "Sonarr repair on {Host}: automatic replacement-search limit reached for episode file {EpisodeFileId}; " +
+                            "the file was removed and its download blocklisted without another search.",
+                            Host,
+                            mediaFile.FileId);
+                        return ArrRepairOutcome.RemoveAndBlocklistSucceededSearchWithheld;
+                    }
+                    else
+                    {
+                        await ExecuteWithTransientRetryAsync(
+                            commandToken => CommandAsync(
+                                new { name = "EpisodeSearch", episodeIds },
+                                commandToken),
+                            token).ConfigureAwait(false);
+                    }
+                }
+                catch (OperationCanceledException) { throw; }
+                catch (Exception ex)
+                {
+                    Log.Warning(
+                        ex,
+                        "Sonarr repair on {Host}: failed to request EpisodeSearch for episode file {EpisodeFileId}",
+                        Host,
+                        mediaFile.FileId);
+                }
 
-        try
-        {
-            if (episodeIds.Count == 0)
-            {
-                Log.Warning(
-                    "Sonarr repair on {Host}: no episodes linked to episode file {EpisodeFileId}; skipping EpisodeSearch",
-                    Host,
-                    mediaFile.FileId);
-            }
-            else if (shouldRequestSearch is not null &&
-                     !shouldRequestSearch(episodeIds.Select(id => $"episode:{id}").ToArray()))
-            {
-                Log.Warning(
-                    "Sonarr repair on {Host}: automatic replacement-search limit reached for episode file {EpisodeFileId}; " +
-                    "the file was removed and its download blocklisted without starting another search.",
-                    Host,
-                    mediaFile.FileId);
-                return ArrRepairOutcome.RemoveAndBlocklistSucceededSearchWithheld;
-            }
-            else
-            {
-                await ExecuteWithTransientRetryAsync(
-                    token => CommandAsync(new { name = "EpisodeSearch", episodeIds }, token),
-                    ct).ConfigureAwait(false);
-            }
-        }
-        catch (OperationCanceledException) { throw; }
-        catch (Exception ex)
-        {
-            Log.Warning(
-                ex,
-                "Sonarr repair on {Host}: failed to request EpisodeSearch for episode file {EpisodeFileId}",
-                Host,
-                mediaFile.FileId);
-        }
-
-        return ArrRepairOutcome.RemoveAndBlocklistSucceeded;
+                return ArrRepairOutcome.RemoveAndBlocklistSucceeded;
+            },
+            ct).ConfigureAwait(false);
     }
 
     public override Task<ArrHistory> GetMediaImportHistoryAsync(

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -178,6 +178,7 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
     { get; set; }
     internal Func<Guid, CancellationToken, Task>? ProcessCandidateOverride { get; set; }
     internal Func<bool>? HasActiveQueueItemsOverride { get; set; }
+    internal Func<ArrClient[]>? CreateRepairArrClientsOverride { get; set; }
     internal IReadOnlyCollection<Guid> InProgressHealthCheckIds => _inProgress.Keys.ToArray();
 
     public HealthCheckService
@@ -2572,6 +2573,10 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
         /// replacement search was withheld by the per-media search budget.
         /// </summary>
         RemoveAndBlocklistSucceededSearchWithheld,
+        /// <summary>Arr accepted media removal, but failed-download/blocklist completion is unconfirmed.</summary>
+        MediaRemovedBlocklistUnconfirmed,
+        /// <summary>Arr confirmed blocklisting, but replacement-search completion is unconfirmed.</summary>
+        MediaRemovedBlocklistConfirmedSearchUnconfirmed,
         /// <summary>
         /// At least one Arr instance was unreachable/unusable and no instance completed repair —
         /// leave the DavItem in place.
@@ -2832,6 +2837,22 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             {
                 return new ArrLinkedRepairResult(
                     ArrLinkedRepairDecision.RemoveAndBlocklistSucceededSearchWithheld,
+                    persistedRecovery,
+                    recoveryHost);
+            }
+
+            if (repairOutcome == ArrRepairOutcome.MediaRemovedBlocklistUnconfirmed)
+            {
+                return new ArrLinkedRepairResult(
+                    ArrLinkedRepairDecision.MediaRemovedBlocklistUnconfirmed,
+                    persistedRecovery,
+                    recoveryHost);
+            }
+
+            if (repairOutcome == ArrRepairOutcome.MediaRemovedBlocklistConfirmedSearchUnconfirmed)
+            {
+                return new ArrLinkedRepairResult(
+                    ArrLinkedRepairDecision.MediaRemovedBlocklistConfirmedSearchUnconfirmed,
                     persistedRecovery,
                     recoveryHost);
             }
@@ -3148,7 +3169,8 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             // new filename), so replacement searches are additionally budgeted by the Arr
             // media identity, which stays stable across re-grabs of the same movie/episode.
             var arrConfig = _configManager.GetArrConfig();
-            var arrClients = arrConfig.GetArrClients().ToArray();
+            var arrClients = CreateRepairArrClientsOverride?.Invoke()
+                ?? arrConfig.GetArrClients().ToArray();
             if (arrClients.Length == 0)
             {
                 var utcNow = DateTimeOffset.UtcNow;
@@ -3190,6 +3212,29 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             }
 
             var arrDecision = arrResult.Decision;
+
+            if (arrDecision is ArrLinkedRepairDecision.MediaRemovedBlocklistUnconfirmed
+                or ArrLinkedRepairDecision.MediaRemovedBlocklistConfirmedSearchUnconfirmed)
+            {
+                await RecordIncompleteArrRepairAsync(
+                    davItem,
+                    dbClient,
+                    linkedPath,
+                    arrDecision).ConfigureAwait(false);
+                if (!ct.IsCancellationRequested)
+                {
+                    try
+                    {
+                        await SeedRejectedReleaseSegmentsAsync(davItem, dbClient, ct).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // The incomplete repair state is already persisted; seeding is optional.
+                    }
+                }
+
+                return;
+            }
 
             if (arrDecision is ArrLinkedRepairDecision.RemoveAndBlocklistSucceeded
                 or ArrLinkedRepairDecision.RemoveAndBlocklistSucceededSearchWithheld)
@@ -3337,6 +3382,52 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 HealthCheckResult.HealthResult.Unhealthy,
                 HealthCheckResult.RepairAction.ActionNeeded,
                 $"Error performing file repair: {e.Message}", ct).ConfigureAwait(false);
+        }
+    }
+
+    private async Task RecordIncompleteArrRepairAsync(
+        DavItem davItem,
+        DavDatabaseClient dbClient,
+        string linkedPath,
+        ArrLinkedRepairDecision decision)
+    {
+        var message = decision switch
+        {
+            ArrLinkedRepairDecision.MediaRemovedBlocklistUnconfirmed =>
+                "Arr accepted removal of the media file, but the original download's failed/blocklist " +
+                "state could not be confirmed. InfiniDysk did not request a replacement search. " +
+                "The WebDAV item was retained. Review the item and failed-download/blocklist history " +
+                "in Radarr/Sonarr before retrying repair.",
+            ArrLinkedRepairDecision.MediaRemovedBlocklistConfirmedSearchUnconfirmed =>
+                "Arr accepted removal of the media file and confirmed the failed-download/blocklist " +
+                "request, but InfiniDysk could not confirm completion of its replacement-search step. " +
+                "The WebDAV item was retained. Review the item and existing searches in Radarr/Sonarr " +
+                "before retrying repair.",
+            _ => throw new ArgumentOutOfRangeException(nameof(decision), decision, null),
+        };
+        var now = _timeProvider.GetUtcNow();
+        davItem.LastHealthCheck = now;
+        davItem.NextHealthCheck = now + TimeSpan.FromDays(1);
+        davItem.HealthRepairPending = false;
+        RecordRepairRemoval(linkedPath, now);
+
+        try
+        {
+            await RecordHealthResult(
+                dbClient,
+                davItem,
+                HealthCheckResult.HealthResult.Unhealthy,
+                HealthCheckResult.RepairAction.ActionNeeded,
+                message,
+                CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            Log.Error(
+                exception,
+                "Incomplete Arr repair state for DavItem {DavItemId} could not be persisted; stage {RepairStage}",
+                davItem.Id,
+                decision);
         }
     }
 

--- a/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
@@ -729,6 +729,30 @@ public class RadarrSonarrClientTests
             request.StartsWith("POST /api/v3/command", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public async Task CompleteRepair_CancelledAfterBlocklist_DoesNotEnterSearchCallback()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var handler = new CancellingResponseHandler(cancellation);
+        using var httpClient = new HttpClient(handler);
+        var client = new TestArrClient(httpClient);
+        var searchCallbackCalls = 0;
+
+        var outcome = await client.CompleteRepairForTestAsync(
+            new ArrMediaFileMatch(ArrMediaKind.Movie, FileId: 203, MediaIds: [303]),
+            historyId: 403,
+            _ =>
+            {
+                searchCallbackCalls++;
+                return Task.FromResult(ArrRepairOutcome.RemoveAndBlocklistSucceededSearchWithheld);
+            },
+            cancellation.Token);
+
+        Assert.Equal(ArrRepairOutcome.MediaRemovedBlocklistConfirmedSearchUnconfirmed, outcome);
+        Assert.Equal(0, searchCallbackCalls);
+        Assert.Equal(["POST /api/v3/history/failed/403"], handler.Requests);
+    }
+
     private static HttpResponseMessage Status(HttpStatusCode code) => new(code);
 
     private static HttpResponseMessage JsonResponse(string json) =>
@@ -802,6 +826,40 @@ public class RadarrSonarrClientTests
         }
 
         protected override HttpClient Client => _client;
+
+        public Task<ArrRepairOutcome> CompleteRepairForTestAsync(
+            ArrMediaFileMatch mediaFile,
+            int historyId,
+            Func<CancellationToken, Task<ArrRepairOutcome>> finishSearch,
+            CancellationToken ct) =>
+            CompleteRepairAfterMediaRemovalAsync(mediaFile, historyId, finishSearch, ct);
+    }
+
+    private sealed class CancellingResponseHandler(CancellationTokenSource cancellation)
+        : HttpMessageHandler
+    {
+        public List<string> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests.Add($"{request.Method} {request.RequestUri!.PathAndQuery}");
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new CancellingContent(cancellation),
+            });
+        }
+    }
+
+    private sealed class CancellingContent(CancellationTokenSource cancellation)
+        : StringContent("{}", Encoding.UTF8, "application/json")
+    {
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (disposing) cancellation.Cancel();
+        }
     }
 
     private sealed class ResponseQueueHandler(

--- a/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
+++ b/tests/NzbWebDAV.Tests/Clients/RadarrSonarrClientTests.cs
@@ -650,6 +650,85 @@ public class RadarrSonarrClientTests
         Assert.Equal(TimeSpan.FromSeconds(30), ArrClient.RequestTimeout);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Repair_MediaRemovedBlocklistUnconfirmed_DoesNotSearch(bool sonarr)
+    {
+        var downloadId = Guid.Parse("13640000-0000-0000-0000-000000000001");
+        var mediaFile = new ArrMediaFileMatch(
+            sonarr ? ArrMediaKind.Episode : ArrMediaKind.Movie,
+            FileId: 201,
+            MediaIds: new[] { 301 });
+        var historyRequest =
+            $"GET /api/v3/history?downloadId={downloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending";
+        var deleteRequest = sonarr
+            ? "DELETE /api/v3/episodefile/201"
+            : "DELETE /api/v3/moviefile/201";
+        var handler = CreateHandler(
+            (historyRequest, JsonResponse("""{"records":[{"id":401}]}""")),
+            (deleteRequest, Status(HttpStatusCode.NoContent)),
+            ("POST /api/v3/history/failed/401", Status(HttpStatusCode.ServiceUnavailable)));
+        using var httpClient = new HttpClient(handler);
+        ArrClient client = sonarr
+            ? new TestSonarrClient(httpClient)
+            : new TestRadarrClient(httpClient);
+        var searchBudgetCalls = 0;
+
+        var outcome = await client.RemoveAndBlocklist(
+            mediaFile,
+            downloadId,
+            _ =>
+            {
+                searchBudgetCalls++;
+                return true;
+            });
+
+        Assert.Equal(ArrRepairOutcome.MediaRemovedBlocklistUnconfirmed, outcome);
+        Assert.Equal(new[] { historyRequest, deleteRequest, "POST /api/v3/history/failed/401" }, handler.Requests);
+        Assert.Equal(1, handler.Requests.Count(request => request.StartsWith("DELETE ", StringComparison.Ordinal)));
+        Assert.Equal(1, handler.Requests.Count(request =>
+            request.StartsWith("POST /api/v3/history/failed/", StringComparison.Ordinal)));
+        Assert.DoesNotContain(handler.Requests, request =>
+            request.StartsWith("POST /api/v3/command", StringComparison.Ordinal));
+        Assert.Equal(0, searchBudgetCalls);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Repair_BlocklistConfirmedThenCancelled_PreservesConfirmedStage(bool sonarr)
+    {
+        var downloadId = Guid.Parse("13640000-0000-0000-0000-000000000003");
+        var mediaFile = new ArrMediaFileMatch(
+            sonarr ? ArrMediaKind.Episode : ArrMediaKind.Movie,
+            FileId: 202,
+            MediaIds: [302]);
+        var historyRequest =
+            $"GET /api/v3/history?downloadId={downloadId:D}&eventType=1&page=1&pageSize=1&sortKey=date&sortDirection=descending";
+        var deleteRequest = sonarr
+            ? "DELETE /api/v3/episodefile/202"
+            : "DELETE /api/v3/moviefile/202";
+        var handler = CreateHandler(
+            (historyRequest, JsonResponse("""{"records":[{"id":402}]}""")),
+            (deleteRequest, Status(HttpStatusCode.NoContent)),
+            ("POST /api/v3/history/failed/402", JsonResponse("{}")));
+        using var httpClient = new HttpClient(handler);
+        ArrClient client = sonarr
+            ? new TestSonarrClient(httpClient)
+            : new TestRadarrClient(httpClient);
+
+        var outcome = await client.RemoveAndBlocklist(
+            mediaFile,
+            downloadId,
+            _ => throw new OperationCanceledException("cancelled after blocklist"));
+
+        Assert.Equal(ArrRepairOutcome.MediaRemovedBlocklistConfirmedSearchUnconfirmed, outcome);
+        Assert.Equal([historyRequest, deleteRequest, "POST /api/v3/history/failed/402"], handler.Requests);
+        Assert.DoesNotContain(handler.Requests, request =>
+            request.StartsWith("POST /api/v3/command", StringComparison.Ordinal));
+    }
+
     private static HttpResponseMessage Status(HttpStatusCode code) => new(code);
 
     private static HttpResponseMessage JsonResponse(string json) =>

--- a/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/ArrLinkedRepairDecisionTests.cs
@@ -134,6 +134,47 @@ public class ArrLinkedRepairDecisionTests
             result.Decision);
     }
 
+    [Theory]
+    [InlineData(ArrRepairOutcome.MediaRemovedBlocklistUnconfirmed)]
+    [InlineData(ArrRepairOutcome.MediaRemovedBlocklistConfirmedSearchUnconfirmed)]
+    public async Task PartialRepair_ReturnsImmediatelyWithoutConsultingAnotherInstance(
+        ArrRepairOutcome outcome)
+    {
+        var firstClient = new ScriptedArrClient(
+            host: "http://unreachable",
+            rootFolders: () => throw new HttpRequestException("connection refused"),
+            removeAndBlocklist: (_, _) => throw new InvalidOperationException("should not mutate"));
+        var partialClient = new ScriptedArrClient(
+            host: "http://partial",
+            rootFolders: () => Task.FromResult(new List<ArrRootFolder>
+            {
+                new() { Path = "/media/movies" },
+            }),
+            removeAndBlocklist: (_, _) => Task.FromResult(outcome));
+        var laterCalls = 0;
+        var laterClient = new ScriptedArrClient(
+            host: "http://later",
+            rootFolders: () =>
+            {
+                laterCalls++;
+                return Task.FromResult(new List<ArrRootFolder>());
+            },
+            removeAndBlocklist: (_, _) => throw new InvalidOperationException("should not mutate"));
+
+        var result = await HealthCheckService.DecideArrLinkedRepairAsync(
+            [firstClient, partialClient, laterClient],
+            LibraryPath,
+            DownloadId,
+            CancellationToken.None);
+
+        var expected = outcome == ArrRepairOutcome.MediaRemovedBlocklistUnconfirmed
+            ? HealthCheckService.ArrLinkedRepairDecision.MediaRemovedBlocklistUnconfirmed
+            : HealthCheckService.ArrLinkedRepairDecision.MediaRemovedBlocklistConfirmedSearchUnconfirmed;
+        Assert.Equal(expected, result.Decision);
+        Assert.Equal(0, laterCalls);
+        Assert.Empty(laterClient.BlocklistDownloadIds);
+    }
+
     [Fact]
     public async Task MissingDownloadIdentity_DefersWithoutCallingArrRepair()
     {

--- a/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/HealthCheckDegradedClassificationTests.cs
@@ -3,6 +3,8 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
+using NzbWebDAV.Clients.RadarrSonarr;
+using NzbWebDAV.Clients.RadarrSonarr.BaseModels;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
@@ -407,6 +409,52 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
         Assert.Contains("No enabled Radarr/Sonarr instances are configured", row.Message);
         Assert.Equal(1, _context.Items.AsNoTracking().Count(x => x.Id == item.Id));
         Assert.True(File.Exists(libraryPath));
+    }
+
+    [Fact]
+    public async Task PartialArrRepair_DuringCancellation_PersistsActionNeededAndRetainsLocalItem()
+    {
+        var segments = NewSegmentIds(3);
+        var sizes = Enumerable.Repeat(10_000L, segments.Length).ToArray();
+        var (item, _) = await AddVideoFileAsync("partial-arr-repair.mkv", segments, sizes);
+        item.ArrDownloadId = Guid.Parse("13640000-0000-0000-0000-000000000002");
+        item.NextHealthCheck = DateTimeOffset.UnixEpoch;
+        item.HealthRepairPending = true;
+        await _context.SaveChangesAsync();
+
+        var libraryPath = Path.Join(_configRoot, "library", "partial-arr-repair.strm");
+        await File.WriteAllTextAsync(
+            libraryPath,
+            $"http://localhost:3000/view/.ids/{item.Id}.mkv");
+        var fake = NewFakeClient(segments, missing: [0]);
+        var (service, _) = await NewServiceAsync(fake, par2Outcome: false);
+        using var cancellation = new CancellationTokenSource();
+        var arrClient = new PartialRepairArrClient(cancellation, libraryPath);
+        service.CreateRepairArrClientsOverride = () => [arrClient];
+        service.CreateDbContextOverride = () => new DavDatabaseContext(_options);
+
+        await service.PerformHealthCheck(item, _dbClient, concurrency: 4, cancellation.Token);
+
+        _context.ChangeTracker.Clear();
+        var persisted = ReloadItem(item.Id);
+        Assert.False(persisted.HealthRepairPending);
+        Assert.True(persisted.NextHealthCheck > DateTimeOffset.UtcNow.AddHours(23));
+        Assert.False(File.Exists(libraryPath));
+        Assert.True(BlobStore.Exists(persisted.FileBlobId!.Value));
+        var row = Assert.Single(GetHealthRows(item.Id));
+        Assert.Equal(HealthCheckResult.HealthResult.Unhealthy, row.Result);
+        Assert.Equal(HealthCheckResult.RepairAction.ActionNeeded, row.RepairStatus);
+        Assert.Contains("accepted removal of the media file", row.Message, StringComparison.Ordinal);
+        Assert.Contains("WebDAV item was retained", row.Message, StringComparison.Ordinal);
+        Assert.Equal(1, arrClient.RemoveCalls);
+
+        var selected = await service.SelectNextHealthCheckIdsAsync(
+            [],
+            allowChecks: true,
+            allowRepairs: true,
+            maximumCount: 10,
+            CancellationToken.None);
+        Assert.DoesNotContain(item.Id, selected);
     }
 
     [Fact]
@@ -1290,6 +1338,35 @@ public sealed class HealthCheckDegradedClassificationTests : IAsyncLifetime
         public bool Exists(Guid id) => false;
 
         public bool Delete(Guid id) => throw new NotSupportedException();
+    }
+
+    private sealed class PartialRepairArrClient(
+        CancellationTokenSource cancellation,
+        string externallyRemovedPath)
+        : ArrClient("http://radarr.test", "test-key")
+    {
+        public int RemoveCalls { get; private set; }
+
+        public override Task<List<ArrRootFolder>> GetRootFolders(CancellationToken ct = default) =>
+            Task.FromResult(new List<ArrRootFolder> { new() { Path = "/" } });
+
+        public override Task<ArrMediaFileMatch?> FindMediaFileAsync(
+            string symlinkOrStrmPath,
+            CancellationToken ct = default) =>
+            Task.FromResult<ArrMediaFileMatch?>(
+                new ArrMediaFileMatch(ArrMediaKind.Movie, FileId: 201, MediaIds: [301]));
+
+        public override Task<ArrRepairOutcome> RemoveAndBlocklist(
+            ArrMediaFileMatch mediaFile,
+            Guid downloadId,
+            Func<IReadOnlyList<string>, bool>? shouldRequestSearch = null,
+            CancellationToken ct = default)
+        {
+            RemoveCalls++;
+            File.Delete(externallyRemovedPath);
+            cancellation.Cancel();
+            return Task.FromResult(ArrRepairOutcome.MediaRemovedBlocklistUnconfirmed);
+        }
     }
 
     private async Task<(HealthCheckService Service, ScriptedPar2RepairService Par2)> NewServiceAsync(


### PR DESCRIPTION
## Summary

- preserve the confirmed Arr repair stage after media-file deletion when failed-download/blocklist or replacement-search completion cannot be confirmed
- stop cross-instance fallthrough and avoid issuing an explicit replacement search after an unconfirmed failed-history request
- retain the local WebDAV item and persist an actionable `Unhealthy` / `ActionNeeded` result, including when the worker token is cancelled
- clear pending-repair admission and record the removal for replacement-loop protection

Closes #1364.

## Test plan

- reproduced the original 204 DELETE followed by 503 failed-history failure for both Radarr and Sonarr before the client fix
- `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --filter "FullyQualifiedName~RadarrSonarrClientTests|FullyQualifiedName~ArrLinkedRepairDecisionTests|FullyQualifiedName~HealthCheckDegradedClassificationTests" --no-restore`
  - 115 passed, 0 failed
- `git diff --check`

## Notes

No schema, setting, setup-wizard, or frontend changes are required. This preserves stage information for ordinary failures and cancellation; an abrupt process termination between the remote deletion and local persistence remains outside the scope of this fix because there is no durable cross-system operation journal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media repair handling when blocklist confirmation or replacement searches are interrupted or fail.
  * Partial repairs now retain accurate status instead of being reported as fully successful.
  * Health checks flag incomplete repairs for action, retain local items when appropriate, and schedule follow-up checks.
  * Cancellation and service failures now produce clearer outcomes and logging.
* **Tests**
  * Added coverage for interrupted repairs, failed blocklist confirmation, and Radarr/Sonarr repair behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->