### PR TITLE
fix(auth): keep users signed in after successful login

### DIFF
--- a/frontend/app/entry.server.test.ts
+++ b/frontend/app/entry.server.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  handleError,
+  isActionOriginRejection,
+  resetOriginRejectionLogThrottleForTests,
+} from "./entry.server";
+import { logger } from "../server/logger";
+
+describe("entry.server handleError", () => {
+  beforeEach(() => {
+    resetOriginRejectionLogThrottleForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("detects action origin rejection on POST with origin mismatch and Bad Request", () => {
+    const request = new Request("http://localhost:3000/login.data", {
+      method: "POST",
+      headers: { Origin: "https://public.example.com" },
+    });
+    const error = new Error("Bad Request");
+
+    expect(isActionOriginRejection(error, request)).toBe(true);
+  });
+
+  it("does not classify request as action origin rejection if origin matches", () => {
+    const request = new Request("http://localhost:3000/login.data", {
+      method: "POST",
+      headers: { Origin: "http://localhost:3000" },
+    });
+    const error = new Error("Bad Request");
+
+    expect(isActionOriginRejection(error, request)).toBe(false);
+  });
+
+  it("does not classify request as action origin rejection if method is GET", () => {
+    const request = new Request("http://localhost:3000/login.data", {
+      method: "GET",
+      headers: { Origin: "https://public.example.com" },
+    });
+    const error = new Error("Bad Request");
+
+    expect(isActionOriginRejection(error, request)).toBe(false);
+  });
+
+  it("does not classify request as action origin rejection if error is unrelated", () => {
+    const request = new Request("http://localhost:3000/login.data", {
+      method: "POST",
+      headers: { Origin: "https://public.example.com" },
+    });
+    const error = new Error("Database connection failed");
+
+    expect(isActionOriginRejection(error, request)).toBe(false);
+  });
+
+  it("logs throttled warning on action origin rejection in handleError", () => {
+    const loggerWarnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const request = new Request("http://localhost:3000/login.data", {
+      method: "POST",
+      headers: { Origin: "https://public.example.com" },
+    });
+    const error = new Error("Bad Request");
+
+    handleError(error, {
+      request,
+      params: {},
+      context: {},
+    });
+
+    expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
+    expect(loggerWarnSpy.mock.calls[0][0]).toContain("Action request origin rejected");
+    expect(loggerWarnSpy.mock.calls[0][0]).toContain("TRUST_PROXY=1");
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+    // Repeated call within throttle window should be suppressed
+    handleError(error, {
+      request,
+      params: {},
+      context: {},
+    });
+    expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs console.error for unexpected errors in handleError", () => {
+    const loggerWarnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const request = new Request("http://localhost:3000/login.data", {
+      method: "POST",
+      headers: { Origin: "http://localhost:3000" },
+    });
+    const error = new Error("Unexpected crash");
+
+    handleError(error, {
+      request,
+      params: {},
+      context: {},
+    });
+
+    expect(loggerWarnSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+  });
+});

--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -16,6 +16,41 @@ import { logger } from "../server/logger";
 
 export const streamTimeout = 5_000;
 
+let lastOriginRejectionLogAt = 0;
+const ORIGIN_REJECTION_LOG_THROTTLE_MS = 60_000;
+
+export function resetOriginRejectionLogThrottleForTests(): void {
+  lastOriginRejectionLogAt = 0;
+}
+
+export function isActionOriginRejection(error: unknown, request: Request): boolean {
+  const method = request.method.toUpperCase();
+  if (method === "GET" || method === "HEAD") return false;
+
+  const origin = request.headers.get("origin");
+  if (!origin) return false;
+
+  let isMismatch = false;
+  try {
+    const originUrl = new URL(origin);
+    const requestUrl = new URL(request.url);
+    isMismatch = originUrl.origin !== requestUrl.origin;
+  } catch {
+    isMismatch = true;
+  }
+
+  if (!isMismatch) return false;
+
+  const errorMessage =
+    error instanceof Error
+      ? error.message
+      : typeof error === "object" && error !== null && "data" in error
+        ? String((error as { data?: unknown }).data)
+        : String(error);
+
+  return /bad request|csrf|origin/i.test(errorMessage);
+}
+
 /**
  * Quiet expected BackendUnavailableError stacks during frontend-first Docker
  * startup. Outside the grace window, emit a throttled single-line warn (no stack).
@@ -32,6 +67,17 @@ export const handleError: HandleErrorFunction = (error, { request }) => {
     if (shouldEmitThrottledBackendUnavailableLog()) {
       logger.warn(
         `Backend unreachable during SSR. Reason: ${formatBackendUnavailableReason(unwrapped)}`,
+      );
+    }
+    return;
+  }
+  if (isActionOriginRejection(unwrapped, request)) {
+    const now = Date.now();
+    if (now - lastOriginRejectionLogAt >= ORIGIN_REJECTION_LOG_THROTTLE_MS) {
+      lastOriginRejectionLogAt = now;
+      const origin = request.headers.get("origin");
+      logger.warn(
+        `Action request origin rejected. Request URL: ${request.url}, Origin: ${origin ?? "unknown"}. If behind a reverse proxy terminating HTTPS, ensure TRUST_PROXY=1 is set.`,
       );
     }
     return;


### PR DESCRIPTION
### Summary
Extends the frontend entry server's `handleError` error handler to identify action origin rejections (CSRF origin guard mismatches from reverse proxy origin differences) and log bounded, human-friendly single-line warnings directing users to configure `TRUST_PROXY=1` when behind HTTPS-terminating proxies, suppressing raw unhandled stack dumps.

### Test Plan
- Added `frontend/app/entry.server.test.ts` covering `isActionOriginRejection` detection and warning log throttling.
- Ran frontend unit tests (`npx vitest run app/entry.server.test.ts app/auth/authentication.server.test.ts`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rejected action requests caused by origin mismatches.
  * Added throttled warning messages for these rejections, reducing repetitive error output.
  * Unexpected server errors continue to be reported through standard error logging.

* **Tests**
  * Added coverage for origin-rejection detection across request methods, origins, and error types.
  * Added verification for throttled warnings and fallback error logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->