### PR TITLE
fix(health): defer contended PAR2 repairs

### DIFF
--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -808,7 +808,7 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
         if (davItem.NextHealthCheck != DateTimeOffset.UnixEpoch)
             davItem.NextHealthCheck = now.AddSeconds(1);
         Log.Warning(
-            "PAR2 repair deferred for {Path}; admission is busy ({Outcome}).",
+            "PAR2 repair deferred for {Path} because repair capacity is contended ({Outcome}).",
             davItem.Path,
             outcome);
         await RecordHealthResult(
@@ -816,7 +816,7 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 davItem,
                 HealthCheckResult.HealthResult.Unhealthy,
                 HealthCheckResult.RepairAction.ActionNeeded,
-                "PAR2 repair remains pending because another repair is active.",
+                "PAR2 repair remains pending because repair capacity is contended.",
                 ct)
             .ConfigureAwait(false);
     }

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -1459,6 +1459,11 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             ? await _par2RepairService.TryPar2RepairAsync(
                 davItem, holeSegmentIds, ct).ConfigureAwait(false)
             : Par2RepairOutcome.NotRepaired;
+        if (par2Outcome == Par2RepairOutcome.DeferredBusy)
+        {
+            await DeferPar2RepairAsync(davItem, dbClient, par2Outcome, ct).ConfigureAwait(false);
+            return;
+        }
         if (par2Outcome is Par2RepairOutcome.Repaired or Par2RepairOutcome.VerifiedClean)
         {
             var utcNow = DateTimeOffset.UtcNow;
@@ -2993,11 +2998,6 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 failureSnapshot.HasTargetableSegmentIds ? failureSnapshot.SegmentIds : null,
                 ct).ConfigureAwait(false)
             : Par2RepairOutcome.NotRepaired;
-        if (par2Outcome == Par2RepairOutcome.DeferredBusy)
-        {
-            await DeferPar2RepairAsync(davItem, dbClient, par2Outcome, ct).ConfigureAwait(false);
-            return;
-        }
         if (par2Outcome == Par2RepairOutcome.DeferredBusy)
         {
             await DeferPar2RepairAsync(davItem, dbClient, par2Outcome, ct).ConfigureAwait(false);

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -348,10 +348,12 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 }
 
                 var availableSlots = _configManager.GetHealthCheckWorkers() - _inProgress.Count;
+                var repairsOpen = admission.RepairsOpen
+                    && (!ShouldAttemptPar2Repair() || _par2RepairService.CanAcceptInlineRepair);
                 var candidateIds = await SelectNextHealthCheckIdsAsync(
                         reservedIds,
                         admission.ChecksOpen,
-                        admission.RepairsOpen,
+                        repairsOpen,
                         availableSlots,
                         ct)
                     .ConfigureAwait(false);
@@ -792,6 +794,31 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             cooldownUntil,
             (_, current) => current >= cooldownUntil ? current : cooldownUntil);
         RecordInfrastructureBackoff();
+    }
+
+    private async Task DeferPar2RepairAsync(
+        DavItem davItem,
+        DavDatabaseClient dbClient,
+        Par2RepairOutcome outcome,
+        CancellationToken ct)
+    {
+        var now = _timeProvider.GetUtcNow();
+        davItem.HealthRepairPending = true;
+        davItem.LastHealthCheck = now;
+        if (davItem.NextHealthCheck != DateTimeOffset.UnixEpoch)
+            davItem.NextHealthCheck = now.AddSeconds(1);
+        Log.Warning(
+            "PAR2 repair deferred for {Path}; admission is busy ({Outcome}).",
+            davItem.Path,
+            outcome);
+        await RecordHealthResult(
+                dbClient,
+                davItem,
+                HealthCheckResult.HealthResult.Unhealthy,
+                HealthCheckResult.RepairAction.ActionNeeded,
+                "PAR2 repair remains pending because another repair is active.",
+                ct)
+            .ConfigureAwait(false);
     }
 
     private bool IsInfrastructureBackoffActive() =>
@@ -1279,7 +1306,12 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 await HandleUnreadablePayloadAsync(davItem, dbClient, exception, ct).ConfigureAwait(false);
                 return;
             }
-            if (par2Outcome is not Par2RepairOutcome.NotRepaired)
+            if (par2Outcome == Par2RepairOutcome.DeferredBusy)
+            {
+                await DeferPar2RepairAsync(davItem, dbClient, par2Outcome, ct).ConfigureAwait(false);
+                return;
+            }
+            if (par2Outcome is Par2RepairOutcome.Repaired or Par2RepairOutcome.VerifiedClean)
             {
                 var utcNow = DateTimeOffset.UtcNow;
                 davItem.LastHealthCheck = utcNow;
@@ -1427,7 +1459,7 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
             ? await _par2RepairService.TryPar2RepairAsync(
                 davItem, holeSegmentIds, ct).ConfigureAwait(false)
             : Par2RepairOutcome.NotRepaired;
-        if (par2Outcome is not Par2RepairOutcome.NotRepaired)
+        if (par2Outcome is Par2RepairOutcome.Repaired or Par2RepairOutcome.VerifiedClean)
         {
             var utcNow = DateTimeOffset.UtcNow;
             davItem.LastHealthCheck = utcNow;
@@ -2961,7 +2993,17 @@ public class HealthCheckService : BackgroundService, IHealthCheckQuiescence
                 failureSnapshot.HasTargetableSegmentIds ? failureSnapshot.SegmentIds : null,
                 ct).ConfigureAwait(false)
             : Par2RepairOutcome.NotRepaired;
-        if (par2Outcome is not Par2RepairOutcome.NotRepaired)
+        if (par2Outcome == Par2RepairOutcome.DeferredBusy)
+        {
+            await DeferPar2RepairAsync(davItem, dbClient, par2Outcome, ct).ConfigureAwait(false);
+            return;
+        }
+        if (par2Outcome == Par2RepairOutcome.DeferredBusy)
+        {
+            await DeferPar2RepairAsync(davItem, dbClient, par2Outcome, ct).ConfigureAwait(false);
+            return;
+        }
+        if (par2Outcome is Par2RepairOutcome.Repaired or Par2RepairOutcome.VerifiedClean)
         {
             var utcNow = DateTimeOffset.UtcNow;
             davItem.LastHealthCheck = utcNow;

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -726,7 +726,6 @@ public partial class Par2RepairService : BackgroundService
                 {
                     await _repairAdmission.WaitAsync(ct).ConfigureAwait(false);
                     admitted = true;
-                    Interlocked.Exchange(ref _admissionActive, 1);
                 }
                 finally
                 {

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -30,10 +30,17 @@ public enum Par2RepairOutcome
     NotRepaired = 0,
     Repaired = 1,
     VerifiedClean = 2,
+    DeferredBusy = 3,
 }
 
 public partial class Par2RepairService : BackgroundService
 {
+    private enum RepairAdmissionMode
+    {
+        InlineTryOnce,
+        QueuedWait,
+    }
+
     private const int MaxQueueLength = 50;
     private const int MaxAttempts = 3;
     private static readonly TimeSpan CatalogWarningInterval = TimeSpan.FromMinutes(1);
@@ -246,21 +253,26 @@ public partial class Par2RepairService : BackgroundService
             var mine = new RepairFlight(missingSegmentIds);
             var flight = _repairFlights.GetOrAdd(davItem.Id, mine);
             if (ReferenceEquals(flight, mine))
-                return await RunFlightAsync(flight, davItem, missingSegmentIds, queueGuard: false, ct).ConfigureAwait(false);
+                return await RunFlightAsync(flight, davItem, missingSegmentIds, queueGuard: false, RepairAdmissionMode.InlineTryOnce, ct).ConfigureAwait(false);
+            if (!flight.Task.IsCompleted)
+                return Par2RepairOutcome.DeferredBusy;
             try
             {
                 var result = await flight.Task.WaitAsync(ct).ConfigureAwait(false);
                 if (result == Par2RepairOutcome.NotRepaired || flight.Covers(missingSegmentIds)
                     || missingSegmentIds is { Count: > 0 } && missingSegmentIds.All(_patchStore.HasUsablePatch))
                     return result;
-                await flight.Finished.Task.WaitAsync(ct).ConfigureAwait(false);
+                if (!flight.Finished.Task.IsCompleted)
+                    return Par2RepairOutcome.DeferredBusy;
+                _repairFlights.TryRemove(new KeyValuePair<Guid, RepairFlight>(davItem.Id, flight));
             }
             catch (OperationCanceledException) when (!ct.IsCancellationRequested)
             {
-                return Par2RepairOutcome.NotRepaired;
+                return Par2RepairOutcome.DeferredBusy;
             }
         }
-        return Par2RepairOutcome.NotRepaired;
+        Log.Warning("PAR2 repair for {DavItemId} deferred after repeated flight contention.", davItem.Id);
+        return Par2RepairOutcome.DeferredBusy;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -673,7 +685,7 @@ public partial class Par2RepairService : BackgroundService
             return;
         }
 
-        await RunFlightAsync(item.Flight, davItem, item.MissingSegmentIds, queueGuard: true, ct)
+        await RunFlightAsync(item.Flight, davItem, item.MissingSegmentIds, queueGuard: true, RepairAdmissionMode.QueuedWait, ct)
             .ConfigureAwait(false);
     }
 
@@ -682,6 +694,7 @@ public partial class Par2RepairService : BackgroundService
         DavItem davItem,
         IReadOnlyList<string>? missingSegmentIds,
         bool queueGuard,
+        RepairAdmissionMode admissionMode,
         CancellationToken ct)
     {
         var admitted = false;
@@ -694,24 +707,40 @@ public partial class Par2RepairService : BackgroundService
                 _admissionUsers++;
                 admissionUser = true;
             }
-            var wait = Stopwatch.StartNew();
-            Interlocked.Increment(ref _admissionWaiters);
-            PublishAdmissionMetrics();
-            try
+            if (admissionMode == RepairAdmissionMode.InlineTryOnce)
             {
-                await _repairAdmission.WaitAsync(ct).ConfigureAwait(false);
-                admitted = true;
-                Interlocked.Exchange(ref _admissionActive, 1);
+                ct.ThrowIfCancellationRequested();
+                admitted = await _repairAdmission.WaitAsync(0, ct).ConfigureAwait(false);
+                if (!admitted)
+                {
+                    flight.Completion.TrySetResult(Par2RepairOutcome.DeferredBusy);
+                    return Par2RepairOutcome.DeferredBusy;
+                }
             }
-            finally
+            else
             {
-                Interlocked.Decrement(ref _admissionWaiters);
-                wait.Stop();
-                Interlocked.Add(ref _totalAdmissionWaitTicks, wait.Elapsed.Ticks);
-                Interlocked.Exchange(ref _latestAdmissionWaitTicks, wait.Elapsed.Ticks);
-                PrometheusMetrics.Current?.ObservePar2AdmissionWait(wait.Elapsed);
+                var wait = Stopwatch.StartNew();
+                Interlocked.Increment(ref _admissionWaiters);
                 PublishAdmissionMetrics();
+                try
+                {
+                    await _repairAdmission.WaitAsync(ct).ConfigureAwait(false);
+                    admitted = true;
+                    Interlocked.Exchange(ref _admissionActive, 1);
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref _admissionWaiters);
+                    wait.Stop();
+                    Interlocked.Add(ref _totalAdmissionWaitTicks, wait.Elapsed.Ticks);
+                    Interlocked.Exchange(ref _latestAdmissionWaitTicks, wait.Elapsed.Ticks);
+                    PrometheusMetrics.Current?.ObservePar2AdmissionWait(wait.Elapsed);
+                    PublishAdmissionMetrics();
+                }
             }
+
+            Interlocked.Exchange(ref _admissionActive, 1);
+            PublishAdmissionMetrics();
             var result = await RunRepairAsync(davItem, missingSegmentIds, flight, ct).ConfigureAwait(false);
             flight.Completion.TrySetResult(result);
             return result;
@@ -1384,6 +1413,11 @@ public partial class Par2RepairService : BackgroundService
                     source?.RetainedByteLimit ?? 0),
         };
     }
+
+    internal bool CanAcceptInlineRepair =>
+        !_disposeRequested
+        && Volatile.Read(ref _admissionActive) == 0
+        && Volatile.Read(ref _admissionWaiters) == 0;
 
     private void BeginRepairDiagnostics(string path)
     {

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -259,6 +259,8 @@ public partial class Par2RepairService : BackgroundService
             try
             {
                 var result = await flight.Task.WaitAsync(ct).ConfigureAwait(false);
+                if (result == Par2RepairOutcome.DeferredBusy)
+                    return result;
                 if (result == Par2RepairOutcome.NotRepaired || flight.Covers(missingSegmentIds)
                     || missingSegmentIds is { Count: > 0 } && missingSegmentIds.All(_patchStore.HasUsablePatch))
                     return result;
@@ -784,6 +786,49 @@ public partial class Par2RepairService : BackgroundService
         lock (_admissionLifecycle)
         {
             if (--_admissionUsers == 0 && _disposeRequested) _repairAdmission.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Holds the single repair permit without a repairable fixture. Registers as an
+    /// admission user so disposing the service while held cannot destroy the semaphore
+    /// before the returned hold releases it.
+    /// </summary>
+    internal async Task<IAsyncDisposable> HoldAdmissionForTestsAsync(CancellationToken ct)
+    {
+        lock (_admissionLifecycle)
+        {
+            ObjectDisposedException.ThrowIf(_disposeRequested, this);
+            _admissionUsers++;
+        }
+        try
+        {
+            await _repairAdmission.WaitAsync(ct).ConfigureAwait(false);
+        }
+        catch
+        {
+            ReleaseAdmissionUser();
+            throw;
+        }
+        Interlocked.Exchange(ref _admissionActive, 1);
+        PublishAdmissionMetrics();
+        return new AdmissionHold(this);
+    }
+
+    private sealed class AdmissionHold(Par2RepairService service) : IAsyncDisposable
+    {
+        private int _released;
+
+        public ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _released, 1) == 0)
+            {
+                Interlocked.Exchange(ref service._admissionActive, 0);
+                service._repairAdmission.Release();
+                service.PublishAdmissionMetrics();
+                service.ReleaseAdmissionUser();
+            }
+            return ValueTask.CompletedTask;
         }
     }
 

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceCorruptSourceTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceCorruptSourceTests.cs
@@ -281,7 +281,7 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task BackgroundRepair_UrgentCallJoinsFlight_AndCanceledJoinerDoesNotCancelOwner()
+    public async Task BackgroundRepair_InlineJoinersDeferWithoutDisturbingOwner()
     {
         var fileData = PatternBytes(SliceSize * 3, 0x78);
         var sourceReadStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -304,23 +304,23 @@ public sealed class Par2RepairServiceCorruptSourceTests : IAsyncLifetime
             await sourceReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
             using var canceledJoinerCts = new CancellationTokenSource();
-            var canceledJoiner = release.Service.TryPar2RepairAsync(
+            await canceledJoinerCts.CancelAsync();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                release.Service.TryPar2RepairAsync(
                 release.Item,
                 [release.ContentSegmentIds[0]],
-                canceledJoinerCts.Token);
-            canceledJoinerCts.Cancel();
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledJoiner);
+                canceledJoinerCts.Token));
 
             var successfulJoiner = release.Service.TryPar2RepairAsync(
                 release.Item,
                 [release.ContentSegmentIds[0]],
                 CancellationToken.None);
-            Assert.False(successfulJoiner.IsCompleted);
+            Assert.Equal(Par2RepairOutcome.DeferredBusy, await successfulJoiner);
 
             allowSourceRead.TrySetResult(true);
-            Assert.Equal(
-                Par2RepairOutcome.Repaired,
-                await successfulJoiner.WaitAsync(TimeSpan.FromSeconds(10)));
+            using var ownerTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            while (release.Service.GetDiagnosticSnapshot().TotalSucceeded == 0)
+                await Task.Delay(25, ownerTimeout.Token);
             Assert.True(release.Store.Contains(release.ContentSegmentIds[0]));
             Assert.Equal(1, release.Service.GetDiagnosticSnapshot().TotalSucceeded);
 

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceMultipartTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceMultipartTests.cs
@@ -105,6 +105,65 @@ public sealed class Par2RepairServiceMultipartTests : IAsyncLifetime
         finally { flights.Clear(); }
     }
 
+    [Fact]
+    public async Task CompletedDeferredFlight_PropagatesDeferredToJoinerWithoutRetrying()
+    {
+        var data = Data(4096 * 3, "deferred-flight");
+        await using var release = await new Par2RepairTestReleaseBuilder(_config, _root).BuildAsync([
+            new("volume.rar", data, Sizes(data.Length)),
+        ], [1], DavItem.ItemSubType.MultipartFile);
+        const System.Reflection.BindingFlags flags = System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic;
+        var flightType = typeof(Par2RepairService).GetNestedType("RepairFlight", System.Reflection.BindingFlags.NonPublic)!;
+        var flight = Activator.CreateInstance(flightType, flags, null, new object?[] { Array.Empty<string>() }, null)!;
+        ((TaskCompletionSource<Par2RepairOutcome>)flightType.GetProperty("Completion")!.GetValue(flight)!).SetResult(Par2RepairOutcome.DeferredBusy);
+        var flights = (System.Collections.IDictionary)typeof(Par2RepairService).GetField("_repairFlights", flags)!.GetValue(release.Service)!;
+        flights.Add(release.Item.Id, flight);
+        try
+        {
+            var result = await release.Service.TryPar2RepairAsync(release.Item, [release.Files[0].Ids[0]], CancellationToken.None);
+            Assert.Equal(Par2RepairOutcome.DeferredBusy, result);
+            Assert.Equal(0, release.Fake.BodyRequestCount);
+            Assert.Same(flight, flights[release.Item.Id]);
+        }
+        finally { flights.Clear(); }
+    }
+
+    [Fact]
+    public async Task HoldAdmission_DefersInlineCallersUntilReleased()
+    {
+        var data = Data(4096 * 6, "hold-admission");
+        await using var release = await new Par2RepairTestReleaseBuilder(_config, _root).BuildAsync([
+            new("volume.rar", data, Sizes(data.Length), [4]),
+        ], [1], DavItem.ItemSubType.MultipartFile);
+        var id = release.Files[0].Ids[4];
+        var hold = await release.Service.HoldAdmissionForTestsAsync(CancellationToken.None);
+        try
+        {
+            Assert.False(release.Service.CanAcceptInlineRepair);
+            Assert.Equal(1, release.Service.GetDiagnosticSnapshot().AdmissionActive);
+            Assert.Equal(Par2RepairOutcome.DeferredBusy, await release.Service.TryPar2RepairAsync(release.Item, [id], CancellationToken.None));
+            Assert.Equal(0, release.Fake.BodyRequestCount);
+            await using (var context = new DavDatabaseContext())
+                Assert.False(await context.Par2RepairJobs.AnyAsync());
+        }
+        finally { await hold.DisposeAsync(); }
+
+        Assert.True(release.Service.CanAcceptInlineRepair);
+        Assert.Equal(0, release.Service.GetDiagnosticSnapshot().AdmissionActive);
+        Assert.Equal(Par2RepairOutcome.Repaired, await release.Service.TryPar2RepairAsync(release.Item, [id], CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task HoldAdmission_SurvivesServiceDisposalWhileHeld()
+    {
+        var service = new Par2RepairService(_config, null!, new RepairPatchStore(Path.Join(_root, "hold-patches"), 1024 * 1024));
+        var hold = await service.HoldAdmissionForTestsAsync(CancellationToken.None);
+        service.Dispose();
+        await hold.DisposeAsync();
+        await hold.DisposeAsync();
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => service.HoldAdmissionForTestsAsync(CancellationToken.None));
+    }
+
     [Theory]
     [InlineData(Par2RepairJob.RepairJobState.Queued)]
     [InlineData(Par2RepairJob.RepairJobState.Failed)]

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceMultipartTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceMultipartTests.cs
@@ -99,8 +99,8 @@ public sealed class Par2RepairServiceMultipartTests : IAsyncLifetime
         {
             var result = await Task.Run(() => release.Service.TryPar2RepairAsync(release.Item,
                 [release.Files[0].Ids[0]], cancellation.Token), cancellation.Token);
-            Assert.Equal(Par2RepairOutcome.NotRepaired, result);
-            Assert.Equal(0, release.Fake.BodyRequestCount);
+            Assert.Equal(Par2RepairOutcome.Repaired, result);
+            Assert.True(release.Fake.BodyRequestCount > 0);
         }
         finally { flights.Clear(); }
     }
@@ -512,16 +512,14 @@ public sealed class Par2RepairServiceMultipartTests : IAsyncLifetime
             var sameItem = release.Service.TryPar2RepairAsync(release.Item, ids, ownerCancellation.Token);
             var snapshot = release.Service.GetDiagnosticSnapshot();
             Assert.Equal(1, snapshot.AdmissionActive);
-            Assert.Equal(1, snapshot.AdmissionWaiters);
-            Assert.False(sameItem.IsCompleted);
-            await waiterCancellation.CancelAsync();
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiter);
+            Assert.Equal(0, snapshot.AdmissionWaiters);
+            Assert.Equal(Par2RepairOutcome.DeferredBusy, await sameItem);
+            Assert.Equal(Par2RepairOutcome.DeferredBusy, await waiter);
             Assert.Equal(0, release.Service.GetDiagnosticSnapshot().AdmissionWaiters);
             await using (var context = new DavDatabaseContext())
                 Assert.False(await context.Par2RepairJobs.AnyAsync(job => job.DavItemId == other.Id));
             proceed.TrySetResult();
             Assert.Equal(Par2RepairOutcome.Repaired, await owner);
-            Assert.Equal(Par2RepairOutcome.Repaired, await sameItem);
             Assert.Equal(Par2RepairOutcome.Repaired, await release.Service.TryPar2RepairAsync(other, ids, ownerCancellation.Token));
             Assert.Equal(0, release.Service.GetDiagnosticSnapshot().AdmissionActive);
         }
@@ -562,15 +560,14 @@ public sealed class Par2RepairServiceMultipartTests : IAsyncLifetime
             await entered.Task.WaitAsync(cancellation.Token);
             var lateId = release.Files[1].Ids[5];
             var late = release.Service.TryPar2RepairAsync(release.Item, [lateId], cancellation.Token);
-            Assert.False(late.IsCompleted);
+            Assert.Equal(Par2RepairOutcome.DeferredBusy, await late);
             Assert.False(release.Store.HasUsablePatch(lateId));
             Assert.Equal(0, release.Service.GetDiagnosticSnapshot().AdmissionWaiters);
             proceed.TrySetResult();
             Assert.Equal(Par2RepairOutcome.Repaired, await owner);
-            Assert.Equal(Par2RepairOutcome.Repaired, await late);
-            await AssertPatchAsync(release, 1, 5);
+            Assert.False(release.Store.HasUsablePatch(lateId));
             await using var context = new DavDatabaseContext();
-            Assert.Equal(2, await context.Par2RepairJobs.CountAsync(job => job.State == Par2RepairJob.RepairJobState.Succeeded));
+            Assert.Equal(1, await context.Par2RepairJobs.CountAsync(job => job.State == Par2RepairJob.RepairJobState.Succeeded));
         }
         finally
         {

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceMultipartTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceMultipartTests.cs
@@ -484,7 +484,7 @@ public sealed class Par2RepairServiceMultipartTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Admission_CanceledWaiterLeavesNoJobAndCanRetry()
+    public async Task InlineContentionDefersWithoutCreatingJob()
     {
         var data = Data(4096 * 6, "admission");
         await using var release = await new Par2RepairTestReleaseBuilder(_config, _root).BuildAsync([

--- a/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceMultipartTests.cs
+++ b/tests/NzbWebDAV.Tests/Services/Repair/Par2RepairServiceMultipartTests.cs
@@ -595,7 +595,7 @@ public sealed class Par2RepairServiceMultipartTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task LateDifferentVolumeRequest_RunsFollowUpBeforeReturningSuccess()
+    public async Task LateDifferentVolumeRequest_DefersWithoutRunningFollowUp()
     {
         var first = Data(4096 * 6, "late-first");
         var second = Data(4096 * 7, "late-second");


### PR DESCRIPTION
## Summary

This PR replaces #1371 with an independent Phase 1 implementation.

- Adds explicit `DeferredBusy` PAR2 outcomes.
- Makes inline health/playback repair admission non-blocking while preserving queued repair waiting and cleanup ownership.
- Prevents same-file and cross-file inline callers from waiting behind an active repair.
- Records deferred repairs as unhealthy/action-needed and preserves urgent retry intent.
- Suppresses repair candidates while PAR2 admission is busy without suppressing ordinary health checks.
- Updates contention tests for deferred behavior and stale-flight self-healing.

Phase 2 request-reduction and repair-discovery performance work is intentionally left separate for reviewability.

## Validation

- `dotnet test tests/NzbWebDAV.Tests/NzbWebDAV.Tests.csproj -c Release --no-restore --filter FullyQualifiedName~Par2RepairServiceMultipartTests`
- 47 passed
- Workspace diagnostics report no errors in the touched C# files

The terminal stopped returning output during a later combined validation command, so the focused 47-test run and source diagnostics are the reliable validation recorded here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved repair availability checks so new repair candidates are not selected when PAR2 repair capacity is unavailable.
  - Busy repair operations are now deferred immediately instead of blocking or being reported as failed.
  - Deferred repairs are marked pending, recorded as unhealthy where appropriate, and rescheduled shortly when non-urgent.
  - Missing-segment repair results now distinguish deferred work from successful repair or clean verification.
- **Tests**
  - Updated repair coverage for immediate deferral and retry behavior during concurrent requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->