### PR TITLE
fix(queue): import independent RAR and 7z archive sets separately

### DIFF
--- a/backend/Queue/ArchiveSetGrouping.cs
+++ b/backend/Queue/ArchiveSetGrouping.cs
@@ -1,0 +1,77 @@
+using NzbWebDAV.Queue.DeobfuscationSteps._3.GetFileInfos;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Queue;
+
+internal sealed record ArchiveSetDescriptor(
+    string ArchiveSetId,
+    List<GetFileInfosStep.FileInfo> FileInfos,
+    bool IsSevenZip);
+
+internal static class ArchiveSetGrouping
+{
+    internal static List<ArchiveSetDescriptor> Resolve(
+        IReadOnlyList<GetFileInfosStep.FileInfo> fileInfos,
+        ArchiveSetIdAllocator allocator)
+    {
+        var descriptors = new List<ArchiveSetDescriptor>();
+        var rarGroups = new Dictionary<(string BaseName, FilenameUtil.RarVolumeScheme Scheme), List<ArchiveSetDescriptor>>();
+        var sevenZipGroups = new Dictionary<(string BaseName, int? Ordinal), ArchiveSetDescriptor>();
+
+        foreach (var fileInfo in fileInfos)
+        {
+            if (fileInfo.IsRar || FilenameUtil.IsRarFile(fileInfo.FileName))
+            {
+                var volume = FilenameUtil.GetRarVolumeName(fileInfo.FileName);
+                if (volume is null)
+                {
+                    descriptors.Add(new ArchiveSetDescriptor(allocator.Allocate(), [fileInfo], false));
+                    continue;
+                }
+
+                var key = (volume.Value.BaseName.ToLowerInvariant(), volume.Value.Scheme);
+                if (!rarGroups.TryGetValue(key, out var candidates))
+                {
+                    candidates = [];
+                    rarGroups.Add(key, candidates);
+                }
+
+                var descriptor = volume.Value.Scheme == FilenameUtil.RarVolumeScheme.Classic &&
+                                 volume.Value.Ordinal == 0
+                    ? null
+                    : candidates.LastOrDefault();
+                if (descriptor is null)
+                {
+                    descriptor = new ArchiveSetDescriptor(allocator.Allocate(), [], false);
+                    candidates.Add(descriptor);
+                    descriptors.Add(descriptor);
+                }
+
+                descriptor.FileInfos.Add(fileInfo);
+                continue;
+            }
+
+            if (!FilenameUtil.Is7zFile(fileInfo.FileName))
+                continue;
+
+            var sevenZip = FilenameUtil.GetSevenZipVolumeName(fileInfo.FileName);
+            if (sevenZip is null)
+            {
+                descriptors.Add(new ArchiveSetDescriptor(allocator.Allocate(), [fileInfo], true));
+                continue;
+            }
+
+              var sevenZipKey = (sevenZip.Value.BaseName.ToLowerInvariant(), sevenZip.Value.IsMultipart ? 1 : descriptors.Count);
+            if (!sevenZipGroups.TryGetValue(sevenZipKey, out var sevenZipDescriptor))
+            {
+                sevenZipDescriptor = new ArchiveSetDescriptor(allocator.Allocate(), [], true);
+                sevenZipGroups.Add(sevenZipKey, sevenZipDescriptor);
+                descriptors.Add(sevenZipDescriptor);
+            }
+
+            sevenZipDescriptor.FileInfos.Add(fileInfo);
+        }
+
+        return descriptors;
+    }
+}

--- a/backend/Queue/ArchiveSetGrouping.cs
+++ b/backend/Queue/ArchiveSetGrouping.cs
@@ -16,7 +16,7 @@ internal static class ArchiveSetGrouping
     {
         var descriptors = new List<ArchiveSetDescriptor>();
         var rarGroups = new Dictionary<(string BaseName, FilenameUtil.RarVolumeScheme Scheme), List<ArchiveSetDescriptor>>();
-        var sevenZipGroups = new Dictionary<(string BaseName, int? Ordinal), ArchiveSetDescriptor>();
+        var sevenZipGroups = new Dictionary<string, List<ArchiveSetDescriptor>>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var fileInfo in fileInfos)
         {
@@ -68,11 +68,19 @@ internal static class ArchiveSetGrouping
                                         continue;
                                 }
 
-                                var sevenZipKey = (sevenZip.Value.BaseName.ToLowerInvariant(), (int?)1);
-            if (!sevenZipGroups.TryGetValue(sevenZipKey, out var sevenZipDescriptor))
+                                var sevenZipKey = sevenZip.Value.BaseName;
+                                if (!sevenZipGroups.TryGetValue(sevenZipKey, out var sevenZipCandidates))
+                                {
+                                    sevenZipCandidates = [];
+                                    sevenZipGroups.Add(sevenZipKey, sevenZipCandidates);
+                                }
+
+                                var sevenZipDescriptor = sevenZipCandidates.FirstOrDefault(candidate => candidate.FileInfos.All(existing =>
+                                    FilenameUtil.GetSevenZipVolumeName(existing.FileName)?.Ordinal != sevenZip.Value.Ordinal));
+                                if (sevenZipDescriptor is null)
             {
                 sevenZipDescriptor = new ArchiveSetDescriptor(allocator.Allocate(), [], true);
-                sevenZipGroups.Add(sevenZipKey, sevenZipDescriptor);
+                                    sevenZipCandidates.Add(sevenZipDescriptor);
                 descriptors.Add(sevenZipDescriptor);
             }
 

--- a/backend/Queue/ArchiveSetGrouping.cs
+++ b/backend/Queue/ArchiveSetGrouping.cs
@@ -29,18 +29,20 @@ internal static class ArchiveSetGrouping
                     continue;
                 }
 
-                var key = (volume.Value.BaseName.ToLowerInvariant(), volume.Value.Scheme);
+                var volumeValue = volume.Value;
+                var volumeOrdinal = volumeValue.Ordinal;
+                var key = (volumeValue.BaseName.ToLowerInvariant(), volumeValue.Scheme);
                 if (!rarGroups.TryGetValue(key, out var candidates))
                 {
                     candidates = [];
                     rarGroups.Add(key, candidates);
                 }
 
-                var descriptor = volume.Value.Scheme == FilenameUtil.RarVolumeScheme.Part &&
-                                 volume.Value.Ordinal == 0
+                var descriptor = volumeValue.Scheme == FilenameUtil.RarVolumeScheme.Part &&
+                                 volumeOrdinal == 0
                     ? null
                     : candidates.FirstOrDefault(candidate => candidate.FileInfos.All(existing =>
-                        FilenameUtil.GetRarVolumeName(existing.FileName)?.Ordinal != volume.Value.Ordinal));
+                        FilenameUtil.GetRarVolumeName(existing.FileName)?.Ordinal != volumeOrdinal));
                 if (descriptor is null)
                 {
                     descriptor = new ArchiveSetDescriptor(allocator.Allocate(), [], false);
@@ -62,25 +64,26 @@ internal static class ArchiveSetGrouping
                 continue;
             }
 
-                                if (!sevenZip.Value.IsMultipart)
-                                {
-                                        descriptors.Add(new ArchiveSetDescriptor(allocator.Allocate(), [fileInfo], true));
-                                        continue;
-                                }
+            var sevenZipValue = sevenZip.Value;
+            if (!sevenZipValue.IsMultipart)
+            {
+                descriptors.Add(new ArchiveSetDescriptor(allocator.Allocate(), [fileInfo], true));
+                continue;
+            }
 
-                                var sevenZipKey = sevenZip.Value.BaseName;
-                                if (!sevenZipGroups.TryGetValue(sevenZipKey, out var sevenZipCandidates))
-                                {
-                                    sevenZipCandidates = [];
-                                    sevenZipGroups.Add(sevenZipKey, sevenZipCandidates);
-                                }
+            var sevenZipKey = sevenZipValue.BaseName;
+            if (!sevenZipGroups.TryGetValue(sevenZipKey, out var sevenZipCandidates))
+            {
+                sevenZipCandidates = [];
+                sevenZipGroups.Add(sevenZipKey, sevenZipCandidates);
+            }
 
-                                var sevenZipDescriptor = sevenZipCandidates.FirstOrDefault(candidate => candidate.FileInfos.All(existing =>
-                                    FilenameUtil.GetSevenZipVolumeName(existing.FileName)?.Ordinal != sevenZip.Value.Ordinal));
-                                if (sevenZipDescriptor is null)
+            var sevenZipDescriptor = sevenZipCandidates.FirstOrDefault(candidate => candidate.FileInfos.All(existing =>
+                FilenameUtil.GetSevenZipVolumeName(existing.FileName)?.Ordinal != sevenZipValue.Ordinal));
+            if (sevenZipDescriptor is null)
             {
                 sevenZipDescriptor = new ArchiveSetDescriptor(allocator.Allocate(), [], true);
-                                    sevenZipCandidates.Add(sevenZipDescriptor);
+                sevenZipCandidates.Add(sevenZipDescriptor);
                 descriptors.Add(sevenZipDescriptor);
             }
 

--- a/backend/Queue/ArchiveSetGrouping.cs
+++ b/backend/Queue/ArchiveSetGrouping.cs
@@ -41,7 +41,7 @@ internal static class ArchiveSetGrouping
                 var descriptor = volumeValue.Scheme == FilenameUtil.RarVolumeScheme.Part &&
                                  volumeOrdinal == 0
                     ? null
-                    : candidates.FirstOrDefault(candidate => candidate.FileInfos.All(existing =>
+                    : GetUniqueCandidate(candidates, candidate => candidate.FileInfos.All(existing =>
                         FilenameUtil.GetRarVolumeName(existing.FileName)?.Ordinal != volumeOrdinal));
                 if (descriptor is null)
                 {
@@ -78,7 +78,7 @@ internal static class ArchiveSetGrouping
                 sevenZipGroups.Add(sevenZipKey, sevenZipCandidates);
             }
 
-            var sevenZipDescriptor = sevenZipCandidates.FirstOrDefault(candidate => candidate.FileInfos.All(existing =>
+            var sevenZipDescriptor = GetUniqueCandidate(sevenZipCandidates, candidate => candidate.FileInfos.All(existing =>
                 FilenameUtil.GetSevenZipVolumeName(existing.FileName)?.Ordinal != sevenZipValue.Ordinal));
             if (sevenZipDescriptor is null)
             {
@@ -91,5 +91,13 @@ internal static class ArchiveSetGrouping
         }
 
         return descriptors;
+    }
+
+    private static ArchiveSetDescriptor? GetUniqueCandidate(
+        IEnumerable<ArchiveSetDescriptor> candidates,
+        Func<ArchiveSetDescriptor, bool> predicate)
+    {
+        var eligible = candidates.Where(predicate).Take(2).ToList();
+        return eligible.Count == 1 ? eligible[0] : null;
     }
 }

--- a/backend/Queue/ArchiveSetGrouping.cs
+++ b/backend/Queue/ArchiveSetGrouping.cs
@@ -36,10 +36,11 @@ internal static class ArchiveSetGrouping
                     rarGroups.Add(key, candidates);
                 }
 
-                var descriptor = volume.Value.Scheme == FilenameUtil.RarVolumeScheme.Classic &&
+                var descriptor = volume.Value.Scheme == FilenameUtil.RarVolumeScheme.Part &&
                                  volume.Value.Ordinal == 0
                     ? null
-                    : candidates.LastOrDefault();
+                    : candidates.FirstOrDefault(candidate => candidate.FileInfos.All(existing =>
+                        FilenameUtil.GetRarVolumeName(existing.FileName)?.Ordinal != volume.Value.Ordinal));
                 if (descriptor is null)
                 {
                     descriptor = new ArchiveSetDescriptor(allocator.Allocate(), [], false);
@@ -61,7 +62,13 @@ internal static class ArchiveSetGrouping
                 continue;
             }
 
-              var sevenZipKey = (sevenZip.Value.BaseName.ToLowerInvariant(), sevenZip.Value.IsMultipart ? 1 : descriptors.Count);
+                                if (!sevenZip.Value.IsMultipart)
+                                {
+                                        descriptors.Add(new ArchiveSetDescriptor(allocator.Allocate(), [fileInfo], true));
+                                        continue;
+                                }
+
+                                var sevenZipKey = (sevenZip.Value.BaseName.ToLowerInvariant(), (int?)1);
             if (!sevenZipGroups.TryGetValue(sevenZipKey, out var sevenZipDescriptor))
             {
                 sevenZipDescriptor = new ArchiveSetDescriptor(allocator.Allocate(), [], true);

--- a/backend/Queue/ArchiveSetIdAllocator.cs
+++ b/backend/Queue/ArchiveSetIdAllocator.cs
@@ -1,0 +1,14 @@
+using System.Globalization;
+
+namespace NzbWebDAV.Queue;
+
+internal sealed class ArchiveSetIdAllocator
+{
+    private int _next;
+
+    internal string Allocate()
+    {
+        _next = checked(_next + 1);
+        return "set:" + _next.ToString("D10", CultureInfo.InvariantCulture);
+    }
+}

--- a/backend/Queue/ArchiveSetIdAllocator.cs
+++ b/backend/Queue/ArchiveSetIdAllocator.cs
@@ -4,11 +4,17 @@ namespace NzbWebDAV.Queue;
 
 internal sealed class ArchiveSetIdAllocator
 {
+    private readonly string _prefix;
     private int _next;
+
+    internal ArchiveSetIdAllocator(string prefix = "set")
+    {
+        _prefix = prefix;
+    }
 
     internal string Allocate()
     {
         _next = checked(_next + 1);
-        return "set:" + _next.ToString("D10", CultureInfo.InvariantCulture);
+        return _prefix + ":" + _next.ToString("D10", CultureInfo.InvariantCulture);
     }
 }

--- a/backend/Queue/FileAggregators/PlannedImportOutputs.cs
+++ b/backend/Queue/FileAggregators/PlannedImportOutputs.cs
@@ -33,7 +33,7 @@ internal static class PlannedImportOutputs
         var rarGroups = processorResults
             .OfType<RarProcessor.Result>()
             .SelectMany(x => x.StoredFileSegments)
-            .GroupBy(x => x.PathWithinArchive)
+                        .GroupBy(x => (x.ArchiveSetId, x.PathWithinArchive))
             .ToList();
         foreach (var group in rarGroups)
         {
@@ -43,10 +43,10 @@ internal static class PlannedImportOutputs
                 .FirstOrDefault(x => x is not null);
             yield return (
                 ImportableVideoNamer.Normalize(
-                    PathSanitizer.SanitizeComponent(Path.GetFileName(group.Key)),
+                                        PathSanitizer.SanitizeComponent(Path.GetFileName(group.Key.PathWithinArchive)),
                     sniffedVideoExtension,
                     mountName,
-                    allowBaseRename: rarGroups.Count == 1),
+                      allowBaseRename: rarGroups.Count == 1),
                 RarAggregator.ResolvePublishedFileSize(parts));
         }
 
@@ -63,18 +63,21 @@ internal static class PlannedImportOutputs
 
         foreach (var result in processorResults.OfType<SevenZipProcessor.Result>())
         {
-            var sevenZipFiles = result.SevenZipFiles;
-            foreach (var sevenZipFile in sevenZipFiles)
+            foreach (var sevenZipGroup in result.SevenZipFiles.GroupBy(x => x.ArchiveSetId, StringComparer.Ordinal))
             {
-                var meta = sevenZipFile.DavMultipartFileMeta;
-                yield return (
-                    ImportableVideoNamer.Normalize(
-                        PathSanitizer.SanitizeComponent(Path.GetFileName(sevenZipFile.PathWithinArchive)),
-                        sevenZipFile.SniffedVideoExtension,
-                        mountName,
-                        allowBaseRename: sevenZipFiles.Count == 1),
-                    meta.AesParams?.DecodedSize
-                        ?? meta.FileParts.Sum(x => x.FilePartByteRange.Count));
+                var sevenZipFiles = sevenZipGroup.ToList();
+                foreach (var sevenZipFile in sevenZipFiles)
+                {
+                    var meta = sevenZipFile.DavMultipartFileMeta;
+                    yield return (
+                        ImportableVideoNamer.Normalize(
+                            PathSanitizer.SanitizeComponent(Path.GetFileName(sevenZipFile.PathWithinArchive)),
+                            sevenZipFile.SniffedVideoExtension,
+                            mountName,
+                            allowBaseRename: sevenZipFiles.Count == 1),
+                        meta.AesParams?.DecodedSize
+                            ?? meta.FileParts.Sum(x => x.FilePartByteRange.Count));
+                }
             }
         }
 

--- a/backend/Queue/FileAggregators/RarAggregator.cs
+++ b/backend/Queue/FileAggregators/RarAggregator.cs
@@ -74,35 +74,47 @@ public class RarAggregator(DavDatabaseClient dbClient, DavItem mountDirectory, b
         dbClient.Ctx.AddBlob(davMultipartFile);
     }
 
+    internal readonly record struct RarMemberKey(string ArchiveSetId, string PathWithinArchive);
+
+    internal static List<IGrouping<RarMemberKey, RarProcessor.StoredFileSegment>> GroupArchiveMembers(
+        IEnumerable<RarProcessor.StoredFileSegment> segments)
+    {
+        return segments
+            .Select(segment => segment.ArchiveSetId is not null
+                ? segment
+                : throw new InvalidDataException("RAR archive-set membership was not resolved."))
+            .GroupBy(
+                segment => new RarMemberKey(segment.ArchiveSetId!, segment.PathWithinArchive))
+            .ToList();
+    }
+
+    internal static RarProcessor.StoredFileSegment[] PrepareMember(
+        List<RarProcessor.StoredFileSegment> members)
+    {
+        var sorted = SortByPartNumber(members);
+        ValidateVolumes(sorted.ToList());
+        return sorted;
+    }
+
     private void ProcessArchive(List<RarProcessor.StoredFileSegment> fileSegments)
     {
-        var archiveFiles = new Dictionary<string, List<RarProcessor.StoredFileSegment>>();
-        foreach (var fileSegment in fileSegments)
-        {
-            if (!archiveFiles.ContainsKey(fileSegment.PathWithinArchive))
-                archiveFiles.Add(fileSegment.PathWithinArchive, []);
-
-            archiveFiles[fileSegment.PathWithinArchive].Add(fileSegment);
-        }
+        var archiveFiles = GroupArchiveMembers(fileSegments);
 
         foreach (var archiveFile in archiveFiles)
         {
-            // Ensure we have all volumes necessary for this file.
-            ValidateVolumes(archiveFile.Value);
-
             // Initialize dav-item fields
-            var pathWithinArchive = archiveFile.Key;
-            var fileParts = SortByPartNumber(archiveFile.Value);
+            var pathWithinArchive = archiveFile.Key.PathWithinArchive;
+            var fileParts = PrepareMember(archiveFile.ToList());
             var (fileSize, aesParams) = ResolvePublishedSizeAndAes(fileParts);
             var parentDirectory = EnsureParentDirectory(pathWithinArchive);
-            var sniffedVideoExtension = archiveFile.Value
+                        var sniffedVideoExtension = archiveFile
                 .Select(x => x.SniffedVideoExtension)
                 .FirstOrDefault(x => x is not null);
             var name = ImportableVideoNamer.Normalize(
                 SanitizeDavName(Path.GetFileName(pathWithinArchive)),
                 sniffedVideoExtension,
                 mountDirectory.Name,
-                allowBaseRename: archiveFiles.Count == 1);
+                                allowBaseRename: archiveFiles.Count == 1);
 
             var davMultipartFile = new DavMultipartFile()
             {

--- a/backend/Queue/FileAggregators/SevenZipAggregator.cs
+++ b/backend/Queue/FileAggregators/SevenZipAggregator.cs
@@ -21,7 +21,8 @@ public class SevenZipAggregator(
             .SelectMany(x => x.SevenZipFiles)
             .ToList();
 
-        ProcessSevenZipFile(sevenZipFiles);
+        foreach (var archiveSet in sevenZipFiles.GroupBy(x => x.ArchiveSetId, StringComparer.Ordinal))
+            ProcessSevenZipFile(archiveSet.ToList());
     }
 
     private void ProcessSevenZipFile(List<SevenZipProcessor.SevenZipFile> sevenZipFiles)

--- a/backend/Queue/FileProcessors/LazyRarProcessor.cs
+++ b/backend/Queue/FileProcessors/LazyRarProcessor.cs
@@ -20,9 +20,18 @@ public class LazyRarProcessor(
     List<GetFileInfosStep.FileInfo> fileInfos,
     INntpClient usenetClient,
     string? password,
+    string archiveSetId,
     CancellationToken ct
 ) : BaseProcessor
 {
+    public LazyRarProcessor(
+        List<GetFileInfosStep.FileInfo> fileInfos,
+        INntpClient usenetClient,
+        string? password,
+        CancellationToken ct)
+        : this(fileInfos, usenetClient, password, "set:legacy", ct)
+    {
+    }
     // Conservative upper bound for the RAR continuation header at the start
     // of trailing volumes. Real values are typically 30-70 bytes. Wrong
     // estimates only affect seek targeting before resolution; the lazy
@@ -266,6 +275,7 @@ public class LazyRarProcessor(
 
         return new Result
         {
+            ArchiveSetId = archiveSetId,
             PathInArchive = pathInArchive,
             TotalFileSize = totalFileSize,
             Password = password,
@@ -500,6 +510,7 @@ public class LazyRarProcessor(
 
     public new class Result : BaseProcessor.Result
     {
+        public required string ArchiveSetId { get; init; }
         public required string PathInArchive { get; init; }
         public required long TotalFileSize { get; init; }
         public required string? Password { get; init; }

--- a/backend/Queue/FileProcessors/RarProcessor.cs
+++ b/backend/Queue/FileProcessors/RarProcessor.cs
@@ -14,9 +14,18 @@ public class RarProcessor(
     GetFileInfosStep.FileInfo fileInfo,
     INntpClient usenetClient,
     string? password,
+    string? archiveSetId,
     CancellationToken ct
 ) : BaseProcessor
 {
+    public RarProcessor(
+        GetFileInfosStep.FileInfo fileInfo,
+        INntpClient usenetClient,
+        string? password,
+        CancellationToken ct)
+        : this(fileInfo, usenetClient, password, null, ct)
+    {
+    }
     public override async Task<BaseProcessor.Result?> ProcessAsync()
     {
         await using var stream = await GetNzbFileStream().ConfigureAwait(false);
@@ -37,6 +46,7 @@ public class RarProcessor(
                 .Select(x => new StoredFileSegment()
                 {
                     NzbFile = fileInfo.NzbFile,
+                    ArchiveSetId = archiveSetId,
                     PartSize = ResolvePartSize(
                         stream.Length,
                         x.DataStartPosition,
@@ -132,6 +142,7 @@ public class RarProcessor(
     public class StoredFileSegment
     {
         public required NzbFile NzbFile { get; init; }
+        public string? ArchiveSetId { get; init; }
         public required long PartSize { get; init; }
         public required string ArchiveName { get; init; }
         public required PartNumber PartNumber { get; init; }

--- a/backend/Queue/FileProcessors/SevenZipProcessor.cs
+++ b/backend/Queue/FileProcessors/SevenZipProcessor.cs
@@ -188,7 +188,7 @@ public class SevenZipProcessor : BaseProcessor
         }
 
         if (volumes.Any(x => !x.Volume!.Value.IsMultipart ||
-                             !string.Equals(x.Volume.Value.BaseName, first.BaseName, StringComparison.OrdinalIgnoreCase)))
+                             !string.Equals(x.Volume!.Value.BaseName, first.BaseName, StringComparison.OrdinalIgnoreCase)))
             throw new NonRetryableDownloadException("7z archive volumes do not belong to one multipart set.");
 
         var ordered = volumes

--- a/backend/Queue/FileProcessors/SevenZipProcessor.cs
+++ b/backend/Queue/FileProcessors/SevenZipProcessor.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.RegularExpressions;
-using NzbWebDAV.Clients.Usenet;
+﻿using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Exceptions;
@@ -26,6 +25,7 @@ public class SevenZipProcessor : BaseProcessor
         INntpClient usenetClient,
         ConfigManager configManager,
         string? archivePassword,
+        string archiveSetId,
         CancellationToken ct
     )
     {
@@ -33,8 +33,11 @@ public class SevenZipProcessor : BaseProcessor
         _usenetClient = usenetClient;
         _configManager = configManager;
         _archivePassword = archivePassword;
+        ArchiveSetId = archiveSetId;
         _ct = ct;
     }
+
+    private string ArchiveSetId { get; }
 
     public override async Task<BaseProcessor.Result?> ProcessAsync(IProgress<int> progress)
     {
@@ -65,6 +68,7 @@ public class SevenZipProcessor : BaseProcessor
             {
                 SevenZipFiles = sevenZipEntries.Select(x => new SevenZipFile()
                 {
+                    ArchiveSetId = ArchiveSetId,
                     PathWithinArchive = x.PathWithinArchive,
                     DavMultipartFileMeta = GetDavMultipartFileMeta(x, multipartFile),
                     ReleaseDate = _fileInfos.First().ReleaseDate,
@@ -83,8 +87,9 @@ public class SevenZipProcessor : BaseProcessor
 
     private async Task<MultipartFile> GetMultipartFile(IProgress<int> progress)
     {
-        var fileInfos = await PopulateMissingFileSizes(_fileInfos, progress).ConfigureAwait(false);
-        var sortedFileInfos = fileInfos.OrderBy(f => GetPartNumber(f.FileName)).ToList();
+        var sortedFileInfos = OrderVolumes(_fileInfos);
+        var populatedFileInfos = await PopulateMissingFileSizes(sortedFileInfos, progress).ConfigureAwait(false);
+        sortedFileInfos = OrderVolumes(populatedFileInfos);
         var fileParts = new List<MultipartFile.FilePart>();
         long startInclusive = 0;
         foreach (var fileInfo in sortedFileInfos)
@@ -97,7 +102,17 @@ public class SevenZipProcessor : BaseProcessor
             // persists this part's segment byte ranges.
             await nzbFile.ProbeSecondSegmentRangeAsync(_usenetClient, fileSize, _ct)
                 .ConfigureAwait(false);
-            var endExclusive = startInclusive + fileSize;
+            long endExclusive;
+            try
+            {
+                endExclusive = checked(startInclusive + fileSize);
+            }
+            catch (OverflowException exception)
+            {
+                throw new NonRetryableDownloadException(
+                    "7z archive volume sizes exceed the supported range.",
+                    exception);
+            }
             fileParts.Add(new MultipartFile.FilePart()
             {
                 NzbFile = fileInfo.NzbFile,
@@ -152,10 +167,40 @@ public class SevenZipProcessor : BaseProcessor
         };
     }
 
-    private static int GetPartNumber(string filename)
+    internal static List<GetFileInfosStep.FileInfo> OrderVolumes(
+        IReadOnlyList<GetFileInfosStep.FileInfo> fileInfos)
     {
-        var match = Regex.Match(filename, @"\.7z(\.(\d+))?$", RegexOptions.IgnoreCase);
-        return string.IsNullOrEmpty(match.Groups[2].Value) ? -1 : int.Parse(match.Groups[2].Value);
+        if (fileInfos.Count == 0)
+            throw new NonRetryableDownloadException("7z archive set has no volumes.");
+
+        var volumes = fileInfos
+            .Select(fileInfo => (Info: fileInfo, Volume: FilenameUtil.GetSevenZipVolumeName(fileInfo.FileName)))
+            .ToList();
+        if (volumes.Any(x => x.Volume is null))
+            throw new NonRetryableDownloadException("7z archive set contains an invalid volume name.");
+
+        var first = volumes[0].Volume!.Value;
+        if (!first.IsMultipart)
+        {
+            if (volumes.Count != 1)
+                throw new NonRetryableDownloadException("Standalone 7z archives cannot be concatenated.");
+            return [volumes[0].Info];
+        }
+
+        if (volumes.Any(x => !x.Volume!.Value.IsMultipart ||
+                             !string.Equals(x.Volume.Value.BaseName, first.BaseName, StringComparison.OrdinalIgnoreCase)))
+            throw new NonRetryableDownloadException("7z archive volumes do not belong to one multipart set.");
+
+        var ordered = volumes
+            .OrderBy(x => x.Volume!.Value.Ordinal)
+            .ToList();
+        for (var index = 0; index < ordered.Count; index++)
+        {
+            if (ordered[index].Volume!.Value.Ordinal != index + 1)
+                throw new NonRetryableDownloadException("7z archive volumes have a gap or are missing the first volume.");
+        }
+
+        return ordered.Select(x => x.Info).ToList();
     }
 
     private DavMultipartFile.Meta GetDavMultipartFileMeta
@@ -220,6 +265,7 @@ public class SevenZipProcessor : BaseProcessor
 
     public class SevenZipFile
     {
+        public required string ArchiveSetId { get; init; }
         public required string PathWithinArchive { get; init; }
         public required DavMultipartFile.Meta DavMultipartFileMeta { get; init; }
         public required DateTimeOffset ReleaseDate { get; init; }

--- a/backend/Queue/NestedRarExpansion/NestedRarExpansionStep.cs
+++ b/backend/Queue/NestedRarExpansion/NestedRarExpansionStep.cs
@@ -81,11 +81,12 @@ public static class NestedRarExpansionStep
         int maxDepth = DefaultMaxDepth)
     {
         var current = segments;
+        var childArchiveSetIds = new ArchiveSetIdAllocator();
         for (var depth = 0; depth < maxDepth; depth++)
         {
             var nestedGroups = current
-                .GroupBy(segment => segment.PathWithinArchive, StringComparer.Ordinal)
-                .Where(group => FilenameUtil.IsRarFile(Path.GetFileName(group.Key)))
+            .GroupBy(segment => (segment.ArchiveSetId, segment.PathWithinArchive))
+                .Where(group => FilenameUtil.IsRarFile(Path.GetFileName(group.Key.PathWithinArchive)))
                 .ToList();
             if (nestedGroups.Count == 0)
                 break;
@@ -93,17 +94,21 @@ public static class NestedRarExpansionStep
             var next = new List<RarProcessor.StoredFileSegment>(current.Count);
             var expandedAny = false;
 
-            foreach (var group in current.GroupBy(segment => segment.PathWithinArchive, StringComparer.Ordinal))
+            foreach (var group in current.GroupBy(segment => (segment.ArchiveSetId, segment.PathWithinArchive)))
             {
                 var members = group.ToList();
-                if (!FilenameUtil.IsRarFile(Path.GetFileName(group.Key)))
+                if (!FilenameUtil.IsRarFile(Path.GetFileName(group.Key.PathWithinArchive)))
                 {
                     next.AddRange(members);
                     continue;
                 }
 
                 var expanded = await TryExpandGroupAsync(
-                    members, openComposedStream, password, ct).ConfigureAwait(false);
+                    members,
+                    childArchiveSetIds.Allocate(),
+                    openComposedStream,
+                    password,
+                    ct).ConfigureAwait(false);
                 if (expanded is null)
                 {
                     next.AddRange(members);
@@ -124,6 +129,7 @@ public static class NestedRarExpansionStep
 
     private static async Task<List<RarProcessor.StoredFileSegment>?> TryExpandGroupAsync(
         List<RarProcessor.StoredFileSegment> members,
+        string childArchiveSetId,
         Func<RarProcessor.StoredFileSegment[], CancellationToken, Task<Stream>> openComposedStream,
         string? password,
         CancellationToken ct)
@@ -223,6 +229,7 @@ public static class NestedRarExpansionStep
                     sorted,
                     innerPath,
                     archiveName,
+                    childArchiveSetId,
                     partNumber,
                     header.GetAesParams(password),
                     header.UncompressedSize,

--- a/backend/Queue/NestedRarExpansion/NestedRarExpansionStep.cs
+++ b/backend/Queue/NestedRarExpansion/NestedRarExpansionStep.cs
@@ -81,7 +81,7 @@ public static class NestedRarExpansionStep
         int maxDepth = DefaultMaxDepth)
     {
         var current = segments;
-        var childArchiveSetIds = new ArchiveSetIdAllocator();
+        var childArchiveSetIds = new ArchiveSetIdAllocator("nested");
         for (var depth = 0; depth < maxDepth; depth++)
         {
             var nestedGroups = current

--- a/backend/Queue/NestedRarExpansion/NestedRarRangeMapper.cs
+++ b/backend/Queue/NestedRarExpansion/NestedRarRangeMapper.cs
@@ -64,6 +64,7 @@ public static class NestedRarRangeMapper
             results.Add(new RarProcessor.StoredFileSegment
             {
                 NzbFile = layout.Outer.NzbFile,
+                ArchiveSetId = layout.Outer.ArchiveSetId,
                 PartSize = layout.Outer.PartSize,
                 ArchiveName = archiveName,
                 PartNumber = mappedPartNumber,

--- a/backend/Queue/NestedRarExpansion/NestedRarRangeMapper.cs
+++ b/backend/Queue/NestedRarExpansion/NestedRarRangeMapper.cs
@@ -15,6 +15,7 @@ public static class NestedRarRangeMapper
         RarProcessor.StoredFileSegment[] sortedOuterSegments,
         string pathWithinArchive,
         string archiveName,
+        string archiveSetId,
         RarProcessor.PartNumber partNumber,
         AesParams? aesParams,
         long fileUncompressedSize,
@@ -64,7 +65,7 @@ public static class NestedRarRangeMapper
             results.Add(new RarProcessor.StoredFileSegment
             {
                 NzbFile = layout.Outer.NzbFile,
-                ArchiveSetId = layout.Outer.ArchiveSetId,
+                  ArchiveSetId = archiveSetId,
                 PartSize = layout.Outer.PartSize,
                 ArchiveName = archiveName,
                 PartNumber = mappedPartNumber,

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -579,35 +579,54 @@ public class QueueItemProcessor(
         // continuation-header prefixes are validated before the rar group is
         // skipped in step 2b. On ineligibility — multi-file, compressed,
         // solid, or header-parse failure — fall through to the eager pipeline.
-        LazyRarProcessor.Result? lazyRarResult = null;
-        var rarFiles = fileInfos.Where(x => GetGroupName(x) == "rar").ToList();
-        if (configManager.IsLazyRarParsingEnabled() && rarFiles.Count > 0)
+        var archiveSetAllocator = new ArchiveSetIdAllocator();
+        var archiveSets = ArchiveSetGrouping.Resolve(fileInfos, archiveSetAllocator);
+        var lazyRarResults = new List<LazyRarProcessor.Result>();
+        var lazyRarSetIds = new HashSet<string>(StringComparer.Ordinal);
+        var rarSets = archiveSets
+            .Where(x => !x.IsSevenZip)
+            .Where(x => x.FileInfos.All(fileInfo => FilenameUtil.GetRarVolumeName(fileInfo.FileName) is not null))
+            .ToList();
+        if (configManager.IsLazyRarParsingEnabled() && rarSets.Count > 0)
         {
-            var lazyProc = new LazyRarProcessor(rarFiles, usenetClient, archivePassword, ct);
             IProgress<int> lazyRarProgress = progress
                 .Offset(55)
                 .Scale(5, 100);
-            lazyRarResult = await RunStageAsync("lazy-rar", async () =>
+            await RunStageAsync("lazy-rar", async () =>
             {
-                var result = await lazyProc.ProcessAsync().ConfigureAwait(false);
+                foreach (var archiveSet in rarSets)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    var result = await new LazyRarProcessor(
+                        archiveSet.FileInfos,
+                        usenetClient,
+                        archivePassword,
+                        archiveSet.ArchiveSetId,
+                        ct).ProcessAsync().ConfigureAwait(false) as LazyRarProcessor.Result;
+                    if (result is not null &&
+                        !FilenameUtil.IsRarFile(Path.GetFileName(result.PathInArchive)))
+                    {
+                        lazyRarResults.Add(result);
+                        lazyRarSetIds.Add(archiveSet.ArchiveSetId);
+                    }
+                }
+
                 lazyRarProgress.Report(100);
-                return result;
-            }).ConfigureAwait(false) as LazyRarProcessor.Result;
-            // Nested archives need the full eager pass + NestedRarExpansionStep.
-            if (lazyRarResult is not null &&
-                FilenameUtil.IsRarFile(Path.GetFileName(lazyRarResult.PathInArchive)))
-            {
-                lazyRarResult = null;
-            }
+                return (BaseProcessor.Result?)null;
+            }).ConfigureAwait(false);
         }
         var msRar = stepTimer.ElapsedMilliseconds;
         stepTimer.Restart();
 
         // step 2b -- per-file processing for everything else (and for the
         // rar group when lazy mounting was skipped or unsupported).
-        var skipRarGroup = lazyRarResult is not null;
         using var processorCts = ContextualCancellationTokenSource.CreateLinkedTokenSource(ct);
-        var fileProcessors = GetFileProcessors(fileInfos, archivePassword, skipRarGroup, processorCts.Token).ToList();
+        var fileProcessors = GetFileProcessors(
+            fileInfos,
+            archiveSets,
+            lazyRarSetIds,
+            archivePassword,
+            processorCts.Token).ToList();
         var part2Progress = progress
             .Offset(60)
             .Scale(40, 100)
@@ -623,7 +642,7 @@ public class QueueItemProcessor(
                 .Where(x => x is not null)
                 .Select(x => x!)
                 .ToList();
-            if (lazyRarResult is not null) results.Add(lazyRarResult);
+            results.AddRange(lazyRarResults);
             return await NestedRarExpansionStep.ExpandAsync(
                 results, usenetClient, archivePassword, ct).ConfigureAwait(false);
         }).ConfigureAwait(false);
@@ -771,26 +790,43 @@ public class QueueItemProcessor(
     private IEnumerable<BaseProcessor> GetFileProcessors
     (
         List<GetFileInfosStep.FileInfo> fileInfos,
+        List<ArchiveSetDescriptor> archiveSets,
+        HashSet<string> lazyRarSetIds,
         string? archivePassword,
-        bool skipRarGroup,
         CancellationToken rarProcessorCt
     )
     {
-        var groups = GroupFilesForProcessing(fileInfos);
+        foreach (var archiveSet in archiveSets)
+        {
+            if (archiveSet.IsSevenZip)
+            {
+                yield return new SevenZipProcessor(
+                    archiveSet.FileInfos,
+                    usenetClient,
+                    configManager,
+                    archivePassword,
+                    archiveSet.ArchiveSetId,
+                    ct);
+            }
+            else if (!lazyRarSetIds.Contains(archiveSet.ArchiveSetId))
+            {
+                foreach (var fileInfo in archiveSet.FileInfos)
+                    yield return new RarProcessor(
+                        fileInfo,
+                        usenetClient,
+                        archivePassword,
+                        archiveSet.ArchiveSetId,
+                        rarProcessorCt);
+            }
+        }
+
+        var groups = GroupFilesForProcessing(
+            fileInfos.Where(x => !x.IsRar && !FilenameUtil.IsRarFile(x.FileName) && !FilenameUtil.Is7zFile(x.FileName))
+                .ToList());
 
         foreach (var group in groups)
         {
-            if (group.Key == "7z")
-                yield return new SevenZipProcessor(group.ToList(), usenetClient, configManager, archivePassword, ct);
-
-            else if (group.Key == "rar")
-            {
-                if (skipRarGroup) continue;
-                foreach (var fileInfo in group)
-                    yield return new RarProcessor(fileInfo, usenetClient, archivePassword, rarProcessorCt);
-            }
-
-            else if (group.Key.StartsWith("split-video:", StringComparison.Ordinal))
+            if (group.Key.StartsWith("split-video:", StringComparison.Ordinal))
                 yield return new MultipartMkvProcessor(group.ToList(), usenetClient, ct);
 
             else if (group.Key == "other")

--- a/backend/Utils/FilenameUtil.cs
+++ b/backend/Utils/FilenameUtil.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace NzbWebDAV.Utils;
 
@@ -101,12 +102,88 @@ public static partial class FilenameUtil
     {
         if (string.IsNullOrEmpty(filename)) return null;
         var partMatch = Regex.Match(filename, @"\.part(\d+)\.rar$", RegexOptions.IgnoreCase);
-        if (partMatch.Success) return int.Parse(partMatch.Groups[1].Value);
+        if (partMatch.Success && int.TryParse(
+                partMatch.Groups[1].Value,
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out var partOrdinal))
+            return partOrdinal;
         var rMatch = Regex.Match(filename, @"\.r(\d+)$", RegexOptions.IgnoreCase);
-        if (rMatch.Success) return int.Parse(rMatch.Groups[1].Value) + 100_000;
+        if (rMatch.Success && int.TryParse(
+                rMatch.Groups[1].Value,
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out var rOrdinal) && rOrdinal <= int.MaxValue - 100_000)
+            return rOrdinal + 100_000;
         if (filename.EndsWith(".rar", StringComparison.OrdinalIgnoreCase)) return -1;
         return null;
     }
+
+    [GeneratedRegex(@"\A(?<base>.+)\.part(?<ordinal>[0-9]+)\.rar\z", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex RarPartVolumeRegex { get; }
+
+    [GeneratedRegex(@"\A(?<base>.+)\.r(?<ordinal>[0-9]+)\z", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex RarClassicVolumeRegex { get; }
+
+    [GeneratedRegex(@"\A(?<base>.+)\.rar\z", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex RarSingleVolumeRegex { get; }
+
+    [GeneratedRegex(@"\A(?<base>.+)\.7z(?:\.(?<ordinal>[0-9]+))?\z", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SevenZipVolumeRegex { get; }
+
+    public enum RarVolumeScheme
+    {
+        Part,
+        Classic,
+    }
+
+    public readonly record struct RarVolumeName(string BaseName, RarVolumeScheme Scheme, int Ordinal);
+
+    public readonly record struct SevenZipVolumeName(string BaseName, int? Ordinal)
+    {
+        public bool IsMultipart => Ordinal.HasValue;
+    }
+
+    public static RarVolumeName? GetRarVolumeName(string? filename)
+    {
+        if (string.IsNullOrEmpty(filename)) return null;
+
+        var partMatch = RarPartVolumeRegex.Match(filename);
+        if (partMatch.Success && TryParsePositiveOrdinal(partMatch.Groups["ordinal"].Value, out var partOrdinal))
+            return new RarVolumeName(partMatch.Groups["base"].Value, RarVolumeScheme.Part, partOrdinal - 1);
+
+        var classicMatch = RarClassicVolumeRegex.Match(filename);
+        if (classicMatch.Success && TryParseOrdinal(classicMatch.Groups["ordinal"].Value, out var classicOrdinal))
+            return new RarVolumeName(classicMatch.Groups["base"].Value, RarVolumeScheme.Classic, classicOrdinal + 1);
+
+        var singleMatch = RarSingleVolumeRegex.Match(filename);
+        return singleMatch.Success
+            ? new RarVolumeName(singleMatch.Groups["base"].Value, RarVolumeScheme.Classic, 0)
+            : null;
+    }
+
+    public static SevenZipVolumeName? GetSevenZipVolumeName(string? filename)
+    {
+        if (string.IsNullOrEmpty(filename)) return null;
+
+        var match = SevenZipVolumeRegex.Match(filename);
+        if (!match.Success || !match.Groups["ordinal"].Success)
+            return match.Success ? new SevenZipVolumeName(match.Groups["base"].Value, null) : null;
+
+        return int.TryParse(
+            match.Groups["ordinal"].Value,
+            NumberStyles.None,
+            CultureInfo.InvariantCulture,
+            out var ordinal) && ordinal > 0
+            ? new SevenZipVolumeName(match.Groups["base"].Value, ordinal)
+            : null;
+    }
+
+    private static bool TryParseOrdinal(string value, out int ordinal) =>
+        int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out ordinal);
+
+    private static bool TryParsePositiveOrdinal(string value, out int ordinal) =>
+        TryParseOrdinal(value, out ordinal) && ordinal > 0;
 
     public static bool Is7zFile(string? filename)
     {

--- a/docs/features/archives.md
+++ b/docs/features/archives.md
@@ -9,3 +9,9 @@ When inner files use obfuscated or non-video extensions (for example `.xyz`), In
 When a completed job mounts **exactly one** video (direct, RAR, lazy-RAR, 7z, nested, or multipart), InfiniDysk renames that video to `{release-folder}{extension}` so hash-named files like `b082fa0beaa644d3aa01045d5b8d0b36.mkv` appear as `Release.Name.2026.mkv`. Companion files (subtitles, NFO) do not block the rename; two or more videos never rename. A name collision logs a warning and keeps the original filename. Disable `api.rename-single-video-to-release` to keep today's names. Existing mounts are not backfilled [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since }.
 
 If a release is archive-only and *Arr cannot import, check Automatic Queue Management rules and ignored-file globs under [SABnzbd settings](../configuration/sabnzbd.md).
+
+## Independent archive sets [since 1.3.0](https://github.com/infinidysk/infinidysk/releases/tag/v1.3.0){ .nzbdav-since }
+
+Multiple RAR or 7z sets in one NZB are imported independently, including sets whose inner files have the same path. Duplicate visible names use the existing duplicate-output naming without sharing archive bytes. Each resolved RAR set makes its own lazy or eager processing decision; an eager fallback does not extract files to disk.
+
+Archive membership uses filename and archive-header evidence. Ambiguous obfuscated RAR membership fails clearly instead of combining unrelated volumes. Disabling health checks does not skip archive metadata validation. This applies to new imports only; re-import affected NZBs after upgrading rather than expecting existing mounts to be rewritten. Multiple outputs retain their member names, while the existing configurable single-video rename still applies when exactly one video remains.

--- a/tests/NzbWebDAV.Tests/Queue/ArchiveSetGroupingTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/ArchiveSetGroupingTests.cs
@@ -95,6 +95,20 @@ public class ArchiveSetGroupingTests
         AssertStandaloneAndMultipartSevenZipRemainSeparate(["A.7z.001", "A.7z.002", "A.7z"]);
     }
 
+    [Fact]
+    public void Resolve_RepeatedMultipartSevenZipSetsRemainSeparate()
+    {
+        var descriptors = ArchiveSetGrouping.Resolve([
+            Info("A.7z.001"),
+            Info("A.7z.002"),
+            Info("A.7z.001"),
+            Info("A.7z.002"),
+        ], new ArchiveSetIdAllocator());
+
+        Assert.Equal(2, descriptors.Count);
+        Assert.All(descriptors, descriptor => Assert.Equal(2, descriptor.FileInfos.Count));
+    }
+
     private static void AssertStandaloneAndMultipartSevenZipRemainSeparate(string[] filenames)
     {
         var descriptors = ArchiveSetGrouping.Resolve(filenames.Select(Info).ToList(), new ArchiveSetIdAllocator());

--- a/tests/NzbWebDAV.Tests/Queue/ArchiveSetGroupingTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/ArchiveSetGroupingTests.cs
@@ -57,6 +57,53 @@ public class ArchiveSetGroupingTests
         Assert.Equal(2, descriptors.Count);
     }
 
+    [Fact]
+    public void Resolve_RepeatedPartSetsStartNewSetAtPartOne()
+    {
+        var descriptors = ArchiveSetGrouping.Resolve([
+            Info("Episode.part01.rar"),
+            Info("Episode.part02.rar"),
+            Info("Episode.part01.rar"),
+            Info("Episode.part02.rar"),
+        ], new ArchiveSetIdAllocator());
+
+        Assert.Equal(2, descriptors.Count);
+        Assert.All(descriptors, descriptor => Assert.Equal(2, descriptor.FileInfos.Count));
+    }
+
+    [Fact]
+    public void Resolve_ClassicVolumesMatchWhenContinuationPrecedesFirst()
+    {
+        var descriptors = ArchiveSetGrouping.Resolve([
+            Info("Episode.r00"),
+            Info("Episode.rar"),
+        ], new ArchiveSetIdAllocator());
+
+        Assert.Single(descriptors);
+        Assert.Equal(2, descriptors[0].FileInfos.Count);
+    }
+
+    [Fact]
+    public void Resolve_StandaloneBeforeMultipartSevenZipRemainSeparate()
+    {
+        AssertStandaloneAndMultipartSevenZipRemainSeparate(["A.7z", "A.7z.001", "A.7z.002"]);
+    }
+
+    [Fact]
+    public void Resolve_MultipartBeforeStandaloneSevenZipRemainSeparate()
+    {
+        AssertStandaloneAndMultipartSevenZipRemainSeparate(["A.7z.001", "A.7z.002", "A.7z"]);
+    }
+
+    private static void AssertStandaloneAndMultipartSevenZipRemainSeparate(string[] filenames)
+    {
+        var descriptors = ArchiveSetGrouping.Resolve(filenames.Select(Info).ToList(), new ArchiveSetIdAllocator());
+
+        Assert.Equal(2, descriptors.Count);
+        Assert.Contains(descriptors, descriptor => descriptor.FileInfos.Count == 1);
+        Assert.Contains(descriptors, descriptor => descriptor.FileInfos.Count == 2);
+    }
+
     private static GetFileInfosStep.FileInfo Info(string filename) =>
         new()
         {

--- a/tests/NzbWebDAV.Tests/Queue/ArchiveSetGroupingTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/ArchiveSetGroupingTests.cs
@@ -1,0 +1,75 @@
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Queue;
+using NzbWebDAV.Queue.DeobfuscationSteps._3.GetFileInfos;
+
+namespace NzbWebDAV.Tests.Queue;
+
+public class ArchiveSetGroupingTests
+{
+    [Fact]
+    public void Resolve_IndependentRarBasesGetIndependentIds()
+    {
+        var descriptors = ArchiveSetGrouping.Resolve([
+            Info("Episode01.part01.rar"),
+            Info("Episode02.part01.rar"),
+        ], new ArchiveSetIdAllocator());
+
+        Assert.Equal(2, descriptors.Count);
+        Assert.All(descriptors, descriptor => Assert.Single(descriptor.FileInfos));
+        Assert.NotEqual(descriptors[0].ArchiveSetId, descriptors[1].ArchiveSetId);
+    }
+
+    [Fact]
+    public void Resolve_MixedCaseRarBaseSharesOneSet()
+    {
+        var descriptors = ArchiveSetGrouping.Resolve([
+            Info("Episode.part01.rar"),
+            Info("episode.part02.rar"),
+        ], new ArchiveSetIdAllocator());
+
+        var descriptor = Assert.Single(descriptors);
+        Assert.Equal(2, descriptor.FileInfos.Count);
+    }
+
+    [Fact]
+    public void Resolve_IndependentSevenZipBasesGetIndependentIds()
+    {
+        var descriptors = ArchiveSetGrouping.Resolve([
+            Info("A.7z.001"),
+            Info("A.7z.002"),
+            Info("B.7z.001"),
+            Info("B.7z.002"),
+        ], new ArchiveSetIdAllocator());
+
+        Assert.Equal(2, descriptors.Count);
+        Assert.Equal(["A.7z.001", "A.7z.002"], descriptors[0].FileInfos.Select(x => x.FileName));
+        Assert.Equal(["B.7z.001", "B.7z.002"], descriptors[1].FileInfos.Select(x => x.FileName));
+    }
+
+    [Fact]
+    public void Resolve_RepeatedStandaloneRarStartsNewSet()
+    {
+        var descriptors = ArchiveSetGrouping.Resolve([
+            Info("Movie.rar"),
+            Info("Movie.rar"),
+        ], new ArchiveSetIdAllocator());
+
+        Assert.Equal(2, descriptors.Count);
+    }
+
+    private static GetFileInfosStep.FileInfo Info(string filename) =>
+        new()
+        {
+            NzbFile = new NzbFile
+            {
+                Subject = filename,
+                Segments =
+                {
+                    new NzbSegment { MessageId = $"{filename}@example.com", Bytes = 1024 }
+                },
+            },
+            FileName = filename,
+            ReleaseDate = DateTimeOffset.UnixEpoch,
+            IsRar = filename.EndsWith(".rar", StringComparison.OrdinalIgnoreCase),
+        };
+}

--- a/tests/NzbWebDAV.Tests/Queue/ArchiveSetGroupingTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/ArchiveSetGroupingTests.cs
@@ -109,16 +109,29 @@ public class ArchiveSetGroupingTests
         Assert.All(descriptors, descriptor => Assert.Equal(2, descriptor.FileInfos.Count));
     }
 
+    [Fact]
+    public void Resolve_AmbiguousMultipartSevenZipVolumeDoesNotMergeSets()
+    {
+        var descriptors = ArchiveSetGrouping.Resolve([
+            Info("A.7z.001", "first-001"),
+            Info("A.7z.001", "second-001"),
+            Info("A.7z.002", "ambiguous-002"),
+        ], new ArchiveSetIdAllocator());
+
+        Assert.Equal(3, descriptors.Count);
+        Assert.All(descriptors, descriptor => Assert.Single(descriptor.FileInfos));
+    }
+
     private static void AssertStandaloneAndMultipartSevenZipRemainSeparate(string[] filenames)
     {
-        var descriptors = ArchiveSetGrouping.Resolve(filenames.Select(Info).ToList(), new ArchiveSetIdAllocator());
+        var descriptors = ArchiveSetGrouping.Resolve(filenames.Select(filename => Info(filename)).ToList(), new ArchiveSetIdAllocator());
 
         Assert.Equal(2, descriptors.Count);
         Assert.Contains(descriptors, descriptor => descriptor.FileInfos.Count == 1);
         Assert.Contains(descriptors, descriptor => descriptor.FileInfos.Count == 2);
     }
 
-    private static GetFileInfosStep.FileInfo Info(string filename) =>
+    private static GetFileInfosStep.FileInfo Info(string filename, string? messageId = null) =>
         new()
         {
             NzbFile = new NzbFile
@@ -126,7 +139,7 @@ public class ArchiveSetGroupingTests
                 Subject = filename,
                 Segments =
                 {
-                    new NzbSegment { MessageId = $"{filename}@example.com", Bytes = 1024 }
+                    new NzbSegment { MessageId = messageId ?? $"{filename}@example.com", Bytes = 1024 }
                 },
             },
             FileName = filename,

--- a/tests/NzbWebDAV.Tests/Queue/NestedRarExpansionStepTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/NestedRarExpansionStepTests.cs
@@ -62,6 +62,8 @@ public class NestedRarExpansionStepTests
         var movie = Assert.Single(expanded, segment => segment.PathWithinArchive == "movie.mkv");
         Assert.Equal(moviePayload.Length, movie.FileUncompressedSize);
         Assert.Equal(moviePayload.Length, movie.ByteRangeWithinPart.Count);
+        Assert.StartsWith("nested:", movie.ArchiveSetId);
+        Assert.NotEqual(nested.ArchiveSetId, movie.ArchiveSetId);
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Queue/NestedRarExpansionStepTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/NestedRarExpansionStepTests.cs
@@ -20,7 +20,8 @@ public class NestedRarExpansionStepTests
             LongRange.FromStartAndSize(40, 30),
             [first, second],
             pathWithinArchive: "movie.mkv",
-            archiveName: "inner",
+                    archiveName: "inner",
+                    archiveSetId: "set:child",
             partNumber: new RarProcessor.PartNumber { PartNumberFromHeader = -1, PartNumberFromFilename = -1 },
             aesParams: null,
             fileUncompressedSize: 30,
@@ -32,6 +33,7 @@ public class NestedRarExpansionStepTests
         Assert.Equal(LongRange.FromStartAndSize(0, 20), mapped[1].ByteRangeWithinPart);
         Assert.Equal(second.PartNumber, mapped[1].PartNumber);
         Assert.All(mapped, segment => Assert.Equal("movie.mkv", segment.PathWithinArchive));
+        Assert.All(mapped, segment => Assert.Equal("set:child", segment.ArchiveSetId));
     }
 
     [Fact]

--- a/tests/NzbWebDAV.Tests/Queue/RarAggregatorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/RarAggregatorTests.cs
@@ -108,6 +108,19 @@ public class RarAggregatorTests
     }
 
     [Fact]
+    public void GroupArchiveMembers_KeepsIndependentSetsWithSameInnerPathApart()
+    {
+        var first = SegmentNullable(0, 1, 0, 5, archiveSetId: "set:one");
+        var second = SegmentNullable(0, 1, 0, 5, archiveSetId: "set:two");
+
+        var groups = RarAggregator.GroupArchiveMembers([first, second]);
+
+        Assert.Equal(2, groups.Count);
+        Assert.All(groups, group => Assert.Equal("movie.mkv", group.Key.PathWithinArchive));
+        Assert.NotEqual(groups[0].Key.ArchiveSetId, groups[1].Key.ArchiveSetId);
+    }
+
+    [Fact]
     public void ValidateVolumes_RejectsMissingData()
     {
         var segment = Segment(headerPart: 0, filenamePart: 1, start: 0, length: 10);
@@ -183,11 +196,13 @@ public class RarAggregatorTests
         RarProcessor.StoredFileSegment segment,
         long fileUncompressedSize,
         bool unknown,
-        AesParams? aes = null)
+        AesParams? aes = null,
+        string? archiveSetId = "set:test")
     {
         return new RarProcessor.StoredFileSegment
         {
             NzbFile = segment.NzbFile,
+            ArchiveSetId = archiveSetId,
             PartSize = segment.PartSize,
             ArchiveName = segment.ArchiveName,
             PartNumber = segment.PartNumber,
@@ -206,7 +221,8 @@ public class RarAggregatorTests
 
     private static RarProcessor.StoredFileSegment SegmentNullable(
         int? headerPart, int? filenamePart, long start, long length,
-        string messageId = "shared@example.com")
+        string messageId = "shared@example.com",
+        string? archiveSetId = "set:test")
     {
         return new RarProcessor.StoredFileSegment
         {
@@ -218,6 +234,7 @@ public class RarAggregatorTests
                     new NzbSegment { MessageId = messageId, Bytes = length }
                 },
             },
+            ArchiveSetId = archiveSetId,
             PartSize = length,
             ArchiveName = "archive",
             PartNumber = new RarProcessor.PartNumber

--- a/tests/NzbWebDAV.Tests/Queue/SevenZipProcessorTests.cs
+++ b/tests/NzbWebDAV.Tests/Queue/SevenZipProcessorTests.cs
@@ -1,0 +1,93 @@
+using NzbWebDAV.Config;
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Queue.DeobfuscationSteps._3.GetFileInfos;
+using NzbWebDAV.Queue.FileProcessors;
+using NzbWebDAV.Exceptions;
+
+namespace NzbWebDAV.Tests.Queue;
+
+public class SevenZipProcessorTests
+{
+    [Theory]
+    [InlineData(new[] { "A.7z.003", "A.7z.001", "A.7z.002" }, new[] { "A.7z.001", "A.7z.002", "A.7z.003" })]
+    [InlineData(new[] { "Movie.7z" }, new[] { "Movie.7z" })]
+    public void OrderVolumes_SortsByOrdinal(string[] names, string[] expected)
+    {
+        var ordered = SevenZipProcessor.OrderVolumes(names.Select(name => Info(name)).ToList());
+
+        Assert.Equal(expected, ordered.Select(x => x.FileName).ToArray());
+    }
+
+    [Fact]
+    public void OrderVolumes_MultipartBaseIsCaseInsensitive()
+    {
+        var ordered = SevenZipProcessor.OrderVolumes([
+            Info("A.7z.002"),
+            Info("a.7Z.001"),
+        ]);
+
+        Assert.Equal(["a.7Z.001", "A.7z.002"], ordered.Select(x => x.FileName).ToArray());
+    }
+
+    [Fact]
+    public void OrderVolumes_DuplicateOrdinalIsRejected()
+    {
+        Assert.Throws<NonRetryableDownloadException>(() => SevenZipProcessor.OrderVolumes([
+            Info("A.7z.001", "a@example.com"),
+            Info("A.7z.001", "b@example.com"),
+            Info("A.7z.002"),
+        ]));
+    }
+
+    [Theory]
+    [InlineData("A.7z.001", "A.7z.003")]
+    [InlineData("A.7z.002", "A.7z.003")]
+    [InlineData("A.7z.002")]
+    public void OrderVolumes_GapOrMissingFirstVolumeIsRejected(params string[] names)
+    {
+        Assert.Throws<NonRetryableDownloadException>(() => SevenZipProcessor.OrderVolumes(names.Select(name => Info(name)).ToList()));
+    }
+
+    [Fact]
+    public void OrderVolumes_DifferentBasesAreRejected()
+    {
+        Assert.Throws<NonRetryableDownloadException>(() => SevenZipProcessor.OrderVolumes([
+            Info("A.7z.001"),
+            Info("B.7z.002"),
+        ]));
+    }
+
+    [Fact]
+    public void OrderVolumes_StandaloneAndMultipartAreRejected()
+    {
+        Assert.Throws<NonRetryableDownloadException>(() => SevenZipProcessor.OrderVolumes([
+            Info("A.7z"),
+            Info("A.7z.001"),
+        ]));
+    }
+
+    [Theory]
+    [InlineData("A.7z.000")]
+    [InlineData("A.7z.999999999999")]
+    [InlineData("A.7z.001\n")]
+    public void OrderVolumes_InvalidNamesAreRejected(string name)
+    {
+        Assert.Throws<NonRetryableDownloadException>(() => SevenZipProcessor.OrderVolumes([Info(name)]));
+    }
+
+    private static GetFileInfosStep.FileInfo Info(string filename, string messageId = "archive@example.com") =>
+        new()
+        {
+            NzbFile = new NzbFile
+            {
+                Subject = filename,
+                Segments =
+                {
+                    new NzbSegment { MessageId = messageId, Bytes = 1024 }
+                },
+            },
+            FileName = filename,
+            FileSize = 1024,
+            ReleaseDate = DateTimeOffset.UnixEpoch,
+        };
+}

--- a/tests/NzbWebDAV.Tests/Utils/UtilityTests.cs
+++ b/tests/NzbWebDAV.Tests/Utils/UtilityTests.cs
@@ -73,6 +73,54 @@ public class UtilityTests
     }
 
     [Theory]
+    [InlineData("Episode.part01.rar", "Episode", FilenameUtil.RarVolumeScheme.Part, 0)]
+    [InlineData("Episode.PART2.RAR", "Episode", FilenameUtil.RarVolumeScheme.Part, 1)]
+    [InlineData("Episode.r07", "Episode", FilenameUtil.RarVolumeScheme.Classic, 8)]
+    [InlineData("Episode.rar", "Episode", FilenameUtil.RarVolumeScheme.Classic, 0)]
+    public void GetRarVolumeName_PreservesSchemeAndZeroBasedOrdinal(
+        string filename,
+        string expectedBaseName,
+        FilenameUtil.RarVolumeScheme expectedScheme,
+        int expectedOrdinal)
+    {
+        var volume = FilenameUtil.GetRarVolumeName(filename);
+
+        Assert.Equal(new FilenameUtil.RarVolumeName(expectedBaseName, expectedScheme, expectedOrdinal), volume);
+    }
+
+    [Fact]
+    public void GetRarVolumeName_DoesNotCollideAcrossSchemes()
+    {
+        var partVolume = FilenameUtil.GetRarVolumeName("Episode.part100007.rar");
+        var classicVolume = FilenameUtil.GetRarVolumeName("Episode.r07");
+
+        Assert.NotEqual(partVolume, classicVolume);
+    }
+
+    [Theory]
+    [InlineData("Episode.7z", "Episode", null)]
+    [InlineData("Episode.7z.001", "Episode", 1)]
+    [InlineData("episode.7Z.010", "episode", 10)]
+    public void GetSevenZipVolumeName_SplitsBaseAndOrdinal(string filename, string expectedBaseName, int? expectedOrdinal)
+    {
+        var volume = FilenameUtil.GetSevenZipVolumeName(filename);
+
+        Assert.Equal(new FilenameUtil.SevenZipVolumeName(expectedBaseName, expectedOrdinal), volume);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(".7z")]
+    [InlineData("Episode.7z.000")]
+    [InlineData("Episode.7z.999999999999")]
+    [InlineData("Episode.７z.001")]
+    [InlineData("Episode.7z.001\n")]
+    public void GetSevenZipVolumeName_RejectsMalformedNames(string filename)
+    {
+        Assert.Null(FilenameUtil.GetSevenZipVolumeName(filename));
+    }
+
+    [Theory]
     [InlineData("Movie {{secret}}.nzb", "Movie", "secret")]
     [InlineData("Movie password=secret.nzb", "Movie", "secret")]
     [InlineData("Movie.nzb", "Movie", null)]


### PR DESCRIPTION
## Summary
- isolate independent RAR and 7z archive sets with transient archive-set identities
- make lazy RAR decisions per set and prevent unrelated volumes from sharing aggregation output
- validate 7z multipart membership and add focused regressions plus archive documentation

## Validation
- `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore --filter 'FullyQualifiedName~ArchiveSet|FullyQualifiedName~UtilityTests.GetRarVolumeName|FullyQualifiedName~UtilityTests.GetSevenZipVolumeName|FullyQualifiedName~QueueItemProcessor|FullyQualifiedName~SplitVideoGroupingTests|FullyQualifiedName~RarAggregatorTests|FullyQualifiedName~LazyRarProcessorTests|FullyQualifiedName~QueueRarTimeoutTests|FullyQualifiedName~SevenZipProcessorTests|FullyQualifiedName~NestedRarExpansionStepTests|FullyQualifiedName~FinalMediaReadinessValidatorTests'`
- `dotnet build NzbWebDAV.sln -c Release --no-restore`
- `zensical build --clean --strict`

Closes #1372
Closes #1378
Closes #1379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multiple RAR and 7z archive sets in a single import are processed independently.
  * Files with identical paths from different archive sets remain separate, with duplicate outputs handled safely.
  * Nested archive contents retain their archive-set identity.
  * Archive volume ordering and membership validation are more robust.
  * Ambiguous or invalid archive layouts now fail clearly instead of being merged incorrectly.

* **Documentation**
  * Added guidance on multi-set archive imports, validation, processing behavior, and duplicate naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->