### PR TITLE
perf(health): reduce redundant PAR2 repair work

### DIFF
--- a/backend/Services/Repair/Par2RepairService.Discovery.cs
+++ b/backend/Services/Repair/Par2RepairService.Discovery.cs
@@ -306,6 +306,7 @@ public partial class Par2RepairService
         catch (Exception exception) when (exception is UsenetArticleNotFoundException or UsenetCorruptArticleException or InvalidDataException or EndOfStreamException)
         {
             reads.Headers[id] = null;
+            reads.NoteUnavailable(id, exception);
             return null;
         }
     }
@@ -313,10 +314,12 @@ public partial class Par2RepairService
     private async Task<bool> SniffPar2MagicAsync(NzbFile file, RepairReadContext reads, CancellationToken ct)
     {
         if (file.Segments.Count == 0) return false;
+        var id = file.Segments[0].MessageId;
+        if (reads.UnavailableIds.Contains(id)) return false;
         await reads.FetchGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            var response = await _usenetClient.DecodedBodyAsync(file.Segments[0].MessageId, ct).ConfigureAwait(false);
+            var response = await _usenetClient.DecodedBodyAsync(id, ct).ConfigureAwait(false);
             await using var stream = response.Stream!;
             var buffer = new byte[64];
             var count = 0;
@@ -330,7 +333,10 @@ public partial class Par2RepairService
             return buffer.AsSpan(0, 8).SequenceEqual("PAR2\0PKT"u8);
         }
         catch (Exception exception) when (exception is UsenetArticleNotFoundException or UsenetCorruptArticleException or InvalidDataException or EndOfStreamException)
-        { return false; }
+        {
+            reads.NoteUnavailable(id, exception);
+            return false;
+        }
         finally { reads.FetchGate.Release(); }
     }
 

--- a/backend/Services/Repair/Par2RepairService.Volumes.cs
+++ b/backend/Services/Repair/Par2RepairService.Volumes.cs
@@ -7,6 +7,7 @@ using NzbWebDAV.Models;
 using NzbWebDAV.Models.Nzb;
 using NzbWebDAV.Par2Recovery.Packets;
 using NzbWebDAV.Par2Recovery.ReedSolomon;
+using UsenetSharp.Models;
 
 namespace NzbWebDAV.Services.Repair;
 
@@ -191,23 +192,71 @@ public partial class Par2RepairService
     {
         if (reads.Observations.TryGetValue(file, out var cached)) return cached;
         reads.Budget.Charge(256);
-        await reads.FetchGate.WaitAsync(ct).ConfigureAwait(false);
-        try
+        var indices = Enumerable.Range(0, file.Segments.Count)
+            .OrderBy(index => index == 0 ? 0 : index == file.Segments.Count - 1 ? 1 : 2)
+            .ToArray();
+        var concurrency = Math.Max(1, Math.Min(reads.FetchGate.CurrentCount, indices.Length));
+        foreach (var window in indices.Chunk(concurrency))
         {
-            foreach (var index in Enumerable.Range(0, file.Segments.Count).OrderBy(index => index == 0 ? 0 : index == file.Segments.Count - 1 ? 1 : 2))
+            ct.ThrowIfCancellationRequested();
+            var probes = new HeaderProbeResult[window.Length];
+            var tasks = new Task<HeaderProbeResult>[window.Length];
+            for (var offset = 0; offset < window.Length; offset++)
             {
-                var header = await ReadHeaderCoreAsync(file.Segments[index].MessageId, reads, ct, identity: true).ConfigureAwait(false);
-                if (header is not { FileSize: > 0 }) continue;
-                var observation = new NzbFileObservation(header.FileSize, null);
+                var index = window[offset];
+                var id = file.Segments[index].MessageId;
+                if (reads.UnavailableIds.Contains(id))
+                {
+                    tasks[offset] = Task.FromResult(new HeaderProbeResult(index, id, null, false, true));
+                    continue;
+                }
+                if (reads.Headers.TryGetValue(id, out var cachedHeader))
+                {
+                    tasks[offset] = Task.FromResult(new HeaderProbeResult(index, id, cachedHeader, false, cachedHeader is null));
+                    continue;
+                }
+                reads.AdmitIdentityWork(0, request: true);
+                reads.Budget.Charge(512 + 2L * id.Length);
+                tasks[offset] = FetchHeaderObservationAsync(index, id, reads, ct);
+            }
+            probes = await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            foreach (var probe in probes)
+            {
+                if (probe.Header is not null)
+                    reads.Headers[probe.Id] = probe.Header;
+                else if (probe.IsUnavailable)
+                    reads.NoteUnavailable(probe.Id, probe.IsMissing
+                        ? new UsenetArticleNotFoundException(probe.Id)
+                        : new InvalidDataException("PAR2 identity header probe failed."));
+                if (probe.Header is not { FileSize: > 0 }) continue;
+                var observation = new NzbFileObservation(probe.Header.FileSize, null);
                 reads.Observations[file] = observation;
                 return observation;
             }
-            var unavailable = new NzbFileObservation(null, null);
-            reads.Observations[file] = unavailable;
-            return unavailable;
+        }
+        var unavailable = new NzbFileObservation(null, null);
+        reads.Observations[file] = unavailable;
+        return unavailable;
+    }
+
+    private async Task<HeaderProbeResult> FetchHeaderObservationAsync(int index, string id, RepairReadContext reads, CancellationToken ct)
+    {
+        await reads.FetchGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var response = await _usenetClient.DecodedBodyAsync(id, ct).ConfigureAwait(false);
+            await using var stream = response.Stream!;
+            return new HeaderProbeResult(index, id, await stream.GetYencHeadersAsync(ct).ConfigureAwait(false), false, false);
+        }
+        catch (Exception exception) when (exception is UsenetArticleNotFoundException or UsenetCorruptArticleException or InvalidDataException or EndOfStreamException)
+        {
+            return new HeaderProbeResult(index, id, null, exception is UsenetArticleNotFoundException, true);
         }
         finally { reads.FetchGate.Release(); }
     }
+
+    private sealed record HeaderProbeResult(int Index, string Id, UsenetYencHeader? Header, bool IsMissing, bool IsUnavailable);
 
     private async Task<LongRange[]> ResolveVolumeRangesAsync(NzbFile file, RepairPayload payload, long length,
         RepairReadContext reads, CancellationToken ct)

--- a/backend/Services/Repair/Par2RepairService.Volumes.cs
+++ b/backend/Services/Repair/Par2RepairService.Volumes.cs
@@ -199,7 +199,6 @@ public partial class Par2RepairService
         foreach (var window in indices.Chunk(concurrency))
         {
             ct.ThrowIfCancellationRequested();
-            var probes = new HeaderProbeResult[window.Length];
             var tasks = new Task<HeaderProbeResult>[window.Length];
             for (var offset = 0; offset < window.Length; offset++)
             {
@@ -207,28 +206,24 @@ public partial class Par2RepairService
                 var id = file.Segments[index].MessageId;
                 if (reads.UnavailableIds.Contains(id))
                 {
-                    tasks[offset] = Task.FromResult(new HeaderProbeResult(index, id, null, false, true));
+                    tasks[offset] = Task.FromResult(new HeaderProbeResult(id, null));
                     continue;
                 }
                 if (reads.Headers.TryGetValue(id, out var cachedHeader))
                 {
-                    tasks[offset] = Task.FromResult(new HeaderProbeResult(index, id, cachedHeader, false, cachedHeader is null));
+                    tasks[offset] = Task.FromResult(new HeaderProbeResult(id, cachedHeader));
                     continue;
                 }
                 reads.AdmitIdentityWork(0, request: true);
                 reads.Budget.Charge(512 + 2L * id.Length);
-                tasks[offset] = FetchHeaderObservationAsync(index, id, reads, ct);
+                tasks[offset] = FetchHeaderObservationAsync(id, reads, ct);
             }
-            probes = await Task.WhenAll(tasks).ConfigureAwait(false);
+            var probes = await Task.WhenAll(tasks).ConfigureAwait(false);
 
             foreach (var probe in probes)
             {
                 if (probe.Header is not null)
                     reads.Headers[probe.Id] = probe.Header;
-                else if (probe.IsUnavailable)
-                    reads.NoteUnavailable(probe.Id, probe.IsMissing
-                        ? new UsenetArticleNotFoundException(probe.Id)
-                        : new InvalidDataException("PAR2 identity header probe failed."));
                 if (probe.Header is not { FileSize: > 0 }) continue;
                 var observation = new NzbFileObservation(probe.Header.FileSize, null);
                 reads.Observations[file] = observation;
@@ -240,23 +235,24 @@ public partial class Par2RepairService
         return unavailable;
     }
 
-    private async Task<HeaderProbeResult> FetchHeaderObservationAsync(int index, string id, RepairReadContext reads, CancellationToken ct)
+    private async Task<HeaderProbeResult> FetchHeaderObservationAsync(string id, RepairReadContext reads, CancellationToken ct)
     {
         await reads.FetchGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
             var response = await _usenetClient.DecodedBodyAsync(id, ct).ConfigureAwait(false);
             await using var stream = response.Stream!;
-            return new HeaderProbeResult(index, id, await stream.GetYencHeadersAsync(ct).ConfigureAwait(false), false, false);
+            return new HeaderProbeResult(id, await stream.GetYencHeadersAsync(ct).ConfigureAwait(false));
         }
         catch (Exception exception) when (exception is UsenetArticleNotFoundException or UsenetCorruptArticleException or InvalidDataException or EndOfStreamException)
         {
-            return new HeaderProbeResult(index, id, null, exception is UsenetArticleNotFoundException, true);
+            reads.NoteUnavailable(id, exception);
+            return new HeaderProbeResult(id, null);
         }
         finally { reads.FetchGate.Release(); }
     }
 
-    private sealed record HeaderProbeResult(int Index, string Id, UsenetYencHeader? Header, bool IsMissing, bool IsUnavailable);
+    private sealed record HeaderProbeResult(string Id, UsenetYencHeader? Header);
 
     private async Task<LongRange[]> ResolveVolumeRangesAsync(NzbFile file, RepairPayload payload, long length,
         RepairReadContext reads, CancellationToken ct)

--- a/backend/Services/Repair/Par2RepairService.Volumes.cs
+++ b/backend/Services/Repair/Par2RepairService.Volumes.cs
@@ -216,7 +216,14 @@ public partial class Par2RepairService
                 }
                 reads.AdmitIdentityWork(0, request: true);
                 reads.Budget.Charge(512 + 2L * id.Length);
-                tasks[offset] = FetchHeaderObservationAsync(id, reads, ct);
+            }
+
+            for (var offset = 0; offset < window.Length; offset++)
+            {
+                var index = window[offset];
+                var id = file.Segments[index].MessageId;
+                if (tasks[offset] is null)
+                    tasks[offset] = FetchHeaderObservationAsync(id, reads, ct);
             }
             var probes = await Task.WhenAll(tasks).ConfigureAwait(false);
 
@@ -224,6 +231,10 @@ public partial class Par2RepairService
             {
                 if (probe.Header is not null)
                     reads.Headers[probe.Id] = probe.Header;
+                else if (probe.IsUnavailable)
+                    reads.NoteUnavailable(probe.Id, probe.IsMissing
+                        ? new UsenetArticleNotFoundException(probe.Id)
+                        : new InvalidDataException("PAR2 identity header probe failed."));
                 if (probe.Header is not { FileSize: > 0 }) continue;
                 var observation = new NzbFileObservation(probe.Header.FileSize, null);
                 reads.Observations[file] = observation;
@@ -246,13 +257,16 @@ public partial class Par2RepairService
         }
         catch (Exception exception) when (exception is UsenetArticleNotFoundException or UsenetCorruptArticleException or InvalidDataException or EndOfStreamException)
         {
-            reads.NoteUnavailable(id, exception);
-            return new HeaderProbeResult(id, null);
+            return new HeaderProbeResult(id, null, true, exception is UsenetArticleNotFoundException);
         }
         finally { reads.FetchGate.Release(); }
     }
 
-    private sealed record HeaderProbeResult(string Id, UsenetYencHeader? Header);
+    private sealed record HeaderProbeResult(
+        string Id,
+        UsenetYencHeader? Header,
+        bool IsUnavailable = false,
+        bool IsMissing = false);
 
     private async Task<LongRange[]> ResolveVolumeRangesAsync(NzbFile file, RepairPayload payload, long length,
         RepairReadContext reads, CancellationToken ct)

--- a/backend/Services/Repair/Par2RepairService.cs
+++ b/backend/Services/Repair/Par2RepairService.cs
@@ -997,36 +997,32 @@ public partial class Par2RepairService : BackgroundService
         int maxMissingSlices,
         CancellationToken ct)
     {
-        var expanded = true;
-        while (expanded)
+        ct.ThrowIfCancellationRequested();
+        accessor.BeginSequentialPass();
+        AbsorbAccessorDiscoveries(accessor, sliceMap, unavailableSegments, unavailableSlices);
+        if (unavailableSlices.Count > maxMissingSlices)
+            return true;
+
+        for (var local = 0; local < sliceMap.SliceCount; local++)
         {
             ct.ThrowIfCancellationRequested();
-            expanded = false;
-            accessor.BeginSequentialPass();
-            AbsorbAccessorDiscoveries(accessor, sliceMap, unavailableSegments, unavailableSlices, ref expanded);
+            var globalSlice = checked(sliceMap.GlobalSliceBase + local);
+            if (unavailableSlices.Contains(globalSlice))
+                continue;
+
+            var assembled = await accessor.FetchSliceBytesAsync(globalSlice, sliceMap.SliceSize, ct)
+                .ConfigureAwait(false);
+            var valid = assembled is not null && Par2Reconstructor.VerifySliceChecksum(assembled, targetIfsc.Slices[local]);
+            if (assembled is not null && !valid)
+            {
+                foreach (var segmentIndex in sliceMap.SegmentIndicesForGlobalSlice(globalSlice))
+                    accessor.NoteCorrupt(segmentIndex);
+            }
+            AbsorbAccessorDiscoveries(accessor, sliceMap, unavailableSegments, unavailableSlices);
+            if (!valid)
+                unavailableSlices.Add(globalSlice);
             if (unavailableSlices.Count > maxMissingSlices)
                 return true;
-
-            for (var local = 0; local < sliceMap.SliceCount; local++)
-            {
-                ct.ThrowIfCancellationRequested();
-                var globalSlice = checked(sliceMap.GlobalSliceBase + local);
-                if (unavailableSlices.Contains(globalSlice))
-                    continue;
-
-                var assembled = await accessor.FetchSliceBytesAsync(globalSlice, sliceMap.SliceSize, ct)
-                    .ConfigureAwait(false);
-                var valid = assembled is not null && Par2Reconstructor.VerifySliceChecksum(assembled, targetIfsc.Slices[local]);
-                if (assembled is not null && !valid)
-                {
-                    foreach (var segmentIndex in sliceMap.SegmentIndicesForGlobalSlice(globalSlice))
-                        accessor.NoteCorrupt(segmentIndex);
-                }
-                AbsorbAccessorDiscoveries(accessor, sliceMap, unavailableSegments, unavailableSlices, ref expanded);
-                expanded |= !valid && unavailableSlices.Add(globalSlice);
-                if (unavailableSlices.Count > maxMissingSlices)
-                    return true;
-            }
         }
 
         return false;
@@ -1036,15 +1032,13 @@ public partial class Par2RepairService : BackgroundService
         ResolvedSliceAccessor accessor,
         Par2FileSliceMap sliceMap,
         HashSet<int> unavailableSegments,
-        HashSet<int> unavailableSlices,
-        ref bool expanded)
+        HashSet<int> unavailableSlices)
     {
         foreach (var index in accessor.MissingSegmentIndices
                      .Concat(accessor.CorruptSegmentIndices)
                      .Where(unavailableSegments.Add))
         {
-            foreach (var slice in sliceMap.GlobalSlicesForSegment(index).Where(unavailableSlices.Add))
-                expanded = true;
+            unavailableSlices.UnionWith(sliceMap.GlobalSlicesForSegment(index));
         }
     }
 


### PR DESCRIPTION
## Summary

This single PR contains the completed, independently validated Phase 2 performance work:

- remove redundant full PAR2 discovery rescans using one monotonic sequential pass
- reuse definitive missing/corrupt article observations across discovery probes within one repair attempt
- bound PAR2 volume header probing by the configured fetch concurrency and merge results deterministically
- preserve existing checksum validation, memory/request limits, cancellation, patch publication, and independent whole-file verification

The persisted no-progress budget (`DeferredBudget`) remains intentionally out of this PR until its cancellation, job-state, restart reconciliation, and health persistence paths have complete coverage.

## Validation

- `Par2RepairServiceCorruptSourceTests`: 19 passed
- `Par2RepairServiceMultipartTests`: 50 passed
- `HealthCheckDegradedClassificationTests`: 43 passed
- Total focused tests: 112 passed
- diagnostics clean
- `git diff --check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved repair-source discovery by checking article headers concurrently, reducing delays during recovery operations.
  - Avoided repeated fetch attempts for articles already identified as unavailable.

- **Bug Fixes**
  - More reliably identifies and records missing or corrupt articles during repair.
  - Improved handling of failed article retrievals and unavailable sources.
  - Streamlined unavailable-source discovery while preserving safeguards for repairs exceeding the allowed missing-source limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->